### PR TITLE
Apple Notes source: gunzip → protobuf decode, newest-1000 cap

### DIFF
--- a/Sentient OS macOS/Documentation/Apple Notes Source (NoteStore).md
+++ b/Sentient OS macOS/Documentation/Apple Notes Source (NoteStore).md
@@ -1,0 +1,49 @@
+# Apple Notes Source (NoteStore.sqlite)
+
+`Sources/NotesSource.swift` — the `DataSource` over Apple Notes' local store. Simplest source
+shape: one note = one Artifact, no windows, no picker (all notes in; the cap + triage filter).
+Needs Full Disk Access.
+
+## The decode (the whole reason this file exists)
+
+`ZICNOTEDATA.ZDATA` is double-wrapped: **gzip outside** (magic `1f 8b 08`), **protobuf inside**.
+
+1. `gunzip(_:)` — validate magic, skip the header (incl. optional FLG fields), raw-DEFLATE
+   inflate via the Compression framework (`COMPRESSION_ZLIB` = raw deflate; the gzip trailer
+   past end-of-stream is ignored).
+2. `firstMessage(field:in:)` — a minimal protobuf wire-format walker (varint +
+   length-delimited; no schema, no library). Follow **fields 2 → 3 → 2**; the bytes there are
+   the note text, UTF-8.
+
+Fail-closed: undecodable → the note is skipped (never garbled text to the model).
+[MEASURED] 100% decode: 249 notes in research, 87/87 live during this build. Rows with
+NULL/non-gzip `ZDATA` exist (6/94 on the dev Mac — likely iCloud notes not downloaded
+locally) — they're skipped and counted in the self-test.
+
+## NoteStore facts
+
+- **Path:** `~/Library/Group Containers/group.com.apple.notes/NoteStore.sqlite` via
+  `SQLiteDB.walSafeCopy`.
+- **Join:** `ZICCLOUDSYNCINGOBJECT o JOIN ZICNOTEDATA d ON o.ZNOTEDATA = d.Z_PK` —
+  `ZICCLOUDSYNCINGOBJECT` is one giant table for all entity types; note rows are the ones
+  with `ZNOTEDATA` set. Folder names: `o.ZFOLDER → (folder row).ZTITLE2`, fallback `"Notes"`
+  (orphans exist).
+- **Skip in SQL:** `ZISPASSWORDPROTECTED`, `ZMARKEDFORDELETION`.
+- **Dates are seconds since 2001** (`+ 978307200` → Unix) — NOT ns like iMessage. Creation
+  date column name varies by macOS version → `COALESCE(ZCREATIONDATE3, …2, …1, ZCREATIONDATE)`.
+- **Limit:** newest **1,000** by `ZMODIFICATIONDATE1` (TODO-plan cap). No time floor — old
+  notes are often the most vault-worthy.
+- **Reprocess-on-edit:** id = `ZIDENTIFIER` (stable UUID), signature = modification date —
+  an edited note changes signature and re-enters the pipeline (the Files `size:mtime` pattern).
+
+## Triage routing
+
+`Triage.prompt` routes `.notes` through the **file prompt** (a note is a document the user
+wrote; vault-worthiness framing fits). Model sees `"Apple Notes · <folder> · <title>"` +
+text capped at 8k chars (same cap as files). No dedicated notes prompt until dumps prove
+verdicts need one.
+
+## Self-tests (`Self Tests - Temp/`, need FDA on the spawning terminal)
+
+- `SENTIENT_SELFTEST=notesdecode` — decode-rate stats on the real store (no model, no content).
+- `SENTIENT_SELFTEST=notes` — full dump through the model (`SENTIENT_SELFTEST_N` to limit).

--- a/Sentient OS macOS/Self Tests - Temp/SelfTest_Triage_Pipeline_and_Vault.swift
+++ b/Sentient OS macOS/Self Tests - Temp/SelfTest_Triage_Pipeline_and_Vault.swift
@@ -14,8 +14,8 @@
 //  Invoke (after building):
 //    SENTIENT_SELFTEST=whatsapp "<app>/Contents/MacOS/Sentient OS macOS"
 //  Env knobs:
