### PR TITLE
Files source: code/dataset skipping overhaul + connector caps

### DIFF
--- a/Sentient OS macOS/Documentation/Files Source (Skipping & Caps).md
+++ b/Sentient OS macOS/Documentation/Files Source (Skipping & Caps).md
@@ -1,0 +1,61 @@
+# Files Source — Skipping & Caps
+
+How `FilesSource.scan()` decides what *never* reaches the model. Two halves: **subtree pruning**
+(directories we refuse to walk into) and **caps** (bounds on what survives the walk). All of it
+lives in `Sources/FilesSource.swift`; everything here happens at the walk level via
+`enumerator.skipDescendants()`, so a skipped item never becomes a Candidate, never hits the
+ledger, never sees inference.
+
+## Pruning — `pruneReason(_:) -> String?`
+
+One directory listing is read per directory; every rule runs against it. First match wins:
+
+| Rule | Trigger | Example |
+|---|---|---|
+| noindex | dir name ends `.noindex` | `Cache.noindex` |
+| name blocklist | dep/build/cache/dataset names | `node_modules`, `venv`, `dist`, `datasets`, `checkpoints` |
+| never-index marker | `.metadata_never_index` present | Spotlight opt-outs |
+| **Obsidian exemption** | `.obsidian` present → **never prune** (overrides everything below) | personal vaults, even with a stray `package.json` |
+| manifest | a known project manifest present | `package.json`, `Cargo.toml`, `Makefile`, `CMakeLists.txt`, `pyproject.toml`… |
+| project bundle | any `*.xcodeproj` / `*.sln` entry | Xcode/VS project folders |
+| code-density | ≥10 extensioned entries, majority source-code extensions | manifest-less script folders |
+| `.git` + code | `.git` present AND (any code file OR a classic code dir like `src`/`tests`) | cloned repos. Markdown-only git repos (notes vaults) pass |
+| **dataset** | ≥100 files of one extension, ≥90% homogeneous, ≥80% machine-generated names (`chunk_0001`, pure numbers, hashes, UUIDs) | scraped corpora, ML datasets. **Skipped entirely** — no sampling (decision June 10) |
+
+**Screenshots & camera rolls are exempt from the dataset rule** (`Screenshot…`, `IMG_…`, `DSC…`
+prefixes): they're personal gold — the per-directory cap bounds their volume instead.
+
+Hidden dirs and bundle *contents* are already excluded by the enumerator options
+(`.skipsHiddenFiles`, `.skipsPackageDescendants`).
+
+## Caps (connector-limits decision, June 10)
+
+Applied newest-first (by creation date) after the walk, in `scan()`:
+
+- **Age cutoff** — Downloads only: files older than **1 year** are dropped (old downloads are
+  noise; old Desktop/Documents files can be keepers). `FilesSource.maxAge`.
+- **Per-directory cap** — **100 for Downloads, 300 for every other root**; any one directory
+  contributes at most that many (newest win). The blunt backstop for bulk dumps the heuristics
+  miss. `FileRoot.perDirectoryCap`.
+- **Per-root cap** — newest **1,000** per root, every root. `FilesSource.perRootCap`.
+
+`FileRoot.source` builds the correctly-configured `FilesSource` for each root — use it instead of
+constructing `FilesSource` by hand.
+
+## Thresholds are [STARTING POINT]
+
+The density/dataset numbers (10 / majority · 100 / 90% / 80%) were tuned on real census runs but
+are judgment calls. Tune with evidence, not vibes — that's what the census mode is for.
+
+## Self-test
+
+`Self Tests - Temp/SelfTest_FileSkipping.swift`, no model needed:
+
+```sh
+SENTIENT_SELFTEST=skipping   "<app>/Contents/MacOS/Sentient OS"   # synthetic fixtures, 16 assertions
+SENTIENT_SELFTEST=skipcensus "<app>/Contents/MacOS/Sentient OS"   # read-only real-Mac report:
+                                                                  # every pruned dir + reason, top contributors
+```
+
+June 10 census on Aryaman's Mac: Downloads 218 subtrees pruned (an ML dataset + course repos)
+→ 124 candidates; Desktop screenshots capped at 300; the Documents Obsidian vault fully kept.

--- a/Sentient OS macOS/Documentation/Files Source (Skipping & Caps).md
+++ b/Sentient OS macOS/Documentation/Files Source (Skipping & Caps).md
@@ -15,15 +15,19 @@ One directory listing is read per directory; every rule runs against it. First m
 | noindex | dir name ends `.noindex` | `Cache.noindex` |
 | name blocklist | dep/build/cache/dataset names | `node_modules`, `venv`, `dist`, `datasets`, `checkpoints` |
 | never-index marker | `.metadata_never_index` present | Spotlight opt-outs |
-| **Obsidian exemption** | `.obsidian` present → **never prune** (overrides everything below) | personal vaults, even with a stray `package.json` |
+| **vault exemption** | `.obsidian` or `logseq` present → **never prune** (overrides everything below) | personal vaults — even git-synced, even with a stray `package.json` |
+| **`.git`** | `.git` present → prune, period (decision June 11 — a 38-repo survey found zero notes repos; git notes journals are ~1% and have the escape hatch below) | every cloned/own repo |
 | manifest | a known project manifest present | `package.json`, `Cargo.toml`, `Makefile`, `CMakeLists.txt`, `pyproject.toml`… |
 | project bundle | any `*.xcodeproj` / `*.sln` entry | Xcode/VS project folders |
 | code-density | ≥10 extensioned entries, majority source-code extensions | manifest-less script folders |
