### PR TITLE
iMessage source: chat.db conversation windows + shared chat machinery

### DIFF
--- a/Sentient OS macOS/Documentation/iMessage Source (chat.db).md
+++ b/Sentient OS macOS/Documentation/iMessage Source (chat.db).md
@@ -1,0 +1,46 @@
+# iMessage Source (chat.db)
+
+`Sources/iMessageSource.swift` — the `DataSource` over the Mac's iMessage store. Same shape as
+WhatsApp: WAL-safe copy → extract → delete, conversation windows, per-chat opt-in, group/DM
+triage routing. Needs Full Disk Access.
+
+## The pieces
+
+| File | Job |
+|---|---|
+| `Sources/iMessageSource.swift` | The source: `listChats()` → picker rows · `scan()` → windowed Candidates · the typedstream decoder |
+| `Sources/ChatWindowing.swift` | Shared chat machinery (WhatsApp + iMessage): `ChatMessage`, `ChatInfo`, byte-budget `windows()`, `format()`, the connector limits |
+| `Sources/AddressBookNames.swift` | Raw handles (`+1415…` / emails) → contact names, read straight from the AddressBook SQLite stores (FDA covers them — deliberately **no** Contacts-framework permission prompt) |
+| `Views/ChatPicker.swift` | The shared opt-in sheet (was `WhatsAppChatPicker`); takes a source name + a `listChats` loader |
+
+## chat.db facts (the ones that bite)
+
+- **Path:** `~/Library/Messages/chat.db`. Read via `SQLiteDB.walSafeCopy` like every DB source.
+- **~99% of modern rows have `text = NULL`** — the body lives in `attributedBody` as an Apple
+  typedstream blob. Decoder = the proven `imessage_tools` heuristic ([MEASURED] 99.97% on 12,017
+  real messages): find `NSString`/`NSMutableString`, skip 5 bytes, length = 1 byte or `0x81` +
+  2-byte LE, UTF-8. Deliberately NOT a full typedstream parser — don't overbuild it.
+- **Dates are ns since 2001-01-01:** `date/1e9 + 978307200` → Unix. (Pre-2017 rows used seconds;
+  unreachable inside the 90-day lookback, so unhandled on purpose.)
+- **Tapbacks are message rows** (`associated_message_type` 2000-range) — filtered in SQL or every
+  window fills with `Loved "…"` noise. System events (renames, etc.) = `item_type != 0`, also filtered.
+- **Group vs DM:** `chat.style` 43 = group, 45 = DM. Opt-in key = `chat.guid` (stable).
+  Sender per message via `handle.id` (E.164 phone or email — chat.db stores **no names**, hence
+  AddressBookNames). Unnamed groups get a participant roll-up name ("Alex, Sam & 2 others").
+- **Limits (TODO plan):** 90-day floor AND newest-200k cap per connector, both in SQL — inner
+  `ORDER BY date DESC LIMIT` subquery applies the cap across all chats, outer ORDER restores
+  per-chat ascending iteration.
+
+## Dedup / cursor
+
+v1 matches WhatsApp: ledger-based dedup via stable window ids
+(`imessage:c<chatROWID>:<firstROWID>-<lastROWID>`, signature = message count). A ROWID cursor +
+active-tail hold-back is the Phase-4 (scheduler) hardening for both chat sources.
+
+## Self-tests (`Self Tests - Temp/`, all need FDA on the *spawning* terminal)
+
+- `SENTIENT_SELFTEST=imdecode` — decode-rate stats on the real chat.db (no model, no content
+  printed; rows with both `text` and blob act as ground truth).
+- `SENTIENT_SELFTEST=imchats` — picker enumeration + name resolution sanity.
+- `SENTIENT_SELFTEST=imessage` — full window dump through the model
+  (`SENTIENT_SELFTEST_CHATS="name|name"` to filter).

--- a/Sentient OS macOS/Self Tests - Temp/SelfTest_Triage_Pipeline_and_Vault.swift
+++ b/Sentient OS macOS/Self Tests - Temp/SelfTest_Triage_Pipeline_and_Vault.swift
@@ -14,7 +14,8 @@
 //  Invoke (after building):
 //    SENTIENT_SELFTEST=whatsapp "<app>/Contents/MacOS/Sentient OS macOS"
 //  Env knobs:
-//    SENTIENT_SELFTEST     "whatsapp" | "files"   (which source)
+//    SENTIENT_SELFTEST     "whatsapp" | "imessage" | "files"  (model dump) ·
+//                          "parse" | "chats" | "imchats" | "imdecode" | "claudecli" | "vault"  (no model)
 //    SENTIENT_SELFTEST_N   item count (default 6)
 //    SENTIENT_SELFTEST_OUT output file (default <tmp>/sentient-selftest.txt)
 //    SENTIENT_MODEL_PATH   override the dev model path
@@ -97,15 +98,51 @@ enum SelfTest {
             return
         }
 
