### PR TITLE
Chat connector cap 200k → 100k per revised TODO-plan limits

### DIFF
--- a/Sentient OS macOS/Documentation/iMessage Source (chat.db).md
+++ b/Sentient OS macOS/Documentation/iMessage Source (chat.db).md
@@ -27,7 +27,7 @@ triage routing. Needs Full Disk Access.
 - **Group vs DM:** `chat.style` 43 = group, 45 = DM. Opt-in key = `chat.guid` (stable).
   Sender per message via `handle.id` (E.164 phone or email — chat.db stores **no names**, hence
   AddressBookNames). Unnamed groups get a participant roll-up name ("Alex, Sam & 2 others").
-- **Limits (TODO plan):** 90-day floor AND newest-200k cap per connector, both in SQL — inner
+- **Limits (TODO plan):** 90-day floor AND newest-100k cap per connector, both in SQL — inner
   `ORDER BY date DESC LIMIT` subquery applies the cap across all chats, outer ORDER restores
   per-chat ascending iteration.
 

--- a/Sentient OS macOS/Sources/ChatWindowing.swift
+++ b/Sentient OS macOS/Sources/ChatWindowing.swift
@@ -12,7 +12,7 @@
 //    ChatWindowing.format(...)   — frames a window for the model (chat name, group/DM,
 //                                  "you sent N of M" participation anchor, per-message senders)
 //  Limits (TODO plan): chat connectors read the last `lookbackDays` 90 days OR the newest
-//  `maxMessages` 200k messages per connector — whichever cuts first.
+//  `maxMessages` 100k messages per connector — whichever cuts first.
 //
 
 import Foundation
@@ -41,7 +41,7 @@ struct ChatInfo: Sendable, Identifiable {
 enum ChatWindowing {
     // MARK: Limits — shared by every chat connector
     static let lookbackDays = 90
-    static let maxMessages = 200_000       // newest-first cap, summed across the connector's chats
+    static let maxMessages = 100_000       // newest-first cap, summed across the connector's chats
 
     // We size a window by its UTF-8 BYTE count, NOT chars (and NOT a chars→tokens guess). A
     // byte-level tokenizer emits at most ONE token per byte, so bytes are a HARD upper bound on


### PR DESCRIPTION
Plan limits were revised after PR #1 went up: chat connectors (WhatsApp + iMessage) cap at the newest **100k** messages, not 200k. One-line constant + comment/doc updates.