### PR TITLE
Chat window byte budget 5k → 12k (measured: chat is ~2.4 bytes/token)

### DIFF
--- a/Sentient OS macOS/Engine.swift
+++ b/Sentient OS macOS/Engine.swift
@@ -21,9 +21,15 @@ import LiteRTLM
 actor Engine {
 
     /// Result of a single generation. Sendable so it can hop back to the MainActor.
+    /// Token stats are populated only when the engine was created with `collectStats: true`
+    /// (LiteRT-LM benchmark instrumentation; prefillTokens = the EXACT tokenized prompt size).
     struct Result: Sendable {
         let text: String
         let totalTime: TimeInterval
+        var prefillTokens: Int? = nil
+        var decodeTokens: Int? = nil
+        var prefillTokensPerSecond: Double? = nil
+        var decodeTokensPerSecond: Double? = nil
     }
 
     enum EngineError: Error, CustomStringConvertible {
@@ -40,11 +46,16 @@ actor Engine {
 
     private let modelPath: String
     private let maxNumTokens: Int
+    private let collectStats: Bool
     private var native: LiteRTLM.Engine?
 
-    init(modelPath: String, maxNumTokens: Int = 4096) {
+    /// `collectStats` turns on LiteRT-LM's benchmark instrumentation (must be decided before
+    /// `load()`) so every `Result` carries exact prefill/decode token counts — used by the
+    /// token-budget self-test; leave off in production.
+    init(modelPath: String, maxNumTokens: Int = 4096, collectStats: Bool = false) {
         self.modelPath = modelPath
         self.maxNumTokens = maxNumTokens
+        self.collectStats = collectStats
     }
 
     var isLoaded: Bool { native != nil }
@@ -58,6 +69,7 @@ actor Engine {
         ExperimentalFlags.optIntoExperimentalAPIs()
         ExperimentalFlags.enableSpeculativeDecoding = true   // MTP — Gemma 4 draft heads baked in (~2-3× decode)
         ExperimentalFlags.visualTokenBudget = 560            // Gemma 4 vision detail tier (70/140/280/560/1120)
+        ExperimentalFlags.enableBenchmark = collectStats     // token-count instrumentation (self-test only)
 
         let config = try EngineConfig(
             modelPath: modelPath,
@@ -113,7 +125,14 @@ actor Engine {
 
         let start = Date()
         let response = try await conversation.sendMessage(Message(contents: contents))
-        return Result(text: response.toString, totalTime: Date().timeIntervalSince(start))
+        var result = Result(text: response.toString, totalTime: Date().timeIntervalSince(start))
+        if collectStats, let info = try? conversation.getBenchmarkInfo() {
+            result.prefillTokens = info.lastPrefillTokenCount
+            result.decodeTokens = info.lastDecodeTokenCount
+            result.prefillTokensPerSecond = info.lastPrefillTokensPerSecond
+            result.decodeTokensPerSecond = info.lastDecodeTokensPerSecond
+        }
+        return result
     }
 
     /// Writable scratch dir for LiteRT-LM's shader/compilation cache.

--- a/Sentient OS macOS/Self Tests - Temp/SelfTest_Triage_Pipeline_and_Vault.swift
+++ b/Sentient OS macOS/Self Tests - Temp/SelfTest_Triage_Pipeline_and_Vault.swift
@@ -15,6 +15,7 @@
 //    SENTIENT_SELFTEST=whatsapp "<app>/Contents/MacOS/Sentient OS macOS"
 //  Env knobs:
 //    SENTIENT_SELFTEST     "whatsapp" | "imessage" | "notes" | "files"  (model dump) ·
+//                          "tokens"  (WhatsApp window token-cost measurement, model) ·
 //                          "parse" | "chats" | "imchats" | "imdecode" | "notesdecode" | "claudecli"
 //                          | "vault" | "skipping" | "skipcensus"  (no model)
 //    SENTIENT_SELFTEST_N   item count (default 6)
@@ -273,6 +274,106 @@ enum SelfTest {
             let matched = all.filter { c in want.contains { c.name.lowercased().contains($0) } }
             emit("chat filter → \(matched.count) matched: \(matched.map(\.name).joined(separator: " · "))\n")
             return Set(matched.map(\.id))
+        }
+
+        // Token-budget calibration (mode "tokens"): REAL WhatsApp windows through the REAL chat
+        // prompts on the REAL engine, with LiteRT-LM's benchmark instrumentation reporting the
+        // EXACT prefill token count per window. Answers "how many tokens does a full window
+        // actually cost?" — the datum behind ChatWindowing.maxWindowBytes. Two synthetic
+        // empty-window runs first isolate the fixed prompt-template overhead per flavour, so we
+        // can report a pure conversation-bytes → conversation-tokens ratio. STATS ONLY in the
+        // log — chat names + sizes, never message content.
+        if mode == "tokens" {
+            let source = WhatsAppSource(chatJIDs: chatFilter((try? WhatsAppSource().listChats()) ?? []))
+            let candidates: [Candidate]
+            do { candidates = try source.scan(since: nil) }
+            catch { emit("scan FAILED: \(error)"); return }
+            emit("windows in backlog: \(candidates.count) · current byte budget: \(ChatWindowing.maxWindowBytes)\n")
+            guard !candidates.isEmpty else { return }
+
+            let engine = Engine(modelPath: modelPath, maxNumTokens: 16384, collectStats: true)
+            do { try await engine.load() }
+            catch { emit("engine load FAILED: \(error)"); return }
+
+            // Fixed template overhead per prompt flavour (instructions + chat scaffolding, zero
+            // conversation bytes). Window tokens = prefill − overhead[flavour].
+            var overhead: [String: Int] = [:]
+            for flavour in ["0", "1"] {
+                let cand = Candidate(id: "calibration", kind: .whatsapp, signature: "0",
+                                     metadata: ["isGroup": flavour, "windowText": ""])
+                let prompt = Triage.prompt(for: Artifact(candidate: cand, text: ""), currentDate: Date())
+                do {
+                    let r = try await engine.generate(prompt: prompt)
+                    overhead[flavour] = r.prefillTokens
+                    emit("template overhead \(flavour == "1" ? "(group)" : "(DM)   "): \(r.prefillTokens.map(String.init) ?? "??") tokens · \(prompt.utf8.count) prompt bytes")
+                } catch { emit("calibration \(flavour) FAILED: \(error)") }
+            }
+            emit("")
+
+            // Even-stride sample across the whole backlog → a mix of chats, ages, and languages.
+            // (count == 6 is the harness default — treat it as "unset" and take a bigger sample.)
+            let n = min(count == 6 ? 24 : count, candidates.count)
+            let step = max(1, candidates.count / n)
+            let sample = (0..<n).map { candidates[min($0 * step, candidates.count - 1)] }
+
+            struct Row { let winBytes, winTokens, prefill, decode: Int
+                         let ratio, pTPS, dTPS, secs: Double }
+            var rows: [Row] = []
+            func pad(_ s: String, _ w: Int) -> String {
+                s.count >= w ? s : s.padding(toLength: w, withPad: " ", startingAt: 0)
+            }
+            emit(pad("chat", 26) + " msgs   bytes  prefill  win-tok  B/tok  decode")
+            for (i, cand) in sample.enumerated() {
+                do {
+                    let artifact = try source.load(cand)
+                    let prompt = Triage.prompt(for: artifact, currentDate: Date())
+                    let r = try await engine.generate(prompt: prompt)
+                    guard let prefill = r.prefillTokens, prefill > 0 else {
+                        emit("ITEM \(i + 1): no benchmark info — skipped"); continue
+                    }
+                    let winBytes = (cand.metadata["windowText"] ?? "").utf8.count
+                    let winTokens = max(1, prefill - (overhead[cand.metadata["isGroup"] ?? "0"] ?? 0))
+                    let row = Row(winBytes: winBytes, winTokens: winTokens, prefill: prefill,
+                                  decode: r.decodeTokens ?? 0,
+                                  ratio: Double(winBytes) / Double(winTokens),
+                                  pTPS: r.prefillTokensPerSecond ?? 0,
+                                  dTPS: r.decodeTokensPerSecond ?? 0, secs: r.totalTime)
+                    rows.append(row)
+                    let name = String((cand.metadata["name"] ?? "?").prefix(21))
+                        + (cand.metadata["isGroup"] == "1" ? " [g]" : "")
+                    emit(pad(name, 26)
+                         + String(format: " %4d %7d %8d %8d %6.2f %7d",
+                                  Int(cand.signature) ?? 0, winBytes, prefill, winTokens, row.ratio, row.decode))
+                } catch { emit("ITEM \(i + 1) FAILED: \(error)") }
+            }
+            await engine.unload()
+            guard !rows.isEmpty else { emit("no measurements."); return }
+
+            func med(_ v: [Double]) -> Double { let s = v.sorted(); return s[s.count / 2] }
+            let ratios = rows.map(\.ratio)
+            let minR = ratios.min()!, medR = med(ratios), maxR = ratios.max()!
+            let meanFill = rows.map { Double($0.prefill) }.reduce(0, +) / Double(rows.count)
+            let meanDecode = rows.map { Double($0.decode) }.reduce(0, +) / Double(rows.count)
+            let meanSecs = rows.map(\.secs).reduce(0, +) / Double(rows.count)
+            emit("""
+
+            ===== AGGREGATE (\(rows.count) windows) =====
+            conversation bytes/token   min \(String(format: "%.2f", minR)) · median \(String(format: "%.2f", medR)) · max \(String(format: "%.2f", maxR))
+            mean prefill               \(Int(meanFill)) tokens (\(String(format: "%.1f", 100 * meanFill / 16_384))% of the 16,384 context)
+            mean decode                \(Int(meanDecode)) tokens · mean wall-clock \(String(format: "%.1f", meanSecs))s/window
+            mean prefill / decode toks-per-sec   \(Int(rows.map(\.pTPS).reduce(0, +) / Double(rows.count))) · \(Int(rows.map(\.dTPS).reduce(0, +) / Double(rows.count)))
+
+            ===== WHAT-IF byte budgets (worst-case = min ratio, expected = median) =====
+            """)
+            let groupOverhead = Double(overhead["1"] ?? 0)
+            for budget in [5_000, 10_000, 15_000, 20_000, 25_000, 30_000] {
+                let worst = Double(budget) / minR + groupOverhead
+                let typical = Double(budget) / medR + groupOverhead
+                emit(String(format: "  %6d bytes → prefill ~%5.0f typical · ~%5.0f worst-case  (%4.1f%% / %4.1f%% of 16,384)",
+                            budget, typical, worst, 100 * typical / 16_384, 100 * worst / 16_384))
+            }
+            emit("\n# done → \(outPath)")
+            return
         }
 
         // 1) Build the source + scan candidates.

--- a/Sentient OS macOS/Sources/ChatWindowing.swift
+++ b/Sentient OS macOS/Sources/ChatWindowing.swift
@@ -47,9 +47,16 @@ enum ChatWindowing {
     // byte-level tokenizer emits at most ONE token per byte, so bytes are a HARD upper bound on
     // tokens — a window can never overflow the model's token budget, even for emoji / CJK /
     // multilingual chats where characters wildly under-count tokens. (That mismatch is what made
-    // the model "go quiet": a 26k-char window tokenized to 18.6k tokens, >2× the 8,192 budget.)
-    // ~5,000 bytes ⇒ ≤ ~5k tokens, leaving comfortable room for the prompt + reply inside 8,192.
-    static let maxWindowBytes = 5_000
+    // the model "go quiet": a 26k-char window tokenized to 18.6k tokens, >2× an 8,192 budget.)
+    //
+    // 12,000 is sized from measurement (June 11 `tokens` self-test, 24 real windows across 14
+    // chats): real chat runs ~2.4 bytes/token (min 2.05), so a full window is ~5k tokens typical
+    // — and even the adversarial worst case (1 token/byte) fits the chat engine's 16,384
+    // maxNumTokens with room for the group prompt template (1,567 tokens measured) + reply.
+    // The old 5,000 left ~83% of the context empty and paid that fixed template cost once per
+    // ~30 messages. Quality, not token math, is the gate on raising this further — more
+    // speakers per window = more attribution risk for a 4B judge.
+    static let maxWindowBytes = 12_000
     static let maxMessageChars = 1_000     // cap a single pasted-essay message so it can't dominate a window
 
     /// The 90-day floor as a Date (sources convert to their own epoch/units for SQL).


### PR DESCRIPTION
## Why

The 5,000-byte window budget was priced for the worst case (1 byte = 1 token). Real chat never gets close. Measured with exact tokenizer counts (LiteRT-LM benchmark API) on 24 real WhatsApp windows across 14 chats — DMs, groups, emoji-heavy, multilingual:

| Measurement | Value |
|---|---|
| Conversation bytes/token | min **2.05** · median **2.43** · max 3.49 |
| DM template overhead | **979 tokens** fixed per window |
| Group template overhead | **1,567 tokens** fixed per window |
| Mean prefill at the old budget | **2,836 tokens = 17.3%** of the 16,384 context |

So ~83% of every chat context was empty, and a full 5k group window spent **~52% of its prefill on the instruction template** — we paid the attribution sermon once per ~30 messages.

## What

- `ChatWindowing.maxWindowBytes` **5,000 → 12,000**. The math guarantee survives: even adversarial 1-token/byte content fits — 12,000 + 1,567 (group template) + reply < 16,384. Typical full window now ~5k conversation tokens (~40% fill), window count drops ~2.4×, and downstream Stage-2 sees ~2.4× fewer chat summaries.
- Fixed the stale `8,192` context reference in the same comment (chat engine runs 16,384, `ProcessingView.swift:292`).
- `Engine`: opt-in `collectStats` — `Result` gains exact prefill/decode token counts + tok/s from LiteRT-LM's benchmark instrumentation. Default off; zero change to production paths.
- New harness mode `SENTIENT_SELFTEST=tokens`: self-calibrates template overhead (empty-window runs per prompt flavour), measures real windows, prints ratio aggregates + a what-if budget table. Stats only — no message content in the log.

## Why not higher (25k would fit typical-case)

Beyond ~13k bytes the hard guarantee gives way to empirical-ratio reliance, and more importantly the gate is **quality, not token math**: more speakers per window = more attribution risk for the 4B judge (the known AMA-bio weak spot gets worse with size). Next step if we want more: eyeball a `SENTIENT_SELFTEST=whatsapp` dump at 12k for verdict quality before pushing further.

## Verify

```bash
SENTIENT_SELFTEST=tokens "<DerivedData>/Debug/Sentient OS.app/Contents/MacOS/Sentient OS"
```

Built clean via `xcodebuild` (Debug). NOTE for reviewer: don't re-run the tokens mode while a real processing batch is running — it loads a second engine instance onto the GPU.