-        // Chat-list mode: deterministic, no model — verify WhatsAppSource.listChats() enumeration.
-        if mode == "chats" {
+        // Chat-list modes: deterministic, no model — verify listChats() enumeration (and, for
+        // iMessage, that names resolved instead of raw +1415… handles).
+        if mode == "chats" || mode == "imchats" {
             do {
-                let list = try WhatsAppSource().listChats()
-                emit("active chats in the last \(WhatsAppSource.lookbackDays) days: \(list.count)\n")
+                let list = mode == "chats" ? try WhatsAppSource().listChats()
+                                           : try iMessageSource().listChats()
+                emit("active chats in the last \(ChatWindowing.lookbackDays) days: \(list.count)\n")
                 for c in list.prefix(count > 6 ? count : 20) {
                     emit("  [\(c.isGroup ? "group" : "DM  ")] \(c.name)  —  \(c.messageCount) msgs · last \(c.lastActive)")
                 }
             } catch { emit("listChats FAILED: \(error)") }
+            return
+        }
+
+        // iMessage decode-rate validation: deterministic, no model, STATS ONLY (no message
+        // content) — proves the typedstream heuristic on this Mac's real chat.db. Rows carrying
+        // BOTH plain text and a blob are ground truth: the decoded blob must equal the text.
+        if mode == "imdecode" {
+            do {
+                let (dbURL, tempDir) = try SQLiteDB.walSafeCopy(of: iMessageSource().dbPath)
+                defer { try? FileManager.default.removeItem(at: tempDir) }
+                let reader = try SQLiteReader(path: dbURL.path)
+                let floorNS = Int64(ChatWindowing.lookbackFloor.timeIntervalSinceReferenceDate * 1e9)
+                var ok = 0, fail = 0, match = 0, mismatch = 0, checked = 0, plainOnly = 0, empty = 0
+                try reader.forEachRow("""
+                    SELECT text, attributedBody FROM message
+                    WHERE date >= \(floorNS) AND associated_message_type = 0 AND item_type = 0
+                    """) { r in
+                    let text = r.text(0)
+                    guard let blob = r.blob(1) else {
+                        if text?.isEmpty == false { plainOnly += 1 } else { empty += 1 }
+                        return
+                    }
+                    guard let decoded = iMessageSource.typedstreamText(blob) else { fail += 1; return }
+                    ok += 1
+                    if let text, !text.isEmpty {
+                        checked += 1
+                        if decoded == text { match += 1 } else { mismatch += 1 }
+                    }
+                }
+                emit("last \(ChatWindowing.lookbackDays) days · blob rows: \(ok) decoded / \(fail) failed (\(String(format: "%.2f", 100.0 * Double(ok) / Double(max(ok + fail, 1))))%)")
+                emit("plain-text-only rows: \(plainOnly) · no-body rows skipped: \(empty)")
+                emit("ground truth (rows with text AND blob): \(match) match / \(mismatch) mismatch of \(checked)")
+                emit(fail == 0 && mismatch == 0 ? "✅ decode clean" : "⚠️ inspect failures before trusting windows")
+            } catch { emit("imdecode FAILED: \(error)") }
             return
         }
 
@@ -152,29 +189,34 @@ enum SelfTest {
             return
         }
 
+        // Optional chat filter for the chat-source dumps: SENTIENT_SELFTEST_CHATS = name
+        // substrings joined by "|". Returns the matched chat ids, or nil for "all chats".
+        func chatFilter(_ all: [ChatInfo]) -> Set<String>? {
+            let want = (ProcessInfo.processInfo.environment["SENTIENT_SELFTEST_CHATS"] ?? "")
+                .split(separator: "|").map { $0.trimmingCharacters(in: .whitespaces).lowercased() }.filter { !$0.isEmpty }
+            guard !want.isEmpty else { return nil }
+            let matched = all.filter { c in want.contains { c.name.lowercased().contains($0) } }
+            emit("chat filter → \(matched.count) matched: \(matched.map(\.name).joined(separator: " · "))\n")
+            return Set(matched.map(\.id))
+        }
+
         // 1) Build the source + scan candidates.
         let source: any DataSource
         let maxTokens: Int
         switch mode {
         case "whatsapp":
-            // Optional chat filter: SENTIENT_SELFTEST_CHATS = name substrings joined by "|".
-            let want = (ProcessInfo.processInfo.environment["SENTIENT_SELFTEST_CHATS"] ?? "")
-                .split(separator: "|").map { $0.trimmingCharacters(in: .whitespaces).lowercased() }.filter { !$0.isEmpty }
-            var jids: Set<String>? = nil
-            if !want.isEmpty {
-                let all = (try? WhatsAppSource().listChats()) ?? []
-                let matched = all.filter { c in want.contains { c.name.lowercased().contains($0) } }
-                jids = Set(matched.map(\.jid))
-                emit("chat filter → \(matched.count) matched: \(matched.map(\.name).joined(separator: " · "))\n")
-            }
-            source = WhatsAppSource(chatJIDs: jids); maxTokens = 16384
+            source = WhatsAppSource(chatJIDs: chatFilter((try? WhatsAppSource().listChats()) ?? []))
+            maxTokens = 16384
+        case "imessage":
+            source = iMessageSource(chatGUIDs: chatFilter((try? iMessageSource().listChats()) ?? []))
+            maxTokens = 16384
         case "files":
             guard let dl = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first else {
                 emit("could not locate ~/Downloads"); return
             }
             source = FilesSource(root: dl, label: "Downloads"); maxTokens = 4096
         default:
-            emit("unknown mode '\(mode)' (use whatsapp | files)"); return
+            emit("unknown mode '\(mode)' (use whatsapp | imessage | files)"); return
         }
 
         let candidates: [Candidate]

--- a/Sentient OS macOS/Sources/AddressBookNames.swift
+++ b/Sentient OS macOS/Sources/AddressBookNames.swift
@@ -1,0 +1,81 @@
+//
+//  AddressBookNames.swift
+//  Sentient OS macOS
+//
+//  Maps raw iMessage handles ("+14155551234" / "friend@icloud.com") → contact display names by
+//  reading the Mac's AddressBook SQLite stores directly. chat.db stores no names at all, and the
+//  official Contacts framework would add a brand-new permission prompt to onboarding — Full Disk
+//  Access already covers these files, so we read them like every other DB source: WAL-safe copy →
+//  read → delete.
+//
+//  Matching: emails compare lowercased; phones compare on a LAST-10-DIGIT suffix, because chat.db
+//  holds E.164 ("+14155551234") while AddressBook holds whatever the user typed ("(415) 555-1234").
+//  Key methods: loadMap() → [key: name] over every store · resolve(_:in:) for one handle.
+//
+
+import Foundation
+
+enum AddressBookNames {
+    /// One pass over every AddressBook store on this Mac (the root store + one per synced
+    /// account under Sources/) → [normalized handle key: display name]. Best-effort: a missing
+    /// or unreadable store contributes nothing. Build once per scan, not per message.
+    static func loadMap() -> [String: String] {
+        var map: [String: String] = [:]
+        let fm = FileManager.default
+        let abRoot = fm.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/AddressBook")
+
+        var stores = [abRoot.appendingPathComponent("AddressBook-v22.abcddb").path]
+        let sourcesDir = abRoot.appendingPathComponent("Sources")
+        if let accounts = try? fm.contentsOfDirectory(at: sourcesDir, includingPropertiesForKeys: nil) {
+            stores += accounts.map { $0.appendingPathComponent("AddressBook-v22.abcddb").path }
+        }
+        for store in stores where fm.fileExists(atPath: store) {
+            merge(store: store, into: &map)
+        }
+        return map
+    }
+
+    /// Resolve one chat.db handle against the map. nil = not in Contacts (caller shows a
+    /// cleaned raw handle instead).
+    static func resolve(_ handle: String, in map: [String: String]) -> String? {
+        map[key(for: handle)]
+    }
+
+    /// Normalize a handle/phone/email into a lookup key: lowercased for emails, last-10-digit
+    /// suffix for phones (short codes with fewer digits key as-is).
+    static func key(for handle: String) -> String {
+        let trimmed = handle.trimmingCharacters(in: .whitespaces)
+        if trimmed.contains("@") { return trimmed.lowercased() }
+        let digits = trimmed.filter(\.isNumber)
+        return String(digits.suffix(10))
+    }
+
+    // MARK: One store → the map
+
+    private static func merge(store: String, into map: inout [String: String]) {
+        guard let (dbURL, tempDir) = try? SQLiteDB.walSafeCopy(of: store) else { return }
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        guard let reader = try? SQLiteReader(path: dbURL.path) else { return }
+
+        // Record pk → display name ("First Last" → organization → nickname).
+        var names: [Int64: String] = [:]
+        try? reader.forEachRow("SELECT Z_PK, ZFIRSTNAME, ZLASTNAME, ZORGANIZATION, ZNICKNAME FROM ZABCDRECORD") { r in
+            let person = [r.text(1), r.text(2)].compactMap { $0 }.joined(separator: " ")
+                .trimmingCharacters(in: .whitespaces)
+            let name = !person.isEmpty ? person : (r.text(3) ?? r.text(4) ?? "")
+            if !name.isEmpty { names[r.int(0)] = name }
+        }
+
+        try? reader.forEachRow("SELECT ZOWNER, ZFULLNUMBER FROM ZABCDPHONENUMBER") { r in
+            guard let name = names[r.int(0)], let number = r.text(1) else { return }
+            let k = key(for: number)
+            if !k.isEmpty, map[k] == nil { map[k] = name }
+        }
+        try? reader.forEachRow("SELECT ZOWNER, ZADDRESS FROM ZABCDEMAILADDRESS") { r in
+            guard let name = names[r.int(0)], let address = r.text(1) else { return }
+            let k = key(for: address)
+            if !k.isEmpty, map[k] == nil { map[k] = name }
+        }
+    }
+}

--- a/Sentient OS macOS/Sources/ChatWindowing.swift
+++ b/Sentient OS macOS/Sources/ChatWindowing.swift
@@ -1,0 +1,90 @@
+//
+//  ChatWindowing.swift
+//  Sentient OS macOS
+//
+//  Shared machinery for the chat sources (WhatsApp + iMessage — the second use case that earned
+//  this extraction). A chat source's unit of analysis is a CONVERSATION WINDOW, not a message:
+//  a run of messages from ONE chat, time-ordered, sized by a UTF-8 BYTE budget, flowing through
+//  the pipeline as one Artifact. Key pieces:
+//    ChatMessage          — one decoded message, normalized across sources
+//    ChatInfo             — a row for the opt-in chat picker
+//    ChatWindowing.windows(of:)  — greedy byte-budget batching
+//    ChatWindowing.format(...)   — frames a window for the model (chat name, group/DM,
+//                                  "you sent N of M" participation anchor, per-message senders)
+//  Limits (TODO plan): chat connectors read the last `lookbackDays` 90 days OR the newest
+//  `maxMessages` 200k messages per connector — whichever cuts first.
+//
+
+import Foundation
+
+/// One decoded chat message, normalized across sources. `sender` is the display label the model
+/// sees — "Me" for the user, a resolved contact/push name, or a clean generic ("a group member");
+/// raw handles/JIDs must be resolved or cleaned by the source BEFORE constructing this.
+struct ChatMessage: Sendable {
+    let id: Int64          // source row id (WhatsApp Z_PK / iMessage ROWID) → stable window ids
+    let date: Date
+    let sender: String
+    let isFromMe: Bool
+    let text: String       // capped at ChatWindowing.maxMessageChars by the source
+}
+
+/// A chat as shown in the opt-in picker — active within the lookback, with how busy it's been.
+/// `id` is the source's stable opt-in key (WhatsApp JID / iMessage chat GUID).
+struct ChatInfo: Sendable, Identifiable {
+    let id: String
+    let name: String
+    let isGroup: Bool
+    let messageCount: Int
+    let lastActive: Date
+}
+
+enum ChatWindowing {
+    // MARK: Limits — shared by every chat connector
+    static let lookbackDays = 90
+    static let maxMessages = 200_000       // newest-first cap, summed across the connector's chats
+
+    // We size a window by its UTF-8 BYTE count, NOT chars (and NOT a chars→tokens guess). A
+    // byte-level tokenizer emits at most ONE token per byte, so bytes are a HARD upper bound on
+    // tokens — a window can never overflow the model's token budget, even for emoji / CJK /
+    // multilingual chats where characters wildly under-count tokens. (That mismatch is what made
+    // the model "go quiet": a 26k-char window tokenized to 18.6k tokens, >2× the 8,192 budget.)
+    // ~5,000 bytes ⇒ ≤ ~5k tokens, leaving comfortable room for the prompt + reply inside 8,192.
+    static let maxWindowBytes = 5_000
+    static let maxMessageChars = 1_000     // cap a single pasted-essay message so it can't dominate a window
+
+    /// The 90-day floor as a Date (sources convert to their own epoch/units for SQL).
+    static var lookbackFloor: Date { Date().addingTimeInterval(-Double(lookbackDays) * 86_400) }
+
+    // MARK: Windowing — per chat, time-ordered, greedy up to the byte budget
+
+    static func windows(of msgs: [ChatMessage]) -> [[ChatMessage]] {
+        var out: [[ChatMessage]] = []
+        var cur: [ChatMessage] = []
+        var bytes = 0
+        for m in msgs {
+            let b = msgBytes(m)
+            if !cur.isEmpty && bytes + b > maxWindowBytes { out.append(cur); cur = []; bytes = 0 }
+            cur.append(m); bytes += b
+        }
+        if !cur.isEmpty { out.append(cur) }
+        return out
+    }
+
+    /// UTF-8 byte size of a formatted line — the upper bound on its token count.
+    private static func msgBytes(_ m: ChatMessage) -> Int { m.text.utf8.count + 28 }   // + date/sender label overhead
+
+    // MARK: Formatting — frame the window for the model
+
+    static func format(chatName: String, isGroup: Bool, messages: [ChatMessage]) -> String {
+        let mine = messages.lazy.filter(\.isFromMe).count
+        var out = "Chat: \"\(chatName)\" (\(isGroup ? "group" : "direct message"))\n"
+        out += "In this slice, you (\"Me\") sent \(mine) of \(messages.count) messages.\n"
+        for m in messages { out += "[\(dateString(m.date))] \(m.sender): \(m.text)\n" }
+        return out
+    }
+
+    private static let df: DateFormatter = {
+        let f = DateFormatter(); f.dateFormat = "MMM d, h:mm a"; return f
+    }()
+    private static func dateString(_ d: Date) -> String { df.string(from: d) }
+}

--- a/Sentient OS macOS/Sources/SQLiteDB.swift
+++ b/Sentient OS macOS/Sources/SQLiteDB.swift
@@ -84,5 +84,9 @@ final class SQLiteReader {
             guard sqlite3_column_type(stmt, i) != SQLITE_NULL, let c = sqlite3_column_text(stmt, i) else { return nil }
             return String(cString: c)
         }
+        func blob(_ i: Int32) -> Data? {
+            guard sqlite3_column_type(stmt, i) != SQLITE_NULL, let p = sqlite3_column_blob(stmt, i) else { return nil }
+            return Data(bytes: p, count: Int(sqlite3_column_bytes(stmt, i)))
+        }
     }
 }