-//    SENTIENT_SELFTEST     "whatsapp" | "imessage" | "files"  (model dump) ·
-//                          "parse" | "chats" | "imchats" | "imdecode" | "claudecli" | "vault"  (no model)
+//    SENTIENT_SELFTEST     "whatsapp" | "imessage" | "notes" | "files"  (model dump) ·
+//                          "parse" | "chats" | "imchats" | "imdecode" | "notesdecode" | "claudecli" | "vault"  (no model)
 //    SENTIENT_SELFTEST_N   item count (default 6)
 //    SENTIENT_SELFTEST_OUT output file (default <tmp>/sentient-selftest.txt)
 //    SENTIENT_MODEL_PATH   override the dev model path
@@ -168,6 +168,33 @@ enum SelfTest {
             return
         }
 
+        // Notes decode-rate validation: deterministic, no model, STATS ONLY (no note content) —
+        // proves the gunzip → protobuf 2→3→2 recipe on this Mac's real NoteStore.sqlite.
+        if mode == "notesdecode" {
+            do {
+                let (dbURL, tempDir) = try SQLiteDB.walSafeCopy(of: NotesSource().dbPath)
+                defer { try? FileManager.default.removeItem(at: tempDir) }
+                let reader = try SQLiteReader(path: dbURL.path)
+                var total = 0, locked = 0, deleted = 0, noBlob = 0, ok = 0, fail = 0, empty = 0
+                try reader.forEachRow("""
+                    SELECT o.ZISPASSWORDPROTECTED, o.ZMARKEDFORDELETION, d.ZDATA
+                    FROM ZICCLOUDSYNCINGOBJECT o JOIN ZICNOTEDATA d ON o.ZNOTEDATA = d.Z_PK
+                    """) { r in
+                    total += 1
+                    if r.int(0) == 1 { locked += 1; return }
+                    if r.int(1) == 1 { deleted += 1; return }
+                    guard let blob = r.blob(2) else { noBlob += 1; return }
+                    guard let text = NotesSource.decodeBody(blob) else { fail += 1; return }
+                    if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { empty += 1 }
+                    else { ok += 1 }
+                }
+                emit("note rows: \(total) · locked: \(locked) · deleted: \(deleted) · no-blob: \(noBlob)")
+                emit("decode: \(ok) ok / \(fail) FAIL / \(empty) empty-text")
+                emit(fail == 0 ? "✅ decode clean" : "⚠️ inspect failures before trusting notes")
+            } catch { emit("notesdecode FAILED: \(error)") }
+            return
+        }
+
         // Vault mode: exercise the REAL Stage-2 path (Store → VaultGenerator → ~/Sentient OS -- The Vault).
         //   SENTIENT_SELFTEST_N>0   → subset (cheap plumbing check);  0/unset → full vault
         //   SENTIENT_VAULT_EFFORT   → effort override (default xhigh; direct route only)
@@ -232,13 +259,15 @@ enum SelfTest {
         case "imessage":
             source = iMessageSource(chatGUIDs: chatFilter((try? iMessageSource().listChats()) ?? []))
             maxTokens = 16384
+        case "notes":
+            source = NotesSource(); maxTokens = 4096
         case "files":
             guard let dl = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first else {
                 emit("could not locate ~/Downloads"); return
             }
             source = FilesSource(root: dl, label: "Downloads"); maxTokens = 4096
         default:
-            emit("unknown mode '\(mode)' (use whatsapp | imessage | files)"); return
+            emit("unknown mode '\(mode)' (use whatsapp | imessage | notes | files)"); return
         }
 
         let candidates: [Candidate]

