### PR TITLE
Log() tee helper — codebase-wide print() replacement

### DIFF
--- a/Sentient OS macOS/Log.swift
+++ b/Sentient OS macOS/Log.swift
@@ -1,0 +1,51 @@
+//
+//  Log.swift
+//  Sentient OS macOS
+//
+//  Log() — the codebase-wide replacement for print() (bare print is a code smell;
+//  Dev Notes §Eval culture). Prints to stdout/Xcode console as usual and, in DEBUG
+//  builds only, tees a timestamped copy to /tmp/sentient-dev.log (append-mode, one
+//  banner per launch) so agents can `tail -f` a GUI-run session live. Release builds
+//  never write the file.
+//
+
+import Foundation
+
+/// Drop-in for `print()`: same signature, same console output, plus the DEBUG file tee.
+func Log(_ items: Any..., separator: String = " ", terminator: String = "\n") {
+    let message = items.map { String(describing: $0) }.joined(separator: separator)
+    print(message, terminator: terminator)
+    #if DEBUG
+    LogFile.shared.append(message)
+    #endif
+}
+
+#if DEBUG
+/// Serial appender for /tmp/sentient-dev.log. All writes funnel through one queue,
+/// so calls are safe from any thread or actor.
+private final class LogFile: @unchecked Sendable {
+    static let shared = LogFile()
+    private let queue = DispatchQueue(label: "sentientos.logfile")
+    private let handle: FileHandle?
+    private let clock: DateFormatter
+
+    private init() {
+        let path = "/tmp/sentient-dev.log"
+        if !FileManager.default.fileExists(atPath: path) {
+            FileManager.default.createFile(atPath: path, contents: nil)
+        }
+        handle = FileHandle(forWritingAtPath: path)
+        handle?.seekToEndOfFile()
+        clock = DateFormatter()
+        clock.dateFormat = "HH:mm:ss.SSS"
+        let banner = "\n=== \(ProcessInfo.processInfo.processName) launched \(Date()) (pid \(ProcessInfo.processInfo.processIdentifier)) ===\n"
+        handle?.write(Data(banner.utf8))
+    }
+
+    func append(_ message: String) {
+        queue.async { [self] in
+            handle?.write(Data("[\(clock.string(from: Date()))] \(message)\n".utf8))
+        }
+    }
+}
+#endif

--- a/Sentient OS macOS/Pipeline.swift
+++ b/Sentient OS macOS/Pipeline.swift
@@ -91,7 +91,7 @@ actor Pipeline {
                 )
                 let outcome = Triage.decide(result.text)
                 #if DEBUG
-                print("• \(cand.metadata["displayPath"] ?? cand.id)\n  → \(outcome.verdict) | \(result.text.replacingOccurrences(of: "\n", with: " "))")
+                Log("• \(cand.metadata["displayPath"] ?? cand.id)\n  → \(outcome.verdict) | \(result.text.replacingOccurrences(of: "\n", with: " "))")
                 #endif
                 try await store.save(artifact: artifact, verdict: outcome.verdict, summary: outcome.draft)
 
@@ -116,7 +116,7 @@ actor Pipeline {
                 if consecutiveFailures >= failuresBeforeReload {
                     guard reloadsWithoutProgress < maxReloadsWithoutProgress else {
                         #if DEBUG
-                        print("⛔️ Engine not recovering after \(reloadsWithoutProgress) reloads — stopping this pass.")
+                        Log("⛔️ Engine not recovering after \(reloadsWithoutProgress) reloads — stopping this pass.")
                         #endif
                         break   // reloading isn't helping — stop hammering a dead engine
                     }

--- a/Sentient OS macOS/Self Tests - Temp/SelfTest_Triage_Pipeline_and_Vault.swift
+++ b/Sentient OS macOS/Self Tests - Temp/SelfTest_Triage_Pipeline_and_Vault.swift
@@ -245,8 +245,8 @@ enum SelfTest {
                 let gen = VaultGenerator()
                 let onP: @Sendable (VaultGenerator.Progress) -> Void = { p in
                     switch p {
-                    case .receiving(let c): if c % 15_000 < 1_600 { print("  …received \(c) chars") }
-                    case .writing(let n):   print("  …\(n) notes written")
+                    case .receiving(let c): if c % 15_000 < 1_600 { Log("  …received \(c) chars") }
+                    case .writing(let n):   Log("  …\(n) notes written")
                     default: break
                     }
                 }

--- a/Sentient OS macOS/VaultGenerator.swift
+++ b/Sentient OS macOS/VaultGenerator.swift
@@ -95,7 +95,7 @@ actor VaultGenerator {
             return try await generateAgentic(summaries: summaries, resume: nil, onProgress: onProgress)
         }
         #if DEBUG
-        print("VaultGenerator: Claude Code unavailable → direct-API fallback")
+        Log("VaultGenerator: Claude Code unavailable → direct-API fallback")
         #endif
         return try await generateDirect(summaries: summaries, effort: effort,
                                         maxTokens: maxTokens, onProgress: onProgress)


### PR DESCRIPTION
## What
Implements the `Log()` tee helper from the TODO (Phase: small things, claimed by Jesai).

- **`Log.swift`** — global `Log(_ items: Any..., separator:terminator:)` mirroring `print()`'s exact signature, so swaps are mechanical. Always prints to stdout/Xcode console; in **DEBUG builds only** it also appends a timestamped line to `/tmp/sentient-dev.log` through a serial queue (thread/actor-safe). Append mode + a per-launch run banner, so `tail -f` survives relaunches. Release builds never touch the file.
- Swapped all 5 existing bare `print()` sites: `Pipeline.swift` ×2, `VaultGenerator.swift` ×1, `SelfTest_Triage_Pipeline_and_Vault.swift` ×2. Existing `#if DEBUG` wrappers around call sites preserved — Release output behavior is unchanged.

## Why
Claudes can now `tail -f /tmp/sentient-dev.log` while a human clicks around a GUI-run session — no more console copy-paste. Also gives the upcoming scheduler/updater/proactive work a day-one logging home ("what did the scheduler do at 11 PM?" is now answerable next morning).

## Notes
- The log file contains **only our own `Log()` lines** — no framework/Metal/LiteRT chatter.
- Bare `print()` is now a code smell per Dev Notes; the context docs (files 3 + 4) were updated in the team vault alongside this PR.

## Testing
- Full Debug build green via `xcodebuild` (same DerivedData as the GUI build).