--- a/Sentient OS macOS/Sources/WhatsAppSource.swift
+++ b/Sentient OS macOS/Sources/WhatsAppSource.swift
@@ -6,14 +6,12 @@
 //  plaintext in WAL mode → we WAL-safe COPY → EXTRACT → DELETE immediately (privacy: a plaintext
 //  copy of the whole chat history never lingers).
 //
-//  THE UNIT OF ANALYSIS IS A CONVERSATION WINDOW, not a message. A single message is meaningless
-//  alone ("ok", "haha", "5pm?"); meaning lives in the conversation. So we batch a run of messages
-//  from ONE chat, in time order, up to the model's context budget (~8k-token windows), and each
-//  window flows through the SAME pipeline as a file: one window = one Artifact = one bouncer
-//  verdict (Triage's chat-flavored prompt). The vast majority of chat is ephemeral → junk; the
-//  rare keeper → one summary. The model sees the chat name, DM-vs-group, and per-message sender.
+//  THE UNIT OF ANALYSIS IS A CONVERSATION WINDOW, not a message (see ChatWindowing.swift — the
+//  windowing/formatting/limits shared with iMessage live there). Each window flows through the
+//  SAME pipeline as a file: one window = one Artifact = one bouncer verdict (Triage's
+//  chat-flavored prompt). The model sees the chat name, DM-vs-group, and per-message sender.
 //
-//  Requires Full Disk Access (Permissions.swift). v1 scope: backfills the last `lookbackDays`;
+//  Requires Full Disk Access (Permissions.swift). v1 scope: backfills the lookback window;
 //  dedup is ledger-based via stable window ids (like Files). A Z_PK cursor, hold-back of the
 //  active tail, and slide-proof window anchoring are a Phase-4 (scheduler) hardening — see Arch §3.1.
 //