--- a/Sentient OS macOS/Sources/NotesSource.swift
+++ b/Sentient OS macOS/Sources/NotesSource.swift
@@ -1,0 +1,196 @@
+//
+//  NotesSource.swift
+//  Sentient OS macOS
+//
+//  DataSource over Apple Notes' local store, NoteStore.sqlite (Arch §4, [MEASURED]: the
+//  gunzip → protobuf 2→3→2 recipe decoded 100% of real notes — 249 in research, 87/87 on a
+//  live Mac during this build). One note = one Artifact through the file-flavored triage
+//  prompt — no windows, no picker; the newest-1000 cap + triage do the filtering.
+//
+//  The note body is DOUBLE-wrapped: gzip outside (magic 1f 8b 08), protobuf inside. We gunzip
+//  via the Compression framework, then walk the protobuf wire format down fields 2 → 3 → 2 —
+//  deliberately NOT a schema-aware protobuf parser. Fail-closed: anything undecodable is
+//  skipped, never fed garbled to the model.
+//
+//  Dedup: id = the note's stable UUID (ZIDENTIFIER); signature = modification date, so an
+//  edited note reprocesses automatically (the Files size:mtime pattern). Locked
+//  (ZISPASSWORDPROTECTED) and deleted (ZMARKEDFORDELETION) notes are skipped in SQL.
+//  Requires Full Disk Access. Key methods: scan(since:) · load(_:) · decodeBody(_:).
+//
+
+import Foundation
+import Compression
+
+struct NotesSource: DataSource, Sendable {
+    let kind: SourceKind = .notes
+
+    // MARK: Tunables
+    static let maxNotes = 1_000            // newest-first cap (TODO-plan connector limits)
+    static let maxContentChars = 8_000     // same cap as file extraction
+
+    var dbPath: String {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Group Containers/group.com.apple.notes/NoteStore.sqlite")
+            .path
+    }
+
+    // MARK: Scan — copy → query → decode → delete
+
+    func scan(since cursor: String?) throws -> [Candidate] {
+        let (dbURL, tempDir) = try SQLiteDB.walSafeCopy(of: dbPath)
+        defer { try? FileManager.default.removeItem(at: tempDir) }   // delete the plaintext copy immediately
+        let reader = try SQLiteReader(path: dbURL.path)
+
+        // Folder names: folder entities are rows in the same table; ZTITLE2 is the folder title.
+        var folders: [Int64: String] = [:]
+        try reader.forEachRow("SELECT Z_PK, ZTITLE2 FROM ZICCLOUDSYNCINGOBJECT WHERE ZTITLE2 IS NOT NULL") { r in
+            if let t = r.text(1) { folders[r.int(0)] = t }
+        }
+
+        // Newest notes first; locked/deleted skipped in SQL. Creation-date column name varies
+        // across macOS versions → COALESCE the known variants.
+        var out: [Candidate] = []
+        try reader.forEachRow("""
+            SELECT o.ZIDENTIFIER, o.ZTITLE1, o.ZMODIFICATIONDATE1,
+                   COALESCE(o.ZCREATIONDATE3, o.ZCREATIONDATE2, o.ZCREATIONDATE1, o.ZCREATIONDATE),
+                   o.ZFOLDER, d.ZDATA
+            FROM ZICCLOUDSYNCINGOBJECT o JOIN ZICNOTEDATA d ON o.ZNOTEDATA = d.Z_PK
+            WHERE o.ZISPASSWORDPROTECTED IS NOT 1 AND o.ZMARKEDFORDELETION IS NOT 1
+            ORDER BY o.ZMODIFICATIONDATE1 DESC LIMIT \(Self.maxNotes)
+            """) { r in
+            guard let id = r.text(0), let blob = r.blob(5),
+                  let decoded = Self.decodeBody(blob) else { return }   // no/undecodable body → skip (fail-closed)
+            let body = decoded.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !body.isEmpty else { return }                         // attachment-only / blank notes
+
+            let title = r.text(1) ?? String(body.prefix(40))
+            let folder = folders[r.int(4)] ?? "Notes"
+            let modified = r.double(2)
+            let createdTS = r.double(3)
+            let created = Date(timeIntervalSinceReferenceDate: createdTS > 0 ? createdTS : modified)
+
+            out.append(Candidate(
+                id: "notes:\(id)",
+                kind: .notes,
+                signature: "\(Int(modified))",     // mod-date signature → edited notes reprocess
+                metadata: [
+                    "folder": folder,              // per-folder tag → folder pills in the viewer
+                    "name": title,
+                    "displayPath": "Apple Notes · \(folder) · \(title)",
+                    "created": Self.dateString(created),
+                    "noteText": String(body.prefix(Self.maxContentChars)),
+                ]))
+        }
+        return out   // already newest-first from the ORDER BY
+    }
+
+    func load(_ candidate: Candidate) throws -> Artifact {
+        Artifact(candidate: candidate, text: candidate.metadata["noteText"] ?? "")
+    }
+
+    // MARK: Body decode — gunzip, then protobuf fields 2 → 3 → 2
+
+    /// ZICNOTEDATA.ZDATA → the note's plain text. nil = not decodable (skip the note).
+    static func decodeBody(_ zdata: Data) -> String? {
+        guard let raw = gunzip(zdata),
+              let document = firstMessage(field: 2, in: raw),
+              let note = firstMessage(field: 3, in: document),
+              let textBytes = firstMessage(field: 2, in: note) else { return nil }
+        return String(data: textBytes, encoding: .utf8)
+    }
+
+    /// Minimal gzip unwrap: validate the magic, skip the header (+ optional FLG fields), then
+    /// raw-DEFLATE inflate via the Compression framework (COMPRESSION_ZLIB = raw deflate; the
+    /// 8-byte gzip trailer past end-of-stream is ignored by the decoder).
+    private static func gunzip(_ data: Data) -> Data? {
+        guard data.count > 18, data[0] == 0x1F, data[1] == 0x8B, data[2] == 0x08 else { return nil }
+        let flags = data[3]
+        var i = 10
+        if flags & 0x04 != 0 {                                   // FEXTRA: 2-byte LE length + payload
+            guard i + 2 <= data.count else { return nil }
+            let xlen = Int(data[i]) | (Int(data[i + 1]) << 8)
+            i += 2 + xlen
+        }
+        for flag: UInt8 in [0x08, 0x10] where flags & flag != 0 { // FNAME, FCOMMENT: NUL-terminated
+            while i < data.count, data[i] != 0 { i += 1 }
+            i += 1
+        }
+        if flags & 0x02 != 0 { i += 2 }                          // FHCRC
+        guard i < data.count else { return nil }
+        return inflateRaw(data.subdata(in: i..<data.count))
+    }
+
+    private static func inflateRaw(_ src: Data) -> Data? {
+        let chunk = 64 * 1024
+        let dst = UnsafeMutablePointer<UInt8>.allocate(capacity: chunk)
+        defer { dst.deallocate() }
+
+        return src.withUnsafeBytes { (rawBuf: UnsafeRawBufferPointer) -> Data? in
+            let srcPtr = rawBuf.bindMemory(to: UInt8.self).baseAddress!
+            // No default init in Swift; compression_stream_init resets the fields anyway,
+            // so the real src pointer is assigned after init.
+            var stream = compression_stream(dst_ptr: dst, dst_size: chunk,
+                                            src_ptr: srcPtr, src_size: src.count, state: nil)
+            guard compression_stream_init(&stream, COMPRESSION_STREAM_DECODE, COMPRESSION_ZLIB) == COMPRESSION_STATUS_OK else { return nil }
+            defer { compression_stream_destroy(&stream) }
+            stream.src_ptr = srcPtr
+            stream.src_size = src.count
+            var out = Data()
+            while true {
+                stream.dst_ptr = dst
+                stream.dst_size = chunk
+                switch compression_stream_process(&stream, Int32(COMPRESSION_STREAM_FINALIZE.rawValue)) {
+                case COMPRESSION_STATUS_OK:
+                    out.append(dst, count: chunk - stream.dst_size)
+                case COMPRESSION_STATUS_END:
+                    out.append(dst, count: chunk - stream.dst_size)
+                    return out
+                default:
+                    return nil
+                }
+            }
+        }
+    }
+
+    /// The first length-delimited occurrence of `field` in a protobuf message — a minimal
+    /// wire-format walk (varints + length-delimited; fixed32/64 skipped), no schema needed.
+    private static func firstMessage(field want: Int, in buf: Data) -> Data? {
+        var i = buf.startIndex
+        func varint() -> UInt64? {
+            var value: UInt64 = 0, shift: UInt64 = 0
+            while i < buf.endIndex, shift <= 63 {
+                let b = buf[i]; i += 1
+                value |= UInt64(b & 0x7F) << shift; shift += 7
+                if b & 0x80 == 0 { return value }
+            }
+            return nil
+        }
+        while i < buf.endIndex {
+            guard let key = varint() else { return nil }
+            let field = Int(key >> 3)
+            switch key & 7 {
+            case 0:                                       // varint
+                guard varint() != nil else { return nil }
+            case 1:                                       // fixed64
+                guard i + 8 <= buf.endIndex else { return nil }
+                i += 8
+            case 2:                                       // length-delimited
+                guard let len64 = varint(), let len = Int(exactly: len64),
+                      len >= 0, i + len <= buf.endIndex else { return nil }
+                if field == want { return buf[i ..< i + len] }
+                i += len
+            case 5:                                       // fixed32
+                guard i + 4 <= buf.endIndex else { return nil }
+                i += 4
+            default:                                      // groups/unknown → bail (fail-closed)
+                return nil
+            }
+        }
+        return nil
+    }
+
+    private static let df: DateFormatter = {
+        let f = DateFormatter(); f.dateFormat = "MMM d, yyyy"; return f
+    }()
+    private static func dateString(_ d: Date) -> String { df.string(from: d) }
+}

