### PR TITLE
WhatsApp cleanup: no more community spam, real names for unnamed groups

### DIFF
--- a/Sentient OS macOS/Self Tests - Temp/SelfTest_Triage_Pipeline_and_Vault.swift
+++ b/Sentient OS macOS/Self Tests - Temp/SelfTest_Triage_Pipeline_and_Vault.swift
@@ -121,7 +121,8 @@ enum SelfTest {
         }
 
         // Chat-list modes: deterministic, no model — verify listChats() enumeration (and, for
-        // iMessage, that names resolved instead of raw +1415… handles).
+        // iMessage, that names resolved instead of raw +1415… handles). The WhatsApp flavor also
+        // prints the session-type distribution + what the community filters removed (counts only).
         if mode == "chats" || mode == "imchats" {
             do {
                 let list = mode == "chats" ? try WhatsAppSource().listChats()
@@ -129,6 +130,25 @@ enum SelfTest {
                 emit("active chats in the last \(ChatWindowing.lookbackDays) days: \(list.count)\n")
                 for c in list.prefix(count > 6 ? count : 20) {
                     emit("  [\(c.isGroup ? "group" : "DM  ")] \(c.name)  —  \(c.messageCount) msgs · last \(c.lastActive)")
+                }
+                if mode == "chats" {
+                    let (dbURL, tempDir) = try SQLiteDB.walSafeCopy(of: WhatsAppSource().dbPath)
+                    defer { try? FileManager.default.removeItem(at: tempDir) }
+                    let reader = try SQLiteReader(path: dbURL.path)
+                    var dist: [(Int64, Int64)] = []
+                    try reader.forEachRow("SELECT ZSESSIONTYPE, COUNT(*) FROM ZWACHATSESSION GROUP BY 1 ORDER BY 1") { r in
+                        dist.append((r.int(0), r.int(1)))
+                    }
+                    var twins: Int64 = 0
+                    try reader.forEachRow("""
+                        SELECT COUNT(*) FROM ZWACHATSESSION s
+                        WHERE s.ZSESSIONTYPE = 1 AND s.ZPARTNERNAME IN
+                            (SELECT ZPARTNERNAME FROM ZWACHATSESSION
+                             WHERE ZSESSIONTYPE = 4 AND ZPARTNERNAME IS NOT NULL)
+                        """) { r in twins = r.int(0) }
+                    emit("\nsession types (0=DM 1=group 2=broadcast 3=status 4=community): "
+                         + dist.map { "\($0.0)=\($0.1)" }.joined(separator: " · "))
+                    emit("community filter removes: \(dist.first { $0.0 == 4 }?.1 ?? 0) homes + \(twins) announcement twins")
                 }
             } catch { emit("listChats FAILED: \(error)") }
             return

--- a/Sentient OS macOS/Sources/ChatWindowing.swift
+++ b/Sentient OS macOS/Sources/ChatWindowing.swift
@@ -83,6 +83,18 @@ enum ChatWindowing {
         return out
     }
 
+    /// "Alex, Sam & 2 others" — display name for a group without an explicit one, synthesized
+    /// from its CURRENT participants (both chat sources use this; members who left are excluded
+    /// by the caller).
+    static func groupName(of participants: [String]) -> String {
+        switch participants.count {
+        case 0:  return "Group chat"
+        case 1:  return participants[0]
+        case 2:  return "\(participants[0]) & \(participants[1])"
+        default: return "\(participants[0]), \(participants[1]) & \(participants.count - 2) others"
+        }
+    }
+
     private static let df: DateFormatter = {
         let f = DateFormatter(); f.dateFormat = "MMM d, h:mm a"; return f
     }()

--- a/Sentient OS macOS/Sources/WhatsAppSource.swift
+++ b/Sentient OS macOS/Sources/WhatsAppSource.swift
@@ -26,6 +26,23 @@ struct WhatsAppSource: DataSource, Sendable {
 
     init(chatJIDs: Set<String>? = nil) { self.chatJIDs = chatJIDs }
 
+    /// Sessions worth analyzing — a WHITELIST of DMs (0) and real groups (1), so broadcast
+    /// lists (2), status (3), community homes (4), and whatever WhatsApp invents next are
+    /// excluded automatically. The second clause removes community ANNOUNCEMENT channels:
+    /// they're stored as ordinary type-1 groups, but always wear the community's exact
+    /// ZPARTNERNAME — a name-twin of a type-4 session ([MEASURED]: the only marker in this
+    /// schema; no parent-JID column exists, JID prefixes proved unreliable). Community
+    /// sub-groups are indistinguishable from normal groups and deliberately stay (they're
+    /// real conversations; the per-chat opt-in gates them anyway).
+    /// ⚠️ The IS NOT NULL inside the subquery is load-bearing: one NULL there and SQL's
+    /// NOT IN semantics silently hide EVERY group.
+    private static let sessionFilter = """
+        s.ZSESSIONTYPE IN (0, 1)
+            AND NOT (s.ZSESSIONTYPE = 1 AND s.ZPARTNERNAME IN
+                (SELECT ZPARTNERNAME FROM ZWACHATSESSION
+                 WHERE ZSESSIONTYPE = 4 AND ZPARTNERNAME IS NOT NULL))
+        """
+
     /// Active chats (text messages within the lookback) for the picker — newest first, with counts.
     /// Its own WAL-safe copy → query → delete.
     func listChats() throws -> [ChatInfo] {
@@ -39,13 +56,14 @@ struct WhatsAppSource: DataSource, Sendable {
             SELECT s.ZCONTACTJID, s.ZPARTNERNAME, COUNT(m.Z_PK), MAX(m.ZMESSAGEDATE)
             FROM ZWAMESSAGE m JOIN ZWACHATSESSION s ON m.ZCHATSESSION = s.Z_PK
             WHERE m.ZTEXT IS NOT NULL AND length(m.ZTEXT) > 0 AND m.ZMESSAGEDATE >= \(floor)
+              AND \(Self.sessionFilter)
             GROUP BY s.Z_PK
             ORDER BY MAX(m.ZMESSAGEDATE) DESC
             """) { r in
             let jid = r.text(0) ?? ""
             guard !jid.isEmpty else { return }
             out.append(ChatInfo(id: jid,
-                                name: r.text(1) ?? Self.handle(jid),
+                                name: Self.displayName(r.text(1), jid: jid),
                                 isGroup: jid.hasSuffix("@g.us"),
                                 messageCount: Int(r.int(2)),
                                 lastActive: Date(timeIntervalSinceReferenceDate: r.double(3))))
@@ -73,15 +91,18 @@ struct WhatsAppSource: DataSource, Sendable {
         defer { try? FileManager.default.removeItem(at: tempDir) }   // delete the plaintext copy immediately
         let reader = try SQLiteReader(path: dbURL.path)
 
-        // Chat sessions → name + DM/group.
+        // Chat sessions → name + DM/group. The session filter here also drops community noise
+        // from scan itself — so a stale opted-in JID (or the self-test's all-chats mode) can
+        // never window an excluded session.
         var chats: [Int64: Chat] = [:]
-        try reader.forEachRow("SELECT Z_PK, ZPARTNERNAME, ZCONTACTJID FROM ZWACHATSESSION") { r in
+        try reader.forEachRow("SELECT s.Z_PK, s.ZPARTNERNAME, s.ZCONTACTJID FROM ZWACHATSESSION s WHERE \(Self.sessionFilter)") { r in
             let jid = r.text(2) ?? ""
-            let name = r.text(1) ?? (jid.isEmpty ? "Unknown chat" : Self.handle(jid))
-            chats[r.int(0)] = Chat(pk: r.int(0), jid: jid, name: name, isGroup: jid.hasSuffix("@g.us"))
+            chats[r.int(0)] = Chat(pk: r.int(0), jid: jid,
+                                   name: Self.displayName(r.text(1), jid: jid),
+                                   isGroup: jid.hasSuffix("@g.us"))
         }
 
-        // Text messages within the limits (90-day floor AND newest-200k cap — the inner
+        // Text messages within the limits (90-day floor AND newest-`maxMessages` cap — the inner
         // newest-first LIMIT applies the cap across ALL chats; the outer ORDER restores
         // per-chat ascending iteration), oldest → newest per chat.
         let floor = ChatWindowing.lookbackFloor.timeIntervalSinceReferenceDate
@@ -154,4 +175,12 @@ struct WhatsAppSource: DataSource, Sendable {
 
     /// Phone/handle from a JID like "14155551234@s.whatsapp.net" → "14155551234" (chat-name fallback only).
     private static func handle(_ jid: String) -> String { String(jid.prefix { $0 != "@" }) }
+
+    /// Chat display name: validated partner name → phone handle — but NEVER an opaque @lid
+    /// identifier (a privacy-mode chat without a saved name shows a clean generic instead).
+    private static func displayName(_ partnerName: String?, jid: String) -> String {
+        if let n = cleanName(partnerName) { return n }
+        if jid.isEmpty || jid.hasSuffix("@lid") { return "Unknown chat" }
+        return handle(jid)
+    }
 }

--- a/Sentient OS macOS/Sources/WhatsAppSource.swift
+++ b/Sentient OS macOS/Sources/WhatsAppSource.swift
@@ -49,17 +49,23 @@ struct WhatsAppSource: DataSource, Sendable {
     /// WhatsApp itself does ("Aditya, Ondrej & 2 others"). ZISACTIVE excludes members who LEFT,
     /// so a shrunk group is named after who's actually in it now. Saved contact names are
     /// preferred, but [MEASURED] they're often empty STRINGS (not NULL) — the self-set profile
-    /// push-name (ZWAPROFILEPUSHNAME, joined by member JID) is the reliable fallback, and it's
-    /// what WhatsApp's own chat list shows.
-    private static func activeMemberNames(_ reader: SQLiteReader) throws -> [Int64: [String]] {
+    /// push-name (ZWAPROFILEPUSHNAME, by member JID) is the reliable fallback, and it's what
+    /// WhatsApp's own chat list shows. Two flat queries + a dict (no SQL join): no dependence
+    /// on an index existing, and duplicate ZJID rows can't duplicate members. Non-throwing by
+    /// design — names are a nicety; a schema oddity must degrade to "Group chat", never kill
+    /// the connector.
+    private static func activeMemberNames(_ reader: SQLiteReader) -> [Int64: [String]] {
+        var push: [String: String] = [:]
+        try? reader.forEachRow("SELECT ZJID, ZPUSHNAME FROM ZWAPROFILEPUSHNAME") { r in
+            if let jid = r.text(0), let name = r.text(1) { push[jid] = name }
+        }
         var out: [Int64: [String]] = [:]
-        try reader.forEachRow("""
-            SELECT gm.ZCHATSESSION, gm.ZCONTACTNAME, gm.ZFIRSTNAME, pn.ZPUSHNAME
-            FROM ZWAGROUPMEMBER gm
-            LEFT JOIN ZWAPROFILEPUSHNAME pn ON pn.ZJID = gm.ZMEMBERJID
-            WHERE gm.ZISACTIVE = 1
+        try? reader.forEachRow("""
+            SELECT ZCHATSESSION, ZCONTACTNAME, ZFIRSTNAME, ZMEMBERJID
+            FROM ZWAGROUPMEMBER WHERE ZISACTIVE = 1
             """) { r in
-            if let n = cleanName(r.text(1)) ?? cleanName(r.text(2)) ?? cleanName(r.text(3)) {
+            let pushName = r.text(3).flatMap { push[$0] }
+            if let n = cleanName(r.text(1)) ?? cleanName(r.text(2)) ?? cleanName(pushName) {
                 out[r.int(0), default: []].append(n)
             }
         }
@@ -74,7 +80,7 @@ struct WhatsAppSource: DataSource, Sendable {
         let reader = try SQLiteReader(path: dbURL.path)
 
         let floor = ChatWindowing.lookbackFloor.timeIntervalSinceReferenceDate
-        let members = try Self.activeMemberNames(reader)
+        let members = Self.activeMemberNames(reader)
         var out: [ChatInfo] = []
         try reader.forEachRow("""
             SELECT s.ZCONTACTJID, s.ZPARTNERNAME, COUNT(m.Z_PK), MAX(m.ZMESSAGEDATE), s.Z_PK
@@ -118,7 +124,7 @@ struct WhatsAppSource: DataSource, Sendable {
         // Chat sessions → name + DM/group. The session filter here also drops community noise
         // from scan itself — so a stale opted-in JID (or the self-test's all-chats mode) can
         // never window an excluded session.
-        let members = try Self.activeMemberNames(reader)
+        let members = Self.activeMemberNames(reader)
         var chats: [Int64: Chat] = [:]
         try reader.forEachRow("SELECT s.Z_PK, s.ZPARTNERNAME, s.ZCONTACTJID FROM ZWACHATSESSION s WHERE \(Self.sessionFilter)") { r in
             let jid = r.text(2) ?? ""
@@ -127,9 +133,17 @@ struct WhatsAppSource: DataSource, Sendable {
                                    isGroup: jid.hasSuffix("@g.us"))
         }
 
-        // Text messages within the limits (90-day floor AND newest-`maxMessages` cap — the inner
-        // newest-first LIMIT applies the cap across ALL chats; the outer ORDER restores
-        // per-chat ascending iteration), oldest → newest per chat.
+        // Opt-in + session filtering happen INSIDE the capped query: the newest-`maxMessages`
+        // budget must be spent on chats we'll actually analyze — otherwise a community-heavy
+        // or busy non-opted chat eats the cap for nothing.
+        let analyzedPKs = chats.values
+            .filter { chatJIDs == nil || chatJIDs!.contains($0.jid) }
+            .map(\.pk)
+        guard !analyzedPKs.isEmpty else { return [] }
+
+        // Text messages within the limits (90-day floor AND newest-`maxMessages` cap over the
+        // analyzed chats; the outer ORDER restores per-chat ascending iteration), oldest →
+        // newest per chat.
         let floor = ChatWindowing.lookbackFloor.timeIntervalSinceReferenceDate
         var byChat: [Int64: [ChatMessage]] = [:]
         // LEFT JOIN the group-member row (indexed on Z_PK → near-free) so senders without a
@@ -138,12 +152,12 @@ struct WhatsAppSource: DataSource, Sendable {
             SELECT m.Z_PK, m.ZMESSAGEDATE, m.ZISFROMME, m.ZTEXT, m.ZPUSHNAME, m.ZCHATSESSION, gm.ZCONTACTNAME, gm.ZFIRSTNAME
             FROM (SELECT * FROM ZWAMESSAGE
                   WHERE ZTEXT IS NOT NULL AND length(ZTEXT) > 0 AND ZMESSAGEDATE >= \(floor)
+                        AND ZCHATSESSION IN (\(analyzedPKs.sorted().map(String.init).joined(separator: ",")))
                   ORDER BY ZMESSAGEDATE DESC LIMIT \(ChatWindowing.maxMessages)) m
             LEFT JOIN ZWAGROUPMEMBER gm ON m.ZGROUPMEMBER = gm.Z_PK
             ORDER BY m.ZCHATSESSION, m.Z_PK
             """) { r in
             guard let chat = chats[r.int(5)] else { return }
-            if let only = chatJIDs, !only.contains(chat.jid) { return }   // opt-in filter
             let isFromMe = r.int(2) == 1
             byChat[r.int(5), default: []].append(ChatMessage(
                 id: r.int(0),

--- a/Sentient OS macOS/Sources/WhatsAppSource.swift
+++ b/Sentient OS macOS/Sources/WhatsAppSource.swift
@@ -189,12 +189,14 @@ struct WhatsAppSource: DataSource, Sendable {
         return chat.name   // DM: the other party is the chat partner
     }
 
-    /// A real display name, or nil if it's actually an opaque WhatsApp JID/LID blob. Real names are
-    /// short or contain spaces; LIDs are long, unbroken, and contain '/' (e.g. "CIW9/tAGIA…").
+    /// A real display name, or nil if it's actually an opaque WhatsApp JID/LID blob. LID blobs
+    /// are long, UNBROKEN base64-ish tokens (e.g. "CIW9/tAGIA…") — they never contain spaces.
+    /// Anything multi-word is a real name, slashes and all ("Amrit Sanju Uncle T34/1803" is a
+    /// real saved contact; rejecting on '/' alone showed the raw number instead).
     private static func cleanName(_ s: String?) -> String? {
         guard let s = s?.trimmingCharacters(in: .whitespaces), !s.isEmpty else { return nil }
-        if s.contains("/") { return nil }                    // LID/JID blobs contain '/'
-        if s.count > 24 && !s.contains(" ") { return nil }   // long unbroken token → not a real name
+        if s.contains(" ") { return s }                      // multi-word → a real name
+        if s.contains("/") || s.count > 24 { return nil }    // single long/slashed token → LID/JID blob
         return s
     }
 

--- a/Sentient OS macOS/Sources/WhatsAppSource.swift
+++ b/Sentient OS macOS/Sources/WhatsAppSource.swift
@@ -36,12 +36,35 @@ struct WhatsAppSource: DataSource, Sendable {
     /// real conversations; the per-chat opt-in gates them anyway).
     /// ⚠️ The IS NOT NULL inside the subquery is load-bearing: one NULL there and SQL's
     /// NOT IN semantics silently hide EVERY group.
+    /// (The row-side IS NOT NULL matters too: an unnamed group's NULL ZPARTNERNAME would make
+    /// the whole NOT(...) evaluate NULL and silently hide the group.)
     private static let sessionFilter = """
         s.ZSESSIONTYPE IN (0, 1)
-            AND NOT (s.ZSESSIONTYPE = 1 AND s.ZPARTNERNAME IN
+            AND NOT (s.ZSESSIONTYPE = 1 AND s.ZPARTNERNAME IS NOT NULL AND s.ZPARTNERNAME IN
                 (SELECT ZPARTNERNAME FROM ZWACHATSESSION
                  WHERE ZSESSIONTYPE = 4 AND ZPARTNERNAME IS NOT NULL))
         """
+
+    /// Active group members with usable names, per chat session — names unnamed groups the way
+    /// WhatsApp itself does ("Aditya, Ondrej & 2 others"). ZISACTIVE excludes members who LEFT,
+    /// so a shrunk group is named after who's actually in it now. Saved contact names are
+    /// preferred, but [MEASURED] they're often empty STRINGS (not NULL) — the self-set profile
+    /// push-name (ZWAPROFILEPUSHNAME, joined by member JID) is the reliable fallback, and it's
+    /// what WhatsApp's own chat list shows.
+    private static func activeMemberNames(_ reader: SQLiteReader) throws -> [Int64: [String]] {
+        var out: [Int64: [String]] = [:]
+        try reader.forEachRow("""
+            SELECT gm.ZCHATSESSION, gm.ZCONTACTNAME, gm.ZFIRSTNAME, pn.ZPUSHNAME
+            FROM ZWAGROUPMEMBER gm
+            LEFT JOIN ZWAPROFILEPUSHNAME pn ON pn.ZJID = gm.ZMEMBERJID
+            WHERE gm.ZISACTIVE = 1
+            """) { r in
+            if let n = cleanName(r.text(1)) ?? cleanName(r.text(2)) ?? cleanName(r.text(3)) {
+                out[r.int(0), default: []].append(n)
+            }
+        }
+        return out
+    }
 
     /// Active chats (text messages within the lookback) for the picker — newest first, with counts.
     /// Its own WAL-safe copy → query → delete.
@@ -51,9 +74,10 @@ struct WhatsAppSource: DataSource, Sendable {
         let reader = try SQLiteReader(path: dbURL.path)
 
         let floor = ChatWindowing.lookbackFloor.timeIntervalSinceReferenceDate
+        let members = try Self.activeMemberNames(reader)
         var out: [ChatInfo] = []
         try reader.forEachRow("""
-            SELECT s.ZCONTACTJID, s.ZPARTNERNAME, COUNT(m.Z_PK), MAX(m.ZMESSAGEDATE)
+            SELECT s.ZCONTACTJID, s.ZPARTNERNAME, COUNT(m.Z_PK), MAX(m.ZMESSAGEDATE), s.Z_PK
             FROM ZWAMESSAGE m JOIN ZWACHATSESSION s ON m.ZCHATSESSION = s.Z_PK
             WHERE m.ZTEXT IS NOT NULL AND length(m.ZTEXT) > 0 AND m.ZMESSAGEDATE >= \(floor)
               AND \(Self.sessionFilter)
@@ -63,7 +87,7 @@ struct WhatsAppSource: DataSource, Sendable {
             let jid = r.text(0) ?? ""
             guard !jid.isEmpty else { return }
             out.append(ChatInfo(id: jid,
-                                name: Self.displayName(r.text(1), jid: jid),
+                                name: Self.displayName(r.text(1), jid: jid, members: members[r.int(4)]),
                                 isGroup: jid.hasSuffix("@g.us"),
                                 messageCount: Int(r.int(2)),
                                 lastActive: Date(timeIntervalSinceReferenceDate: r.double(3))))
@@ -94,11 +118,12 @@ struct WhatsAppSource: DataSource, Sendable {
         // Chat sessions → name + DM/group. The session filter here also drops community noise
         // from scan itself — so a stale opted-in JID (or the self-test's all-chats mode) can
         // never window an excluded session.
+        let members = try Self.activeMemberNames(reader)
         var chats: [Int64: Chat] = [:]
         try reader.forEachRow("SELECT s.Z_PK, s.ZPARTNERNAME, s.ZCONTACTJID FROM ZWACHATSESSION s WHERE \(Self.sessionFilter)") { r in
             let jid = r.text(2) ?? ""
             chats[r.int(0)] = Chat(pk: r.int(0), jid: jid,
-                                   name: Self.displayName(r.text(1), jid: jid),
+                                   name: Self.displayName(r.text(1), jid: jid, members: members[r.int(0)]),
                                    isGroup: jid.hasSuffix("@g.us"))
         }
 
@@ -176,10 +201,12 @@ struct WhatsAppSource: DataSource, Sendable {
     /// Phone/handle from a JID like "14155551234@s.whatsapp.net" → "14155551234" (chat-name fallback only).
     private static func handle(_ jid: String) -> String { String(jid.prefix { $0 != "@" }) }
 
-    /// Chat display name: validated partner name → phone handle — but NEVER an opaque @lid
-    /// identifier (a privacy-mode chat without a saved name shows a clean generic instead).
-    private static func displayName(_ partnerName: String?, jid: String) -> String {
+    /// Chat display name: validated partner name → participant roll-up for unnamed groups
+    /// ("Aditya & Ondrej", like WhatsApp itself) → phone handle — but NEVER an opaque @lid
+    /// identifier or a raw group JID (a chat we can't name shows a clean generic instead).
+    private static func displayName(_ partnerName: String?, jid: String, members: [String]?) -> String {
         if let n = cleanName(partnerName) { return n }
+        if jid.hasSuffix("@g.us") { return ChatWindowing.groupName(of: members ?? []) }
         if jid.isEmpty || jid.hasSuffix("@lid") { return "Unknown chat" }
         return handle(jid)
     }

--- a/Sentient OS macOS/Sources/iMessageSource.swift
+++ b/Sentient OS macOS/Sources/iMessageSource.swift
@@ -107,7 +107,7 @@ struct iMessageSource: DataSource, Sendable {
             if !explicit.isEmpty {
                 name = explicit
             } else if isGroup {
-                name = groupName(of: (members[r.int(0)] ?? []).map { resolved($0, contacts) })
+                name = ChatWindowing.groupName(of: (members[r.int(0)] ?? []).map { resolved($0, contacts) })
             } else {
                 name = resolved(identifier, contacts)
             }
@@ -120,16 +120,6 @@ struct iMessageSource: DataSource, Sendable {
     /// unlike WhatsApp's LID blobs there's nothing opaque to hide).
     private static func resolved(_ handle: String, _ contacts: [String: String]) -> String {
         AddressBookNames.resolve(handle, in: contacts) ?? handle
-    }
-
-    /// "Alex, Sam & 2 others" for groups without an explicit name.
-    private static func groupName(of participants: [String]) -> String {
-        switch participants.count {
-        case 0:  return "Group chat"
-        case 1:  return participants[0]
-        case 2:  return "\(participants[0]) & \(participants[1])"
-        default: return "\(participants[0]), \(participants[1]) & \(participants.count - 2) others"
-        }
     }
 
     // MARK: Scan — copy → query → decode → window → delete

--- a/Sentient OS macOS/Sources/iMessageSource.swift
+++ b/Sentient OS macOS/Sources/iMessageSource.swift
@@ -132,21 +132,28 @@ struct iMessageSource: DataSource, Sendable {
         let chats = try Self.chats(reader)
         let contacts = AddressBookNames.loadMap()
 
-        // Messages within the limits (90-day floor AND newest-200k cap — the inner newest-first
-        // LIMIT applies the cap across ALL chats; the outer ORDER restores per-chat ascending
-        // iteration), decoded text ?? typedstream, grouped per chat.
+        // Opt-in filtering happens INSIDE the capped query: the newest-`maxMessages` budget
+        // must be spent on the chats we'll actually analyze, not eaten by busy non-opted ones.
+        let analyzedROWIDs = chats.values
+            .filter { chatGUIDs == nil || chatGUIDs!.contains($0.guid) }
+            .map(\.rowid)
+        guard !analyzedROWIDs.isEmpty else { return [] }
+
+        // Messages within the limits (90-day floor AND newest-`maxMessages` cap over the
+        // analyzed chats; the outer ORDER restores per-chat ascending iteration), decoded
+        // text ?? typedstream, grouped per chat.
         var byChat: [Int64: [ChatMessage]] = [:]
         try reader.forEachRow("""
-            SELECT m.ROWID, m.date, m.is_from_me, m.text, m.attributedBody, cmj.chat_id, h.id
-            FROM (SELECT ROWID, date, is_from_me, text, attributedBody, handle_id FROM message
+            SELECT m.ROWID, m.date, m.is_from_me, m.text, m.attributedBody, m.chat_id, h.id
+            FROM (SELECT message.ROWID, date, is_from_me, text, attributedBody, handle_id, cmj.chat_id
+                  FROM message JOIN chat_message_join cmj ON cmj.message_id = message.ROWID
                   WHERE date >= \(Self.floorNS) AND \(Self.messageFilter)
+                        AND cmj.chat_id IN (\(analyzedROWIDs.sorted().map(String.init).joined(separator: ",")))
                   ORDER BY date DESC LIMIT \(ChatWindowing.maxMessages)) m
-            JOIN chat_message_join cmj ON cmj.message_id = m.ROWID
             LEFT JOIN handle h ON h.ROWID = m.handle_id
-            ORDER BY cmj.chat_id, m.ROWID
+            ORDER BY m.chat_id, m.ROWID
             """) { r in
             guard let chat = chats[r.int(5)] else { return }
-            if let only = chatGUIDs, !only.contains(chat.guid) { return }   // opt-in filter
 
             let body = r.text(3) ?? r.blob(4).flatMap(Self.typedstreamText)
             guard let body, !body.trimmingCharacters(in: .whitespaces).isEmpty else { return }


### PR DESCRIPTION
Went down a rabbit hole after spotting junk in my chat picker — ended up fixing four things:

## Communities & announcements are gone
WhatsApp communities show up as two fake chats: the community 'home' and its announcements feed. Homes are `ZSESSIONTYPE = 4`, so the picker/scan now **whitelist** types 0+1 (DMs + real groups) — which also future-proofs us against whatever session types WhatsApp invents next. Announcement feeds are sneakier: they're stored as normal type-1 groups but always wear the community's exact name, so any group name-twinned with a type-4 session gets filtered too. Real community sub-groups stay (they're actual conversations, and opt-in gates them anyway).

⚠️ SQL trap worth knowing: a single NULL in either side of that `NOT IN` comparison silently hides EVERY group. Both sides are guarded — don't simplify them away.

## Unnamed groups get real names
Groups created without a name showed as blank rows. Now they roll up from **current** members like WhatsApp itself does ('Aditya, Ondrej & 2 others'). Fun findings along the way: `ZCONTACTNAME` is usually an empty *string* (not NULL), so the reliable source is the profile push-name table — and members who left are `ZISACTIVE = 0`, so a shrunk group is named after who's actually still in it.

## Names with slashes aren't LID blobs
My LID-blob detector rejected any name containing '/', which turned saved contacts like 'Amrit Sanju Uncle T34/1803' into raw phone numbers. LIDs are unbroken base64-ish tokens — multi-word names are now always trusted.

## The 100k cap lands on the right messages (WhatsApp **and** iMessage)
The newest-100k budget was computed before the opt-in/community filters, so on heavy accounts busy non-opted chats ate the cap for nothing. Both sources now apply the cap only to the chats being analyzed.

## Validation (all on my real DB)
- Picker: 35 → 33 chats, the removed two = exactly my two announcement feeds
- Both blank groups now named; the group David left rolls up without him
- Zero bare-number DM rows across the full picker
- Both scan paths re-run end to end through the model after the SQL restructure

## For reviewers
- **Jesai**: please run `SENTIENT_SELFTEST=chats` — your account has *active* communities, mine are quiet, so you're the real test of the name-twin heuristic (the output prints session-type distribution + what got filtered).
- Known cosmetic limits: roll-up names include yourself, and '& N others' counts only nameable members.