-| `.git` + code | `.git` present AND (any code file OR a classic code dir like `src`/`tests`) | cloned repos. Markdown-only git repos (notes vaults) pass |
 | **dataset** | ≥100 files of one extension, ≥90% homogeneous, ≥80% machine-generated names (`chunk_0001`, pure numbers, hashes, UUIDs) | scraped corpora, ML datasets. **Skipped entirely** — no sampling (decision June 10) |
 
 **Screenshots & camera rolls are exempt from the dataset rule** (`Screenshot…`, `IMG_…`, `DSC…`
 prefixes): they're personal gold — the per-directory cap bounds their volume instead.
+
+**The escape hatch (by construction):** `pruneReason` only runs on *subdirectories* — a root the
+user explicitly added in Sources is never itself prune-checked. Anyone whose plain git notes repo
+gets skipped can add that folder as a custom root and it walks fine.
 
 Hidden dirs and bundle *contents* are already excluded by the enumerator options
 (`.skipsHiddenFiles`, `.skipsPackageDescendants`).

--- a/Sentient OS macOS/Documentation/Files Source (Skipping & Caps).md
+++ b/Sentient OS macOS/Documentation/Files Source (Skipping & Caps).md
@@ -38,9 +38,9 @@ Applied newest-first (by creation date) after the walk, in `scan()`:
 
 - **Age cutoff** — Downloads only: files older than **1 year** are dropped (old downloads are
   noise; old Desktop/Documents files can be keepers). `FilesSource.maxAge`.
-- **Per-directory cap** — **100 for Downloads, 300 for every other root**; any one directory
-  contributes at most that many (newest win). The blunt backstop for bulk dumps the heuristics
-  miss. `FileRoot.perDirectoryCap`.
+- **Per-directory cap** — **300, every root** (raised from 100 for Downloads, June 11 — downloads
+  are high-signal: tickets, receipts, PDFs); any one directory contributes at most that many
+  (newest win). The blunt backstop for bulk dumps the heuristics miss. `FilesSource.perDirectoryCap`.
 - **Per-root cap** — newest **1,000** per root, every root. `FilesSource.perRootCap`.
 
 `FileRoot.source` builds the correctly-configured `FilesSource` for each root — use it instead of