@@ -28,16 +26,6 @@ struct WhatsAppSource: DataSource, Sendable {
 
     init(chatJIDs: Set<String>? = nil) { self.chatJIDs = chatJIDs }
 
-    /// A chat as shown in the opt-in picker — active within the lookback, with how busy it's been.
-    struct ChatInfo: Sendable, Identifiable {
-        let jid: String
-        let name: String
-        let isGroup: Bool
-        let messageCount: Int
-        let lastActive: Date
-        var id: String { jid }
-    }
-
     /// Active chats (text messages within the lookback) for the picker — newest first, with counts.
     /// Its own WAL-safe copy → query → delete.
     func listChats() throws -> [ChatInfo] {
@@ -45,7 +33,7 @@ struct WhatsAppSource: DataSource, Sendable {
         defer { try? FileManager.default.removeItem(at: tempDir) }
         let reader = try SQLiteReader(path: dbURL.path)
 
-        let floor = Date().addingTimeInterval(-Double(Self.lookbackDays) * 86_400).timeIntervalSinceReferenceDate
+        let floor = ChatWindowing.lookbackFloor.timeIntervalSinceReferenceDate
         var out: [ChatInfo] = []
         try reader.forEachRow("""
             SELECT s.ZCONTACTJID, s.ZPARTNERNAME, COUNT(m.Z_PK), MAX(m.ZMESSAGEDATE)
@@ -56,7 +44,7 @@ struct WhatsAppSource: DataSource, Sendable {
             """) { r in
             let jid = r.text(0) ?? ""
             guard !jid.isEmpty else { return }
-            out.append(ChatInfo(jid: jid,
+            out.append(ChatInfo(id: jid,
                                 name: r.text(1) ?? Self.handle(jid),
                                 isGroup: jid.hasSuffix("@g.us"),
                                 messageCount: Int(r.int(2)),
@@ -65,32 +53,12 @@ struct WhatsAppSource: DataSource, Sendable {
         return out
     }
 
-    // MARK: Tunables
-    static let lookbackDays = 31
-    // We size a window by its UTF-8 BYTE count, NOT chars (and NOT a chars→tokens guess). A
-    // byte-level tokenizer emits at most ONE token per byte, so bytes are a HARD upper bound on
-    // tokens — a window can never overflow the model's token budget, even for emoji / CJK /
-    // multilingual chats where characters wildly under-count tokens. (That mismatch is what made
-    // the model "go quiet": a 26k-char window tokenized to 18.6k tokens, >2× the 8,192 budget.)
-    // ~5,000 bytes ⇒ ≤ ~5k tokens, leaving comfortable room for the prompt + reply inside 8,192.
-    static let maxWindowBytes = 5_000
-    static let maxMessageChars = 1_000     // cap a single pasted-essay message so it can't dominate a window
-
     var dbPath: String {
         FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Library/Group Containers/group.net.whatsapp.WhatsApp.shared/ChatStorage.sqlite")
             .path
     }
 
-    // MARK: Decoded rows
-    private struct Msg {
-        let pk: Int64
-        let date: Date
-        let isFromMe: Bool
-        let text: String
-        let pushName: String?     // ZWAMESSAGE.ZPUSHNAME — the sender's display name, right on the message
-        let memberName: String?   // ZWAGROUPMEMBER contact/first name (group senders without a push-name)
-    }
     private struct Chat {
         let pk: Int64
         let jid: String           // ZCONTACTJID — the stable opt-in key
@@ -113,41 +81,47 @@ struct WhatsAppSource: DataSource, Sendable {
             chats[r.int(0)] = Chat(pk: r.int(0), jid: jid, name: name, isGroup: jid.hasSuffix("@g.us"))
         }
 
-        // Text messages within the lookback, grouped per chat, oldest → newest.
-        let floor = Date().addingTimeInterval(-Double(Self.lookbackDays) * 86_400).timeIntervalSinceReferenceDate
-        var byChat: [Int64: [Msg]] = [:]
+        // Text messages within the limits (90-day floor AND newest-200k cap — the inner
+        // newest-first LIMIT applies the cap across ALL chats; the outer ORDER restores
+        // per-chat ascending iteration), oldest → newest per chat.
+        let floor = ChatWindowing.lookbackFloor.timeIntervalSinceReferenceDate
+        var byChat: [Int64: [ChatMessage]] = [:]
         // LEFT JOIN the group-member row (indexed on Z_PK → near-free) so senders without a
         // push-name resolve to their saved contact name instead of a raw JID/LID.
         try reader.forEachRow("""
             SELECT m.Z_PK, m.ZMESSAGEDATE, m.ZISFROMME, m.ZTEXT, m.ZPUSHNAME, m.ZCHATSESSION, gm.ZCONTACTNAME, gm.ZFIRSTNAME
-            FROM ZWAMESSAGE m
+            FROM (SELECT * FROM ZWAMESSAGE
+                  WHERE ZTEXT IS NOT NULL AND length(ZTEXT) > 0 AND ZMESSAGEDATE >= \(floor)
+                  ORDER BY ZMESSAGEDATE DESC LIMIT \(ChatWindowing.maxMessages)) m
             LEFT JOIN ZWAGROUPMEMBER gm ON m.ZGROUPMEMBER = gm.Z_PK
-            WHERE m.ZTEXT IS NOT NULL AND length(m.ZTEXT) > 0 AND m.ZMESSAGEDATE >= \(floor)
             ORDER BY m.ZCHATSESSION, m.Z_PK
             """) { r in
-            byChat[r.int(5), default: []].append(Msg(
-                pk: r.int(0),
+            guard let chat = chats[r.int(5)] else { return }
+            if let only = chatJIDs, !only.contains(chat.jid) { return }   // opt-in filter
+            let isFromMe = r.int(2) == 1
+            byChat[r.int(5), default: []].append(ChatMessage(
+                id: r.int(0),
                 date: Date(timeIntervalSinceReferenceDate: r.double(1)),
-                isFromMe: r.int(2) == 1,
-                text: String((r.text(3) ?? "").prefix(Self.maxMessageChars)),
-                pushName: r.text(4),
-                memberName: r.text(6) ?? r.text(7)))   // ZCONTACTNAME ?? ZFIRSTNAME
+                sender: isFromMe ? "Me" : Self.sender(pushName: r.text(4),
+                                                      memberName: r.text(6) ?? r.text(7),   // ZCONTACTNAME ?? ZFIRSTNAME
+                                                      chat: chat),
+                isFromMe: isFromMe,
+                text: String((r.text(3) ?? "").prefix(ChatWindowing.maxMessageChars))))
         }
 
-        // Window each chat to the char budget; one window = one Artifact.
+        // Window each chat to the byte budget; one window = one Artifact.
         var built: [(candidate: Candidate, last: Date)] = []
         for (chatPK, msgs) in byChat {
             guard let chat = chats[chatPK] else { continue }
-            if let only = chatJIDs, !only.contains(chat.jid) { continue }   // opt-in filter
-            for win in Self.windows(of: msgs) where !win.isEmpty {
+            for win in ChatWindowing.windows(of: msgs) where !win.isEmpty {
                 let meta: [String: String] = [
                     "folder": chat.name,                         // per-chat tag → folder pills in the viewer
                     "name": chat.name,
                     "displayPath": "WhatsApp · \(chat.name)",
                     "isGroup": chat.isGroup ? "1" : "0",         // → group vs DM bouncer prompt
-                    "windowText": Self.format(chat: chat, messages: win),
+                    "windowText": ChatWindowing.format(chatName: chat.name, isGroup: chat.isGroup, messages: win),
                 ]
-                let id = "whatsapp:c\(chatPK):\(win.first!.pk)-\(win.last!.pk)"
+                let id = "whatsapp:c\(chatPK):\(win.first!.id)-\(win.last!.id)"
                 built.append((Candidate(id: id, kind: .whatsapp, signature: "\(win.count)", metadata: meta),
                               win.last!.date))
             }
@@ -159,40 +133,13 @@ struct WhatsAppSource: DataSource, Sendable {
         Artifact(candidate: candidate, text: candidate.metadata["windowText"] ?? "")
     }
 
-    // MARK: Windowing — per chat, time-ordered, greedy up to the char budget
+    // MARK: Sender labels
 
-    private static func windows(of msgs: [Msg]) -> [[Msg]] {
-        var out: [[Msg]] = []
-        var cur: [Msg] = []
-        var bytes = 0
-        for m in msgs {
-            let b = msgBytes(m)
-            if !cur.isEmpty && bytes + b > maxWindowBytes { out.append(cur); cur = []; bytes = 0 }
-            cur.append(m); bytes += b
-        }
-        if !cur.isEmpty { out.append(cur) }
-        return out
-    }
-
-    /// UTF-8 byte size of a formatted line — the upper bound on its token count.
-    private static func msgBytes(_ m: Msg) -> Int { m.text.utf8.count + 28 }   // + date/sender label overhead
-
-    // MARK: Formatting — frame the window for the model
-
-    private static func format(chat: Chat, messages: [Msg]) -> String {
-        let mine = messages.lazy.filter(\.isFromMe).count
-        var out = "Chat: \"\(chat.name)\" (\(chat.isGroup ? "group" : "direct message"))\n"
-        out += "In this slice, you (\"Me\") sent \(mine) of \(messages.count) messages.\n"
-        for m in messages { out += "[\(dateString(m.date))] \(sender(m, chat: chat)): \(m.text)\n" }
-        return out
-    }
-
-    private static func sender(_ m: Msg, chat: Chat) -> String {
-        if m.isFromMe { return "Me" }
+    private static func sender(pushName: String?, memberName: String?, chat: Chat) -> String {
         // Group: push-name → saved contact name → a clean generic. Each candidate is validated, because
         // WhatsApp stores an opaque LID blob as the "name" for some privacy-mode members — that must
         // NEVER reach a summary.
-        if chat.isGroup { return cleanName(m.pushName) ?? cleanName(m.memberName) ?? "a group member" }
+        if chat.isGroup { return cleanName(pushName) ?? cleanName(memberName) ?? "a group member" }
         return chat.name   // DM: the other party is the chat partner
     }
 
@@ -207,9 +154,4 @@ struct WhatsAppSource: DataSource, Sendable {
 
     /// Phone/handle from a JID like "14155551234@s.whatsapp.net" → "14155551234" (chat-name fallback only).
     private static func handle(_ jid: String) -> String { String(jid.prefix { $0 != "@" }) }
-
-    private static let df: DateFormatter = {
-        let f = DateFormatter(); f.dateFormat = "MMM d, h:mm a"; return f
-    }()
-    private static func dateString(_ d: Date) -> String { df.string(from: d) }
 }

--- a/Sentient OS macOS/Sources/iMessageSource.swift
+++ b/Sentient OS macOS/Sources/iMessageSource.swift
@@ -1,0 +1,226 @@
+//
+//  iMessageSource.swift
+//  Sentient OS macOS
+//
+//  DataSource over the Mac's iMessage store, ~/Library/Messages/chat.db (Arch §4, [MEASURED]:
+//  the typedstream heuristic decoded 99.97% of 12,017 real messages). Same shape as WhatsApp:
+//  WAL-safe COPY → EXTRACT → DELETE, conversation windows via ChatWindowing, opt-in per chat
+//  (chat GUIDs), group/DM routed to the matching triage prompt.
+//
+//  The one iMessage-specific trick: ~99% of modern rows have `text = NULL` — the body lives in
+//  `attributedBody` as an Apple typedstream blob. We port the proven imessage_tools heuristic
+//  (find the NSString marker, skip 5 bytes, 1-byte or 0x81+2-byte-LE length, UTF-8) and
+//  deliberately do NOT build a full typedstream parser. Sender handles (E.164 phones / emails —
+//  chat.db stores no names) resolve through AddressBookNames.
+//
+//  Key methods: listChats() (picker rows) · scan(since:) · load(_:). Limits per ChatWindowing:
+//  90-day floor AND newest-200k cap. Tapbacks (associated_message_type != 0) and system items
+//  (item_type != 0) are filtered in SQL — they'd spam every window otherwise.
+//
+
+import Foundation
+
+struct iMessageSource: DataSource, Sendable {
+    let kind: SourceKind = .imessage
+
+    /// Opt-in filter: only these chat GUIDs are analyzed. nil = every chat (used by the self-test dump).
+    let chatGUIDs: Set<String>?
+
+    init(chatGUIDs: Set<String>? = nil) { self.chatGUIDs = chatGUIDs }
+
+    var dbPath: String {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Messages/chat.db").path
+    }
+
+    /// Apple's ns-since-2001 message epoch ↔ Date (Arch §4 epoch cheat-sheet).
+    private static func date(fromAppleNS ns: Int64) -> Date {
+        Date(timeIntervalSinceReferenceDate: Double(ns) / 1e9)
+    }
+    private static var floorNS: Int64 {
+        Int64(ChatWindowing.lookbackFloor.timeIntervalSinceReferenceDate * 1e9)
+    }
+
+    /// Messages worth analyzing: real conversation text only — no tapbacks ("Loved …"), no
+    /// system items (group renames etc.), and a body present in one of the two columns.
+    private static let messageFilter = """
+        associated_message_type = 0 AND item_type = 0
+        AND ((text IS NOT NULL AND length(text) > 0) OR attributedBody IS NOT NULL)
+        """
+
+    // MARK: Chats
+
+    private struct Chat {
+        let rowid: Int64
+        let guid: String          // the stable opt-in key
+        let name: String          // resolved display name (never a blank)
+        let isGroup: Bool         // chat.style 43 = group, 45 = DM
+    }
+
+    /// Active chats (analyzable messages within the lookback) for the picker — newest first.
+    func listChats() throws -> [ChatInfo] {
+        let (dbURL, tempDir) = try SQLiteDB.walSafeCopy(of: dbPath)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let reader = try SQLiteReader(path: dbURL.path)
+        let chats = try Self.chats(reader)
+
+        var out: [(info: ChatInfo, last: Int64)] = []
+        try reader.forEachRow("""
+            SELECT cmj.chat_id, COUNT(m.ROWID), MAX(m.date)
+            FROM message m JOIN chat_message_join cmj ON cmj.message_id = m.ROWID
+            WHERE m.date >= \(Self.floorNS) AND \(Self.messageFilter)
+            GROUP BY cmj.chat_id
+            ORDER BY MAX(m.date) DESC
+            """) { r in
+            guard let chat = chats[r.int(0)] else { return }
+            out.append((ChatInfo(id: chat.guid,
+                                 name: chat.name,
+                                 isGroup: chat.isGroup,
+                                 messageCount: Int(r.int(1)),
+                                 lastActive: Self.date(fromAppleNS: r.int(2))),
+                        r.int(2)))
+        }
+        return out.map(\.info)
+    }
+
+    /// All chats keyed by ROWID, with display names resolved: explicit display_name → contact
+    /// name for the DM partner → participant roll-up for unnamed groups → the raw identifier.
+    private static func chats(_ reader: SQLiteReader) throws -> [Int64: Chat] {
+        let contacts = AddressBookNames.loadMap()
+
+        // Participant handles per chat (needed to name display_name-less groups).
+        var members: [Int64: [String]] = [:]
+        try reader.forEachRow("""
+            SELECT chj.chat_id, h.id FROM chat_handle_join chj
+            JOIN handle h ON h.ROWID = chj.handle_id
+            """) { r in
+            if let handle = r.text(1) { members[r.int(0), default: []].append(handle) }
+        }
+
+        var out: [Int64: Chat] = [:]
+        try reader.forEachRow("SELECT ROWID, guid, style, display_name, chat_identifier FROM chat") { r in
+            guard let guid = r.text(1) else { return }
+            let isGroup = r.int(2) == 43
+            let explicit = (r.text(3) ?? "").trimmingCharacters(in: .whitespaces)
+            let identifier = r.text(4) ?? guid
+            let name: String
+            if !explicit.isEmpty {
+                name = explicit
+            } else if isGroup {
+                name = groupName(of: (members[r.int(0)] ?? []).map { resolved($0, contacts) })
+            } else {
+                name = resolved(identifier, contacts)
+            }
+            out[r.int(0)] = Chat(rowid: r.int(0), guid: guid, name: name, isGroup: isGroup)
+        }
+        return out
+    }
+
+    /// Contact name for a handle, else the raw handle (a phone/email is honest and meaningful —
+    /// unlike WhatsApp's LID blobs there's nothing opaque to hide).
+    private static func resolved(_ handle: String, _ contacts: [String: String]) -> String {
+        AddressBookNames.resolve(handle, in: contacts) ?? handle
+    }
+
+    /// "Alex, Sam & 2 others" for groups without an explicit name.
+    private static func groupName(of participants: [String]) -> String {
+        switch participants.count {
+        case 0:  return "Group chat"
+        case 1:  return participants[0]
+        case 2:  return "\(participants[0]) & \(participants[1])"
+        default: return "\(participants[0]), \(participants[1]) & \(participants.count - 2) others"
+        }
+    }
+
+    // MARK: Scan — copy → query → decode → window → delete
+
+    func scan(since cursor: String?) throws -> [Candidate] {
+        let (dbURL, tempDir) = try SQLiteDB.walSafeCopy(of: dbPath)
+        defer { try? FileManager.default.removeItem(at: tempDir) }   // delete the plaintext copy immediately
+        let reader = try SQLiteReader(path: dbURL.path)
+
+        let chats = try Self.chats(reader)
+        let contacts = AddressBookNames.loadMap()
+
+        // Messages within the limits (90-day floor AND newest-200k cap — the inner newest-first
+        // LIMIT applies the cap across ALL chats; the outer ORDER restores per-chat ascending
+        // iteration), decoded text ?? typedstream, grouped per chat.
+        var byChat: [Int64: [ChatMessage]] = [:]
+        try reader.forEachRow("""
+            SELECT m.ROWID, m.date, m.is_from_me, m.text, m.attributedBody, cmj.chat_id, h.id
+            FROM (SELECT ROWID, date, is_from_me, text, attributedBody, handle_id FROM message
+                  WHERE date >= \(Self.floorNS) AND \(Self.messageFilter)
+                  ORDER BY date DESC LIMIT \(ChatWindowing.maxMessages)) m
+            JOIN chat_message_join cmj ON cmj.message_id = m.ROWID
+            LEFT JOIN handle h ON h.ROWID = m.handle_id
+            ORDER BY cmj.chat_id, m.ROWID
+            """) { r in
+            guard let chat = chats[r.int(5)] else { return }
+            if let only = chatGUIDs, !only.contains(chat.guid) { return }   // opt-in filter
+
+            let body = r.text(3) ?? r.blob(4).flatMap(Self.typedstreamText)
+            guard let body, !body.trimmingCharacters(in: .whitespaces).isEmpty else { return }
+
+            let isFromMe = r.int(2) == 1
+            let sender: String
+            if isFromMe { sender = "Me" }
+            else if chat.isGroup { sender = Self.resolved(r.text(6) ?? "", contacts) }
+            else { sender = chat.name }   // DM: the other party is the chat partner
+
+            byChat[r.int(5), default: []].append(ChatMessage(
+                id: r.int(0),
+                date: Self.date(fromAppleNS: r.int(1)),
+                sender: sender,
+                isFromMe: isFromMe,
+                text: String(body.prefix(ChatWindowing.maxMessageChars))))
+        }
+
+        // Window each chat to the byte budget; one window = one Artifact.
+        var built: [(candidate: Candidate, last: Date)] = []
+        for (chatROWID, msgs) in byChat {
+            guard let chat = chats[chatROWID] else { continue }
+            for win in ChatWindowing.windows(of: msgs) where !win.isEmpty {
+                let meta: [String: String] = [
+                    "folder": chat.name,                         // per-chat tag → folder pills in the viewer
+                    "name": chat.name,
+                    "displayPath": "iMessage · \(chat.name)",
+                    "isGroup": chat.isGroup ? "1" : "0",         // → group vs DM bouncer prompt
+                    "windowText": ChatWindowing.format(chatName: chat.name, isGroup: chat.isGroup, messages: win),
+                ]
+                let id = "imessage:c\(chatROWID):\(win.first!.id)-\(win.last!.id)"
+                built.append((Candidate(id: id, kind: .imessage, signature: "\(win.count)", metadata: meta),
+                              win.last!.date))
+            }
+        }
+        return built.sorted { $0.last > $1.last }.map(\.candidate)   // newest conversations first
+    }
+
+    func load(_ candidate: Candidate) throws -> Artifact {
+        Artifact(candidate: candidate, text: candidate.metadata["windowText"] ?? "")
+    }
+
+    // MARK: The typedstream heuristic — deliberately NOT a full parser (Arch §4)
+
+    /// Extract the message body from an `attributedBody` typedstream blob: find the NSString /
+    /// NSMutableString class marker, skip the 5-byte preamble, read the length (one byte, or
+    /// 0x81 + two bytes little-endian for long messages), decode UTF-8. nil = not decodable
+    /// (attachment-only rows land here; the caller skips them).
+    static func typedstreamText(_ blob: Data) -> String? {
+        let marker = blob.range(of: Data("NSString".utf8))
+            ?? blob.range(of: Data("NSMutableString".utf8))
+        guard let marker else { return nil }
+
+        var i = marker.upperBound + 5                      // the 5-byte preamble after the class name
+        guard i < blob.endIndex else { return nil }
+        var length = Int(blob[i])
+        if blob[i] == 0x81 {
+            guard i + 2 < blob.endIndex else { return nil }
+            length = Int(blob[i + 1]) | (Int(blob[i + 2]) << 8)   // 2-byte little-endian
+            i += 3
+        } else {
+            i += 1
+        }
+        guard length > 0, i + length <= blob.endIndex else { return nil }
+        return String(data: blob[i ..< (i + length)], encoding: .utf8)
+    }
+}

--- a/Sentient OS macOS/Views/ChatPicker.swift
+++ b/Sentient OS macOS/Views/ChatPicker.swift
@@ -1,33 +1,38 @@
 //
-//  WhatsAppChatPicker.swift
+//  ChatPicker.swift
 //  Sentient OS macOS
 //
-//  The opt-in "Choose chats & groups" sheet. Lists the WhatsApp chats ACTIVE within the scan
-//  window (newest first, with message counts), with search + per-chat checkboxes + bulk
-//  All-DMs / All-groups / Clear. "Done" hands the selected chat JIDs back to the caller, which
-//  persists them and lights up the WhatsApp source chip.
+//  The opt-in "Choose chats & groups" sheet, shared by the chat sources (WhatsApp + iMessage).
+//  Lists the chats ACTIVE within the scan window (newest first, with message counts), with
+//  search + per-chat checkboxes + bulk All-DMs / All-groups / Clear. "Done" hands the selected
+//  chat ids (JIDs / GUIDs) back to the caller, which persists them and lights up the source chip.
 //
 
 import SwiftUI
 
-struct WhatsAppChatPicker: View {
+struct ChatPicker: View {
+    let sourceName: String                                   // "WhatsApp" / "iMessage" — for error/empty states
+    let loadChats: @Sendable () throws -> [ChatInfo]
     let initialSelection: Set<String>
     var onDone: (Set<String>) -> Void
 
     @Environment(\.dismiss) private var dismiss
-    @State private var chats: [WhatsAppSource.ChatInfo] = []
+    @State private var chats: [ChatInfo] = []
     @State private var selection: Set<String>
     @State private var search = ""
     @State private var loaded = false
     @State private var loadError: String?
 
-    init(initialSelection: Set<String>, onDone: @escaping (Set<String>) -> Void) {
+    init(sourceName: String, loadChats: @escaping @Sendable () throws -> [ChatInfo],
+         initialSelection: Set<String>, onDone: @escaping (Set<String>) -> Void) {
+        self.sourceName = sourceName
+        self.loadChats = loadChats
         self.initialSelection = initialSelection
         self.onDone = onDone
         _selection = State(initialValue: initialSelection)
     }
 
-    private var filtered: [WhatsAppSource.ChatInfo] {
+    private var filtered: [ChatInfo] {
         search.isEmpty ? chats : chats.filter { $0.name.localizedCaseInsensitiveContains(search) }
     }
 
@@ -48,7 +53,7 @@ struct WhatsAppChatPicker: View {
         VStack(alignment: .leading, spacing: 4) {
             Text("Choose chats & groups").font(.serif(24)).italic().foregroundStyle(.white)
             Text(loaded
-                 ? "\(selection.count) selected · \(chats.count) active in the last \(WhatsAppSource.lookbackDays) days"
+                 ? "\(selection.count) selected · \(chats.count) active in the last \(ChatWindowing.lookbackDays) days"
                  : "Reading your chats…")
                 .font(.footnote).foregroundStyle(Theme.secondary)
         }
@@ -65,8 +70,8 @@ struct WhatsAppChatPicker: View {
             .padding(.horizontal, 12).padding(.vertical, 9).glassCard(radius: 10)
 
             HStack(spacing: 7) {
-                bulk("All DMs")    { for c in filtered where !c.isGroup { selection.insert(c.jid) } }
-                bulk("All groups") { for c in filtered where c.isGroup  { selection.insert(c.jid) } }
+                bulk("All DMs")    { for c in filtered where !c.isGroup { selection.insert(c.id) } }
+                bulk("All groups") { for c in filtered where c.isGroup  { selection.insert(c.id) } }
                 bulk("Clear")      { selection.removeAll() }
                 Spacer()
             }
@@ -88,7 +93,7 @@ struct WhatsAppChatPicker: View {
         if let loadError {
             centered {
                 Image(systemName: "exclamationmark.triangle").font(.largeTitle).foregroundStyle(.orange)
-                Text("Couldn't read WhatsApp").foregroundStyle(.white)
+                Text("Couldn't read \(sourceName)").foregroundStyle(.white)
                 Text(loadError).font(.caption).foregroundStyle(Theme.faint)
                     .multilineTextAlignment(.center).padding(.horizontal, 30)
             }
@@ -97,7 +102,7 @@ struct WhatsAppChatPicker: View {
         } else if chats.isEmpty {
             centered {
                 Image(systemName: "bubble.left.and.bubble.right").font(.largeTitle).foregroundStyle(Theme.faint)
-                Text("No active chats in the last \(WhatsAppSource.lookbackDays) days").foregroundStyle(Theme.secondary)
+                Text("No active chats in the last \(ChatWindowing.lookbackDays) days").foregroundStyle(Theme.secondary)
             }
         } else {
             ScrollView {
@@ -109,8 +114,8 @@ struct WhatsAppChatPicker: View {
         }
     }
 
-    private func row(_ chat: WhatsAppSource.ChatInfo) -> some View {
-        let on = selection.contains(chat.jid)
+    private func row(_ chat: ChatInfo) -> some View {
+        let on = selection.contains(chat.id)
         return HStack(spacing: 12) {
             Image(systemName: on ? "checkmark.circle.fill" : "circle")
                 .font(.system(size: 18)).foregroundStyle(on ? Theme.accent : Theme.faint)
@@ -129,7 +134,7 @@ struct WhatsAppChatPicker: View {
         .overlay(RoundedRectangle(cornerRadius: 10, style: .continuous)
             .strokeBorder(on ? Theme.accent.opacity(0.5) : Color.white.opacity(0.06), lineWidth: 1))
         .contentShape(Rectangle())
-        .onTapGesture { if on { selection.remove(chat.jid) } else { selection.insert(chat.jid) } }
+        .onTapGesture { if on { selection.remove(chat.id) } else { selection.insert(chat.id) } }
     }
 
     private var footer: some View {
@@ -155,7 +160,8 @@ struct WhatsAppChatPicker: View {
     private func load() async {
         guard !loaded else { return }
         do {
-            chats = try await Task.detached { try WhatsAppSource().listChats() }.value
+            let loader = loadChats
+            chats = try await Task.detached { try loader() }.value
         } catch {
             loadError = "\(error)"
         }

--- a/Sentient OS macOS/Views/ProcessingView.swift
+++ b/Sentient OS macOS/Views/ProcessingView.swift
@@ -15,12 +15,22 @@ import SwiftUI
 /// own pass through the pipeline. (iMessage / Notes slot in here as they land.)
 enum RunSource: Hashable {
     case files(FileRoot)
-    case whatsapp(chatJIDs: Set<String>)   // the opt-in chats to analyze
+    case whatsapp(chatJIDs: Set<String>)    // the opt-in chats to analyze
+    case imessage(chatGUIDs: Set<String>)   // the opt-in chats to analyze
 
     var label: String {
         switch self {
         case .files(let root): return root.label
         case .whatsapp:        return "WhatsApp"
+        case .imessage:        return "iMessage"
+        }
+    }
+
+    /// Chat sources feed the model big conversation windows → they need the large KV cache.
+    var isChatSource: Bool {
+        switch self {
+        case .whatsapp, .imessage: return true
+        case .files:               return false
         }
     }
 }
@@ -276,7 +286,7 @@ struct ProcessingView: View {
         do {
             // Chat windows are big (and prompt scaffolding is sizeable); size the KV cache with
             // comfortable headroom so a window + prompt can never overflow (we have the RAM).
-            let needsBigContext = sources.contains { if case .whatsapp = $0 { return true }; return false }
+            let needsBigContext = sources.contains(where: \.isChatSource)
             let engine = Engine(modelPath: modelPath, maxNumTokens: needsBigContext ? 16384 : 4096)
             try await engine.load()
             self.engine = engine
@@ -297,6 +307,8 @@ struct ProcessingView: View {
                     try await runPass(FilesSource(root: url, label: root.label), pipeline: pipeline)
                 case .whatsapp(let jids):
                     try await runPass(WhatsAppSource(chatJIDs: jids), pipeline: pipeline)
+                case .imessage(let guids):
+                    try await runPass(iMessageSource(chatGUIDs: guids), pipeline: pipeline)
                 }
             }
 

--- a/Sentient OS macOS/Views/RootView.swift
+++ b/Sentient OS macOS/Views/RootView.swift
@@ -29,8 +29,11 @@ struct RootView: View {
     @AppStorage("dbg.run.documents") private var runDocuments = true
     @AppStorage("dbg.run.whatsapp")  private var runWhatsApp = false   // is WhatsApp active this run (chip lit)
     @AppStorage("dbg.whatsapp.chats") private var selectedChatsCSV = ""  // opt-in chat JIDs, comma-joined
+    @AppStorage("dbg.run.imessage")  private var runIMessage = false   // is iMessage active this run (chip lit)
+    @AppStorage("dbg.imessage.chats") private var selectedIMessageChatsCSV = ""  // opt-in chat GUIDs, comma-joined
     @State private var customRoots: [URL] = []
     @State private var showChatPicker = false
+    @State private var showIMessagePicker = false
     @State private var resetResult: String?
     @State private var isResetting = false
     // "More Options" — advanced debug (Full Disk Access + the DB sources), tucked away so the
@@ -48,8 +51,12 @@ struct RootView: View {
         if runDesktop   { s.append(.files(.desktop)) }
         if runDocuments { s.append(.files(.documents)) }
         s.append(contentsOf: customRoots.map { .files(.custom($0)) })
-        if runWhatsApp && fdaGranted && !selectedChatJIDs.isEmpty {   // never run a DB source without FDA + a chat selection
+        // Never run a DB source without FDA + a chat selection.
+        if runWhatsApp && fdaGranted && !selectedChatJIDs.isEmpty {
             s.append(.whatsapp(chatJIDs: selectedChatJIDs))
+        }
+        if runIMessage && fdaGranted && !selectedIMessageGUIDs.isEmpty {
+            s.append(.imessage(chatGUIDs: selectedIMessageGUIDs))
         }
         return s
         #else
@@ -58,9 +65,12 @@ struct RootView: View {
     }
 
     #if DEBUG
-    /// The opt-in WhatsApp chats, decoded from the persisted comma-joined JID list.
+    /// The opt-in chats, decoded from the persisted comma-joined id lists (WhatsApp JIDs / iMessage GUIDs).
     private var selectedChatJIDs: Set<String> {
         Set(selectedChatsCSV.split(separator: ",").map(String.init))
+    }
+    private var selectedIMessageGUIDs: Set<String> {
+        Set(selectedIMessageChatsCSV.split(separator: ",").map(String.init))
     }
     #endif
 
@@ -80,9 +90,19 @@ struct RootView: View {
         .frame(minWidth: 560, minHeight: 640)
         #if DEBUG
         .sheet(isPresented: $showChatPicker) {
-            WhatsAppChatPicker(initialSelection: selectedChatJIDs) { newSel in
+            ChatPicker(sourceName: "WhatsApp",
+                       loadChats: { try WhatsAppSource().listChats() },
+                       initialSelection: selectedChatJIDs) { newSel in
                 selectedChatsCSV = newSel.sorted().joined(separator: ",")
                 runWhatsApp = !newSel.isEmpty   // lit only if at least one chat is chosen
+            }
+        }
+        .sheet(isPresented: $showIMessagePicker) {
+            ChatPicker(sourceName: "iMessage",
+                       loadChats: { try iMessageSource().listChats() },
+                       initialSelection: selectedIMessageGUIDs) { newSel in
+                selectedIMessageChatsCSV = newSel.sorted().joined(separator: ",")
+                runIMessage = !newSel.isEmpty
             }
         }
         #endif
@@ -201,7 +221,17 @@ struct RootView: View {
                     }
                 }
                 chooseFolderChip
-                whatsAppChip   // DB source — enabled once Full Disk Access is granted (see More Options)
+                // DB sources — enabled once Full Disk Access is granted (see More Options).
+                chatSourceChip("WhatsApp", systemImage: "message.fill",
+                               isOn: runWhatsApp && fdaGranted && !selectedChatJIDs.isEmpty,
+                               count: selectedChatJIDs.count,
+                               turnOff: { runWhatsApp = false },
+                               openPicker: { showChatPicker = true })
+                chatSourceChip("iMessage", systemImage: "bubble.left.fill",
+                               isOn: runIMessage && fdaGranted && !selectedIMessageGUIDs.isEmpty,
+                               count: selectedIMessageGUIDs.count,
+                               turnOff: { runIMessage = false },
+                               openPicker: { showIMessagePicker = true })
             }
             .frame(maxWidth: 420)
 
@@ -210,32 +240,33 @@ struct RootView: View {
                     .font(.caption2).foregroundStyle(Theme.faint)
             }
             if !fdaGranted {
-                Text("WhatsApp needs Full Disk Access — grant it in More Options below.")
+                Text("WhatsApp & iMessage need Full Disk Access — grant it in More Options below.")
                     .font(.caption2).foregroundStyle(Theme.faint)
             }
         }
         .onAppear { fdaGranted = Permissions.hasFullDiskAccess() }
     }
 
-    /// WhatsApp source chip. Tap when OFF → opens the chat picker → Done lights it up (with the
-    /// chat count). Tap when ON → turns it off (keeps the selection for next time).
-    private var whatsAppChip: some View {
-        let count = selectedChatJIDs.count
-        let on = runWhatsApp && fdaGranted && count > 0
-        return HStack(spacing: 6) {
-            Image(systemName: on ? "checkmark.circle.fill" : "message.fill").font(.system(size: 11))
-            Text(on ? "WhatsApp · \(count)" : "WhatsApp").font(.caption.weight(.medium)).lineLimit(1)
+    /// A chat-DB source chip (WhatsApp / iMessage). Tap when OFF → opens that source's chat
+    /// picker → Done lights it up (with the chat count). Tap when ON → turns it off (keeps the
+    /// selection for next time).
+    private func chatSourceChip(_ name: String, systemImage: String, isOn: Bool, count: Int,
+                                turnOff: @escaping () -> Void,
+                                openPicker: @escaping () -> Void) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: isOn ? "checkmark.circle.fill" : systemImage).font(.system(size: 11))
+            Text(isOn ? "\(name) · \(count)" : name).font(.caption.weight(.medium)).lineLimit(1)
         }
-        .foregroundStyle(on ? .black : (fdaGranted ? Theme.secondary : Theme.faint))
+        .foregroundStyle(isOn ? .black : (fdaGranted ? Theme.secondary : Theme.faint))
         .frame(maxWidth: .infinity)
         .padding(.horizontal, 11).padding(.vertical, 6)
-        .background(on ? Theme.accent : Color.white.opacity(0.06), in: Capsule())
-        .overlay(Capsule().strokeBorder(on ? .clear : Theme.stroke, lineWidth: 1))
+        .background(isOn ? Theme.accent : Color.white.opacity(0.06), in: Capsule())
+        .overlay(Capsule().strokeBorder(isOn ? .clear : Theme.stroke, lineWidth: 1))
         .contentShape(Capsule())
         .onTapGesture {
             guard fdaGranted else { return }
-            if on { runWhatsApp = false }       // ON → off (selection kept)
-            else { showChatPicker = true }      // OFF → choose chats
+            if isOn { turnOff() }          // ON → off (selection kept)
+            else { openPicker() }          // OFF → choose chats
         }
     }
 


### PR DESCRIPTION
## What

- **`iMessageSource`** — `DataSource` over `~/Library/Messages/chat.db`: WAL-safe copy → extract → delete, per-chat GUID opt-in, group/DM triage routing, ledger-dedup window ids (`imessage:c<chat>:<first>-<last>`).
- **Typedstream decode** — the `imessage_tools` heuristic (find `NSString`, skip 5, 1-byte / `0x81`+2LE length). Deliberately not a full parser.
- **Limits in SQL** — 90-day floor AND newest-200k cap (per the new TODO-plan connector limits), plus tapback (`associated_message_type != 0`) and system-item (`item_type != 0`) filtering.
- **`ChatWindowing`** — windowing/formatting/`ChatInfo`/limits extracted from `WhatsAppSource` (second real use case). WhatsApp moves from 31 → 90-day lookback + the 200k cap in the same stroke.
- **`AddressBookNames`** — handle → contact-name resolution read straight from the AddressBook SQLite stores (FDA covers them; **no** new Contacts permission prompt). Phones match on last-10-digit suffix, emails lowercased.
- **`ChatPicker`** — `WhatsAppChatPicker` generalized; both chat sources feed it.
- Wiring: `RunSource.imessage`, RootView chip + picker + persistence; `SQLiteDB.Row.blob()`.
- SelfTest modes `imdecode` / `imchats` / `imessage` + `Documentation/iMessage Source (chat.db).md`.

## Validation (real data, Aryaman's Mac)

- `imdecode`: **130/130 blobs decoded (100%)**; ground truth **125/125 exact matches** on rows carrying both `text` and `attributedBody`.
- `imchats`: 13 chats enumerated, correct group/DM split + ordering.
- `imessage` (model run): 4/4 windows generated, 0 empty, valid triage JSON.
- WhatsApp regression: `chats` mode green post-refactor (35 active chats @ 90 days).

## Notes for reviewers

- My Mac has almost no synced contacts, so picker names showed raw handles here — **please run `SENTIENT_SELFTEST=imchats` + `imdecode` on a contact-synced, heavier chat.db** before merge.
- Decided with Jesai/Aryaman: unresolved handles ship as-is (full raw handle as sender label); revisit post-dogfood if it's common.
- ROWID cursor + active-tail hold-back stays Phase-4 hardening, same as WhatsApp.