--- a/Sentient OS macOS/Triage.swift
+++ b/Sentient OS macOS/Triage.swift
@@ -18,11 +18,14 @@ enum Triage {
 
     // MARK: Prompt
 
-    /// Dispatches to a source-flavored prompt: a file judges one document; chat sources judge a
-    /// CONVERSATION WINDOW — with a dedicated, far stricter prompt for GROUP chats (attribution is
-    /// the hard part). All emit the SAME JSON contract, so parse()/decide() are shared & unchanged.
+    /// Dispatches to a source-flavored prompt: a file judges one document (Apple Notes ride the
+    /// same path — a note IS a document the user wrote); chat sources judge a CONVERSATION
+    /// WINDOW — with a dedicated, far stricter prompt for GROUP chats (attribution is the hard
+    /// part). All emit the SAME JSON contract, so parse()/decide() are shared & unchanged.
     static func prompt(for artifact: Artifact, currentDate: Date) -> String {
-        if artifact.kind == .file { return filePrompt(for: artifact, currentDate: currentDate) }
+        if artifact.kind == .file || artifact.kind == .notes {
+            return filePrompt(for: artifact, currentDate: currentDate)
+        }
         return artifact.metadata["isGroup"] == "1"
             ? groupChatPrompt(for: artifact, currentDate: currentDate)
             : chatPrompt(for: artifact, currentDate: currentDate)

--- a/Sentient OS macOS/Views/ProcessingView.swift
+++ b/Sentient OS macOS/Views/ProcessingView.swift
@@ -17,12 +17,14 @@ enum RunSource: Hashable {
     case files(FileRoot)
     case whatsapp(chatJIDs: Set<String>)    // the opt-in chats to analyze
     case imessage(chatGUIDs: Set<String>)   // the opt-in chats to analyze
+    case notes                              // all notes (newest-1000 cap inside the source)
 
     var label: String {
         switch self {
         case .files(let root): return root.label
         case .whatsapp:        return "WhatsApp"
         case .imessage:        return "iMessage"
+        case .notes:           return "Apple Notes"
         }
     }
 
@@ -30,7 +32,7 @@ enum RunSource: Hashable {
     var isChatSource: Bool {
         switch self {
         case .whatsapp, .imessage: return true
-        case .files:               return false
+        case .files, .notes:       return false
         }
     }
 }
@@ -309,6 +311,8 @@ struct ProcessingView: View {
                     try await runPass(WhatsAppSource(chatJIDs: jids), pipeline: pipeline)
                 case .imessage(let guids):
                     try await runPass(iMessageSource(chatGUIDs: guids), pipeline: pipeline)
+                case .notes:
+                    try await runPass(NotesSource(), pipeline: pipeline)
                 }
             }
 

--- a/Sentient OS macOS/Views/RootView.swift
+++ b/Sentient OS macOS/Views/RootView.swift
@@ -31,6 +31,7 @@ struct RootView: View {
     @AppStorage("dbg.whatsapp.chats") private var selectedChatsCSV = ""  // opt-in chat JIDs, comma-joined
     @AppStorage("dbg.run.imessage")  private var runIMessage = false   // is iMessage active this run (chip lit)
     @AppStorage("dbg.imessage.chats") private var selectedIMessageChatsCSV = ""  // opt-in chat GUIDs, comma-joined
+    @AppStorage("dbg.run.notes")     private var runNotes = false      // Apple Notes (no picker — all notes, capped)
     @State private var customRoots: [URL] = []
     @State private var showChatPicker = false
     @State private var showIMessagePicker = false
@@ -58,6 +59,7 @@ struct RootView: View {
         if runIMessage && fdaGranted && !selectedIMessageGUIDs.isEmpty {
             s.append(.imessage(chatGUIDs: selectedIMessageGUIDs))
         }
+        if runNotes && fdaGranted { s.append(.notes) }
         return s
         #else
         return FileRoot.standard.map { .files($0) }
@@ -232,6 +234,7 @@ struct RootView: View {
                                count: selectedIMessageGUIDs.count,
                                turnOff: { runIMessage = false },
                                openPicker: { showIMessagePicker = true })
+                notesChip
             }
             .frame(maxWidth: 420)
 
@@ -240,11 +243,31 @@ struct RootView: View {
                     .font(.caption2).foregroundStyle(Theme.faint)
             }
             if !fdaGranted {
-                Text("WhatsApp & iMessage need Full Disk Access — grant it in More Options below.")
+                Text("WhatsApp, iMessage & Apple Notes need Full Disk Access — grant it in More Options below.")
                     .font(.caption2).foregroundStyle(Theme.faint)
             }
         }
         .onAppear { fdaGranted = Permissions.hasFullDiskAccess() }
+    }
+
+    /// Apple Notes chip — a plain FDA-gated toggle (no picker: all notes go in, capped inside
+    /// the source). Same look as the chat chips, minus the count.
+    private var notesChip: some View {
+        let on = runNotes && fdaGranted
+        return HStack(spacing: 6) {
+            Image(systemName: on ? "checkmark.circle.fill" : "note.text").font(.system(size: 11))
+            Text("Apple Notes").font(.caption.weight(.medium)).lineLimit(1)
+        }
+        .foregroundStyle(on ? .black : (fdaGranted ? Theme.secondary : Theme.faint))
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 11).padding(.vertical, 6)
+        .background(on ? Theme.accent : Color.white.opacity(0.06), in: Capsule())
+        .overlay(Capsule().strokeBorder(on ? .clear : Theme.stroke, lineWidth: 1))
+        .contentShape(Capsule())
+        .onTapGesture {
+            guard fdaGranted else { return }
+            runNotes.toggle()
+        }
     }
 
     /// A chat-DB source chip (WhatsApp / iMessage). Tap when OFF → opens that source's chat