@@ -61,5 +61,7 @@ SENTIENT_SELFTEST=skipcensus "<app>/Contents/MacOS/Sentient OS"   # read-only re
                                                                   # every pruned dir + reason, top contributors
 ```
 
-June 10 census on Aryaman's Mac: Downloads 218 subtrees pruned (an ML dataset + course repos)
-→ 124 candidates; Desktop screenshots capped at 300; the Documents Obsidian vault fully kept.
+June 11 census on Aryaman's Mac (waterfall: 21,364 raw whitelisted files in Downloads → 5,286
+after pruning → 551 after the 1-year cutoff → 324 after caps; Desktop 19,216 → 582 → 375):
+218 Downloads subtrees pruned (an ML dataset + course repos); Desktop screenshots capped at 300;
+the Documents Obsidian vault fully kept.

--- a/Sentient OS macOS/Self Tests - Temp/SelfTest_FileSkipping.swift
+++ b/Sentient OS macOS/Self Tests - Temp/SelfTest_FileSkipping.swift
@@ -1,0 +1,171 @@
+//
+//  SelfTest_FileSkipping.swift — deterministic harness for FilesSource skipping & caps
+//  Sentient OS macOS
+//
+//  Two no-model modes, dispatched from SelfTest.runIfRequested():
+//    SENTIENT_SELFTEST=skipping    builds a synthetic fixture tree in /tmp (code repos, datasets,
+//                                  screenshot dumps, an Obsidian vault…) and asserts EXACTLY what
+//                                  survives scan() — pruning rules, per-dir/per-root caps, age cutoff.
+//    SENTIENT_SELFTEST=skipcensus  read-only walk of the REAL standard folders: every pruned
+//                                  subtree with its reason + the top contributing directories.
+//                                  This is the tuning tool — run it on all three Macs and eyeball.
+//
+
+#if DEBUG
+import Foundation
+
+enum SelfTestFileSkipping {
+
+    // MARK: - Synthetic fixture assertions
+
+    static func synthetic(emit: (String) -> Void) {
+        let fm = FileManager.default
+        var base = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("sentient-skiptest-\(UUID().uuidString.prefix(8))")
+        try? fm.createDirectory(at: base, withIntermediateDirectories: true)
+        // The enumerator yields canonical /private/var/… paths while NSTemporaryDirectory() hands
+        // out the /var/… symlink form — canonicalize so the prefix grouping below matches.
+        if let canon = try? base.resourceValues(forKeys: [.canonicalPathKey]).canonicalPath {
+            base = URL(fileURLWithPath: canon, isDirectory: true)
+        }
+        defer { try? fm.removeItem(at: base) }
+
+        var pass = 0, fail = 0
+        func check(_ name: String, expected: Int, actual: Int) {
+            let ok = expected == actual
+            if ok { pass += 1 } else { fail += 1 }
+            emit("\(ok ? "✅" : "❌") \(name): expected \(expected), got \(actual)")
+        }
+        func dir(_ path: String) -> URL {
+            let u = base.appendingPathComponent(path)
+            try? fm.createDirectory(at: u, withIntermediateDirectories: true)
+            return u
+        }
+        func touch(_ folder: URL, _ name: String, age: TimeInterval = 0) {
+            let p = folder.appendingPathComponent(name).path
+            fm.createFile(atPath: p, contents: Data("x".utf8))
+            if age > 0 {
+                let then = Date().addingTimeInterval(-age)
+                try? fm.setAttributes([.creationDate: then, .modificationDate: then], ofItemAtPath: p)
+            }
+        }
+        /// Survivor count per top-level fixture dir for one scan.
+        func counts(_ source: FilesSource) -> [String: Int] {
+            let rootPath = source.root.path + "/"
+            var by: [String: Int] = [:]
+            for c in (try? source.scan(since: nil)) ?? [] {
+                guard let p = c.metadata["path"], p.hasPrefix(rootPath) else { continue }
+                by[String(p.dropFirst(rootPath.count).split(separator: "/").first ?? "?"), default: 0] += 1
+            }
+            return by
+        }
+
+        // ── Root 1: pruning rules ────────────────────────────────────────────────
+        let docs = dir("prune/docs")
+        touch(docs, "resume.pdf"); touch(docs, "notes.md"); touch(docs, "photo.jpg")
+        let npm = dir("prune/npm-app");   touch(npm, "package.json"); touch(npm, "README.md")
+        let mk  = dir("prune/make-tool"); touch(mk, "Makefile");      touch(mk, "README.md")
+        let gc  = dir("prune/git-code");  touch(dir("prune/git-code/.git"), "HEAD")
+        touch(gc, "main.py"); touch(gc, "README.md")
+        let gn  = dir("prune/git-notes"); touch(dir("prune/git-notes/.git"), "HEAD")
+        for i in 1...6 { touch(gn, "idea \(i).md") }
+        let ob  = dir("prune/obsidian");  touch(dir("prune/obsidian/.obsidian"), "app.json")
+        touch(ob, "package.json")   // stray manifest — the .obsidian exemption must win
+        for i in 1...5 { touch(ob, "journal \(i).md") }
+        let xc  = dir("prune/xcode");     _ = dir("prune/xcode/Foo.xcodeproj"); touch(xc, "README.md")
+        let den = dir("prune/density")
+        for i in 1...12 { touch(den, "module\(i).py") }
+        touch(den, "README.md"); touch(den, "guide.md")
+        let ds  = dir("prune/dataset-txt")
+        for i in 1...120 { touch(ds, String(format: "chunk_%04d.txt", i)) }
+        let sc  = dir("prune/screenshots")
+        for i in 1...120 { touch(sc, "Screenshot 2026-06-09 at 9.41.\(i) AM.png") }
+        touch(dir("prune/node_modules"), "README.md")
+
+        let pruneRoot = FilesSource(root: base.appendingPathComponent("prune"), label: "Prune")
+        let p = counts(pruneRoot)
+        check("docs survive untouched",            expected: 3,   actual: p["docs"] ?? 0)
+        check("package.json repo pruned",          expected: 0,   actual: p["npm-app"] ?? 0)
+        check("Makefile repo pruned (new manifest)", expected: 0, actual: p["make-tool"] ?? 0)
+        check(".git + code pruned",                expected: 0,   actual: p["git-code"] ?? 0)
+        check(".git markdown-only repo KEPT",      expected: 6,   actual: p["git-notes"] ?? 0)
+        check(".obsidian beats stray manifest",    expected: 5,   actual: p["obsidian"] ?? 0)
+        check(".xcodeproj sibling pruned",         expected: 0,   actual: p["xcode"] ?? 0)
+        check("code-density (no manifest) pruned", expected: 0,   actual: p["density"] ?? 0)
+        check("120× chunk_NNNN.txt dataset pruned", expected: 0,  actual: p["dataset-txt"] ?? 0)
+        check("120 screenshots exempt from dataset rule", expected: 120, actual: p["screenshots"] ?? 0)
+        check("node_modules pruned by name",       expected: 0,   actual: p["node_modules"] ?? 0)
+
+        // ── Root 2: per-root cap (4 dirs × 280 → 1,120 files → newest 1,000) ────
+        for d in 1...4 {
+            let bulk = dir("caps/bulk\(d)")
+            for i in 1...280 { touch(bulk, "meeting notes \(i).md") }
+        }
+        let capsTotal = counts(FilesSource(root: base.appendingPathComponent("caps"), label: "Caps"))
+            .values.reduce(0, +)
+        check("per-root cap (1,120 files → 1,000)", expected: FilesSource.perRootCap, actual: capsTotal)
+
+        // ── Root 3: per-directory cap on a screenshot dump (350 files) ──────────
+        let shots = dir("screens/shots")
+        for i in 1...350 { touch(shots, "Screenshot 2026-06-09 at 10.\(i) AM.png") }
+        let screensRoot = base.appendingPathComponent("screens")
+        check("per-dir cap 300 (350 screenshots → 300)", expected: 300,
+              actual: counts(FilesSource(root: screensRoot, label: "S", perDirectoryCap: 300))["shots"] ?? 0)
+        check("per-dir cap 100 — the Downloads number", expected: 100,
+              actual: counts(FilesSource(root: screensRoot, label: "S", perDirectoryCap: 100))["shots"] ?? 0)
+
+        // ── Root 4: age cutoff (2 fresh + 3 two-year-old files) ─────────────────
+        let aged = dir("age/stuff")
+        touch(aged, "new one.md"); touch(aged, "new two.md")
+        for i in 1...3 { touch(aged, "ancient \(i).md", age: 2 * 365 * 24 * 3_600) }
+        let ageRoot = base.appendingPathComponent("age")
+        check("no age cutoff → all 5", expected: 5,
+              actual: counts(FilesSource(root: ageRoot, label: "A"))["stuff"] ?? 0)
+        check("1-year cutoff → only the 2 fresh", expected: 2,
+              actual: counts(FilesSource(root: ageRoot, label: "A", maxAge: 365 * 24 * 3_600))["stuff"] ?? 0)
+
+        emit("\n# \(fail == 0 ? "✅ ALL PASS" : "❌ FAILURES") — \(pass) passed · \(fail) failed")
+    }
+
+    // MARK: - Real-Mac census (read-only; the threshold-tuning tool)
+
+    static func census(emit: (String) -> Void) {
+        let home = NSHomeDirectory()
+        func tilde(_ p: String) -> String { p.hasPrefix(home) ? "~" + p.dropFirst(home.count) : p }
+
+        for root in FileRoot.standard {
+            guard let source = root.source else { continue }
+            emit("\n══════════ \(root.label) ══════════")
+
+            // Every pruned subtree + why (same walk options as scan()).
+            if let en = FileManager.default.enumerator(
+                at: source.root, includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles, .skipsPackageDescendants]
+            ) {
+                var pruned = 0
+                for case let url as URL in en {
+                    guard (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true else { continue }
+                    if let reason = FilesSource.pruneReason(url) {
+                        en.skipDescendants(); pruned += 1
+                        emit("  ⛔ \(tilde(url.path))  [\(reason)]")
+                    }
+                }
+                emit("  (\(pruned) subtrees pruned)")
+            }
+
+            // What survives, and which directories contribute the most.
+            let candidates = (try? source.scan(since: nil)) ?? []
+            var byDir: [String: Int] = [:]
+            for c in candidates {
+                byDir[((c.metadata["path"] ?? "?") as NSString).deletingLastPathComponent, default: 0] += 1
+            }
+            let age = source.maxAge.map { "\(Int($0 / 86_400))d" } ?? "∞"
+            emit("  → \(candidates.count) candidates from \(byDir.count) dirs "
+                 + "(caps: \(source.perDirectoryCap)/dir · \(FilesSource.perRootCap)/root · age \(age))")
+            for (d, n) in byDir.sorted(by: { $0.value > $1.value }).prefix(15) {
+                emit("    \(String(format: "%4d", n))  \(tilde(d))")
+            }
+        }
+    }
+}
+#endif

--- a/Sentient OS macOS/Self Tests - Temp/SelfTest_FileSkipping.swift
+++ b/Sentient OS macOS/Self Tests - Temp/SelfTest_FileSkipping.swift
@@ -72,6 +72,9 @@ enum SelfTestFileSkipping {
         let ob  = dir("prune/obsidian");  touch(dir("prune/obsidian/.obsidian"), "app.json")
         touch(ob, "package.json")   // stray manifest — the .obsidian exemption must win
         for i in 1...5 { touch(ob, "journal \(i).md") }
+        let lg  = dir("prune/logseq-graph"); _ = dir("prune/logseq-graph/logseq")
+        touch(dir("prune/logseq-graph/.git"), "HEAD")   // git-synced Logseq graph — exemption must win
+        for i in 1...4 { touch(lg, "page \(i).md") }
         let xc  = dir("prune/xcode");     _ = dir("prune/xcode/Foo.xcodeproj"); touch(xc, "README.md")
         let den = dir("prune/density")
         for i in 1...12 { touch(den, "module\(i).py") }
@@ -88,8 +91,9 @@ enum SelfTestFileSkipping {
         check("package.json repo pruned",          expected: 0,   actual: p["npm-app"] ?? 0)
         check("Makefile repo pruned (new manifest)", expected: 0, actual: p["make-tool"] ?? 0)
         check(".git + code pruned",                expected: 0,   actual: p["git-code"] ?? 0)
-        check(".git markdown-only repo KEPT",      expected: 6,   actual: p["git-notes"] ?? 0)
+        check(".git markdown-only repo pruned too (June 11)", expected: 0, actual: p["git-notes"] ?? 0)
         check(".obsidian beats stray manifest",    expected: 5,   actual: p["obsidian"] ?? 0)
+        check("logseq marker beats .git",          expected: 4,   actual: p["logseq-graph"] ?? 0)
         check(".xcodeproj sibling pruned",         expected: 0,   actual: p["xcode"] ?? 0)
         check("code-density (no manifest) pruned", expected: 0,   actual: p["density"] ?? 0)
         check("120× chunk_NNNN.txt dataset pruned", expected: 0,  actual: p["dataset-txt"] ?? 0)

--- a/Sentient OS macOS/Self Tests - Temp/SelfTest_FileSkipping.swift
+++ b/Sentient OS macOS/Self Tests - Temp/SelfTest_FileSkipping.swift
@@ -115,7 +115,7 @@ enum SelfTestFileSkipping {
         let screensRoot = base.appendingPathComponent("screens")
         check("per-dir cap 300 (350 screenshots → 300)", expected: 300,
               actual: counts(FilesSource(root: screensRoot, label: "S", perDirectoryCap: 300))["shots"] ?? 0)
-        check("per-dir cap 100 — the Downloads number", expected: 100,
+        check("per-dir cap honors a custom value (100)", expected: 100,
               actual: counts(FilesSource(root: screensRoot, label: "S", perDirectoryCap: 100))["shots"] ?? 0)
 
         // ── Root 4: age cutoff (2 fresh + 3 two-year-old files) ─────────────────

--- a/Sentient OS macOS/Self Tests - Temp/SelfTest_Triage_Pipeline_and_Vault.swift
+++ b/Sentient OS macOS/Self Tests - Temp/SelfTest_Triage_Pipeline_and_Vault.swift
@@ -15,7 +15,8 @@
 //    SENTIENT_SELFTEST=whatsapp "<app>/Contents/MacOS/Sentient OS macOS"
 //  Env knobs:
 //    SENTIENT_SELFTEST     "whatsapp" | "imessage" | "notes" | "files"  (model dump) ·
-//                          "parse" | "chats" | "imchats" | "imdecode" | "notesdecode" | "claudecli" | "vault"  (no model)
+//                          "parse" | "chats" | "imchats" | "imdecode" | "notesdecode" | "claudecli"
+//                          | "vault" | "skipping" | "skipcensus"  (no model)
 //    SENTIENT_SELFTEST_N   item count (default 6)
 //    SENTIENT_SELFTEST_OUT output file (default <tmp>/sentient-selftest.txt)
 //    SENTIENT_MODEL_PATH   override the dev model path
@@ -77,6 +78,11 @@ enum SelfTest {
             }
             return
         }
+
+        // File-skipping modes: deterministic, no model — fixture assertions ("skipping") and a
+        // read-only census of the real standard folders ("skipcensus"). See SelfTest_FileSkipping.swift.
+        if mode == "skipping" { SelfTestFileSkipping.synthetic(emit: emit); return }
+        if mode == "skipcensus" { SelfTestFileSkipping.census(emit: emit); return }
 
         // ClaudeCLI mode: no model needed — discovery, ping, and one tiny run through the REAL
         // claude -p spine (binary → env → stdin → JSON envelope). Verifies the compute waterfall's
@@ -282,10 +288,10 @@ enum SelfTest {
         case "notes":
             source = NotesSource(); maxTokens = 4096
         case "files":
-            guard let dl = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first else {
+            guard let files = FileRoot.downloads.source else {
                 emit("could not locate ~/Downloads"); return
             }
-            source = FilesSource(root: dl, label: "Downloads"); maxTokens = 4096
+            source = files; maxTokens = 4096
         default:
             emit("unknown mode '\(mode)' (use whatsapp | imessage | notes | files)"); return
         }

--- a/Sentient OS macOS/Sources/FilesSource.swift
+++ b/Sentient OS macOS/Sources/FilesSource.swift
@@ -12,6 +12,10 @@
 //  The model is given the home-relative path (e.g. ~/Downloads/Useless Stuff/x.jpg) + creation
 //  date — the folder structure alone is strong signal for junk/intent.
 //
+//  Skipping & caps (see Documentation/Files Source (Skipping & Caps).md): code repos and
+//  machine-generated datasets are pruned at the walk level (`pruneReason`), and `scan` bounds
+//  every run — newest 1,000 per root, 100/300 per directory, 1-year age cutoff for Downloads.
+//
 
 import Foundation
 import PDFKit
@@ -23,41 +27,121 @@ struct FilesSource: DataSource, Sendable {
     let kind: SourceKind = .file
     let root: URL
     let label: String   // human folder name ("Downloads", "Desktop", a custom folder…) → stored as each artifact's `folder` tag
+    let perDirectoryCap: Int     // max candidates any single directory contributes (newest win)
+    let maxAge: TimeInterval?    // drop files older than this (nil = no age cutoff)
+
+    init(root: URL, label: String, perDirectoryCap: Int = 300, maxAge: TimeInterval? = nil) {
+        self.root = root
+        self.label = label
+        self.perDirectoryCap = perDirectoryCap
+        self.maxAge = maxAge
+    }
 
     static let allowedExtensions: Set<String> = ["pdf", "doc", "docx", "md", "txt", "png", "jpg", "jpeg", "heic"]
+    static let perRootCap = 1_000   // connector limit (June 10): newest 1,000 per root, every root
     private static let imageExtensions: Set<String> = ["png", "jpg", "jpeg", "heic"]
     private static let maxContentChars = 8_000
     private static let pdfPageLimit = 3
     private static let imageMaxPixel = 1_280   // ≈ 720p short edge on 16:9
 
-    // MARK: Pruning (skip code repos / dependency caches — Spotlight-style)
+    // MARK: Skipping (code repos / dependency caches / datasets — Spotlight-style)
 
-    /// Dependency / build / cache directories — pruned by name (their subtree is never walked).
+    /// Dependency / build / cache / dataset directories — pruned by name (subtree never walked).
     private static let skipDirNames: Set<String> = [
         "node_modules", "bower_components", "jspm_packages", "vendor", "pods", "carthage",
         "dist", "build", "target", ".build", "__pycache__", "venv", ".venv", ".tox",
         ".mypy_cache", ".pytest_cache", ".gradle", "deriveddata", ".dart_tool",
         ".next", ".nuxt", ".svelte-kit", ".angular",
+        "site-packages", "dataset", "datasets", "corpus", "checkpoints",
     ]
 
     /// Hard "this is a code project" manifests — if present, skip the WHOLE folder. Deliberately
-    /// NOT `.git`: Obsidian vaults & personal note repos are git repos full of markdown we WANT.
-    private static let projectManifests: [String] = [
+    /// NOT `.git` alone: Obsidian vaults & personal note repos are git repos full of markdown we
+    /// WANT (`.git` only prunes alongside code signals — see `pruneReason`).
+    private static let projectManifests: Set<String> = [
         "package.json", "Cargo.toml", "go.mod", "Package.swift", "pom.xml",
         "build.gradle", "build.gradle.kts", "composer.json", "Gemfile",
         "pyproject.toml", "Pipfile", "requirements.txt",
+        "Makefile", "makefile", "CMakeLists.txt", "mix.exs", "deno.json", "build.sbt",
     ]
 
-    /// Should this directory's whole subtree be skipped? (dep/build dir · *.noindex · OS
-    /// never-index marker · code-project root). `.app`/`.xcodeproj` bundles + hidden dirs are
-    /// already handled by the enumerator options.
-    private static func shouldPrune(_ dir: URL) -> Bool {
+    /// Source-code extensions for the density heuristic — a folder that's mostly these is a code
+    /// project even without a recognized manifest.
+    private static let codeExtensions: Set<String> = [
+        "py", "js", "jsx", "ts", "tsx", "mjs", "c", "h", "cpp", "cc", "hpp", "m", "mm",
+        "swift", "java", "kt", "rs", "go", "rb", "php", "cs", "scala", "sh", "lua",
+        "dart", "vue", "svelte", "sql", "pl", "r",
+    ]
+
+    /// Classic code-project directory names — with `.git` present, any of these confirms "repo".
+    private static let codeDirNames: Set<String> = [
+        "src", "lib", "tests", "test", "spec", "include", "cmd", "pkg", "sources", "bin",
+    ]
+
+    /// Why this directory's whole subtree is skipped — nil means walk in. Reads the directory
+    /// listing ONCE and runs every check against it. `.app`/`.xcodeproj` bundle *descendants* +
+    /// hidden dirs are already excluded by the enumerator options; this prunes at the parent.
+    /// Internal (not private) so the skipping self-test's census can report reasons.
+    static func pruneReason(_ dir: URL) -> String? {
         let name = dir.lastPathComponent
-        if name.hasSuffix(".noindex") { return true }
-        if skipDirNames.contains(name.lowercased()) { return true }
-        let fm = FileManager.default
-        if fm.fileExists(atPath: dir.appendingPathComponent(".metadata_never_index").path) { return true }
-        return projectManifests.contains { fm.fileExists(atPath: dir.appendingPathComponent($0).path) }
+        if name.hasSuffix(".noindex") { return "noindex" }
+        if skipDirNames.contains(name.lowercased()) { return "dep/build/dataset dir name" }
+
+        guard let listing = try? FileManager.default.contentsOfDirectory(atPath: dir.path) else { return nil }
+        let names = Set(listing)
+        if names.contains(".metadata_never_index") { return "never-index marker" }
+        if names.contains(".obsidian") { return nil }   // Obsidian vault — always keep, no further checks
+
+        if let manifest = projectManifests.first(where: { names.contains($0) }) { return "manifest: \(manifest)" }
+        if let bundle = listing.first(where: { $0.hasSuffix(".xcodeproj") || $0.hasSuffix(".sln") }) {
+            return "project bundle: \(bundle)"
+        }
+
+        // Code-density: ≥10 extensioned entries and source code is the majority.
+        let exts = listing.compactMap { n -> String? in
+            let e = (n as NSString).pathExtension.lowercased()
+            return e.isEmpty ? nil : e
+        }
+        let codeCount = exts.count(where: { codeExtensions.contains($0) })
+        if exts.count >= 10, codeCount * 2 >= exts.count { return "code-density \(codeCount)/\(exts.count)" }
+
+        // Bare repo: .git + any code file or a classic code dir (markdown-only git repos pass).
+        let lowered = Set(listing.map { $0.lowercased() })
+        if names.contains(".git"), codeCount > 0 || !codeDirNames.isDisjoint(with: lowered) {
+            return ".git + code"
+        }
+
+        // Dataset: ≥100 files of one extension, ≥90% homogeneous, ≥80% machine-generated names.
+        // Skipped ENTIRELY (decision June 10) — a sampled dataset still pollutes the vault.
+        if exts.count >= 100 {
+            var counts: [String: Int] = [:]
+            for e in exts { counts[e, default: 0] += 1 }
+            if let top = counts.max(by: { $0.value < $1.value }),
+               top.value >= 100, top.value * 10 >= exts.count * 9 {
+                let members = listing.filter { ($0 as NSString).pathExtension.lowercased() == top.key }
+                let machine = members.count(where: { isDatasetName($0) })
+                if machine * 5 >= members.count * 4 { return "dataset: \(top.value)×.\(top.key)" }
+            }
+        }
+        return nil
+    }
+
+    /// Machine-generated filename (pure numbers, sequential frames/chunks, hashes, UUIDs) — the
+    /// signature of a dataset, not a life. Screenshots & camera rolls are deliberately exempt
+    /// (personal gold; the per-directory cap bounds their volume instead — decision June 10).
+    private static func isDatasetName(_ name: String) -> Bool {
+        let base = (name as NSString).deletingPathExtension.lowercased()
+        if base.hasPrefix("screenshot") || base.hasPrefix("screen shot")
+            || base.hasPrefix("cleanshot") || base.hasPrefix("img_") || base.hasPrefix("dsc") {
+            return false
+        }
+        let patterns = [
+            #"^\d+$"#,                                        // 000123
+            #"^[a-z]+[-_ ]?\d{3,}$"#,                         // frame_0001 · part-00042 · chunk12345
+            #"^[0-9a-f]{12,}$"#,                              // content hashes
+            #"^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$"#,  // UUIDs
+        ]
+        return patterns.contains { base.range(of: $0, options: .regularExpression) != nil }
     }
 
     // MARK: Scan (cheap — stat only, recurses subfolders)
@@ -76,7 +160,7 @@ struct FilesSource: DataSource, Sendable {
             // Prune at the WALK level: skipDescendants() means nothing inside is ever yielded,
             // so it never becomes a Candidate / hits the ledger / sees inference.
             if vals?.isDirectory == true {
-                if Self.shouldPrune(url) { enumerator.skipDescendants() }
+                if Self.pruneReason(url) != nil { enumerator.skipDescendants() }
                 continue   // directories are never candidates themselves
             }
 
@@ -99,8 +183,23 @@ struct FilesSource: DataSource, Sendable {
             let candidate = Candidate(id: "file:\(url.path)", kind: .file, signature: signature, metadata: meta)
             rows.append((candidate, created?.timeIntervalSince1970 ?? mtime))
         }
-        // Newest first — nicer for incremental runs + manual testing.
-        return rows.sorted { $0.sortKey > $1.sortKey }.map(\.candidate)
+        // Newest first, then the caps (connector-limits decision, June 10):
+        //  • optional age cutoff (Downloads: 1 year — downloads age into junk; keepers elsewhere don't)
+        //  • per-directory cap (Downloads 100 / others 300) — the bulk-dump backstop
+        //  • per-root cap (newest 1,000, every root)
+        let cutoff = maxAge.map { Date().timeIntervalSince1970 - $0 }
+        var perDir: [String: Int] = [:]
+        var kept: [Candidate] = []
+        for row in rows.sorted(by: { $0.sortKey > $1.sortKey }) {
+            if kept.count >= Self.perRootCap { break }
+            if let cutoff, row.sortKey < cutoff { break }   // sorted → every later row is older
+            guard let path = row.candidate.metadata["path"] else { continue }
+            let dir = (path as NSString).deletingLastPathComponent
+            if perDir[dir, default: 0] >= perDirectoryCap { continue }
+            perDir[dir, default: 0] += 1
+            kept.append(row.candidate)
+        }
+        return kept
     }
 
     // MARK: Load (expensive — extract content)
@@ -232,6 +331,16 @@ enum FileRoot: Hashable, Identifiable {
         case .documents:        return "Documents"
         case .custom(let url):  return url.lastPathComponent
         }
+    }
+
+    /// Connector limits (decision June 10): Downloads is the junk accumulator — tighter caps,
+    /// plus a 1-year age cutoff (old downloads are noise; old Desktop/Documents files can be keepers).
+    var perDirectoryCap: Int { self == .downloads ? 100 : 300 }
+    var maxAge: TimeInterval? { self == .downloads ? 365 * 24 * 3_600 : nil }
+
+    /// The fully configured source for this root (nil if the system folder can't be resolved).
+    var source: FilesSource? {
+        url.map { FilesSource(root: $0, label: label, perDirectoryCap: perDirectoryCap, maxAge: maxAge) }
     }
 
     /// The three standard folders, in display order.

--- a/Sentient OS macOS/Sources/FilesSource.swift
+++ b/Sentient OS macOS/Sources/FilesSource.swift
@@ -55,9 +55,7 @@ struct FilesSource: DataSource, Sendable {
         "site-packages", "dataset", "datasets", "corpus", "checkpoints",
     ]
 
-    /// Hard "this is a code project" manifests — if present, skip the WHOLE folder. Deliberately
-    /// NOT `.git` alone: Obsidian vaults & personal note repos are git repos full of markdown we
-    /// WANT (`.git` only prunes alongside code signals — see `pruneReason`).
+    /// Hard "this is a code project" manifests — if present, skip the WHOLE folder.
     private static let projectManifests: Set<String> = [
         "package.json", "Cargo.toml", "go.mod", "Package.swift", "pom.xml",
         "build.gradle", "build.gradle.kts", "composer.json", "Gemfile",
@@ -73,11 +71,6 @@ struct FilesSource: DataSource, Sendable {
         "dart", "vue", "svelte", "sql", "pl", "r",
     ]
 
-    /// Classic code-project directory names — with `.git` present, any of these confirms "repo".
-    private static let codeDirNames: Set<String> = [
-        "src", "lib", "tests", "test", "spec", "include", "cmd", "pkg", "sources", "bin",
-    ]
-
     /// Why this directory's whole subtree is skipped — nil means walk in. Reads the directory
     /// listing ONCE and runs every check against it. `.app`/`.xcodeproj` bundle *descendants* +
     /// hidden dirs are already excluded by the enumerator options; this prunes at the parent.
@@ -90,7 +83,13 @@ struct FilesSource: DataSource, Sendable {
         guard let listing = try? FileManager.default.contentsOfDirectory(atPath: dir.path) else { return nil }
         let names = Set(listing)
         if names.contains(".metadata_never_index") { return "never-index marker" }
-        if names.contains(".obsidian") { return nil }   // Obsidian vault — always keep, no further checks
+        // Obsidian/Logseq vaults — always keep, no further checks (even git-synced ones).
+        if names.contains(".obsidian") || names.contains("logseq") { return nil }
+
+        // Any other git repo is a code project (decision June 11 — surveyed 38 repos across the
+        // standard folders: zero were notes). The 1% who git-sync a plain markdown journal have a
+        // working escape hatch: explicitly added roots are never themselves prune-checked.
+        if names.contains(".git") { return ".git" }
 
         if let manifest = projectManifests.first(where: { names.contains($0) }) { return "manifest: \(manifest)" }
         if let bundle = listing.first(where: { $0.hasSuffix(".xcodeproj") || $0.hasSuffix(".sln") }) {
@@ -104,12 +103,6 @@ struct FilesSource: DataSource, Sendable {
         }
         let codeCount = exts.count(where: { codeExtensions.contains($0) })
         if exts.count >= 10, codeCount * 2 >= exts.count { return "code-density \(codeCount)/\(exts.count)" }
-
-        // Bare repo: .git + any code file or a classic code dir (markdown-only git repos pass).
-        let lowered = Set(listing.map { $0.lowercased() })
-        if names.contains(".git"), codeCount > 0 || !codeDirNames.isDisjoint(with: lowered) {
-            return ".git + code"
-        }
 
         // Dataset: ≥100 files of one extension, ≥90% homogeneous, ≥80% machine-generated names.
         // Skipped ENTIRELY (decision June 10) — a sampled dataset still pollutes the vault.

--- a/Sentient OS macOS/Sources/FilesSource.swift
+++ b/Sentient OS macOS/Sources/FilesSource.swift
@@ -14,7 +14,7 @@
 //
 //  Skipping & caps (see Documentation/Files Source (Skipping & Caps).md): code repos and
 //  machine-generated datasets are pruned at the walk level (`pruneReason`), and `scan` bounds
-//  every run — newest 1,000 per root, 100/300 per directory, 1-year age cutoff for Downloads.
+//  every run — newest 1,000 per root, 300 per directory, 1-year age cutoff for Downloads.
 //
 
 import Foundation
@@ -176,9 +176,9 @@ struct FilesSource: DataSource, Sendable {
             let candidate = Candidate(id: "file:\(url.path)", kind: .file, signature: signature, metadata: meta)
             rows.append((candidate, created?.timeIntervalSince1970 ?? mtime))
         }
-        // Newest first, then the caps (connector-limits decision, June 10):
+        // Newest first, then the caps (connector-limits decision, June 10–11):
         //  • optional age cutoff (Downloads: 1 year — downloads age into junk; keepers elsewhere don't)
-        //  • per-directory cap (Downloads 100 / others 300) — the bulk-dump backstop
+        //  • per-directory cap (300, every root) — the bulk-dump backstop
         //  • per-root cap (newest 1,000, every root)
         let cutoff = maxAge.map { Date().timeIntervalSince1970 - $0 }
         var perDir: [String: Int] = [:]
@@ -326,14 +326,14 @@ enum FileRoot: Hashable, Identifiable {
         }
     }
 
-    /// Connector limits (decision June 10): Downloads is the junk accumulator — tighter caps,
-    /// plus a 1-year age cutoff (old downloads are noise; old Desktop/Documents files can be keepers).
-    var perDirectoryCap: Int { self == .downloads ? 100 : 300 }
+    /// Connector limits (June 10–11): 1,000/root + 300/dir everywhere (the FilesSource defaults);
+    /// Downloads additionally gets a 1-year age cutoff (old downloads are noise; old
+    /// Desktop/Documents files can be keepers).
     var maxAge: TimeInterval? { self == .downloads ? 365 * 24 * 3_600 : nil }
 
     /// The fully configured source for this root (nil if the system folder can't be resolved).
     var source: FilesSource? {
-        url.map { FilesSource(root: $0, label: label, perDirectoryCap: perDirectoryCap, maxAge: maxAge) }
+        url.map { FilesSource(root: $0, label: label, maxAge: maxAge) }
     }
 
     /// The three standard folders, in display order.

--- a/Sentient OS macOS/Views/ProcessingView.swift
+++ b/Sentient OS macOS/Views/ProcessingView.swift
@@ -305,8 +305,8 @@ struct ProcessingView: View {
 
                 switch src {
                 case .files(let root):
-                    guard let url = root.url else { continue }
-                    try await runPass(FilesSource(root: url, label: root.label), pipeline: pipeline)
+                    guard let source = root.source else { continue }
+                    try await runPass(source, pipeline: pipeline)
                 case .whatsapp(let jids):
                     try await runPass(WhatsAppSource(chatJIDs: jids), pipeline: pipeline)
                 case .imessage(let guids):


### PR DESCRIPTION
## What

The `[Aryaman] significantly improve code/dataset skipping (self test)` task. All decisions locked with Aryaman June 10–11 (screenshots exempt + bounded by caps · datasets skipped entirely, no sampling · 1,000/root everywhere · 300/dir (Downloads raised from 100 after the waterfall review) · **.git = prune, period**).

### Pruning — `FilesSource.pruneReason` (one listing-read per dir, walk-level skip)
- **Vault exemption first**: `.obsidian` or `logseq` present → never prune (even git-synced vaults, even with a stray `package.json`)
- **`.git` → prune, period** (June 11): surveyed all 38 git repos across the standard folders on a real Mac — zero were notes repos. Escape hatch by construction: explicitly-added custom roots are never themselves prune-checked, so a git-synced markdown journal can be added as its own source folder
- Expanded manifests: `Makefile`, `CMakeLists.txt`, `mix.exs`, `deno.json`, `build.sbt` + the originals
- `*.xcodeproj` / `*.sln` project bundles
- **Code-density**: ≥10 extensioned entries, majority source code → prune (catches manifest-less script folders)
- **Dataset rule** (new concept): ≥100 same-extension files, ≥90% homogeneous, ≥80% machine-named (`chunk_0001`, hashes, UUIDs) → skipped entirely; screenshot/camera names exempt

### Caps (newest-first, in `scan()`)
- 1,000 per root (every root) · 300/dir every root · 1-year age cutoff Downloads-only
- `FileRoot.source` builds the configured source; both call sites migrated

### Self-test (no model needed)
- `SENTIENT_SELFTEST=skipping` — synthetic fixture tree, **17 assertions, all green**
- `SENTIENT_SELFTEST=skipcensus` — read-only real-Mac report (every pruned dir + reason, top contributors): the threshold-tuning tool

## Receipts (census on Aryaman's Mac)
- Downloads: **218 subtrees pruned** (a real ML dataset — `BOLD_public`, 178 dataset hits — plus manifest repos) → bounded to **324 candidates** (waterfall: 21,364 raw → 5,286 after pruning → 551 after the 1-yr cutoff → 324 after caps)
- Desktop: `screenshots/` capped at exactly 300; after the .git rule, contributing dirs dropped 17 → 13 (stray repo READMEs gone; 26 subtrees caught by `.git` alone)
- Documents: Obsidian vault fully kept (0 false prunes)

Doc: `Documentation/Files Source (Skipping & Caps).md`. Arch file 2 §4 updated in the team vault.