### PR DESCRIPTION
## What

- **`NotesSource`** — `DataSource` over `NoteStore.sqlite`: one note = one Artifact (no windows, no picker — the cap + triage filter). WAL-safe copy → decode → delete.
- **The decode:** `ZDATA` is gzip-wrapped protobuf. Minimal gzip header skip + raw-DEFLATE inflate (Compression framework), then a schema-less protobuf wire walk down **fields 2 → 3 → 2**. Fail-closed: undecodable → skipped, counted.
- **Limits:** newest **1,000** by `ZMODIFICATIONDATE1` (TODO-plan cap), locked/deleted skipped in SQL. Dates are **seconds** since 2001 (not ns); creation-date column `COALESCE`d across macOS schema variants.
- **Reprocess-on-edit:** id = note UUID, signature = modification date — edited notes automatically re-enter the pipeline (Files `size:mtime` pattern).
- **Triage:** `.notes` routes through the **file prompt** (a note is a document the user wrote). `displayPath: "Apple Notes · <folder> · <title>"`, 8k-char cap same as files.
- Wiring: `RunSource.notes`, Apple Notes toggle chip (FDA-gated, no picker sheet). SelfTest modes `notesdecode` + `notes`; doc file included.

## Validation (real data, Aryaman's Mac)

- `notesdecode`: 94 note rows → **87/87 decodable blobs decoded, 0 failures** (1 empty-text, 6 no-blob rows — iCloud notes not downloaded locally; skipped + counted). Swift decoder matches the Python prototype exactly.
- `notes` (model run): 4/4 generated, 0 empty, sensible verdicts (pitch + research notes kept; a code scribble and old homework junked).
- Build green (signing-disabled CLI).

## Notes for reviewers

- No per-folder opt-in by design — all notes in, cap + triage do the filtering.
- No `ZMODIFICATIONDATE1` cursor yet — ledger dedup handles v1; cursor is Phase-4 hardening like the chat sources.
- Worth re-running `notesdecode` on a Mac with a bigger/heavier Notes library before merge.