### PR TITLE
Kill the Ledger (pointers everywhere) + the Living System

### DIFF
--- a/Sentient OS macOS/DaysEndJob.swift
+++ b/Sentient OS macOS/DaysEndJob.swift
@@ -1,0 +1,89 @@
+//
+//  DaysEndJob.swift
+//  Sentient OS macOS
+//
+//  THE day's-end entry point (Part II §A) — the one function the whole living system hangs
+//  off: editor-idle check → iterative updater → proactive intelligence → mirror push →
+//  notification. Idempotent and safe to re-invoke (an empty unsynced queue is a cheap no-op);
+//  single-flight (a trigger while running is ignored).
+//
+//  TRIGGERS: today, only the dev "Run Proactive Intelligence" button in RootView (it fires
+//  this WHOLE pipeline, not just the judge). The condition-gate scheduler (Phase 3,
+//  deliberately NOT built yet) will simply call `DaysEndJob.shared.run(...)` on its own
+//  clock — no logic lives in the button that the scheduler would need to duplicate.
+//
+//  Doc: Documentation/Days-End Job (Living System).md
+//
+
+import Foundation
+
+actor DaysEndJob {
+
+    static let shared = DaysEndJob()
+
+    /// Single-flight: an actor bool, not a queue (per the handoff — no bookkeeping).
+    private var running = false
+
+    /// The full day's-end pipeline. Returns a one-line status for the dev button / logs.
+    @discardableResult
+    func run(store: Store) async -> String {
+        guard !running else { return "Already running — trigger ignored." }
+        running = true
+        defer { running = false }
+
+        // Editor-idle guard: never block/wait — skip and let the next trigger retry.
+        if await VaultActivity.shared.editorBusy {
+            return "Vault editor is busy — skipped (next trigger retries)."
+        }
+
+        var parts: [String] = []
+
+        // 1) The iterative updater (the heart). A usage limit keeps its session for resume;
+        //    any other failure restored the vault snapshot — either way the unstamped rows
+        //    re-enter the queue and the run continues to the push step (vaultDirty may still
+        //    be set from an earlier change).
+        var folded = 0
+        do {
+            folded = try await VaultUpdater.shared.runDailyUpdate(store: store)
+            parts.append(folded == 0 ? "nothing new to fold" : "folded \(folded) memories")
+        } catch {
+            parts.append((error as? LocalizedError)?.errorDescription ?? "\(error)")
+        }
+
+        // 2) Proactive intelligence — wrapped independently inside `run`; never blocks the push.
+        let proactive = await Proactive.run(store: store)
+        if proactive.judged > 0 {
+            parts.append("judged \(proactive.judged) flagged"
+                         + (proactive.reminders > 0 ? " → 1 reminder" : "")
+                         + (proactive.briefings > 0 ? " → 1 briefing" : ""))
+        }
+        if let note = proactive.note { parts.append(note) }
+
+        // 3) Mirror push — any run that ends with a dirty vault and the mirror enabled.
+        parts.append(await pushIfDirty())
+
+        // 4) Quiet by design: notify only when the vault actually changed.
+        if folded > 0 {
+            await Notify.now(title: "Your knowledge base is up to date",
+                             body: "Folded \(folded) new \(folded == 1 ? "memory" : "memories") in while your Mac rested.")
+        }
+        let status = "Done — " + parts.joined(separator: " · ")
+        Log("DaysEndJob: \(status)")
+        return status
+    }
+
+    /// The push rule (Part II §C): vaultDirty + mirror enabled → push; clear the flag ONLY on
+    /// success (a transient network failure keeps it set for the next run). Also called after
+    /// initial generation — the auto-push wiring file 2 §7 flagged as missing.
+    func pushIfDirty() async -> String {
+        guard await VaultActivity.shared.vaultDirty else { return "mirror: nothing to push" }
+        guard await MirrorClient.shared.isEnabled else { return "mirror: off" }
+        do {
+            try await MirrorClient.shared.push()
+            await MainActor.run { VaultActivity.shared.vaultDirty = false }
+            return "mirror: pushed ✓"
+        } catch {
+            return "mirror: push failed (\((error as? LocalizedError)?.errorDescription ?? "\(error)")) — will retry next run"
+        }
+    }
+}

--- a/Sentient OS macOS/Documentation/Days-End Job (Living System).md
+++ b/Sentient OS macOS/Documentation/Days-End Job (Living System).md
@@ -1,0 +1,75 @@
+# The Day's-End Job — the Living System (June 11)
+
+Everything that makes Sentient *sentient*, behind ONE entry point: `DaysEndJob.shared.run(store:)`.
+Pipeline: editor-idle check → iterative updater → proactive intelligence → mirror push →
+notification. Idempotent (empty queue = cheap no-op), single-flight (an actor bool; re-triggers
+while running are ignored).
+
+**Trigger:** the "Run Proactive Intelligence" dev button in RootView's DEV CONTROLS (it fires
+the whole day's-end pipeline, not just the judge) — deliberately the ONLY trigger until the
+condition-gate scheduler lands. The scheduler will simply call the same function on its own
+clock; no logic lives in the button.
+
+## The iterative updater (`VaultUpdater`)
+
+- **Queue:** every `Summary` with `syncedToVault == nil`, oldest first, carried with
+  `PersistentIdentifier`s — summaries are versioned, so we stamp the EXACT rows we sent, never
+  "by sourceID". The queue self-populates (rows are born unsynced) and self-heals (failed jobs
+  stamp nothing; rows simply re-enter).
+- **The job:** ONE `claude -p` call — `--model sonnet`, tools `Read,Glob,Grep,Write,Edit`,
+  **cwd = the LIVE vault** (no staging dir: inputs are tiny, edits are surgical), 30-min
+  timeout. Stdin = the vault's skeleton tree + the new summaries (title, text, itemDate,
+  source-trust tag) + the editing-flavored port of the Stage-2 core (truth/attribution,
+  source-trust tiers, explore-only-what-you-need, never delete wholesale).
+- **Safety net:** `cp -R` snapshot before the job. A thrown error mid-edit restores it; a
+  **usage limit does NOT** — the half-edited vault is exactly what `--resume` (session id kept
+  in memory) continues from. Either way nothing was stamped, so a fresh restart is also correct.
+- **On success:** stamp the sent rows, set `VaultActivity.vaultDirty`.
+
+## Editor-idle + push (`VaultActivity` — the seam, not the feature)
+
+- `editorBusy` (always false today; the Phase-5 editor will set it): the job returns
+  immediately — never blocks/waits, the next trigger retries.
+- `vaultDirty` (persisted in UserDefaults): set by the updater AND by initial generation;
+  cleared **only after a successful push**, so a transient network failure just retries next
+  run. `DaysEndJob.pushIfDirty()` is the one push path — initial gen calls it too, which
+  closes the "nothing auto-pushes yet" gap from Arch §7.
+
+## Proactive Intelligence (`Proactive`)
+
+- **Selection:** reminder-flagged summaries with `createdAt` past the `proactive` cursor.
+- **The judge:** one Sonnet call, NO tools, `--json-schema` →
+  `{"decisions":[{kind: remind|brief|skip, time, text, reason}]}`. The taste law is in the
+  prompt (*most days: nothing; at most ONE per day; only time-sensitive, personally
+  actionable*) **and enforced in code** — first non-skip decision wins, rest dropped.
+- **Tier 1 (remind):** `Notify.schedule(at:)` — past/unparseable time fires now (better a late
+  nudge than a silent drop).
+- **Tier 2 (brief):** a second agentic call — `Read,Glob,Grep,WebSearch,Write`, cwd = vault
+  (context), `--add-dir` the **Briefings folder** (`~/Library/Application
+  Support/SentientOS/Briefings/`, deliberately OUTSIDE the vault so briefings never ride the
+  mirror push) → one `<yyyy-MM-dd> — <slug>.md` + a notification. **Never auto-sends** — drafts
+  and offers only.
+- Failures never block the updater/push; the pointer doesn't advance and tomorrow re-judges.
+
+## Notifications (`Notify`)
+
+Small `UNUserNotificationCenter` wrapper: `now`/`schedule(at:)→id`/`cancel(id:)`. Permission is
+requested lazily on first use (the real ask moves into onboarding). Quiet by design — no-op
+runs never notify.
+
+## The welcome briefing
+
+Initial generation's second act (`VaultGenerator.writeWelcomeBriefing()`): a cheap Sonnet pass
+over the freshly built vault that writes "What I learned about you" (portrait + 3–5
+cross-domain connections + what happens next) into Briefings — For You's day-one artifact.
+Best-effort, off the UI path, fired alongside the post-gen mirror push.
+
+## Self-tests (real Sonnet calls — they spend a little budget)
+
+- `SENTIENT_SELFTEST=daysend SENTIENT_VAULT_ROOT=/tmp/scratch` — fixture vault + seeded queue
+  → run → asserts the fold, exact-row stamping, vault change, and the second-run no-op.
+  REQUIRES the vault-root override; refuses to run if the mirror is enabled without
+  `SENTIENT_MIRROR_BASE` (the push step would clobber the real hosted mirror).
+- `SENTIENT_SELFTEST=proactive` — seeds one actionable + one stale flagged summary → proves
+  judging, the ≤1/day cap, and the pointer (re-run judges nothing).
+- `SENTIENT_VAULT_ROOT` is honored by everything vault-shaped (generator, updater, mirror zip).

--- a/Sentient OS macOS/Documentation/Pointer Architecture (Kill the Ledger).md
+++ b/Sentient OS macOS/Documentation/Pointer Architecture (Kill the Ledger).md
@@ -1,0 +1,76 @@
+# Pointer Architecture — Kill the Ledger (June 11)
+
+The dedup/incrementality rewrite. The old `LedgerEntry` table (one permanent row per item ever
+analyzed, plus tombstones for junk/sensitive) is **gone**. The only question the system ever
+asks is *"what's new since last time?"* — so every source keeps **pointers**: "I have processed
+everything up to HERE." A run scans past the pointers, processes oldest-first, and advances
+each pointer after its item durably saves.
+
+**The payoff:** initial processing and incremental processing are the SAME code path. Pointer
+absent → everything (connector caps still apply) = the initial pass. Pointer present → only the
+new stuff. And the privacy story got stronger: junk/sensitive items now leave **zero trace** —
+judged on-device, discarded, gone (no tombstones anywhere; `LifetimeStats` keeps only counters).
+
+## The pointers (all rows in `SourceCursor`, key → value)
+
+| Key | Value | Notes |
+|---|---|---|
+| `file:<FileRoot.id>` | `epochSeconds\|path` | One per folder root. Path = same-second tiebreak. |
+| `whatsapp:<jid>` | highest consumed `Z_PK` | **Per chat** (see below). |
+| `imessage:<guid>` | highest consumed `ROWID` | **Per chat**. |
+| `notes` | `modEpochSeconds\|noteUUID` | Edited note → mod-date passes the pointer → re-summarized. |
+| `proactive` | `timeIntervalSinceReferenceDate` | Judged-summaries high-water mark (Part II). ⚠️ Stored in Date's NATIVE representation — epoch conversion round-trips lossily and re-judges the newest item. |
+
+**Why per-chat keys (a deliberate divergence from the handoff's single Z_PK pointer):** chats
+interleave in Z_PK/ROWID space. With one global pointer, saving chat B's window advances the
+pointer past chat A's still-unprocessed older messages — a crash there silently loses them.
+Per-chat keys make every chat independently crash-safe (same shape as Files' per-root keys).
+
+## The file date
+
+`date = min(max(mtime, dateAdded, movedInAncestorDate), now)`
+
+- `dateAdded` catches downloads carrying old mtimes; `mtime` catches edits.
+- `movedInAncestorDate` (each directory's own dateAdded, propagated down during the walk)
+  catches **whole folders dragged into a root** — their files keep old dates and would
+  otherwise be invisible to the pointer forever.
+- The `min(…, now)` clamp keeps a future-dated file (clock weirdness) from poisoning the pointer.
+
+## The shared guards
+
+- **Freshness hold-back (1h, `sourceFreshnessHoldBack`):** items newer than an hour are left
+  for the next run — a doc mid-editing-session, an actively-flowing conversation, or a note
+  being typed is never summarized between keystrokes. Pointers can't advance past `now − 1h`
+  by construction.
+- **Ordering contract (`DataSource.scan`):** candidates come back ascending per `cursorKey`;
+  the pipeline advances each candidate's cursor only after its durable save. Crash = resume,
+  never skip. (Selection is still newest-N for the caps; *consumption* is oldest-first.)
+- **Junk/sensitive advance the pointer with nothing else saved** — the cursor write IS the
+  durable record (`Store.record` does the summary insert + cursor upsert in one transaction).
+
+## Versioned summaries
+
+`Summary.sourceID` is no longer unique — re-analysis INSERTS a new row; our code (not the
+model) appends `" — Edit"` to the title when an older version exists. The cloud model benefits
+from seeing the evolution; `survivorSummaries()` (full generations) collapses to
+latest-per-source. `Summary` also absorbed the ledger's `kind`/`folder` (the vault prompt's
+source-trust tiers need them) and gained `itemDate` (the artifact's own date — the proactive
+judge keys on it). New rows are born `syncedToVault == nil`, which makes the iterative
+updater's queue **self-populating** — nothing to reset, ever.
+
+## Failure policy (no failure bookkeeping, by design)
+
+- An item whose failure triggered a reactive engine reload is **retried once** on the fresh
+  engine (the wedge ate its first try; the retry usually lands).
+- An item that still fails is given up: its pointer is not advanced *by it*, so it's retried
+  next run **only if nothing newer in its pointer key succeeds**. A permanently corrupt file is
+  passed by the next success behind it — no poison pills, no retry tables. (Re-processed
+  survivors are harmless: they're just another version.)
+
+## Self-tests
+
+- `SENTIENT_SELFTEST=incremental` — the pointer-lifecycle proof, no model (11 checks): full
+  pass → no-op → new file only → edited file as `— Edit` version → corpus stamping → junk
+  advances with zero trace.
+- `skipping` (17 checks) still green — fixtures use the `testIgnoreDateAdded` /
+  `testZeroHoldBack` seams on `FilesSource` (real filesystems can't backdate dateAdded).

--- a/Sentient OS macOS/Notify.swift
+++ b/Sentient OS macOS/Notify.swift
@@ -1,0 +1,68 @@
+//
+//  Notify.swift
+//  Sentient OS macOS
+//
+//  One small wrapper over UNUserNotificationCenter (Part II §D). Quiet by design — the
+//  callers (day's-end job, proactive reminders) notify only when something actually happened;
+//  no-op runs never make noise. Permission is requested lazily on first use for now; the
+//  real ask moves into onboarding's notification step.
+//
+//  Key methods: now(title:body:) · schedule(at:title:body:) -> id · cancel(id:).
+//
+
+import Foundation
+import UserNotifications
+
+enum Notify {
+
+    /// Headless self-tests can't answer the system permission dialog — requestAuthorization
+    /// would hang the harness forever (measured: the daysend run wedged here). Notify is a
+    /// silent no-op under SENTIENT_SELFTEST.
+    private static var suppressed: Bool {
+        ProcessInfo.processInfo.environment["SENTIENT_SELFTEST"] != nil
+    }
+
+    /// Ask once per launch, lazily (dev behavior; onboarding owns the real moment later).
+    private static func requestPermissionIfNeeded() async {
+        let center = UNUserNotificationCenter.current()
+        let settings = await center.notificationSettings()
+        guard settings.authorizationStatus == .notDetermined else { return }
+        _ = try? await center.requestAuthorization(options: [.alert, .sound])
+    }
+
+    /// Fire a notification immediately.
+    static func now(title: String, body: String) async {
+        guard !suppressed else { return }
+        await requestPermissionIfNeeded()
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        content.sound = .default
+        try? await UNUserNotificationCenter.current().add(
+            UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil))
+    }
+
+    /// Schedule a notification for a future date; returns the request id (for cancel).
+    /// A past date fires immediately — better a late nudge than a silent drop.
+    @discardableResult
+    static func schedule(at date: Date, title: String, body: String) async -> String {
+        let id = UUID().uuidString
+        guard !suppressed else { return id }
+        await requestPermissionIfNeeded()
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        content.sound = .default
+        let interval = date.timeIntervalSinceNow
+        let trigger = interval > 1
+            ? UNTimeIntervalNotificationTrigger(timeInterval: interval, repeats: false)
+            : nil   // past-dated → deliver now
+        try? await UNUserNotificationCenter.current().add(
+            UNNotificationRequest(identifier: id, content: content, trigger: trigger))
+        return id
+    }
+
+    static func cancel(id: String) {
+        UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [id])
+    }
+}

--- a/Sentient OS macOS/Pipeline.swift
+++ b/Sentient OS macOS/Pipeline.swift
@@ -2,10 +2,18 @@
 //  Pipeline.swift
 //  Sentient OS macOS
 //
-//  The loop that ties Sources + Engine + Store together (Arch §2.1). For each new/changed
-//  item: load content → Engine.generate → Triage.decide → Store.save (tombstone always;
-//  summary only for survivors) → report progress. Runs off-main on its own actor; the heavy
-//  inference hops to the Engine actor, persistence to the Store actor.
+//  The loop that ties Sources + Engine + Store together (Arch §2.1). Fetches the pointer map,
+//  scans each source for items PAST its pointers, and processes them in scan order (ascending
+//  per pointer — the pointer contract): load content → Engine.generate → Triage.decide →
+//  Store.record (summary version for survivors + the pointer advance, one transaction).
+//  Initial run and incremental run are the SAME code path — an empty pointer map simply means
+//  "everything" (connector caps still apply inside each source's scan).
+//
+//  Failure policy (pointer architecture, June 11): a failed item is retried ONCE on a fresh
+//  engine when its failure triggered a reactive reload; an item that still fails is given up —
+//  its pointer is not advanced by it, so it's retried next run only if nothing newer in its
+//  pointer key succeeds (no failure bookkeeping anywhere, by design). Engine-wedge resilience
+//  (preemptive + reactive reloads) is unchanged.
 //
 
 import Foundation
@@ -37,7 +45,7 @@ actor Pipeline {
         self.store = store
     }
 
-    /// Process up to `limit` new/changed items from `source`. `onProgress` fires after each item.
+    /// Process up to `limit` items past `source`'s pointers. `onProgress` fires after each item.
     @discardableResult
     func run<S: DataSource & Sendable>(
         source: S,
@@ -45,8 +53,8 @@ actor Pipeline {
         limit: Int? = nil,
         onProgress: @Sendable (PipelineProgress) -> Void = { _ in }
     ) async throws -> PipelineProgress {
-        let candidates = try source.scan(since: nil)
-        var todo = await store.newOrChanged(candidates)
+        let cursors = await store.cursors()
+        var todo = try source.scan(since: cursors)
         if let limit, todo.count > limit { todo = Array(todo.prefix(limit)) }
 
         var p = PipelineProgress(total: todo.count)
@@ -74,13 +82,9 @@ actor Pipeline {
             sinceReload = 0
         }
 
-        for cand in todo {
-            if Task.isCancelled { break }   // "Stop Analysis" — halt after the current file
-
-            if sinceReload >= preemptiveReloadEvery { await reloadEngine() }
-
-            p.lastPath = cand.metadata["displayPath"] ?? cand.metadata["name"]
-            p.lastFilePath = cand.metadata["path"]
+        // One full attempt at one candidate: load → generate → decide → record (which also
+        // advances the candidate's pointer, durably). Returns false on any failure.
+        func attempt(_ cand: Candidate) async -> Bool {
             do {
                 // Drain transient extraction buffers (image/PDF/AppKit) every file so RAM
                 // doesn't creep across a long batch.
@@ -93,7 +97,8 @@ actor Pipeline {
                 #if DEBUG
                 Log("• \(cand.metadata["displayPath"] ?? cand.id)\n  → \(outcome.verdict) | \(result.text.replacingOccurrences(of: "\n", with: " "))")
                 #endif
-                try await store.save(artifact: artifact, verdict: outcome.verdict, summary: outcome.draft)
+                try await store.record(artifact: artifact, verdict: outcome.verdict, summary: outcome.draft)
+                LifetimeStats.bump(outcome.verdict)
 
                 switch outcome.verdict {
                 case .survivor:  p.survivors += 1
@@ -107,11 +112,23 @@ actor Pipeline {
                 p.lastReminder = outcome.reminder
                 p.lastSeconds = result.totalTime
                 p.totalSeconds += result.totalTime
-                consecutiveFailures = 0
-                reloadsWithoutProgress = 0   // we processed an item → the engine is healthy
+                return true
             } catch {
-                p.failed += 1
                 p.lastSummary = "(skipped: \(error))"
+                return false
+            }
+        }
+
+        for cand in todo {
+            if Task.isCancelled { break }   // "Stop Analysis" — halt after the current item
+
+            if sinceReload >= preemptiveReloadEvery { await reloadEngine() }
+
+            p.lastPath = cand.metadata["displayPath"] ?? cand.metadata["name"]
+            p.lastFilePath = cand.metadata["path"]
+
+            var ok = await attempt(cand)
+            if !ok {
                 consecutiveFailures += 1
                 if consecutiveFailures >= failuresBeforeReload {
                     guard reloadsWithoutProgress < maxReloadsWithoutProgress else {
@@ -123,7 +140,14 @@ actor Pipeline {
                     await reloadEngine()
                     reloadsWithoutProgress += 1
                     consecutiveFailures = 0
+                    ok = await attempt(cand)   // the wedge ate this item's first try — retry it once
                 }
+            }
+            if ok {
+                consecutiveFailures = 0
+                reloadsWithoutProgress = 0   // we processed an item → the engine is healthy
+            } else {
+                p.failed += 1
             }
             sinceReload += 1
             p.done += 1

--- a/Sentient OS macOS/Proactive.swift
+++ b/Sentient OS macOS/Proactive.swift
@@ -1,0 +1,237 @@
+//
+//  Proactive.swift
+//  Sentient OS macOS
+//
+//  Proactive Intelligence (Part II §E) — flagship feature #2, riding the day's-end run.
+//   1. Selection: reminder-flagged summaries newer than the "proactive" pointer (a createdAt
+//      high-water mark in SourceCursor — judged once, no bookkeeping tables, re-runs never
+//      re-judge).
+//   2. The judge: ONE Sonnet call, no tools, structured output — which of these (if any)
+//      genuinely deserve the user's attention. The taste law lives in the prompt AND in code:
+//      at most ONE non-skip decision survives per run.
+//   3. Tier 1 (remind): a scheduled macOS notification. Past/unparseable time → fire now.
+//      Tier 2 (brief): a second, agentic call — vault context + WebSearch → ONE briefing .md
+//      into the Briefings folder (OUTSIDE the vault: briefings are For You artifacts, not the
+//      user's knowledge base — they must never ride the mirror push). Never auto-send.
+//
+//  Failures never block the updater or the mirror push: everything is caught here; worst
+//  case the pointer doesn't advance and tomorrow re-judges.
+//
+//  Doc: Documentation/Days-End Job (Living System).md
+//
+
+import Foundation
+
+/// Where For You artifacts live — `~/Library/Application Support/SentientOS/Briefings/`
+/// [STARTING POINT], deliberately outside the vault. The For You UI just lists this folder.
+enum Briefings {
+    static var dir: URL {
+        let d = URL.applicationSupportDirectory
+            .appendingPathComponent("SentientOS/Briefings", isDirectory: true)
+        try? FileManager.default.createDirectory(at: d, withIntermediateDirectories: true)
+        return d
+    }
+
+    /// All briefings, newest first (by filename — they're date-prefixed — then mtime).
+    static func list() -> [URL] {
+        let fm = FileManager.default
+        let files = (try? fm.contentsOfDirectory(at: dir, includingPropertiesForKeys: [.contentModificationDateKey]))
+            ?? []
+        return files.filter { $0.pathExtension == "md" }
+            .sorted { $0.lastPathComponent > $1.lastPathComponent }
+    }
+}
+
+enum Proactive {
+
+    struct Outcome: Sendable {
+        var judged = 0
+        var reminders = 0
+        var briefings = 0
+        var note: String?    // surfaced in the dev status line
+    }
+
+    private static let cursorKey = "proactive"
+    private static let judgeSchema = """
+        {"type":"object","properties":{"decisions":{"type":"array","items":{"type":"object",\
+        "properties":{"kind":{"type":"string","enum":["remind","brief","skip"]},\
+        "time":{"type":["string","null"]},"text":{"type":"string"},\
+        "reason":{"type":"string"}},"required":["kind","text"]}}},"required":["decisions"]}
+        """
+
+    /// Judge the new reminder-flagged summaries and act on at most ONE. Never throws — the
+    /// day's-end run must finish (and push) regardless of what happens here.
+    static func run(store: Store) async -> Outcome {
+        var out = Outcome()
+        do {
+            // 1) Selection past the pointer (createdAt high-water mark). Stored in Date's
+            // NATIVE representation (seconds since 2001) — an epoch conversion would round-trip
+            // lossily and let the newest judged item leak past the strict `>` next run.
+            let after = (await store.cursor(forKey: cursorKey)).flatMap(Double.init)
+                .map { Date(timeIntervalSinceReferenceDate: $0) }
+            let flagged = await store.flaggedSummaries(after: after)
+            guard !flagged.isEmpty else { return out }
+            out.judged = flagged.count
+
+            // 2) The judge — one structured-output Sonnet call, no tools.
+            var inv = ClaudeCLI.Invocation(prompt: Self.judgePrompt(flagged))
+            inv.model = .sonnet
+            inv.jsonSchema = judgeSchema
+            inv.timeout = 300
+            let envelope = try await ClaudeCLI.shared.run(inv)
+            let decisions = Self.parseDecisions(envelope.result)
+
+            // The taste cap, enforced in CODE: the prompt requests restraint, this guarantees
+            // it — take the first non-skip decision, drop the rest.
+            if let act = decisions.first(where: { $0.kind != "skip" }) {
+                switch act.kind {
+                case "remind":
+                    let when = act.time.flatMap(Self.parseISO) ?? Date()
+                    await Notify.schedule(at: when, title: "Sentient OS", body: act.text)
+                    out.reminders = 1
+                    Log("Proactive: scheduled reminder @ \(when) — \(act.text.prefix(80))")
+                case "brief":
+                    if await Self.writeBriefing(task: act.text) {
+                        out.briefings = 1
+                        await Notify.now(title: "A briefing is ready for you",
+                                         body: String(act.text.prefix(120)))
+                    }
+                default: break
+                }
+            } else {
+                Log("Proactive: judged \(flagged.count) flagged items — nothing worth surfacing (taste).")
+            }
+
+            // 3) Advance the pointer — these items are judged, never re-judged.
+            if let newest = flagged.map(\.createdAt).max() {
+                try await store.advanceCursor("\(newest.timeIntervalSinceReferenceDate)", forKey: cursorKey)
+            }
+        } catch {
+            // Pointer not advanced → tomorrow re-judges. Never blocks the updater/push.
+            out.note = "proactive failed: \(error)"
+            Log("Proactive: ⚠️ \(error) — pointer not advanced, tomorrow re-judges.")
+        }
+        return out
+    }
+
+    // MARK: Tier 2 — the agentic briefing
+
+    /// Research/draft the task with vault context + WebSearch and land ONE .md in Briefings.
+    private static func writeBriefing(task: String) async -> Bool {
+        let date = ISO8601DateFormatter.dateOnly.string(from: Date())
+        let slug = task.lowercased()
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }.prefix(6).joined(separator: "-")
+        let file = Briefings.dir.appendingPathComponent("\(date) — \(slug.isEmpty ? "briefing" : slug).md")
+
+        var inv = ClaudeCLI.Invocation(prompt: """
+            You are preparing a morning briefing for the user of Sentient OS — a private, \
+            personal-intelligence app. Your working directory is their personal knowledge \
+            vault: explore it (Glob/Grep/Read) for context about who they are and what this \
+            task means to them. Use WebSearch for anything that needs current information.
+
+            THE TASK: \(task)
+
+            Write ONE polished markdown briefing to this exact path:
+            \(file.path)
+
+            Shape: a clear title; the payoff up front (the answer, the plan, or the ready-to-use \
+            draft); supporting details below; sources/links at the end. Warm, concise, zero \
+            filler — something the user is delighted to wake up to. If the task involves a \
+            message or email, DRAFT it ready-to-paste — but NEVER send anything on the user's \
+            behalf; you offer, they fire.
+
+            When the briefing is written, reply with one line: DONE.
+            """)
+        inv.model = .sonnet
+        inv.allowedTools = ["Read", "Glob", "Grep", "WebSearch", "Write"]
+        inv.cwd = VaultGenerator.vaultRoot.path
+        inv.addDirs = [Briefings.dir.path]
+        inv.timeout = 900
+        do {
+            _ = try await ClaudeCLI.shared.run(inv)
+            return FileManager.default.fileExists(atPath: file.path)
+        } catch {
+            Log("Proactive: briefing agent failed — \(error)")
+            return false
+        }
+    }
+
+    // MARK: Judge prompt + parsing
+
+    private static func judgePrompt(_ items: [SummaryItem]) -> String {
+        let df = DateFormatter(); df.dateStyle = .medium; df.timeStyle = .short
+        var lines: [String] = []
+        for (i, s) in items.enumerated() {
+            let when = s.itemDate.map { df.string(from: $0) } ?? "unknown"
+            lines.append("#\(i + 1) · item date: \(when) · noticed: \(df.string(from: s.createdAt))\n\((s.title ?? "Untitled")) — \(s.text)")
+        }
+        return """
+        You are the proactive-intelligence judge for Sentient OS, a private personal-AI app. \
+        While reading the user's new files and messages, the on-device model flagged the items \
+        below as *potential* reminders. Decide which — if any — genuinely deserve the user's \
+        attention. Right now it is \(df.string(from: Date())).
+
+        THE TASTE LAW (non-negotiable): most days the right answer is NOTHING. At most ONE item \
+        may surface per day — scarcity is the taste. Only genuinely time-sensitive, personally \
+        actionable items qualify: the user's own deadline, appointment, renewal, booking window, \
+        or dated commitment that is still in the future and still actionable. Stale items, \
+        vague intentions, other people's schedules, and public event dates the user merely saw \
+        → "skip".
+
+        For each item return one decision object:
+        - "skip" — the default, for almost everything.
+        - "remind" — worth a single, well-timed macOS notification. Set "time" to the ideal \
+        ISO-8601 delivery moment (future, e.g. the evening before a deadline) and "text" to the \
+        notification body: specific, warm, ≤140 characters (e.g. "Tickets for the concert you \
+        screenshotted go on sale tomorrow at 5 PM.").
+        - "brief" — RARE: only when acting on it needs research or drafting the user would love \
+        to wake up to (e.g. "research the Lisbon trip the user is planning and present options", \
+        "draft the overdue reply to the landlord"). Set "text" to a one-line task description \
+        for the researcher agent.
+
+        Always include "reason" (one short sentence). Return decisions for ALL items, in order.
+
+        THE FLAGGED ITEMS:
+
+        \(lines.joined(separator: "\n\n"))
+        """
+    }
+
+    struct Decision: Sendable {
+        let kind: String
+        let time: String?
+        let text: String
+    }
+
+    static func parseDecisions(_ result: String) -> [Decision] {
+        // --json-schema makes `result` the JSON object itself; tolerate fenced/prefixed output.
+        let span: String
+        if let start = result.firstIndex(of: "{"), let end = result.lastIndex(of: "}"), start < end {
+            span = String(result[start...end])
+        } else { span = result }
+        guard let data = span.data(using: .utf8),
+              let obj = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+              let arr = obj["decisions"] as? [[String: Any]] else { return [] }
+        return arr.compactMap { d in
+            guard let kind = d["kind"] as? String, let text = d["text"] as? String else { return nil }
+            return Decision(kind: kind, time: d["time"] as? String, text: text)
+        }
+    }
+
+    private static func parseISO(_ s: String) -> Date? {
+        let withFrac = ISO8601DateFormatter()
+        withFrac.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let plain = ISO8601DateFormatter()
+        return withFrac.date(from: s) ?? plain.date(from: s)
+    }
+}
+
+private extension ISO8601DateFormatter {
+    /// "2026-06-11" — briefing filename prefix.
+    static let dateOnly: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withFullDate]
+        return f
+    }()
+}

--- a/Sentient OS macOS/Self Tests - Temp/SelfTest_DaysEnd.swift
+++ b/Sentient OS macOS/Self Tests - Temp/SelfTest_DaysEnd.swift
@@ -1,0 +1,173 @@
+//
+//  SelfTest_DaysEnd.swift — the living-system harness (Part II)
+//  Sentient OS macOS
+//
+//  Two REAL-cloud modes (they spend a little Sonnet budget), dispatched from SelfTest:
+//
+//    SENTIENT_SELFTEST=daysend SENTIENT_VAULT_ROOT=/tmp/some-scratch-dir
+//      Fixture vault + in-memory store seeded with unsynced summaries → DaysEndJob.run()
+//      → asserts the vault changed, exactly the sent rows got stamped, and a second run
+//      is a clean no-op. SENTIENT_VAULT_ROOT is REQUIRED (protects the real vault); add
+//      SENTIENT_MIRROR_BASE for a local mirror push, otherwise the push step must be off.
+//
+//    SENTIENT_SELFTEST=proactive
+//      In-memory store seeded with reminder-flagged summaries (one genuinely actionable,
+//      one stale) → Proactive.run() → prints the judge's decisions, asserts the ≤1/day cap
+//      and that the pointer advanced (a re-run judges nothing).
+//
+//  Safety: daysend REFUSES to run if the mirror is enabled but SENTIENT_MIRROR_BASE isn't
+//  set — the push step would replace the user's real hosted mirror with the fixture vault.
+//
+
+#if DEBUG
+import Foundation
+import SwiftData
+
+enum SelfTestDaysEnd {
+
+    // MARK: Shared plumbing
+
+    private static func freshStore(emit: (String) -> Void) -> Store? {
+        do {
+            let container = try ModelContainer(for: Summary.self, SourceCursor.self,
+                                               configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+            return Store(modelContainer: container)
+        } catch { emit("ModelContainer FAILED: \(error)"); return nil }
+    }
+
+    /// Seed one survivor summary through the REAL record path (synthetic candidate → artifact).
+    private static func seed(_ store: Store, id: String, title: String, text: String,
+                             reminder: Bool = false, itemDate: Date = Date()) async {
+        let cand = Candidate(id: id, kind: .file,
+                             cursorKey: "file:fixture", cursorValue: "\(Date().timeIntervalSince1970)|\(id)",
+                             itemDate: itemDate, metadata: ["folder": "Fixture", "name": title])
+        let artifact = Artifact(candidate: cand, text: text)
+        try? await store.record(artifact: artifact, verdict: .survivor,
+                                summary: SummaryDraft(text: text, title: title, reminderFlagged: reminder))
+    }
+
+    private static func claudeReady(emit: (String) -> Void) async -> Bool {
+        let availability = await ClaudeCLI.shared.validate()
+        guard case .available = availability else {
+            emit("SKIP — Claude Code unavailable: \(availability)")
+            return false
+        }
+        return true
+    }
+
+    // MARK: daysend
+
+    static func daysend(emit: (String) -> Void) async {
+        guard await claudeReady(emit: emit) else { return }
+        let env = ProcessInfo.processInfo.environment
+
+        // The vault override is mandatory: this harness writes into the vault root.
+        let home = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Sentient OS -- The Vault").path
+        guard let scratch = env["SENTIENT_VAULT_ROOT"], !scratch.isEmpty, scratch != home else {
+            emit("SET SENTIENT_VAULT_ROOT to a scratch dir (NOT the real vault) and re-run.")
+            return
+        }
+        // Never let the push step clobber the user's real hosted mirror with a fixture vault.
+        if await MirrorClient.shared.isEnabled && env["SENTIENT_MIRROR_BASE"] == nil {
+            emit("ABORT — the mirror is enabled but SENTIENT_MIRROR_BASE isn't set: the push "
+                 + "step would replace your real hosted mirror with the fixture vault. "
+                 + "Set SENTIENT_MIRROR_BASE to a local server or disable the mirror first.")
+            return
+        }
+
+        var pass = 0, fail = 0
+        func check(_ name: String, _ ok: Bool, _ detail: String = "") {
+            if ok { pass += 1 } else { fail += 1 }
+            emit("\(ok ? "✅" : "❌") \(name)\(detail.isEmpty ? "" : "  (\(detail))")")
+        }
+
+        // Fixture vault: a README portrait + one domain note, like a miniature real vault.
+        let fm = FileManager.default
+        let vault = URL(fileURLWithPath: scratch, isDirectory: true)
+        try? fm.removeItem(at: vault)
+        try? fm.createDirectory(at: vault.appendingPathComponent("Life"), withIntermediateDirectories: true)
+        try? """
+        # README
+        Fixture human. Software engineer in SF; plans a lot of trips; takes notes about coffee.
+        ## Map
+        - Life/ — everything so far
+        """.write(to: vault.appendingPathComponent("README.md"), atomically: true, encoding: .utf8)
+        try? """
+        ---
+        title: Coffee Notes
+        tags: [coffee]
+        refs: [1]
+        ---
+        # Coffee Notes
+        The user likes light-roast pour-overs.
+        """.write(to: vault.appendingPathComponent("Life/Coffee Notes.md"), atomically: true, encoding: .utf8)
+        let before = VaultUpdater.skeleton(of: vault)
+
+        guard let store = freshStore(emit: emit) else { return }
+        await seed(store, id: "file:/tmp/fixture/lisbon.md", title: "Lisbon Trip Planning",
+                   text: "The user booked flights to Lisbon for July 18–25 and is comparing hotels in Alfama.")
+        await seed(store, id: "file:/tmp/fixture/espresso.md", title: "New Espresso Machine",
+                   text: "The user ordered a Gaggia Classic Pro and is researching dial-in recipes.")
+        let queued = await store.unsyncedSummaries()
+        check("seeded queue", queued.count == 2, "\(queued.count)")
+
+        emit("\nrunning DaysEndJob (real Sonnet call — ~a minute)…")
+        let status = await DaysEndJob.shared.run(store: store)
+        emit("status: \(status)\n")
+
+        let after = VaultUpdater.skeleton(of: vault)
+        let readme = (try? String(contentsOf: vault.appendingPathComponent("README.md"), encoding: .utf8)) ?? ""
+        let coffee = (try? String(contentsOf: vault.appendingPathComponent("Life/Coffee Notes.md"), encoding: .utf8)) ?? ""
+        check("status reports the fold", status.contains("folded 2"), status)
+        check("exactly the sent rows stamped", await store.unsyncedSummaries().isEmpty)
+        check("vault actually changed",
+              before != after || coffee.contains("Gaggia") || readme.contains("Lisbon")
+              || after.contains("Lisbon") || after.contains("Espresso"),
+              "skeleton before \(before.split(separator: "\n").count) → after \(after.split(separator: "\n").count) notes")
+
+        let second = await DaysEndJob.shared.run(store: store)
+        check("second run is a no-op", second.contains("nothing new to fold"), second)
+
+        emit("\nvault skeleton after:\n\(after)")
+        emit("\n# \(fail == 0 ? "✅ ALL PASS" : "❌ FAILURES") — \(pass) passed · \(fail) failed")
+    }
+
+    // MARK: proactive
+
+    static func proactive(emit: (String) -> Void) async {
+        guard await claudeReady(emit: emit) else { return }
+        guard let store = freshStore(emit: emit) else { return }
+
+        var pass = 0, fail = 0
+        func check(_ name: String, _ ok: Bool, _ detail: String = "") {
+            if ok { pass += 1 } else { fail += 1 }
+            emit("\(ok ? "✅" : "❌") \(name)\(detail.isEmpty ? "" : "  (\(detail))")")
+        }
+
+        // One genuinely actionable item (dated tomorrow) + one stale one (long past).
+        let tomorrow = Date().addingTimeInterval(86_400)
+        await seed(store, id: "file:/tmp/fixture/tickets.png", title: "Concert Presale Screenshot",
+                   text: "The user screenshotted a presale notice: tickets for the Khruangbin show "
+                       + "go on sale \(tomorrow.formatted(date: .abbreviated, time: .omitted)) at 5 PM.",
+                   reminder: true, itemDate: Date())
+        await seed(store, id: "file:/tmp/fixture/dentist-2024.txt", title: "Old Dentist Reminder",
+                   text: "A note about a dentist appointment that happened back in March 2024.",
+                   reminder: true, itemDate: Date(timeIntervalSinceNow: -700 * 86_400))
+
+        emit("running the proactive judge (real Sonnet call)…")
+        let outcome = await Proactive.run(store: store)
+        check("judged both flagged items", outcome.judged == 2, "\(outcome.judged)")
+        check("taste cap held (≤1 action)", outcome.reminders + outcome.briefings <= 1,
+              "reminders \(outcome.reminders) · briefings \(outcome.briefings)")
+        check("no failure note", outcome.note == nil, outcome.note ?? "")
+        let pointer = await store.cursor(forKey: "proactive")
+        check("pointer advanced", pointer != nil, pointer ?? "nil")
+
+        let again = await Proactive.run(store: store)
+        check("re-run judges nothing (pointer)", again.judged == 0, "\(again.judged)")
+
+        emit("\n# \(fail == 0 ? "✅ ALL PASS" : "❌ FAILURES") — \(pass) passed · \(fail) failed")
+    }
+}
+#endif

--- a/Sentient OS macOS/Self Tests - Temp/SelfTest_FileSkipping.swift
+++ b/Sentient OS macOS/Self Tests - Temp/SelfTest_FileSkipping.swift
@@ -19,6 +19,13 @@ enum SelfTestFileSkipping {
     // MARK: - Synthetic fixture assertions
 
     static func synthetic(emit: (String) -> Void) {
+        // Pointer-architecture test seams: fixtures can't backdate dateAdded (the filesystem
+        // stamps "now"), and just-created files would all be freshness-held-back. Dates in this
+        // harness are therefore mtime-only, with no hold-back.
+        FilesSource.testIgnoreDateAdded = true
+        FilesSource.testZeroHoldBack = true
+        defer { FilesSource.testIgnoreDateAdded = false; FilesSource.testZeroHoldBack = false }
+
         let fm = FileManager.default
         var base = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("sentient-skiptest-\(UUID().uuidString.prefix(8))")
@@ -53,7 +60,7 @@ enum SelfTestFileSkipping {
         func counts(_ source: FilesSource) -> [String: Int] {
             let rootPath = source.root.path + "/"
             var by: [String: Int] = [:]
-            for c in (try? source.scan(since: nil)) ?? [] {
+            for c in (try? source.scan(since: [:])) ?? [] {
                 guard let p = c.metadata["path"], p.hasPrefix(rootPath) else { continue }
                 by[String(p.dropFirst(rootPath.count).split(separator: "/").first ?? "?"), default: 0] += 1
             }
@@ -158,7 +165,7 @@ enum SelfTestFileSkipping {
             }
 
             // What survives, and which directories contribute the most.
-            let candidates = (try? source.scan(since: nil)) ?? []
+            let candidates = (try? source.scan(since: [:])) ?? []
             var byDir: [String: Int] = [:]
             for c in candidates {
                 byDir[((c.metadata["path"] ?? "?") as NSString).deletingLastPathComponent, default: 0] += 1

--- a/Sentient OS macOS/Self Tests - Temp/SelfTest_Incremental.swift
+++ b/Sentient OS macOS/Self Tests - Temp/SelfTest_Incremental.swift
@@ -1,0 +1,118 @@
+//
+//  SelfTest_Incremental.swift — pointer-architecture proof (Kill the Ledger, June 11)
+//  Sentient OS macOS
+//
+//  Deterministic, no model. Dispatched from SelfTest.runIfRequested():
+//    SENTIENT_SELFTEST=incremental
+//  Drives the REAL FilesSource + Store (in-memory container) through the pointer lifecycle:
+//    1. full pass consumes everything, oldest-first
+//    2. immediate re-run is a complete no-op (nothing past the pointer)
+//    3. a new file → only the new file processes
+//    4. an edited file → re-processes as a NEW summary version with a " — Edit" title
+//    5. a junk verdict advances the pointer while persisting NOTHING (zero trace)
+//    6. markCorpusSynced stamps the queue; new versions re-enter it
+//
+//  Uses the mtime-only/zero-hold-back test seams (fixtures can't backdate dateAdded).
+//
+
+#if DEBUG
+import Foundation
+import SwiftData
+
+enum SelfTestIncremental {
+
+    static func run(emit: (String) -> Void) async {
+        FilesSource.testIgnoreDateAdded = true
+        FilesSource.testZeroHoldBack = true
+        defer { FilesSource.testIgnoreDateAdded = false; FilesSource.testZeroHoldBack = false }
+
+        let fm = FileManager.default
+        let base = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("sentient-incremental-\(UUID().uuidString.prefix(8))")
+        try? fm.createDirectory(at: base, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: base) }
+
+        var pass = 0, fail = 0
+        func check(_ name: String, _ ok: Bool, _ detail: String = "") {
+            if ok { pass += 1 } else { fail += 1 }
+            emit("\(ok ? "✅" : "❌") \(name)\(detail.isEmpty ? "" : "  (\(detail))")")
+        }
+        func touch(_ name: String, mtimeAgo: TimeInterval) {
+            let p = base.appendingPathComponent(name).path
+            if !fm.fileExists(atPath: p) { fm.createFile(atPath: p, contents: Data("x".utf8)) }
+            let then = Date().addingTimeInterval(-mtimeAgo)
+            try? fm.setAttributes([.creationDate: then, .modificationDate: then], ofItemAtPath: p)
+        }
+
+        let container: ModelContainer
+        do {
+            container = try ModelContainer(for: Summary.self, SourceCursor.self,
+                                           configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+        } catch { emit("ModelContainer FAILED: \(error)"); return }
+        let store = Store(modelContainer: container)
+        let source = FilesSource(root: base, label: "Fixture", cursorKey: "file:fixture")
+
+        /// One simulated pipeline pass: scan past the pointers, "judge" each candidate with the
+        /// given verdict, record (summary + pointer advance — the real Store path). Returns the
+        /// processed file names in processing order.
+        func runPass(verdict: Verdict = .survivor) async -> [String] {
+            let cands = (try? source.scan(since: await store.cursors())) ?? []
+            for c in cands {
+                guard let artifact = try? source.load(c) else { continue }
+                let draft = verdict == .survivor
+                    ? SummaryDraft(text: "Synthetic summary of \(c.metadata["name"] ?? "?").",
+                                   title: c.metadata["name"])
+                    : nil
+                try? await store.record(artifact: artifact, verdict: verdict, summary: draft)
+            }
+            return cands.map { $0.metadata["name"] ?? "?" }
+        }
+
+        // 1) Initial pass: everything, oldest-first.
+        touch("a.md", mtimeAgo: 7_200)
+        touch("b.md", mtimeAgo: 3_600)
+        let first = await runPass()
+        check("initial pass consumes everything oldest-first", first == ["a.md", "b.md"], "\(first)")
+
+        // 2) Immediate re-run: complete no-op.
+        let second = await runPass()
+        check("re-run is a no-op", second.isEmpty, "\(second)")
+
+        // 3) New file: only the new file.
+        touch("c.md", mtimeAgo: 1_800)
+        let third = await runPass()
+        check("only the NEW file processes", third == ["c.md"], "\(third)")
+
+        // 4) Edited file: re-processes as a new VERSION with the " — Edit" title suffix.
+        touch("a.md", mtimeAgo: 900)   // mtime moves past the pointer
+        let fourth = await runPass()
+        check("only the EDITED file re-processes", fourth == ["a.md"], "\(fourth)")
+        let all = await store.allSummaries()
+        let aVersions = all.filter { $0.sourceID.hasSuffix("/a.md") }
+        check("edit created a second version", aVersions.count == 2, "\(aVersions.count) versions")
+        check("new version title carries ' — Edit'",
+              aVersions.contains { $0.title?.hasSuffix(" — Edit") == true },
+              "\(aVersions.compactMap(\.title))")
+
+        // 5) The updater queue self-populates; a full generation stamps it; new rows re-enter.
+        let queued = await store.unsyncedSummaries()
+        check("unsynced queue holds every version", queued.count == 4, "\(queued.count)")
+        await store.markCorpusSynced(await store.survivorSummaries())
+        let drained = await store.unsyncedSummaries()
+        check("corpus stamp drains the queue", drained.isEmpty, "\(drained.count) left")
+
+        // 6) Junk advances the pointer and leaves ZERO trace.
+        let before = await store.counts()
+        touch("d.md", mtimeAgo: 600)
+        let fifth = await runPass(verdict: .junk)
+        check("junk item was scanned once", fifth == ["d.md"], "\(fifth)")
+        let sixth = await runPass()
+        check("junk never re-scans (pointer passed it)", sixth.isEmpty, "\(sixth)")
+        let after = await store.counts()
+        check("junk persisted nothing", after.versions == before.versions,
+              "versions \(before.versions) → \(after.versions)")
+
+        emit("\n# \(fail == 0 ? "✅ ALL PASS" : "❌ FAILURES") — \(pass) passed · \(fail) failed")
+    }
+}
+#endif

--- a/Sentient OS macOS/Self Tests - Temp/SelfTest_Triage_Pipeline_and_Vault.swift
+++ b/Sentient OS macOS/Self Tests - Temp/SelfTest_Triage_Pipeline_and_Vault.swift
@@ -91,6 +91,12 @@ enum SelfTest {
         // file (versioned summary + " — Edit" title) → junk advances the pointer with zero trace.
         if mode == "incremental" { await SelfTestIncremental.run(emit: emit); return }
 
+        // Living-system harnesses (real Sonnet calls — see SelfTest_DaysEnd.swift):
+        // "daysend" needs SENTIENT_VAULT_ROOT (fixture vault); "proactive" seeds flagged
+        // summaries and proves the judge + the ≤1/day cap + the pointer.
+        if mode == "daysend" { await SelfTestDaysEnd.daysend(emit: emit); return }
+        if mode == "proactive" { await SelfTestDaysEnd.proactive(emit: emit); return }
+
         // ClaudeCLI mode: no model needed — discovery, ping, and one tiny run through the REAL
         // claude -p spine (binary → env → stdin → JSON envelope). Verifies the compute waterfall's
         // tier-1 path end to end on this Mac.

--- a/Sentient OS macOS/Self Tests - Temp/SelfTest_Triage_Pipeline_and_Vault.swift
+++ b/Sentient OS macOS/Self Tests - Temp/SelfTest_Triage_Pipeline_and_Vault.swift
@@ -17,7 +17,8 @@
 //    SENTIENT_SELFTEST     "whatsapp" | "imessage" | "notes" | "files"  (model dump) ·
 //                          "tokens"  (WhatsApp window token-cost measurement, model) ·
 //                          "parse" | "chats" | "imchats" | "imdecode" | "notesdecode" | "claudecli"
-//                          | "vault" | "skipping" | "skipcensus"  (no model)
+//                          | "vault" | "skipping" | "skipcensus"
+//                          | "incremental"  (pointer-architecture proof, no model)
 //    SENTIENT_SELFTEST_N   item count (default 6)
 //    SENTIENT_SELFTEST_OUT output file (default <tmp>/sentient-selftest.txt)
 //    SENTIENT_MODEL_PATH   override the dev model path
@@ -84,6 +85,11 @@ enum SelfTest {
         // read-only census of the real standard folders ("skipcensus"). See SelfTest_FileSkipping.swift.
         if mode == "skipping" { SelfTestFileSkipping.synthetic(emit: emit); return }
         if mode == "skipcensus" { SelfTestFileSkipping.census(emit: emit); return }
+
+        // Incremental-pointer proof: deterministic, no model — runs the REAL FilesSource + Store
+        // (in-memory) through the pointer lifecycle: full pass → no-op pass → new file → edited
+        // file (versioned summary + " — Edit" title) → junk advances the pointer with zero trace.
+        if mode == "incremental" { await SelfTestIncremental.run(emit: emit); return }
 
         // ClaudeCLI mode: no model needed — discovery, ping, and one tiny run through the REAL
         // claude -p spine (binary → env → stdin → JSON envelope). Verifies the compute waterfall's
@@ -232,7 +238,7 @@ enum SelfTest {
             let effort = env["SENTIENT_VAULT_EFFORT"] ?? "xhigh"
             let route = env["SENTIENT_VAULT_ROUTE"] ?? "auto"
             let container: ModelContainer
-            do { container = try ModelContainer(for: LedgerEntry.self, Summary.self, SourceCursor.self) }
+            do { container = try ModelContainer(for: Summary.self, SourceCursor.self) }
             catch { emit("ModelContainer FAILED: \(error)"); return }
             let store = Store(modelContainer: container)
             var summaries = await store.survivorSummaries()
@@ -286,7 +292,7 @@ enum SelfTest {
         if mode == "tokens" {
             let source = WhatsAppSource(chatJIDs: chatFilter((try? WhatsAppSource().listChats()) ?? []))
             let candidates: [Candidate]
-            do { candidates = try source.scan(since: nil) }
+            do { candidates = try source.scan(since: [:]) }
             catch { emit("scan FAILED: \(error)"); return }
             emit("windows in backlog: \(candidates.count) · current byte budget: \(ChatWindowing.maxWindowBytes)\n")
             guard !candidates.isEmpty else { return }
@@ -299,7 +305,8 @@ enum SelfTest {
             // conversation bytes). Window tokens = prefill − overhead[flavour].
             var overhead: [String: Int] = [:]
             for flavour in ["0", "1"] {
-                let cand = Candidate(id: "calibration", kind: .whatsapp, signature: "0",
+                let cand = Candidate(id: "calibration", kind: .whatsapp,
+                                     cursorKey: "", cursorValue: "", itemDate: Date(),
                                      metadata: ["isGroup": flavour, "windowText": ""])
                 let prompt = Triage.prompt(for: Artifact(candidate: cand, text: ""), currentDate: Date())
                 do {
@@ -343,7 +350,7 @@ enum SelfTest {
                         + (cand.metadata["isGroup"] == "1" ? " [g]" : "")
                     emit(pad(name, 26)
                          + String(format: " %4d %7d %8d %8d %6.2f %7d",
-                                  Int(cand.signature) ?? 0, winBytes, prefill, winTokens, row.ratio, row.decode))
+                                  Int(cand.metadata["msgCount"] ?? "") ?? 0, winBytes, prefill, winTokens, row.ratio, row.decode))
                 } catch { emit("ITEM \(i + 1) FAILED: \(error)") }
             }
             await engine.unload()
@@ -398,7 +405,7 @@ enum SelfTest {
         }
 
         let candidates: [Candidate]
-        do { candidates = try source.scan(since: nil) }
+        do { candidates = try source.scan(since: [:]) }
         catch { emit("scan FAILED: \(error)"); return }
         emit("scanned \(candidates.count) candidates; dumping first \(min(count, candidates.count))\n")
         guard !candidates.isEmpty else { emit("nothing to dump."); return }

--- a/Sentient OS macOS/Sentient_OS_macOSApp.swift
+++ b/Sentient OS macOS/Sentient_OS_macOSApp.swift
@@ -22,7 +22,7 @@ struct SentientOSApp: App {
 
         // One container for the whole app; only `Store` ever touches it (Arch §2.3).
         func makeContainer() throws -> ModelContainer {
-            try ModelContainer(for: LedgerEntry.self, Summary.self, SourceCursor.self)
+            try ModelContainer(for: Summary.self, SourceCursor.self)
         }
         do {
             self.store = Store(modelContainer: try makeContainer())

--- a/Sentient OS macOS/Sources/DataSource.swift
+++ b/Sentient OS macOS/Sources/DataSource.swift
@@ -3,17 +3,21 @@
 //  Sentient OS macOS
 //
 //  The ONE abstraction (Arch §2.2). Two-phase, so expensive content extraction is gated by
-//  the dedup ledger:
-//    scan(since:) -> [Candidate]   // cheap: enumerate items (stat only), NO content
+//  the per-source pointers:
+//    scan(since:) -> [Candidate]   // cheap: enumerate items PAST the pointers, NO content
 //    load(_:)     -> Artifact      // expensive: extract text/image for a chosen candidate
 //  Candidate & Artifact are Sendable value types; live @Model objects never cross actors.
 //
-//  NOTE: the WAL-safe DB-copy helper (Arch §3.5) lands in Phase 3 with the first DB source.
+//  THE POINTER CONTRACT (June 11 pointer rewrite — Documentation/Pointer Architecture…):
+//  every candidate names the cursor it advances (`cursorKey` → `cursorValue`). The pipeline
+//  processes candidates in scan order and advances each candidate's cursor only after its
+//  durable save — so scan() MUST return candidates ascending per cursorKey (oldest first).
+//  A crash resumes exactly where it stopped; pointer nil = "everything" = the initial run.
 //
 
 import Foundation
 
-/// The four local sources. `rawValue` is what we persist in the ledger/cursor tables.
+/// The four local sources. `rawValue` is what we persist on summaries and in cursor keys.
 enum SourceKind: String, Codable, Sendable, CaseIterable {
     case file
     case whatsapp
@@ -21,21 +25,29 @@ enum SourceKind: String, Codable, Sendable, CaseIterable {
     case notes
 }
 
-/// Cheap dedup unit produced by `scan` — enough to decide "already processed?" without
-/// reading file contents. `metadata` carries light context (displayPath, name, created…).
+/// Freshness hold-back shared by every source: items newer than this are left for the NEXT
+/// run, so a document mid-editing-session / an actively-flowing conversation / a note being
+/// typed isn't summarized between keystrokes. Pointers never advance past `now − holdBack`
+/// by construction (held-back items are never candidates).
+let sourceFreshnessHoldBack: TimeInterval = 3_600
+
+/// Cheap unit produced by `scan` — enough to order and process without reading content.
+/// `metadata` carries light context (displayPath, name, created…).
 struct Candidate: Sendable, Identifiable {
-    let id: String                    // stable source id → LedgerEntry.sourceID
+    let id: String                    // stable source id, e.g. "file:/Users/…/a.pdf"
     let kind: SourceKind
-    let signature: String             // files: "size:mtime"; db sources: the cursor value
-    let cursor: String                // progress marker (Files dedup via ledger, not cursor)
+    let cursorKey: String             // which pointer this item advances when durably saved
+    let cursorValue: String           // the pointer value after this item is consumed
+    let itemDate: Date                // the artifact's OWN date (drives ordering + Summary.itemDate)
     let metadata: [String: String]
 
-    init(id: String, kind: SourceKind, signature: String,
-         cursor: String = "", metadata: [String: String] = [:]) {
+    init(id: String, kind: SourceKind, cursorKey: String, cursorValue: String,
+         itemDate: Date, metadata: [String: String] = [:]) {
         self.id = id
         self.kind = kind
-        self.signature = signature
-        self.cursor = cursor
+        self.cursorKey = cursorKey
+        self.cursorValue = cursorValue
+        self.itemDate = itemDate
         self.metadata = metadata
     }
 }
@@ -44,35 +56,32 @@ struct Candidate: Sendable, Identifiable {
 struct Artifact: Sendable, Identifiable {
     let id: String
     let kind: SourceKind
-    let signature: String
-    let cursor: String
+    let cursorKey: String
+    let cursorValue: String
+    let itemDate: Date
     let text: String?                 // extracted text (nil for image-only artifacts)
     let imageData: Data?              // downsized image bytes → the vision model
     let metadata: [String: String]
 
-    init(id: String, kind: SourceKind, signature: String, cursor: String = "",
-         text: String? = nil, imageData: Data? = nil, metadata: [String: String] = [:]) {
-        self.id = id
-        self.kind = kind
-        self.signature = signature
-        self.cursor = cursor
-        self.text = text
-        self.imageData = imageData
-        self.metadata = metadata
-    }
-
     /// Build an Artifact from its Candidate plus extracted content.
     init(candidate: Candidate, text: String? = nil, imageData: Data? = nil) {
-        self.init(id: candidate.id, kind: candidate.kind, signature: candidate.signature,
-                  cursor: candidate.cursor, text: text, imageData: imageData,
-                  metadata: candidate.metadata)
+        self.id = candidate.id
+        self.kind = candidate.kind
+        self.cursorKey = candidate.cursorKey
+        self.cursorValue = candidate.cursorValue
+        self.itemDate = candidate.itemDate
+        self.text = text
+        self.imageData = imageData
+        self.metadata = candidate.metadata
     }
 }
 
 protocol DataSource {
     var kind: SourceKind { get }
-    /// Cheap enumeration of items present/new since the cursor — NO content extraction.
-    func scan(since cursor: String?) throws -> [Candidate]
+    /// Enumerate items past the pointers — NO content extraction. `cursors` is the full pointer
+    /// map (a source reads only its own keys; empty map = initial run = everything, connector
+    /// caps still apply). Returned candidates MUST be ascending per cursorKey (see contract above).
+    func scan(since cursors: [String: String]) throws -> [Candidate]
     /// Expensive content extraction for a candidate the pipeline chose to process.
     func load(_ candidate: Candidate) throws -> Artifact
 }

--- a/Sentient OS macOS/Sources/FilesSource.swift
+++ b/Sentient OS macOS/Sources/FilesSource.swift
@@ -2,8 +2,8 @@
 //  FilesSource.swift
 //  Sentient OS macOS
 //
-//  DataSource over a user folder (Phase 1b starts with ~/Downloads). Recurses subfolders,
-//  keeps only whitelisted extensions, and extracts a BOUNDED amount of content per type:
+//  DataSource over a user folder. Recurses subfolders, keeps only whitelisted extensions,
+//  and extracts a BOUNDED amount of content per type:
 //   • pdf              → first 3 pages of text (PDFKit)
 //   • doc / docx       → text (NSAttributedString, best-effort; legacy .doc may be empty)
 //   • md / txt         → text (char-capped)
@@ -11,6 +11,14 @@
 //
 //  The model is given the home-relative path (e.g. ~/Downloads/Useless Stuff/x.jpg) + creation
 //  date — the folder structure alone is strong signal for junk/intent.
+//
+//  POINTER (June 11 rewrite — Documentation/Pointer Architecture (Kill the Ledger).md):
+//  one "(epochSeconds|path)" pointer per folder root (cursorKey = "file:<FileRoot.id>").
+//  A file's date is max(dateAdded, dateModified, nearest moved-in ancestor's dateAdded) —
+//  dateAdded catches downloads with old mtimes, dateModified catches edits, and the ancestor
+//  propagation catches whole folders dragged into a root (their files keep old dates).
+//  Guards: 60-min freshness hold-back (mid-edit files wait for the next run) and a future-date
+//  clamp (clock weirdness can't poison the pointer). Scan returns candidates OLDEST-FIRST.
 //
 //  Skipping & caps (see Documentation/Files Source (Skipping & Caps).md): code repos and
 //  machine-generated datasets are pruned at the walk level (`pruneReason`), and `scan` bounds
@@ -27,12 +35,15 @@ struct FilesSource: DataSource, Sendable {
     let kind: SourceKind = .file
     let root: URL
     let label: String   // human folder name ("Downloads", "Desktop", a custom folder…) → stored as each artifact's `folder` tag
+    let cursorKey: String        // pointer key for this root ("file:<FileRoot.id>")
     let perDirectoryCap: Int     // max candidates any single directory contributes (newest win)
     let maxAge: TimeInterval?    // drop files older than this (nil = no age cutoff)
 
-    init(root: URL, label: String, perDirectoryCap: Int = 300, maxAge: TimeInterval? = nil) {
+    init(root: URL, label: String, cursorKey: String? = nil,
+         perDirectoryCap: Int = 300, maxAge: TimeInterval? = nil) {
         self.root = root
         self.label = label
+        self.cursorKey = cursorKey ?? "file:custom:" + root.path
         self.perDirectoryCap = perDirectoryCap
         self.maxAge = maxAge
     }
@@ -43,6 +54,13 @@ struct FilesSource: DataSource, Sendable {
     private static let maxContentChars = 8_000
     private static let pdfPageLimit = 3
     private static let imageMaxPixel = 1_280   // ≈ 720p short edge on 16:9
+
+    // Test seams (DEBUG self-tests only — production never touches these): fixtures can't
+    // backdate dateAdded on a real filesystem, so date-sensitive assertions couldn't run
+    // otherwise. `testIgnoreDateAdded` makes file dates mtime-only; `testZeroHoldBack`
+    // disables the freshness hold-back (just-created fixtures would all be held back).
+    nonisolated(unsafe) static var testIgnoreDateAdded = false
+    nonisolated(unsafe) static var testZeroHoldBack = false
 
     // MARK: Skipping (code repos / dependency caches / datasets — Spotlight-style)
 
@@ -137,33 +155,70 @@ struct FilesSource: DataSource, Sendable {
         return patterns.contains { base.range(of: $0, options: .regularExpression) != nil }
     }
 
+    // MARK: Pointer encoding — "(epochSeconds|path)", path = same-second tiebreak
+
+    static func pointerValue(date: Date, path: String) -> String {
+        "\(date.timeIntervalSince1970)|\(path)"
+    }
+
+    static func parsePointer(_ raw: String?) -> (date: Double, path: String)? {
+        guard let raw, let bar = raw.firstIndex(of: "|"), let t = Double(raw[..<bar]) else { return nil }
+        return (t, String(raw[raw.index(after: bar)...]))
+    }
+
+    /// Is (date, path) strictly past the pointer? (nil pointer = everything qualifies.)
+    private static func isPast(_ pointer: (date: Double, path: String)?, date: Double, path: String) -> Bool {
+        guard let pointer else { return true }
+        return date > pointer.date || (date == pointer.date && path > pointer.path)
+    }
+
     // MARK: Scan (cheap — stat only, recurses subfolders)
 
-    func scan(since cursor: String?) throws -> [Candidate] {
-        let keys: Set<URLResourceKey> = [.isRegularFileKey, .isDirectoryKey, .fileSizeKey, .contentModificationDateKey, .creationDateKey]
+    func scan(since cursors: [String: String]) throws -> [Candidate] {
+        let pointer = Self.parsePointer(cursors[cursorKey])
+        let now = Date()
+        let holdBack = Self.testZeroHoldBack ? now : now.addingTimeInterval(-sourceFreshnessHoldBack)
+
+        let keys: Set<URLResourceKey> = [.isRegularFileKey, .isDirectoryKey,
+                                         .contentModificationDateKey, .creationDateKey,
+                                         .addedToDirectoryDateKey]
         guard let enumerator = FileManager.default.enumerator(
             at: root, includingPropertiesForKeys: Array(keys),
             options: [.skipsHiddenFiles, .skipsPackageDescendants]
         ) else { return [] }
 
+        // Effective "moved-in" date per directory: a folder dragged into the root carries files
+        // with OLD dates — the folder's own dateAdded (propagated down the tree) rescues them.
+        // The enumerator is preorder (parents before children), so parent lookups always hit.
+        var movedIn: [String: Date] = [root.path: .distantPast]
+
         var rows: [(candidate: Candidate, sortKey: Double)] = []
         for case let url as URL in enumerator {
             let vals = try? url.resourceValues(forKeys: keys)
+            let parentEff = movedIn[url.deletingLastPathComponent().path] ?? .distantPast
 
             // Prune at the WALK level: skipDescendants() means nothing inside is ever yielded,
-            // so it never becomes a Candidate / hits the ledger / sees inference.
+            // so it never becomes a Candidate / sees inference.
             if vals?.isDirectory == true {
-                if Self.pruneReason(url) != nil { enumerator.skipDescendants() }
+                if Self.pruneReason(url) != nil { enumerator.skipDescendants(); continue }
+                let added = Self.testIgnoreDateAdded ? .distantPast
+                                                     : (vals?.addedToDirectoryDate ?? .distantPast)
+                movedIn[url.path] = max(parentEff, min(added, now))   // future-clamped
                 continue   // directories are never candidates themselves
             }
 
             guard vals?.isRegularFile == true,
                   Self.allowedExtensions.contains(url.pathExtension.lowercased()) else { continue }
 
-            let size = vals?.fileSize ?? 0
-            let mtime = vals?.contentModificationDate?.timeIntervalSince1970 ?? 0
-            let created = vals?.creationDate
-            let signature = "\(size):\(Int(mtime))"
+            let mtime = vals?.contentModificationDate ?? .distantPast
+            let added = Self.testIgnoreDateAdded ? .distantPast
+                                                 : (vals?.addedToDirectoryDate ?? .distantPast)
+            // The file's date: whichever signal is closest to today, clamped so a future-dated
+            // file (clock weirdness) is treated as "now" instead of poisoning the pointer.
+            let date = min(max(mtime, added, parentEff), now)
+
+            guard date <= holdBack else { continue }                          // freshness hold-back
+            guard Self.isPast(pointer, date: date.timeIntervalSince1970, path: url.path) else { continue }
 
             var meta: [String: String] = [
                 "path": url.path,
@@ -171,16 +226,19 @@ struct FilesSource: DataSource, Sendable {
                 "name": url.lastPathComponent,
                 "folder": label,
             ]
-            if let created { meta["created"] = Self.dateString(created) }
+            if let created = vals?.creationDate { meta["created"] = Self.dateString(created) }
 
-            let candidate = Candidate(id: "file:\(url.path)", kind: .file, signature: signature, metadata: meta)
-            rows.append((candidate, created?.timeIntervalSince1970 ?? mtime))
+            let candidate = Candidate(id: "file:\(url.path)", kind: .file,
+                                      cursorKey: cursorKey,
+                                      cursorValue: Self.pointerValue(date: date, path: url.path),
+                                      itemDate: date, metadata: meta)
+            rows.append((candidate, date.timeIntervalSince1970))
         }
         // Newest first, then the caps (connector-limits decision, June 10–11):
         //  • optional age cutoff (Downloads: 1 year — downloads age into junk; keepers elsewhere don't)
         //  • per-directory cap (300, every root) — the bulk-dump backstop
         //  • per-root cap (newest 1,000, every root)
-        let cutoff = maxAge.map { Date().timeIntervalSince1970 - $0 }
+        let cutoff = maxAge.map { now.timeIntervalSince1970 - $0 }
         var perDir: [String: Int] = [:]
         var kept: [Candidate] = []
         for row in rows.sorted(by: { $0.sortKey > $1.sortKey }) {
@@ -192,7 +250,11 @@ struct FilesSource: DataSource, Sendable {
             perDir[dir, default: 0] += 1
             kept.append(row.candidate)
         }
-        return kept
+        // Process OLDEST-FIRST (the pointer contract): selection is newest-N, consumption is
+        // ascending, so the pointer sweeps forward and a stopped run resumes exactly here.
+        return kept.sorted {
+            ($0.itemDate, $0.id) < ($1.itemDate, $1.id)   // id = "file:<path>" → path tiebreak
+        }
     }
 
     // MARK: Load (expensive — extract content)
@@ -287,9 +349,10 @@ struct FilesSource: DataSource, Sendable {
 
 // MARK: - FileRoot (which folders the Files pipeline can run over)
 
-/// A user folder the Files pipeline can analyze. The DEBUG picker (RootView) offers the three
+/// A user folder the Files pipeline can analyze. The dev picker (RootView) offers the three
 /// standard folders plus any number of custom-chosen ones; each selected root becomes its own
-/// `FilesSource` pass. Arch §3.4: "suggest Desktop + Downloads, but the user chooses the folders."
+/// `FilesSource` pass with its OWN pointer. Arch §3.4: "suggest Desktop + Downloads, but the
+/// user chooses the folders."
 enum FileRoot: Hashable, Identifiable {
     case downloads
     case desktop
@@ -332,8 +395,9 @@ enum FileRoot: Hashable, Identifiable {
     var maxAge: TimeInterval? { self == .downloads ? 365 * 24 * 3_600 : nil }
 
     /// The fully configured source for this root (nil if the system folder can't be resolved).
+    /// The pointer key uses `id` (never `label` — two custom folders can share a name).
     var source: FilesSource? {
-        url.map { FilesSource(root: $0, label: label, maxAge: maxAge) }
+        url.map { FilesSource(root: $0, label: label, cursorKey: "file:\(id)", maxAge: maxAge) }
     }
 
     /// The three standard folders, in display order.

--- a/Sentient OS macOS/Sources/NotesSource.swift
+++ b/Sentient OS macOS/Sources/NotesSource.swift
@@ -12,9 +12,9 @@
 //  deliberately NOT a schema-aware protobuf parser. Fail-closed: anything undecodable is
 //  skipped, never fed garbled to the model.
 //
-//  Dedup: id = the note's stable UUID (ZIDENTIFIER); signature = modification date, so an
-//  edited note reprocesses automatically (the Files size:mtime pattern). Locked
-//  (ZISPASSWORDPROTECTED) and deleted (ZMARKEDFORDELETION) notes are skipped in SQL.
+//  Incrementality (June 11 pointer rewrite): one "notes" pointer, "(modEpochSeconds|UUID)" —
+//  an edited note's mod-date moves past it and the note re-summarizes as a new version.
+//  Locked (ZISPASSWORDPROTECTED) and deleted (ZMARKEDFORDELETION) notes are skipped in SQL.
 //  Requires Full Disk Access. Key methods: scan(since:) · load(_:) · decodeBody(_:).
 //
 
@@ -36,7 +36,15 @@ struct NotesSource: DataSource, Sendable {
 
     // MARK: Scan — copy → query → decode → delete
 
-    func scan(since cursor: String?) throws -> [Candidate] {
+    /// Pointer (June 11 rewrite): one cursor, key "notes", value "(modEpochSeconds|noteUUID)"
+    /// (UUID = same-second tiebreak). An edited note's mod-date moves past the pointer → it's
+    /// re-summarized as a new version. The one-hour hold-back keeps a note that's being typed
+    /// out of the run. Candidates are emitted OLDEST-FIRST (the pointer contract).
+    func scan(since cursors: [String: String]) throws -> [Candidate] {
+        let pointer = Self.parsePointer(cursors["notes"])
+        let holdBackFloor = Date().addingTimeInterval(-sourceFreshnessHoldBack)
+            .timeIntervalSinceReferenceDate
+
         let (dbURL, tempDir) = try SQLiteDB.walSafeCopy(of: dbPath)
         defer { try? FileManager.default.removeItem(at: tempDir) }   // delete the plaintext copy immediately
         let reader = try SQLiteReader(path: dbURL.path)
@@ -47,8 +55,8 @@ struct NotesSource: DataSource, Sendable {
             if let t = r.text(1) { folders[r.int(0)] = t }
         }
 
-        // Newest notes first; locked/deleted skipped in SQL. Creation-date column name varies
-        // across macOS versions → COALESCE the known variants.
+        // Newest notes first (the cap selects the newest `maxNotes`); locked/deleted skipped in
+        // SQL. Creation-date column name varies across macOS versions → COALESCE the variants.
         var out: [Candidate] = []
         try reader.forEachRow("""
             SELECT o.ZIDENTIFIER, o.ZTITLE1, o.ZMODIFICATIONDATE1,
@@ -58,21 +66,26 @@ struct NotesSource: DataSource, Sendable {
             WHERE o.ZISPASSWORDPROTECTED IS NOT 1 AND o.ZMARKEDFORDELETION IS NOT 1
             ORDER BY o.ZMODIFICATIONDATE1 DESC LIMIT \(Self.maxNotes)
             """) { r in
-            guard let id = r.text(0), let blob = r.blob(5),
+            guard let id = r.text(0) else { return }
+            let modified = r.double(2)
+            guard modified <= holdBackFloor else { return }                       // being typed right now
+            guard Self.isPast(pointer, modified: Int64(modified), uuid: id) else { return }   // already consumed
+            guard let blob = r.blob(5),
                   let decoded = Self.decodeBody(blob) else { return }   // no/undecodable body → skip (fail-closed)
             let body = decoded.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !body.isEmpty else { return }                         // attachment-only / blank notes
 
             let title = r.text(1) ?? String(body.prefix(40))
             let folder = folders[r.int(4)] ?? "Notes"
-            let modified = r.double(2)
             let createdTS = r.double(3)
             let created = Date(timeIntervalSinceReferenceDate: createdTS > 0 ? createdTS : modified)
 
             out.append(Candidate(
                 id: "notes:\(id)",
                 kind: .notes,
-                signature: "\(Int(modified))",     // mod-date signature → edited notes reprocess
+                cursorKey: "notes",
+                cursorValue: "\(Int64(modified))|\(id)",
+                itemDate: Date(timeIntervalSinceReferenceDate: modified),
                 metadata: [
                     "folder": folder,              // per-folder tag → folder pills in the viewer
                     "name": title,
@@ -81,7 +94,20 @@ struct NotesSource: DataSource, Sendable {
                     "noteText": String(body.prefix(Self.maxContentChars)),
                 ]))
         }
-        return out   // already newest-first from the ORDER BY
+        // Selection was newest-first (the cap); consumption is oldest-first (the pointer contract).
+        return out.sorted { ($0.itemDate, $0.id) < ($1.itemDate, $1.id) }
+    }
+
+    // MARK: Pointer encoding — "(modEpochSeconds|noteUUID)"
+
+    private static func parsePointer(_ raw: String?) -> (modified: Int64, uuid: String)? {
+        guard let raw, let bar = raw.firstIndex(of: "|"), let t = Int64(raw[..<bar]) else { return nil }
+        return (t, String(raw[raw.index(after: bar)...]))
+    }
+
+    private static func isPast(_ pointer: (modified: Int64, uuid: String)?, modified: Int64, uuid: String) -> Bool {
+        guard let pointer else { return true }
+        return modified > pointer.modified || (modified == pointer.modified && uuid > pointer.uuid)
     }
 
     func load(_ candidate: Candidate) throws -> Artifact {

--- a/Sentient OS macOS/Sources/WhatsAppSource.swift
+++ b/Sentient OS macOS/Sources/WhatsAppSource.swift
@@ -11,9 +11,9 @@
 //  SAME pipeline as a file: one window = one Artifact = one bouncer verdict (Triage's
 //  chat-flavored prompt). The model sees the chat name, DM-vs-group, and per-message sender.
 //
-//  Requires Full Disk Access (Permissions.swift). v1 scope: backfills the lookback window;
-//  dedup is ledger-based via stable window ids (like Files). A Z_PK cursor, hold-back of the
-//  active tail, and slide-proof window anchoring are a Phase-4 (scheduler) hardening — see Arch §3.1.
+//  Requires Full Disk Access (Permissions.swift). Incrementality: a per-chat Z_PK pointer
+//  ("whatsapp:<jid>" in SourceCursor) + a one-hour tail hold-back — the initial backfill and
+//  the daily delta are the same scan. See Documentation/Pointer Architecture (Kill the Ledger).md.
 //
 
 import Foundation
@@ -116,7 +116,13 @@ struct WhatsAppSource: DataSource, Sendable {
 
     // MARK: Scan — copy → query → window → delete
 
-    func scan(since cursor: String?) throws -> [Candidate] {
+    /// Pointer (June 11 rewrite): ONE cursor per opted-in chat — key "whatsapp:<jid>", value =
+    /// the highest consumed `Z_PK`. Per-chat (not one global Z_PK pointer) because chats
+    /// interleave in Z_PK space: with a single pointer, saving chat B's window would move the
+    /// pointer past chat A's still-unprocessed older messages and a crash would lose them.
+    /// Per-chat keys make every chat independently crash-safe — same shape as Files' per-root
+    /// pointers. Windows are emitted ascending per chat (the pointer contract).
+    func scan(since cursors: [String: String]) throws -> [Candidate] {
         let (dbURL, tempDir) = try SQLiteDB.walSafeCopy(of: dbPath)
         defer { try? FileManager.default.removeItem(at: tempDir) }   // delete the plaintext copy immediately
         let reader = try SQLiteReader(path: dbURL.path)
@@ -141,6 +147,15 @@ struct WhatsAppSource: DataSource, Sendable {
             .map(\.pk)
         guard !analyzedPKs.isEmpty else { return [] }
 
+        // Each analyzed chat's pointer (no row = chat never consumed = everything qualifies).
+        var pointers: [Int64: Int64] = [:]
+        for chat in chats.values {
+            if let v = cursors["whatsapp:\(chat.jid)"].flatMap(Int64.init) { pointers[chat.pk] = v }
+        }
+        // Tail hold-back: an actively-flowing conversation isn't chopped mid-thought — the last
+        // hour's messages are windowed next run (they stay past the pointer until consumed).
+        let tailFloor = Date().addingTimeInterval(-sourceFreshnessHoldBack).timeIntervalSinceReferenceDate
+
         // Text messages within the limits (90-day floor AND newest-`maxMessages` cap over the
         // analyzed chats; the outer ORDER restores per-chat ascending iteration), oldest →
         // newest per chat.
@@ -158,6 +173,8 @@ struct WhatsAppSource: DataSource, Sendable {
             ORDER BY m.ZCHATSESSION, m.Z_PK
             """) { r in
             guard let chat = chats[r.int(5)] else { return }
+            guard r.int(0) > pointers[chat.pk] ?? -1 else { return }   // already consumed
+            guard r.double(1) <= tailFloor else { return }             // tail hold-back
             let isFromMe = r.int(2) == 1
             byChat[r.int(5), default: []].append(ChatMessage(
                 id: r.int(0),
@@ -169,24 +186,33 @@ struct WhatsAppSource: DataSource, Sendable {
                 text: String((r.text(3) ?? "").prefix(ChatWindowing.maxMessageChars))))
         }
 
-        // Window each chat to the byte budget; one window = one Artifact.
-        var built: [(candidate: Candidate, last: Date)] = []
+        // Window each chat to the byte budget; one window = one Artifact. A window's cursor
+        // value is its newest Z_PK — messages arrive ascending, so consuming windows in order
+        // sweeps the chat's pointer forward.
+        var perChat: [(lastActive: Date, candidates: [Candidate])] = []
         for (chatPK, msgs) in byChat {
             guard let chat = chats[chatPK] else { continue }
+            var wins: [Candidate] = []
             for win in ChatWindowing.windows(of: msgs) where !win.isEmpty {
                 let meta: [String: String] = [
                     "folder": chat.name,                         // per-chat tag → folder pills in the viewer
                     "name": chat.name,
                     "displayPath": "WhatsApp · \(chat.name)",
                     "isGroup": chat.isGroup ? "1" : "0",         // → group vs DM bouncer prompt
+                    "msgCount": "\(win.count)",
                     "windowText": ChatWindowing.format(chatName: chat.name, isGroup: chat.isGroup, messages: win),
                 ]
-                let id = "whatsapp:c\(chatPK):\(win.first!.id)-\(win.last!.id)"
-                built.append((Candidate(id: id, kind: .whatsapp, signature: "\(win.count)", metadata: meta),
-                              win.last!.date))
+                wins.append(Candidate(id: "whatsapp:c\(chatPK):\(win.first!.id)-\(win.last!.id)",
+                                      kind: .whatsapp,
+                                      cursorKey: "whatsapp:\(chat.jid)",
+                                      cursorValue: "\(win.last!.id)",
+                                      itemDate: win.last!.date,
+                                      metadata: meta))
             }
+            if !wins.isEmpty { perChat.append((msgs.last!.date, wins)) }
         }
-        return built.sorted { $0.last > $1.last }.map(\.candidate)   // newest conversations first
+        // Active chats first; windows within a chat stay ascending (the pointer contract).
+        return perChat.sorted { $0.lastActive > $1.lastActive }.flatMap(\.candidates)
     }
 
     func load(_ candidate: Candidate) throws -> Artifact {

--- a/Sentient OS macOS/Sources/iMessageSource.swift
+++ b/Sentient OS macOS/Sources/iMessageSource.swift
@@ -14,8 +14,9 @@
 //  chat.db stores no names) resolve through AddressBookNames.
 //
 //  Key methods: listChats() (picker rows) · scan(since:) · load(_:). Limits per ChatWindowing:
-//  90-day floor AND newest-200k cap. Tapbacks (associated_message_type != 0) and system items
-//  (item_type != 0) are filtered in SQL — they'd spam every window otherwise.
+//  90-day floor AND newest-100k cap. Tapbacks (associated_message_type != 0) and system items
+//  (item_type != 0) are filtered in SQL — they'd spam every window otherwise. Incrementality:
+//  a per-chat ROWID pointer ("imessage:<guid>" in SourceCursor) + a one-hour tail hold-back.
 //
 
 import Foundation
@@ -124,7 +125,11 @@ struct iMessageSource: DataSource, Sendable {
 
     // MARK: Scan — copy → query → decode → window → delete
 
-    func scan(since cursor: String?) throws -> [Candidate] {
+    /// Pointer (June 11 rewrite): ONE cursor per opted-in chat — key "imessage:<guid>", value =
+    /// the highest consumed `ROWID` — plus a one-hour tail hold-back. Per-chat (not one global
+    /// ROWID pointer) because chats interleave in ROWID space; see WhatsAppSource.scan for the
+    /// full rationale. Windows are emitted ascending per chat (the pointer contract).
+    func scan(since cursors: [String: String]) throws -> [Candidate] {
         let (dbURL, tempDir) = try SQLiteDB.walSafeCopy(of: dbPath)
         defer { try? FileManager.default.removeItem(at: tempDir) }   // delete the plaintext copy immediately
         let reader = try SQLiteReader(path: dbURL.path)
@@ -138,6 +143,14 @@ struct iMessageSource: DataSource, Sendable {
             .filter { chatGUIDs == nil || chatGUIDs!.contains($0.guid) }
             .map(\.rowid)
         guard !analyzedROWIDs.isEmpty else { return [] }
+
+        // Each analyzed chat's pointer (no row = chat never consumed = everything qualifies).
+        var pointers: [Int64: Int64] = [:]
+        for chat in chats.values {
+            if let v = cursors["imessage:\(chat.guid)"].flatMap(Int64.init) { pointers[chat.rowid] = v }
+        }
+        let tailFloorNS = Int64(Date().addingTimeInterval(-sourceFreshnessHoldBack)
+            .timeIntervalSinceReferenceDate * 1e9)
 
         // Messages within the limits (90-day floor AND newest-`maxMessages` cap over the
         // analyzed chats; the outer ORDER restores per-chat ascending iteration), decoded
@@ -154,6 +167,8 @@ struct iMessageSource: DataSource, Sendable {
             ORDER BY m.chat_id, m.ROWID
             """) { r in
             guard let chat = chats[r.int(5)] else { return }
+            guard r.int(0) > pointers[chat.rowid] ?? -1 else { return }   // already consumed
+            guard r.int(1) <= tailFloorNS else { return }                 // tail hold-back
 
             let body = r.text(3) ?? r.blob(4).flatMap(Self.typedstreamText)
             guard let body, !body.trimmingCharacters(in: .whitespaces).isEmpty else { return }
@@ -172,24 +187,32 @@ struct iMessageSource: DataSource, Sendable {
                 text: String(body.prefix(ChatWindowing.maxMessageChars))))
         }
 
-        // Window each chat to the byte budget; one window = one Artifact.
-        var built: [(candidate: Candidate, last: Date)] = []
+        // Window each chat to the byte budget; one window = one Artifact. A window's cursor
+        // value is its newest ROWID — consuming windows in order sweeps the chat's pointer.
+        var perChat: [(lastActive: Date, candidates: [Candidate])] = []
         for (chatROWID, msgs) in byChat {
             guard let chat = chats[chatROWID] else { continue }
+            var wins: [Candidate] = []
             for win in ChatWindowing.windows(of: msgs) where !win.isEmpty {
                 let meta: [String: String] = [
                     "folder": chat.name,                         // per-chat tag → folder pills in the viewer
                     "name": chat.name,
                     "displayPath": "iMessage · \(chat.name)",
                     "isGroup": chat.isGroup ? "1" : "0",         // → group vs DM bouncer prompt
+                    "msgCount": "\(win.count)",
                     "windowText": ChatWindowing.format(chatName: chat.name, isGroup: chat.isGroup, messages: win),
                 ]
-                let id = "imessage:c\(chatROWID):\(win.first!.id)-\(win.last!.id)"
-                built.append((Candidate(id: id, kind: .imessage, signature: "\(win.count)", metadata: meta),
-                              win.last!.date))
+                wins.append(Candidate(id: "imessage:c\(chatROWID):\(win.first!.id)-\(win.last!.id)",
+                                      kind: .imessage,
+                                      cursorKey: "imessage:\(chat.guid)",
+                                      cursorValue: "\(win.last!.id)",
+                                      itemDate: win.last!.date,
+                                      metadata: meta))
             }
+            if !wins.isEmpty { perChat.append((msgs.last!.date, wins)) }
         }
-        return built.sorted { $0.last > $1.last }.map(\.candidate)   // newest conversations first
+        // Active chats first; windows within a chat stay ascending (the pointer contract).
+        return perChat.sorted { $0.lastActive > $1.lastActive }.flatMap(\.candidates)
     }
 
     func load(_ candidate: Candidate) throws -> Artifact {

--- a/Sentient OS macOS/Store/LifetimeStats.swift
+++ b/Sentient OS macOS/Store/LifetimeStats.swift
@@ -1,0 +1,37 @@
+//
+//  LifetimeStats.swift
+//  Sentient OS macOS
+//
+//  Tiny UserDefaults-backed lifetime counters ("12,438 things understood"). With the ledger
+//  gone, junk/sensitive items leave zero trace — these counters are the only memory that an
+//  item was ever looked at, and they're numbers, not records. Bumped by the Pipeline per
+//  item; reset alongside the dev "Reset store" action.
+//
+
+import Foundation
+
+enum LifetimeStats {
+    private static let key = "stats.lifetime"   // [String: Int]
+
+    static func bump(_ verdict: Verdict) {
+        var d = (UserDefaults.standard.dictionary(forKey: key) as? [String: Int]) ?? [:]
+        d["analyzed", default: 0] += 1
+        switch verdict {
+        case .survivor:  d["survivors", default: 0] += 1
+        case .junk:      d["junk", default: 0] += 1
+        case .sensitive: d["sensitive", default: 0] += 1
+        }
+        UserDefaults.standard.set(d, forKey: key)
+    }
+
+    static var analyzed: Int { value("analyzed") }
+    static var survivors: Int { value("survivors") }
+    static var junk: Int { value("junk") }
+    static var sensitive: Int { value("sensitive") }
+
+    static func reset() { UserDefaults.standard.removeObject(forKey: key) }
+
+    private static func value(_ name: String) -> Int {
+        ((UserDefaults.standard.dictionary(forKey: key) as? [String: Int]) ?? [:])[name] ?? 0
+    }
+}

--- a/Sentient OS macOS/Store/Models.swift
+++ b/Sentient OS macOS/Store/Models.swift
@@ -2,81 +2,83 @@
 //  Models.swift
 //  Sentient OS macOS
 //
-//  SwiftData persistence models — the local "plumbing" store (Arch §6).
-//   - LedgerEntry:  one tombstone per artifact EVER analyzed (dedup; permanent).
-//   - Summary:      survivors only — the ~30-word summaries that feed the Stage-2 vault.
-//   - SourceCursor: per-source resumable progress marker (one row per source kind).
+//  SwiftData persistence models — the local "plumbing" store (Arch §6, pointer architecture).
+//   - Summary:      survivors only, VERSIONED — every (re-)analysis inserts a new row.
+//   - SourceCursor: one row per pointer key — "processed everything up to HERE".
 //   - Verdict:      the on-device "bouncer" decision (survivor / junk / sensitive).
+//
+//  There is NO ledger and NO tombstones (June 11 pointer rewrite): junk and sensitive items
+//  leave ZERO trace — judged on-device, discarded, gone. "What's new?" is answered by the
+//  per-source pointers, not by diffing against a permanent list of the past.
 //
 //  Only the `Store` @ModelActor (Store.swift) ever constructs or mutates these. Everything
 //  else passes Sendable value types (see Sources/DataSource.swift). The vault — not this
-//  DB — is the product; this is just the dedup ledger + a staging area for survivors.
+//  DB — is the product; this is the pointer store + a staging area for survivor summaries.
+//  Doc: Documentation/Pointer Architecture (Kill the Ledger).md
 //
 
 import Foundation
 import SwiftData
 
-/// The on-device model's per-artifact verdict. Decides what survives (Arch §1.1, §5.2).
+/// The on-device model's per-artifact verdict. Survivors get a Summary row; junk/sensitive
+/// save NOTHING (the pointer simply moves past them).
 enum Verdict: Int, Codable, Sendable {
-    case survivor = 0   // useful + not sensitive → tombstone + summary, enters vault (Stage 2)
-    case junk      = 1   // not worth keeping      → tombstone only (summary discarded)
-    case sensitive = 2   // must never leave device → tombstone only (summary discarded)
+    case survivor = 0   // useful + not sensitive → summary row, enters the vault (Stage 2)
+    case junk      = 1   // not worth keeping      → zero trace
+    case sensitive = 2   // must never leave device → zero trace
 }
 
-/// One row per artifact we've EVER analyzed — the permanent dedup tombstone.
-@Model
-final class LedgerEntry {
-    @Attribute(.unique) var sourceID: String   // stable id, e.g. "file:/Users/…/a.pdf", "imessage:1234"
-    var sourceKind: String                      // SourceKind.rawValue
-    var folder: String = ""                     // files: which root it came from ("Downloads", "Desktop", a custom folder…); "" for db sources
-    var signature: String                       // files: "size:mtime"; db sources: the cursor value
-    var verdict: Int                            // Verdict.rawValue
-    var firstSeen: Date
-    var lastSeen: Date
-
-    init(sourceID: String, sourceKind: String, folder: String = "", signature: String,
-         verdict: Int, firstSeen: Date, lastSeen: Date) {
-        self.sourceID = sourceID
-        self.sourceKind = sourceKind
-        self.folder = folder
-        self.signature = signature
-        self.verdict = verdict
-        self.firstSeen = firstSeen
-        self.lastSeen = lastSeen
-    }
-}
-
-/// Survivors only — the clean summaries that get folded into the vault later (Stage 2).
+/// One survivor summary VERSION. `sourceID` is deliberately NOT unique — re-analyzing an
+/// edited artifact INSERTS a new row (our code appends " — Edit" to the title), because the
+/// cloud model benefits from seeing the evolution. `survivorSummaries()` collapses to
+/// latest-per-source for full vault generations; the iterative updater consumes every
+/// unsynced version (`syncedToVault == nil` — rows are born unsynced, so the updater's
+/// queue populates itself with zero extra bookkeeping).
 @Model
 final class Summary {
-    @Attribute(.unique) var sourceID: String
+    var sourceID: String
+    var kind: String                  // SourceKind.rawValue — the vault prompt's source-trust tiers key on it
+    var folder: String                // files: root label ("Downloads"…); chats: chat name; notes: folder
     var text: String                  // ~30-word summary (the model writes this FIRST)
     var title: String?                // short human title (written after the summary)
     var reminderFlagged: Bool
-    var syncedToVault: Date?          // nil until folded into the vault (Stage 2)
+    var itemDate: Date?               // the artifact's OWN date (file date / newest message / note mod-date)
+    var syncedToVault: Date?          // nil until folded into the vault — the updater's input queue
     var createdAt: Date
 
-    init(sourceID: String, text: String, title: String? = nil,
-         reminderFlagged: Bool = false, syncedToVault: Date? = nil, createdAt: Date) {
+    init(sourceID: String, kind: String, folder: String, text: String, title: String? = nil,
+         reminderFlagged: Bool = false, itemDate: Date? = nil, syncedToVault: Date? = nil,
+         createdAt: Date) {
         self.sourceID = sourceID
+        self.kind = kind
+        self.folder = folder
         self.text = text
         self.title = title
         self.reminderFlagged = reminderFlagged
+        self.itemDate = itemDate
         self.syncedToVault = syncedToVault
         self.createdAt = createdAt
     }
 }
 
-/// One row per source kind — the cursor we advance only AFTER a durable save, so a
-/// crashed overnight run resumes rather than skips (Arch §3).
+/// One row per pointer key — "I have processed everything up to HERE." Advanced only after a
+/// durable save (the cursor write IS the durable record for junk/sensitive, which save nothing
+/// else), so a crashed run resumes rather than skips.
+///
+/// Keys in use:
+///   "file:<FileRoot.id>"   per folder root, value "epochSeconds|path" (path = same-second tiebreak)
+///   "whatsapp:<jid>"       per opted-in chat, value = highest consumed Z_PK
+///   "imessage:<guid>"      per opted-in chat, value = highest consumed ROWID
+///   "notes"                value "modEpochSeconds|noteUUID"
+///   "proactive"            judged-summaries high-water mark (createdAt epoch), Part II §E
 @Model
 final class SourceCursor {
-    @Attribute(.unique) var kind: String   // SourceKind.rawValue
-    var value: String                       // opaque marker (Z_PK, ROWID, mod-date, …)
+    @Attribute(.unique) var key: String
+    var value: String
     var updatedAt: Date
 
-    init(kind: String, value: String, updatedAt: Date) {
-        self.kind = kind
+    init(key: String, value: String, updatedAt: Date) {
+        self.key = key
         self.value = value
         self.updatedAt = updatedAt
     }

--- a/Sentient OS macOS/Store/Store.swift
+++ b/Sentient OS macOS/Store/Store.swift
@@ -6,11 +6,12 @@
 //  Callers hand it Sendable value types; it constructs/saves the models internally, which
 //  quarantines SwiftData's non-Sendability to this one actor.
 //
-//  Key methods:
-//   - hasSeen(_:)                       → dedup check ("already analyzed?")
-//   - save(artifact:verdict:summary:)   → tombstone always; Summary row only for survivors
-//   - cursor(for:) / advanceCursor(_:for:) → per-source resumable progress
-//   - counts()                          → ledger/summary totals (UI + debug self-test)
+//  Key methods (pointer architecture — Documentation/Pointer Architecture (Kill the Ledger).md):
+//   - record(artifact:verdict:summary:)  → ONE transaction: survivor summary version (junk/
+//                                          sensitive save nothing) + the pointer advance
+//   - cursors() / advanceCursor(_:forKey:) → the per-source pointers
+//   - survivorSummaries()                → latest version per source (full vault generations)
+//   - unsyncedSummaries() / markSynced(ids:) / markCorpusSynced(_:) → the updater's queue
 //
 
 import Foundation
@@ -30,21 +31,19 @@ struct SummaryDraft: Sendable {
     }
 }
 
-/// A Sendable, read-only snapshot of one analyzed artifact (ledger row + its survivor summary,
-/// if any) — what the Database viewer renders. We never hand live @Model objects to the UI.
-struct RecordSnapshot: Sendable, Identifiable {
-    var id: String { sourceID }
+/// A Sendable, read-only snapshot of ONE summary version — what the Database viewer renders.
+/// We never hand live @Model objects to the UI.
+struct SummaryRecord: Sendable, Identifiable {
+    let id: String              // sourceID + "@" + createdAt (versions of one source stay distinct)
     let sourceID: String
     let kind: SourceKind
-    let folder: String          // files: which root it came from ("Downloads", …); "" for db sources
-    let verdict: Verdict
-    let signature: String
-    let firstSeen: Date
-    let lastSeen: Date
-    let summary: String?        // survivors only
+    let folder: String
     let title: String?
+    let text: String
     let reminderFlagged: Bool
-    let createdAt: Date?
+    let itemDate: Date?
+    let syncedToVault: Date?
+    let createdAt: Date
 
     /// On-disk path for file artifacts (sourceID is "file:/abs/path"); nil for DB sources.
     var filePath: String? { sourceID.hasPrefix("file:") ? String(sourceID.dropFirst(5)) : nil }
@@ -59,195 +58,183 @@ struct RecordSnapshot: Sendable, Identifiable {
     }
 }
 
-/// A Sendable survivor summary handed to Stage 2 (the cloud vault, Arch §8). Joins each `Summary`
-/// (text/title/reminder) to its `LedgerEntry` source tags (folder/kind). Never a live @Model.
+/// A Sendable survivor summary handed to Stage 2 (the cloud vault / the iterative updater).
+/// `persistentID` is the exact row, so cloud jobs can stamp precisely what they consumed
+/// (summaries are versioned — "stamp by sourceID" would be wrong).
 struct SummaryItem: Sendable {
+    let persistentID: PersistentIdentifier
     let sourceID: String
     let kind: SourceKind
     let folder: String
     let title: String?
     let text: String
     let reminderFlagged: Bool
+    let itemDate: Date?
+    let createdAt: Date
 }
 
 @ModelActor
 actor Store {
 
-    // MARK: Dedup
+    // MARK: The one write path
 
-    /// Has this artifact ever been analyzed (survivor, junk, or sensitive)?
-    func hasSeen(_ sourceID: String) -> Bool {
-        let target = sourceID
-        let descriptor = FetchDescriptor<LedgerEntry>(predicate: #Predicate { $0.sourceID == target })
-        return ((try? modelContext.fetchCount(descriptor)) ?? 0) > 0
-    }
-
-    /// Filter candidates to those NOT yet in the ledger, or whose signature changed
-    /// (new/modified items). Used before expensive extraction + inference so we never
-    /// redo work. Candidates from one source are a single kind; we load that kind's
-    /// ledger once and diff in memory.
-    func newOrChanged(_ candidates: [Candidate]) -> [Candidate] {
-        guard let kind = candidates.first?.kind.rawValue else { return [] }
-        let entries = (try? modelContext.fetch(
-            FetchDescriptor<LedgerEntry>(predicate: #Predicate { $0.sourceKind == kind })
-        )) ?? []
-        var seen: [String: String] = [:]
-        for e in entries { seen[e.sourceID] = e.signature }
-        return candidates.filter { seen[$0.id] != $0.signature }
-    }
-
-    // MARK: Save
-
-    /// Records the outcome of analyzing one artifact.
-    /// - Always upserts a `LedgerEntry` tombstone (the permanent dedup record).
-    /// - Writes/updates a `Summary` row **only** for survivors; junk & sensitive are discarded
-    ///   to a tombstone only (Arch §1.1). Caller guarantees `summary != nil` for `.survivor`.
-    func save(artifact: Artifact, verdict: Verdict, summary: SummaryDraft?) throws {
-        let now = Date()
-        let id = artifact.id
-        let folder = artifact.metadata["folder"] ?? ""   // which root this file came from (Arch §3.4)
-
-        // Upsert the ledger tombstone.
-        if let entry = try modelContext.fetch(
-            FetchDescriptor<LedgerEntry>(predicate: #Predicate { $0.sourceID == id })
-        ).first {
-            entry.signature = artifact.signature
-            entry.folder = folder
-            entry.verdict = verdict.rawValue
-            entry.lastSeen = now
-        } else {
-            modelContext.insert(LedgerEntry(
+    /// Records the outcome of analyzing one artifact — ONE durable transaction:
+    /// - Survivors INSERT a new `Summary` version (sourceID is not unique; our code appends
+    ///   " — Edit" to the title when an older version exists). Junk/sensitive save NOTHING.
+    /// - The artifact's pointer advances (`cursorKey` → `cursorValue`). For junk/sensitive the
+    ///   cursor write IS the durable record — there is nothing else to save, and the pointer
+    ///   simply never looks at the item again.
+    func record(artifact: Artifact, verdict: Verdict, summary: SummaryDraft?) throws {
+        if verdict == .survivor, let summary {
+            let id = artifact.id
+            let prior = (try? modelContext.fetchCount(
+                FetchDescriptor<Summary>(predicate: #Predicate { $0.sourceID == id })
+            )) ?? 0
+            let title = (prior > 0 && summary.title != nil) ? summary.title! + " — Edit" : summary.title
+            modelContext.insert(Summary(
                 sourceID: id,
-                sourceKind: artifact.kind.rawValue,
-                folder: folder,
-                signature: artifact.signature,
-                verdict: verdict.rawValue,
-                firstSeen: now,
-                lastSeen: now
+                kind: artifact.kind.rawValue,
+                folder: artifact.metadata["folder"] ?? "",
+                text: summary.text,
+                title: title,
+                reminderFlagged: summary.reminderFlagged,
+                itemDate: artifact.itemDate,
+                createdAt: Date()
             ))
         }
-
-        // Survivors also get a Summary row; junk/sensitive never do.
-        if verdict == .survivor, let summary {
-            if let row = try modelContext.fetch(
-                FetchDescriptor<Summary>(predicate: #Predicate { $0.sourceID == id })
-            ).first {
-                row.text = summary.text
-                row.title = summary.title
-                row.reminderFlagged = summary.reminderFlagged
-            } else {
-                modelContext.insert(Summary(
-                    sourceID: id,
-                    text: summary.text,
-                    title: summary.title,
-                    reminderFlagged: summary.reminderFlagged,
-                    createdAt: now
-                ))
-            }
-        }
-
+        upsertCursor(artifact.cursorValue, forKey: artifact.cursorKey)
         try modelContext.save()
     }
 
-    // MARK: Cursors
+    // MARK: Pointers
 
-    /// The last durable progress marker for a source (nil = never run → process everything).
-    func cursor(for kind: SourceKind) -> String? {
-        let raw = kind.rawValue
-        let descriptor = FetchDescriptor<SourceCursor>(predicate: #Predicate { $0.kind == raw })
+    /// The full pointer map (sources read only their own keys; empty = first run ever).
+    func cursors() -> [String: String] {
+        let rows = (try? modelContext.fetch(FetchDescriptor<SourceCursor>())) ?? []
+        var map: [String: String] = [:]
+        for r in rows { map[r.key] = r.value }
+        return map
+    }
+
+    func cursor(forKey key: String) -> String? {
+        let descriptor = FetchDescriptor<SourceCursor>(predicate: #Predicate { $0.key == key })
         return (try? modelContext.fetch(descriptor))?.first?.value
     }
 
-    /// Advance a source's cursor — call ONLY after a durable save, so a crashed run
-    /// resumes rather than skips (Arch §3).
-    func advanceCursor(_ value: String, for kind: SourceKind) throws {
-        let raw = kind.rawValue
-        if let cursor = try modelContext.fetch(
-            FetchDescriptor<SourceCursor>(predicate: #Predicate { $0.kind == raw })
-        ).first {
-            cursor.value = value
-            cursor.updatedAt = Date()
-        } else {
-            modelContext.insert(SourceCursor(kind: raw, value: value, updatedAt: Date()))
-        }
+    /// Advance a pointer directly (Part II's proactive high-water mark; the pipeline goes
+    /// through `record` so the advance shares the summary's transaction).
+    func advanceCursor(_ value: String, forKey key: String) throws {
+        upsertCursor(value, forKey: key)
         try modelContext.save()
     }
 
-    // MARK: Introspection (counts for UI / debug self-test)
-
-    func counts() -> (ledger: Int, summaries: Int) {
-        let ledger = (try? modelContext.fetchCount(FetchDescriptor<LedgerEntry>())) ?? 0
-        let summaries = (try? modelContext.fetchCount(FetchDescriptor<Summary>())) ?? 0
-        return (ledger, summaries)
+    private func upsertCursor(_ value: String, forKey key: String) {
+        if let row = try? modelContext.fetch(
+            FetchDescriptor<SourceCursor>(predicate: #Predicate { $0.key == key })
+        ).first {
+            row.value = value
+            row.updatedAt = Date()
+        } else {
+            modelContext.insert(SourceCursor(key: key, value: value, updatedAt: Date()))
+        }
     }
 
-    /// Wipe all persisted data (ledger + summaries + cursors). Backs the debug "Reset store"
-    /// action so the pipeline re-judges the same files from scratch.
+    // MARK: Stage 2 — the cloud vault & the iterative updater
+
+    /// The corpus for FULL vault generations (initial gen / Regenerate): the LATEST version per
+    /// source, oldest first (stable ordering → stable `#index` refs). A 50-version file
+    /// contributes exactly one entry.
+    func survivorSummaries() -> [SummaryItem] {
+        let all = (try? modelContext.fetch(
+            FetchDescriptor<Summary>(sortBy: [SortDescriptor(\.createdAt, order: .forward)])
+        )) ?? []
+        var latest: [String: Summary] = [:]
+        for s in all { latest[s.sourceID] = s }       // ascending walk → last write wins
+        return latest.values
+            .sorted { $0.createdAt < $1.createdAt }
+            .map(item(from:))
+    }
+
+    /// The iterative updater's input queue: every version not yet folded into the vault,
+    /// oldest first. Self-populating — rows are born with `syncedToVault == nil`.
+    func unsyncedSummaries() -> [SummaryItem] {
+        let rows = (try? modelContext.fetch(
+            FetchDescriptor<Summary>(predicate: #Predicate { $0.syncedToVault == nil },
+                                     sortBy: [SortDescriptor(\.createdAt, order: .forward)])
+        )) ?? []
+        return rows.map(item(from:))
+    }
+
+    /// Stamp EXACTLY the rows a cloud job consumed (the updater's path). Failed/limited jobs
+    /// stamp nothing — unstamped rows simply re-enter the queue (it self-heals).
+    func markSynced(_ ids: [PersistentIdentifier], date: Date = Date()) {
+        for id in ids {
+            if let row = modelContext.model(for: id) as? Summary { row.syncedToVault = date }
+        }
+        try? modelContext.save()
+    }
+
+    /// Stamp the rows a FULL vault generation just represented: the exact corpus rows PLUS any
+    /// older versions they supersede (same source, created no later than the corpus row).
+    /// Race-safe: a version created after the corpus snapshot stays unsynced for the updater.
+    func markCorpusSynced(_ corpus: [SummaryItem], date: Date = Date()) {
+        var ceiling: [String: Date] = [:]
+        for item in corpus { ceiling[item.sourceID] = item.createdAt }
+        let unsynced = (try? modelContext.fetch(
+            FetchDescriptor<Summary>(predicate: #Predicate { $0.syncedToVault == nil })
+        )) ?? []
+        for row in unsynced {
+            if let c = ceiling[row.sourceID], row.createdAt <= c { row.syncedToVault = date }
+        }
+        try? modelContext.save()
+    }
+
+    private func item(from s: Summary) -> SummaryItem {
+        SummaryItem(persistentID: s.persistentModelID,
+                    sourceID: s.sourceID,
+                    kind: SourceKind(rawValue: s.kind) ?? .file,
+                    folder: s.folder,
+                    title: s.title,
+                    text: s.text,
+                    reminderFlagged: s.reminderFlagged,
+                    itemDate: s.itemDate,
+                    createdAt: s.createdAt)
+    }
+
+    // MARK: Introspection (counts + the Database viewer)
+
+    /// (distinct sources, total versions, pointer rows) — UI + debug.
+    func counts() -> (sources: Int, versions: Int, cursors: Int) {
+        let rows = (try? modelContext.fetch(FetchDescriptor<Summary>())) ?? []
+        let cursors = (try? modelContext.fetchCount(FetchDescriptor<SourceCursor>())) ?? 0
+        return (Set(rows.map(\.sourceID)).count, rows.count, cursors)
+    }
+
+    /// Every summary version as a Sendable snapshot, newest first (the Database viewer groups
+    /// them into per-source version histories).
+    func allSummaries() -> [SummaryRecord] {
+        let rows = (try? modelContext.fetch(
+            FetchDescriptor<Summary>(sortBy: [SortDescriptor(\.createdAt, order: .reverse)])
+        )) ?? []
+        return rows.map { s in
+            SummaryRecord(id: "\(s.sourceID)@\(s.createdAt.timeIntervalSince1970)",
+                          sourceID: s.sourceID,
+                          kind: SourceKind(rawValue: s.kind) ?? .file,
+                          folder: s.folder,
+                          title: s.title,
+                          text: s.text,
+                          reminderFlagged: s.reminderFlagged,
+                          itemDate: s.itemDate,
+                          syncedToVault: s.syncedToVault,
+                          createdAt: s.createdAt)
+        }
+    }
+
+    /// Wipe all persisted data (summaries + pointers). Backs the dev "Reset store" action so
+    /// the pipeline re-judges everything from scratch.
     func reset() throws {
-        try modelContext.delete(model: LedgerEntry.self)
         try modelContext.delete(model: Summary.self)
         try modelContext.delete(model: SourceCursor.self)
         try modelContext.save()
-    }
-
-    /// All analyzed artifacts as Sendable snapshots (newest first), joined with their summaries.
-    func allRecords() -> [RecordSnapshot] {
-        let entries = (try? modelContext.fetch(
-            FetchDescriptor<LedgerEntry>(sortBy: [SortDescriptor(\.lastSeen, order: .reverse)])
-        )) ?? []
-        let summaries = (try? modelContext.fetch(FetchDescriptor<Summary>())) ?? []
-        var byID: [String: Summary] = [:]
-        for s in summaries { byID[s.sourceID] = s }
-
-        return entries.map { e in
-            let s = byID[e.sourceID]
-            return RecordSnapshot(
-                sourceID: e.sourceID,
-                kind: SourceKind(rawValue: e.sourceKind) ?? .file,
-                folder: e.folder,
-                verdict: Verdict(rawValue: e.verdict) ?? .junk,
-                signature: e.signature,
-                firstSeen: e.firstSeen,
-                lastSeen: e.lastSeen,
-                summary: s?.text,
-                title: s?.title,
-                reminderFlagged: s?.reminderFlagged ?? false,
-                createdAt: s?.createdAt
-            )
-        }
-    }
-
-    // MARK: Stage 2 — the cloud vault (Arch §8)
-
-    /// All survivor summaries as Sendable value types, joined to their source tags, oldest first
-    /// (stable ordering → stable `#index` refs). This is the cloud vault's raw material.
-    func survivorSummaries() -> [SummaryItem] {
-        let summaries = (try? modelContext.fetch(
-            FetchDescriptor<Summary>(sortBy: [SortDescriptor(\.createdAt, order: .forward)])
-        )) ?? []
-        let entries = (try? modelContext.fetch(FetchDescriptor<LedgerEntry>())) ?? []
-        var meta: [String: (folder: String, kind: String)] = [:]
-        for e in entries { meta[e.sourceID] = (e.folder, e.sourceKind) }
-        return summaries.map { s in
-            let m = meta[s.sourceID]
-            return SummaryItem(
-                sourceID: s.sourceID,
-                kind: SourceKind(rawValue: m?.kind ?? "file") ?? .file,
-                folder: m?.folder ?? "",
-                title: s.title,
-                text: s.text,
-                reminderFlagged: s.reminderFlagged
-            )
-        }
-    }
-
-    /// Stamp every not-yet-synced survivor as folded into the vault (Stage-2 bookkeeping). v1 does
-    /// a full rebuild, so this is just a marker for future incremental sync.
-    func markAllSurvivorsSynced(date: Date = Date()) {
-        let rows = (try? modelContext.fetch(
-            FetchDescriptor<Summary>(predicate: #Predicate { $0.syncedToVault == nil })
-        )) ?? []
-        for r in rows { r.syncedToVault = date }
-        try? modelContext.save()
     }
 }

--- a/Sentient OS macOS/Store/Store.swift
+++ b/Sentient OS macOS/Store/Store.swift
@@ -165,6 +165,17 @@ actor Store {
         return rows.map(item(from:))
     }
 
+    /// Reminder-flagged summaries newer than the proactive pointer — the judge's input
+    /// (Part II §E). Oldest first; `after == nil` = never judged = everything flagged.
+    func flaggedSummaries(after: Date?) -> [SummaryItem] {
+        let floor = after ?? .distantPast
+        let rows = (try? modelContext.fetch(
+            FetchDescriptor<Summary>(predicate: #Predicate { $0.reminderFlagged && $0.createdAt > floor },
+                                     sortBy: [SortDescriptor(\.createdAt, order: .forward)])
+        )) ?? []
+        return rows.map(item(from:))
+    }
+
     /// Stamp EXACTLY the rows a cloud job consumed (the updater's path). Failed/limited jobs
     /// stamp nothing — unstamped rows simply re-enter the queue (it self-heals).
     func markSynced(_ ids: [PersistentIdentifier], date: Date = Date()) {

--- a/Sentient OS macOS/VaultActivity.swift
+++ b/Sentient OS macOS/VaultActivity.swift
@@ -1,0 +1,36 @@
+//
+//  VaultActivity.swift
+//  Sentient OS macOS
+//
+//  The editor-idle / mirror-push seam (Part II §C). The Phase-5 vault editor doesn't exist
+//  yet, so this is deliberately just the SEAM, not the feature:
+//   - editorBusy:  true while the editor has unsaved changes (always false today; the editor
+//                  sets it later). DaysEndJob checks it and skips the run rather than wait.
+//   - vaultDirty:  set by ANYTHING that changes the local vault (initial gen, the iterative
+//                  updater, future editor saves). Cleared only after a successful mirror push.
+//                  Persisted in UserDefaults so a quit between change and push can't lose the
+//                  pending push.
+//
+
+import Foundation
+import SwiftUI
+
+@MainActor
+@Observable
+final class VaultActivity {
+    static let shared = VaultActivity()
+
+    /// The vault editor has unsaved changes — the day's-end job skips and retries next trigger.
+    var editorBusy = false
+
+    private static let dirtyKey = "vault.dirty"
+
+    /// The local vault changed since the last successful mirror push.
+    var vaultDirty: Bool {
+        didSet { UserDefaults.standard.set(vaultDirty, forKey: Self.dirtyKey) }
+    }
+
+    private init() {
+        vaultDirty = UserDefaults.standard.bool(forKey: Self.dirtyKey)
+    }
+}

--- a/Sentient OS macOS/VaultGenerator.swift
+++ b/Sentient OS macOS/VaultGenerator.swift
@@ -70,8 +70,13 @@ actor VaultGenerator {
     }
 
     /// Where the vault lives on disk — visible, in the user's home folder.
+    /// `SENTIENT_VAULT_ROOT` overrides for self-tests (the daysend harness points everything
+    /// vault-shaped at a fixture dir instead of the real vault).
     static var vaultRoot: URL {
-        FileManager.default.homeDirectoryForCurrentUser
+        if let override = ProcessInfo.processInfo.environment["SENTIENT_VAULT_ROOT"], !override.isEmpty {
+            return URL(fileURLWithPath: override, isDirectory: true)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Sentient OS -- The Vault", isDirectory: true)
     }
 
@@ -181,6 +186,49 @@ actor VaultGenerator {
                       outputTokens: envelope.outputTokens ?? 0,
                       stopReason: envelope.stopReason ?? "end_turn",
                       vaultPath: root.path)
+    }
+
+    /// The welcome briefing — initial gen's second act ("here's what I learned about you"),
+    /// For You's day-one artifact. A cheap Sonnet pass over the freshly built vault that lands
+    /// ONE .md in the Briefings folder (outside the vault — it never rides the mirror push).
+    /// Best-effort: a failure logs and moves on; the vault itself is already safe on disk.
+    func writeWelcomeBriefing() async {
+        let date: String = {
+            let f = ISO8601DateFormatter(); f.formatOptions = [.withFullDate]
+            return f.string(from: Date())
+        }()
+        let file = Briefings.dir.appendingPathComponent("\(date) — What I learned about you.md")
+
+        var inv = ClaudeCLI.Invocation(prompt: """
+            You just finished organizing a person's entire digital life into the Obsidian-style \
+            knowledge vault that is your working directory. Now write them a welcome.
+
+            Read the root README.md first, then explore a handful of the most interesting notes \
+            (Glob/Grep/Read — be selective, not exhaustive). Then write ONE markdown briefing to \
+            this exact path:
+            \(file.path)
+
+            Shape: title "What I learned about you". Open with a warm, specific portrait of who \
+            they are — a few real paragraphs, addressed to them as "you" (never "the user"). \
+            Then 3–5 delightful cross-domain connections you noticed that they might not have \
+            seen themselves (the screenshot trail that matches a note, the plan echoed across \
+            chats…). Close with one short paragraph on what happens next: their vault now stays \
+            current automatically, and their other AIs can read it the moment they connect. \
+            Specific beats flattering; true beats complete. Never include raw private specifics.
+
+            When the briefing is written, reply with one line: DONE.
+            """)
+        inv.model = .sonnet
+        inv.allowedTools = ["Read", "Glob", "Grep", "Write"]
+        inv.cwd = Self.vaultRoot.path
+        inv.addDirs = [Briefings.dir.path]
+        inv.timeout = 600
+        do {
+            _ = try await ClaudeCLI.shared.run(inv)
+            Log("VaultGenerator: welcome briefing → \(file.lastPathComponent)")
+        } catch {
+            Log("VaultGenerator: welcome briefing failed — \(error)")
+        }
     }
 
     /// Count the .md notes (and folders containing them) under a directory.
@@ -319,8 +367,9 @@ actor VaultGenerator {
         """
     }
 
-    /// Location string + the source-trust tag the prompt keys on (the user's own notes vs saved files).
-    private static func locSrc(_ s: SummaryItem) -> (loc: String, source: String) {
+    /// Location string + the source-trust tag the prompt keys on (the user's own notes vs saved
+    /// files). Internal: the iterative updater (VaultUpdater) formats its items with it too.
+    static func locSrc(_ s: SummaryItem) -> (loc: String, source: String) {
         if s.kind == .whatsapp { return (s.folder, "WhatsApp · \(s.folder)") }
         let p = relPath(s.sourceID)
         let low = p.lowercased()

--- a/Sentient OS macOS/VaultUpdater.swift
+++ b/Sentient OS macOS/VaultUpdater.swift
@@ -1,0 +1,176 @@
+//
+//  VaultUpdater.swift
+//  Sentient OS macOS
+//
+//  The iterative vault updater (Part II §B) — the day's-end cloud job that folds NEW survivor
+//  summaries into the EXISTING vault. One `claude -p` call (Sonnet — daily updates are cheap;
+//  Opus stays reserved for initial generation): the vault's skeleton tree + the unsynced
+//  summaries go in over stdin, the agent explores only the notes it needs (Read/Glob/Grep)
+//  and rewrites only what changed (Edit/Write), working directly on the LIVE vault — no
+//  staging dir, because the inputs are tiny and edits are surgical. A cp -R snapshot is the
+//  safety net: a thrown error mid-edit restores it (a usage limit does NOT — the half-edited
+//  state is exactly what --resume continues from).
+//
+//  On success, EXACTLY the consumed rows are stamped (`Store.markSynced(ids:)`) — summaries
+//  are versioned, so stamping by sourceID would be wrong. On usage limit nothing is stamped;
+//  unstamped rows simply re-enter the queue (the pointer philosophy: self-healing, no failure
+//  bookkeeping).
+//
+//  Doc: Documentation/Days-End Job (Living System).md
+//
+
+import Foundation
+
+actor VaultUpdater {
+
+    static let shared = VaultUpdater()
+
+    enum UpdaterError: LocalizedError {
+        case noVault
+        case usageLimit(message: String, sessionID: String?)
+        case cloudFailed(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .noVault:
+                return "No vault on disk yet — run the initial generation first."
+            case .usageLimit(let m, _):
+                return "Claude hit its usage limit — the next run resumes where it left off. (\(m.prefix(160)))"
+            case .cloudFailed(let m):
+                return "Vault update failed: \(m)"
+            }
+        }
+    }
+
+    /// A prior run's usage-limit session — the next trigger resumes it over the half-edited
+    /// vault instead of starting over. In-memory only (an app restart just starts fresh; the
+    /// unstamped queue makes that correct either way).
+    private var resumeSessionID: String?
+
+    /// Fold all unsynced summaries into the vault. Returns the number folded (0 = no-op, no
+    /// cloud call). Throws `.usageLimit` (resumable) or `.cloudFailed` (vault restored).
+    func runDailyUpdate(store: Store) async throws -> Int {
+        let queue = await store.unsyncedSummaries()
+        guard !queue.isEmpty else {
+            Log("VaultUpdater: nothing unsynced — no-op.")
+            return 0
+        }
+        let fm = FileManager.default
+        let vault = VaultGenerator.vaultRoot
+        guard fm.fileExists(atPath: vault.path) else { throw UpdaterError.noVault }
+
+        // Safety net: snapshot the vault (it's KBs). Restored on a thrown error mid-edit;
+        // deliberately NOT restored on a usage limit (resume continues the half-edited state).
+        let snapshot = fm.temporaryDirectory
+            .appendingPathComponent("vault-snapshot-\(UUID().uuidString)", isDirectory: true)
+        try? fm.removeItem(at: snapshot)
+        try fm.copyItem(at: vault, to: snapshot)
+        defer { try? fm.removeItem(at: snapshot) }
+
+        var invocation: ClaudeCLI.Invocation
+        if let resumeSessionID {
+            var inv = ClaudeCLI.Invocation(prompt: """
+                Continue folding the new items into the vault exactly where you left off — the \
+                edits you already made are still on disk. When everything is folded, reply with \
+                one line: the number of notes you created or edited.
+                """)
+            inv.resumeSessionID = resumeSessionID
+            invocation = inv
+        } else {
+            invocation = ClaudeCLI.Invocation(
+                prompt: Self.updatePrompt(skeleton: Self.skeleton(of: vault), items: queue))
+        }
+        invocation.model = .sonnet                                   // daily updates are Sonnet [DECIDED]
+        invocation.allowedTools = ["Read", "Glob", "Grep", "Write", "Edit"]
+        invocation.cwd = vault.path
+        invocation.timeout = 1_800                                   // a daily delta is minutes, not hours
+
+        Log("VaultUpdater: folding \(queue.count) summaries into the vault…")
+        do {
+            let envelope = try await ClaudeCLI.shared.run(invocation)
+            resumeSessionID = nil
+            await store.markSynced(queue.map(\.persistentID))        // EXACTLY the rows we sent
+            await MainActor.run { VaultActivity.shared.vaultDirty = true }
+            Log("VaultUpdater: ✅ folded \(queue.count) (turns \(envelope.numTurns ?? -1), \(envelope.durationMS ?? -1)ms) — \(envelope.result.prefix(120))")
+            return queue.count
+        } catch let ClaudeCLI.CLIError.usageLimit(message, sessionID) {
+            resumeSessionID = sessionID                              // stamp nothing; resume later
+            throw UpdaterError.usageLimit(message: message, sessionID: sessionID)
+        } catch {
+            // Mid-edit failure → restore the pre-job vault; the unstamped queue self-heals.
+            resumeSessionID = nil
+            try? fm.removeItem(at: vault)
+            try? fm.moveItem(at: snapshot, to: vault)
+            throw UpdaterError.cloudFailed("\(error)")
+        }
+    }
+
+    // MARK: Prompt
+
+    /// The vault's current shape — a recursive ls of .md paths. The tree IS the index; the
+    /// agent Reads only what it needs from here.
+    static func skeleton(of root: URL) -> String {
+        let paths = ((try? FileManager.default.subpathsOfDirectory(atPath: root.path)) ?? [])
+            .filter { $0.hasSuffix(".md") && !$0.hasPrefix(".") && !$0.contains("/.") }
+            .sorted()
+        return paths.joined(separator: "\n")
+    }
+
+    /// The editing-flavored port of the Stage-2 core: same truth/attribution wisdom and
+    /// source-trust tiers, scoped to a surgical update instead of a full build.
+    private static func updatePrompt(skeleton: String, items: [SummaryItem]) -> String {
+        var lines: [String] = []
+        lines.reserveCapacity(items.count)
+        let df = DateFormatter(); df.dateStyle = .medium; df.timeStyle = .none
+        for (i, s) in items.enumerated() {
+            let (loc, src) = VaultGenerator.locSrc(s)
+            let title = (s.title?.isEmpty == false) ? s.title! : "(untitled)"
+            let when = s.itemDate.map { " · \(df.string(from: $0))" } ?? ""
+            lines.append("#\(i + 1) · [\(src)] \(loc)\(when)\n\(title) — \(s.text)")
+        }
+
+        return """
+        You are the **Sentient OS Knowledge Base Architect** — the cloud brain of a privacy-first \
+        personal-intelligence product. You previously organized this user's digital life into the \
+        Obsidian-style markdown vault that is your current working directory. While their Mac sat \
+        idle, an on-device LLM privately summarized the user's NEW files, messages, and notes — \
+        you are receiving today's survivors (junk and sensitive items were already discarded \
+        on-device). Your job: fold them into the existing vault, surgically.
+
+        ## The vault's current skeleton (a recursive ls — the tree IS the index)
+        \(skeleton)
+
+        ## How to work — surgical edits, not a rebuild
+        - **Explore only the notes you need.** Use Glob/Grep/Read to find where each new item \
+        belongs; do not re-read the whole vault.
+        - **Rewrite only what changed.** Prefer editing an existing note (Edit) over creating a \
+        new one; create a new note ONLY when no existing note fits, following the existing \
+        folder structure and naming style (`Domain/Specific — Topic.md`, frontmatter included).
+        - **Never delete notes wholesale**, never reorganize folders, never rename existing \
+        notes (links point at them). Keep every `[[wikilink]]` intact; add new ones where a new \
+        item genuinely connects.
+        - **Synthesize, don't append-dump.** Fold an item into the narrative of its note — \
+        update facts, extend timelines, collapse redundancy. Multiple versions of the same item \
+        (titles marked “— Edit”) show its evolution: the NEWEST version is the current truth.
+        - If today's items genuinely change who the user is or what they're up to, update the \
+        root `README.md` portrait — otherwise leave it untouched.
+
+        ## ⚠️ TRUTH & ATTRIBUTION — the most important rule (unchanged from your first build)
+        Other AIs will state these facts back to people as truth; a confident false claim is \
+        worse than an omission. The `[source]` tag tells you how much to trust each item: the \
+        user's own authored notes (Obsidian / user-authored / Apple Notes) are genuinely theirs; \
+        screenshots and saved files are often about OTHER people, products, or topics — never \
+        absorb someone else's biography, job, or project into the user. Chat summaries already \
+        attribute facts per person — preserve that attribution. When ambiguous, omit or phrase \
+        literally ("saved a screenshot of X") rather than "is/did X". Never include raw private \
+        specifics (card/account numbers, passwords, exact medical or financial figures).
+
+        ## Today's new items (each: `#index · [source] location · item date`, then `Title — summary`)
+
+        \(lines.joined(separator: "\n\n"))
+
+        Fold them in now. When you are done, reply with ONE line: the number of notes you \
+        created or edited.
+        """
+    }
+}

--- a/Sentient OS macOS/Views/DatabaseView.swift
+++ b/Sentient OS macOS/Views/DatabaseView.swift
@@ -2,10 +2,12 @@
 //  DatabaseView.swift
 //  Sentient OS macOS
 //
-//  The knowledge inspector — a dark, glassy NavigationSplitView over the analyzed artifacts.
-//  Reads Sendable RecordSnapshots from the Store (never touches @Model directly). Real QuickLook
-//  file previews, verdict pills, reminder gradient, search + verdict filters, and a rich detail
-//  pane with Reveal-in-Finder / Open. Inspiration: the iOS DatabaseViewerView, rebuilt for Mac.
+//  The knowledge inspector — a dark, glassy NavigationSplitView over the survivor summaries.
+//  Reads Sendable SummaryRecords from the Store (never touches @Model directly). With the
+//  ledger gone there are no junk/sensitive rows to show — what's here IS the knowledge.
+//  Summaries are versioned: the sidebar lists the latest version per source; the detail pane
+//  shows that source's full version history (edits over time). Real QuickLook thumbnails,
+//  source/folder filters, reminder gradient, Reveal-in-Finder / Open.
 //
 
 import SwiftUI
@@ -18,30 +20,43 @@ struct DatabaseView: View {
 
     let store: Store
 
-    @State private var records: [RecordSnapshot] = []
+    @State private var records: [SummaryRecord] = []    // every version, newest first
     @State private var selectedID: String?
     @State private var search = ""
-    @State private var verdictFilter: Verdict?     // nil = all
-    @State private var folderFilter: String?       // nil = all folders
+    @State private var kindFilter: SourceKind?      // nil = all sources
+    @State private var folderFilter: String?        // nil = all folders
     @State private var loaded = false
 
-    private var filtered: [RecordSnapshot] {
-        records.filter { r in
-            (verdictFilter == nil || r.verdict == verdictFilter)
+    /// Latest version per source (the sidebar rows), preserving newest-first order.
+    private var latest: [SummaryRecord] {
+        var seen = Set<String>()
+        return records.filter { seen.insert($0.sourceID).inserted }
+    }
+
+    private var filtered: [SummaryRecord] {
+        latest.filter { r in
+            (kindFilter == nil || r.kind == kindFilter)
             && (folderFilter == nil || r.folder == folderFilter)
             && (search.isEmpty
-                || (r.summary?.localizedCaseInsensitiveContains(search) ?? false)
+                || r.text.localizedCaseInsensitiveContains(search)
+                || (r.title?.localizedCaseInsensitiveContains(search) ?? false)
                 || r.sourceID.localizedCaseInsensitiveContains(search))
         }
     }
 
     /// Distinct non-empty folders present in the store (for the folder filter pills).
     private var folders: [String] {
-        Array(Set(records.map(\.folder).filter { !$0.isEmpty })).sorted()
+        Array(Set(latest.map(\.folder).filter { !$0.isEmpty })).sorted()
     }
 
-    private var selected: RecordSnapshot? {
-        records.first { $0.id == selectedID }
+    private var selected: SummaryRecord? {
+        latest.first { $0.id == selectedID }
+    }
+
+    /// Every version of the selected source, newest first (records are already newest-first).
+    private var selectedVersions: [SummaryRecord] {
+        guard let s = selected else { return [] }
+        return records.filter { $0.sourceID == s.sourceID }
     }
 
     var body: some View {
@@ -54,7 +69,7 @@ struct DatabaseView: View {
         .frame(minWidth: 880, minHeight: 600)
         .background(Theme.bg)
         .task {
-            records = await store.allRecords()
+            records = await store.allSummaries()
             loaded = true
         }
     }
@@ -65,7 +80,7 @@ struct DatabaseView: View {
         VStack(spacing: 0) {
             VStack(alignment: .leading, spacing: 4) {
                 Text("Knowledge").font(.serif(28)).italic().foregroundStyle(.white)
-                Text("\(filtered.count) of \(records.count) artifacts")
+                Text("\(filtered.count) of \(latest.count) memories · \(LifetimeStats.analyzed.formatted()) things understood")
                     .font(.footnote).foregroundStyle(Theme.secondary)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -76,7 +91,9 @@ struct DatabaseView: View {
             ScrollView {
                 LazyVStack(spacing: 8) {
                     ForEach(filtered) { record in
-                        RecordRow(record: record, isSelected: record.id == selectedID)
+                        RecordRow(record: record,
+                                  versions: versionCount(record.sourceID),
+                                  isSelected: record.id == selectedID)
                             .onTapGesture { selectedID = record.id }
                     }
                 }
@@ -87,21 +104,25 @@ struct DatabaseView: View {
         .background(Theme.bg)
     }
 
+    private func versionCount(_ sourceID: String) -> Int {
+        records.count(where: { $0.sourceID == sourceID })
+    }
+
     private var filterBar: some View {
         VStack(spacing: 10) {
             HStack(spacing: 8) {
                 Image(systemName: "magnifyingglass").foregroundStyle(Theme.faint)
-                TextField("Search summaries & paths", text: $search)
+                TextField("Search summaries, titles & paths", text: $search)
                     .textFieldStyle(.plain).foregroundStyle(.white)
             }
             .padding(.horizontal, 12).padding(.vertical, 9)
             .glassCard(radius: 10)
 
             HStack(spacing: 7) {
-                pill("All", color: .white, active: verdictFilter == nil) { verdictFilter = nil }
-                ForEach([Verdict.survivor, .junk, .sensitive], id: \.self) { v in
-                    pill(Theme.verdictLabel(v), color: Theme.verdictColor(v), active: verdictFilter == v) {
-                        verdictFilter = (verdictFilter == v) ? nil : v
+                pill("All", color: .white, active: kindFilter == nil) { kindFilter = nil }
+                ForEach(SourceKind.allCases, id: \.self) { k in
+                    pill(Self.kindLabel(k), color: Theme.accent, active: kindFilter == k) {
+                        kindFilter = (kindFilter == k) ? nil : k
                     }
                 }
                 Spacer()
@@ -123,6 +144,15 @@ struct DatabaseView: View {
         .padding(.horizontal, 18).padding(.bottom, 12)
     }
 
+    static func kindLabel(_ k: SourceKind) -> String {
+        switch k {
+        case .file:     return "Files"
+        case .whatsapp: return "WhatsApp"
+        case .imessage: return "iMessage"
+        case .notes:    return "Notes"
+        }
+    }
+
     private func pill(_ title: String, color: Color, active: Bool, _ tap: @escaping () -> Void) -> some View {
         Button(action: tap) {
             Text(title)
@@ -137,8 +167,8 @@ struct DatabaseView: View {
     private var emptyState: some View {
         VStack(spacing: 8) {
             Image(systemName: "sparkles").font(.largeTitle).foregroundStyle(Theme.faint)
-            Text("No artifacts yet").foregroundStyle(Theme.secondary)
-            Text("Run the Files pipeline to populate the store.")
+            Text("No memories yet").foregroundStyle(Theme.secondary)
+            Text("Run an analysis to populate the store.")
                 .font(.caption).foregroundStyle(Theme.faint)
         }
         .padding(40)
@@ -148,12 +178,12 @@ struct DatabaseView: View {
 
     @ViewBuilder private var detail: some View {
         if let record = selected {
-            RecordDetail(record: record)
+            RecordDetail(record: record, versions: selectedVersions)
         } else {
             VStack(spacing: 12) {
                 Image(systemName: "rectangle.on.rectangle.angled")
                     .font(.system(size: 38, weight: .thin)).foregroundStyle(Theme.faint)
-                Text("Select an artifact").font(.serif(20)).italic().foregroundStyle(Theme.secondary)
+                Text("Select a memory").font(.serif(20)).italic().foregroundStyle(Theme.secondary)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(Theme.bg)
@@ -164,26 +194,25 @@ struct DatabaseView: View {
 // MARK: - Row
 
 private struct RecordRow: View {
-    let record: RecordSnapshot
+    let record: SummaryRecord
+    let versions: Int
     let isSelected: Bool
 
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
             FileThumbnail(path: record.filePath, size: 46)
             VStack(alignment: .leading, spacing: 4) {
-                if !record.folder.isEmpty || record.verdict != .survivor || record.reminderFlagged {
-                    HStack(spacing: 6) {
-                        if !record.folder.isEmpty { FolderTag(folder: record.folder) }
-                        if record.verdict != .survivor { VerdictBadge(verdict: record.verdict) }
-                        if record.reminderFlagged {
-                            Image(systemName: "bell.fill").font(.system(size: 9))
-                                .foregroundStyle(Theme.reminderGradient)
-                        }
+                HStack(spacing: 6) {
+                    if !record.folder.isEmpty { FolderTag(folder: record.folder) }
+                    if versions > 1 { VersionTag(count: versions) }
+                    if record.reminderFlagged {
+                        Image(systemName: "bell.fill").font(.system(size: 9))
+                            .foregroundStyle(Theme.reminderGradient)
                     }
                 }
                 Text(record.title ?? record.displayName)
                     .font(.subheadline.weight(.medium)).foregroundStyle(.white).lineLimit(1)
-                Text(record.summary ?? record.displayPath)
+                Text(record.text)
                     .font(.caption).foregroundStyle(Theme.secondary).lineLimit(2)
             }
             Spacer(minLength: 0)
@@ -202,7 +231,8 @@ private struct RecordRow: View {
 // MARK: - Detail
 
 private struct RecordDetail: View {
-    let record: RecordSnapshot
+    let record: SummaryRecord          // the latest version
+    let versions: [SummaryRecord]      // all versions, newest first (incl. `record`)
 
     var body: some View {
         ScrollView {
@@ -214,31 +244,49 @@ private struct RecordDetail: View {
                 }
                 .padding(.top, 10)
 
-                if record.verdict != .survivor || record.reminderFlagged {
-                    HStack(spacing: 8) {
-                        if record.verdict == .sensitive { SensitivePill() }
-                        else if record.verdict == .junk { JunkPill() }
-                        if record.reminderFlagged { ReminderPill() }
-                    }
-                }
+                if record.reminderFlagged { ReminderPill() }
 
                 Text(record.title ?? record.displayName)
                     .font(.serif(26)).italic().foregroundStyle(.white)
                     .textSelection(.enabled)
 
-                if let summary = record.summary { field("Summary", summary) }
+                field("Summary", record.text)
 
                 VStack(alignment: .leading, spacing: 11) {
                     meta("Path", record.displayPath)
-                    meta("Source", record.kind.rawValue)
+                    meta("Source", DatabaseView.kindLabel(record.kind))
                     if !record.folder.isEmpty { meta("Folder", record.folder) }
-                    meta("Signature", record.signature)
-                    meta("First seen", record.firstSeen.formatted(date: .abbreviated, time: .shortened))
-                    meta("Last seen", record.lastSeen.formatted(date: .abbreviated, time: .shortened))
+                    if let d = record.itemDate {
+                        meta("Item date", d.formatted(date: .abbreviated, time: .shortened))
+                    }
+                    meta("Analyzed", record.createdAt.formatted(date: .abbreviated, time: .shortened))
+                    meta("In vault", record.syncedToVault.map {
+                        $0.formatted(date: .abbreviated, time: .shortened)
+                    } ?? "queued for next update")
                 }
                 .padding(16)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .glassCard()
+
+                if versions.count > 1 {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("VERSION HISTORY").font(.caption2.weight(.semibold)).tracking(1.2)
+                            .foregroundStyle(Theme.faint)
+                        ForEach(versions.dropFirst()) { v in
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(v.createdAt.formatted(date: .abbreviated, time: .shortened))
+                                    .font(.caption2.monospaced()).foregroundStyle(Theme.faint)
+                                Text(v.text).font(.caption).foregroundStyle(Theme.secondary)
+                                    .textSelection(.enabled)
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
+                            .padding(10)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(Color.white.opacity(0.03),
+                                        in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+                        }
+                    }
+                }
 
                 if let path = record.filePath {
                     HStack(spacing: 10) {
@@ -280,7 +328,7 @@ private struct RecordDetail: View {
     }
 }
 
-// MARK: - Folder tag
+// MARK: - Tags
 
 /// A small accent chip showing which folder an artifact came from (Downloads / Desktop / …).
 private struct FolderTag: View {
@@ -293,6 +341,18 @@ private struct FolderTag: View {
         .foregroundStyle(Theme.accent)
         .padding(.horizontal, 6).padding(.vertical, 2)
         .background(Theme.accent.opacity(0.14), in: Capsule())
+    }
+}
+
+/// "3 versions" — this source has been re-analyzed after edits (summaries are versioned).
+private struct VersionTag: View {
+    let count: Int
+    var body: some View {
+        Text("\(count) versions")
+            .font(.system(size: 9, weight: .medium))
+            .foregroundStyle(Theme.secondary)
+            .padding(.horizontal, 6).padding(.vertical, 2)
+            .background(Color.white.opacity(0.08), in: Capsule())
     }
 }
 

--- a/Sentient OS macOS/Views/RootView.swift
+++ b/Sentient OS macOS/Views/RootView.swift
@@ -37,6 +37,8 @@ struct RootView: View {
     @State private var showIMessagePicker = false
     @State private var resetResult: String?
     @State private var isResetting = false
+    @State private var daysEndResult: String?
+    @State private var isDaysEndRunning = false
     // "More Options" — advanced debug (Full Disk Access + the DB sources), tucked away so the
     // main debug area stays uncluttered.
     @State private var showMoreOptions = false
@@ -143,6 +145,13 @@ struct RootView: View {
             debugTest(title: "Reset store", systemImage: "trash",
                       isRunning: isResetting, result: resetResult, passPrefix: "Cleared",
                       action: { Task { await runReset() } })
+
+            // The scheduler's stand-in [DECIDED]: this button IS the day's-end trigger until
+            // the condition-gate loop lands — which will call exactly the same entry point
+            // (the full pipeline: updater → proactive intelligence → mirror push → notify).
+            debugTest(title: "Run Proactive Intelligence", systemImage: "bell.badge",
+                      isRunning: isDaysEndRunning, result: daysEndResult, passPrefix: "Done",
+                      action: { Task { await runDaysEnd() } })
 
             Button {
                 withAnimation { showMoreOptions.toggle() }
@@ -344,6 +353,13 @@ struct RootView: View {
                     .frame(maxWidth: 460)
             }
         }
+    }
+
+    @MainActor
+    private func runDaysEnd() async {
+        isDaysEndRunning = true
+        defer { isDaysEndRunning = false }
+        daysEndResult = await DaysEndJob.shared.run(store: store)
     }
 
     @MainActor

--- a/Sentient OS macOS/Views/RootView.swift
+++ b/Sentient OS macOS/Views/RootView.swift
@@ -352,8 +352,9 @@ struct RootView: View {
         defer { isResetting = false }
         do {
             try await store.reset()
+            LifetimeStats.reset()
             let counts = await store.counts()
-            resetResult = "Cleared ✓  ledger=\(counts.ledger)  summaries=\(counts.summaries)"
+            resetResult = "Cleared ✓  summaries=\(counts.versions)  pointers=\(counts.cursors)"
         } catch {
             resetResult = "Reset FAIL: \(error)"
         }

--- a/Sentient OS macOS/Views/VaultView.swift
+++ b/Sentient OS macOS/Views/VaultView.swift
@@ -56,6 +56,13 @@ final class VaultModel {
             // they supersede) — anything newer stays queued for the iterative updater.
             await store.markCorpusSynced(summaries)
             phase = .done
+            // The vault changed → mirror push (if enabled), plus the day-one welcome briefing.
+            // Both best-effort and off the UI path.
+            VaultActivity.shared.vaultDirty = true
+            Task.detached(priority: .utility) {
+                await VaultGenerator().writeWelcomeBriefing()
+                _ = await DaysEndJob.shared.pushIfDirty()
+            }
         } catch let VaultGenerator.VaultError.usageLimit(message, resume) {
             resumeToken = resume
             errorMsg = "Claude hit its usage limit — \"Try again\" later will resume right where it left off. (\(message.prefix(160)))"

--- a/Sentient OS macOS/Views/VaultView.swift
+++ b/Sentient OS macOS/Views/VaultView.swift
@@ -29,7 +29,7 @@ final class VaultModel {
     var resumeToken: VaultGenerator.ResumeToken?
 
     func loadCount(_ store: Store) async {
-        summaryCount = await store.counts().summaries
+        summaryCount = await store.counts().sources   // distinct sources = the corpus size
     }
 
     func run(_ store: Store) async {
@@ -52,7 +52,9 @@ final class VaultModel {
             }
             result = res
             resumeToken = nil
-            await store.markAllSurvivorsSynced()
+            // Stamp exactly what this full generation represented (corpus rows + the versions
+            // they supersede) — anything newer stays queued for the iterative updater.
+            await store.markCorpusSynced(summaries)
             phase = .done
         } catch let VaultGenerator.VaultError.usageLimit(message, resume) {
             resumeToken = resume


### PR DESCRIPTION
The June-11 handoff (Aditya's Corner), both parts, one branch.

## Part I — pointers everywhere (commit 1)
- **LedgerEntry + tombstones deleted.** Per-source pointers in `SourceCursor` answer "what's new?": `file:<root>` = `(date|path)`, `whatsapp:<jid>` / `imessage:<guid>` = per-chat Z_PK/ROWID, `notes` = `(modDate|uuid)`. Initial + incremental analysis are now ONE code path; junk/sensitive leave **zero trace**.
- **Versioned summaries:** `sourceID` no longer unique — re-analysis inserts a new row (` — Edit` title). `Summary` absorbed `kind`/`folder` (the vault prompt's source-trust tiers need them) and gained `itemDate`. Rows are born `syncedToVault == nil` → the updater's queue self-populates.
- **Two deliberate divergences from the handoff text** (flagged in the deep-analysis pass, folded in with Aditya's go-ahead):
  - **Per-chat pointers**, not one global Z_PK/ROWID pointer — chats interleave in PK space; a global pointer loses messages on crash.
  - **Failure policy:** retry-once-after-engine-reload, then the pointer passes the item (no poison pills) — the literal "pointer never passes failures" rule would re-process everything behind one corrupt file forever.
- Files date = `max(dateAdded, mtime, moved-in ancestor dateAdded)` (catches folders dragged into a root), future-clamped; 60-min freshness hold-back everywhere; caps unchanged.
- ⚠️ **Schema change = dev-store wipe.** All three Macs re-run analysis after merge.

## 🔁 Scope change (commit 5f4818a): proactive intelligence backed out
Aditya's call: proactive gets its **own module + own trigger**, sequenced AFTER knowledge-base updates — never inside the day's-end pipeline. This PR now delivers **the pointer rewrite + the iterative updater** behind the **"Update Knowledge Base"** dev button (updater → mirror push → notify). The working proactive scaffold (judge, `--json-schema` decisions, ≤1/day code cap, both tiers) remains minable at `67d8078`, with two measured gotchas documented (native-representation date pointers; never `requestAuthorization` headless). Re-verified after removal: build green, `incremental` 11/11, `daysend` 5/5 live.

## Part II — the living system (commit 2)
- **`DaysEndJob.run()`** — the one entry point (editor-idle check → updater → proactive → mirror push → notify), single-flight; the **"Update Knowledge Base" dev button** fires it until the scheduler lands (the scheduler just calls the same function).
- **`VaultUpdater`:** unsynced summaries + skeleton tree → ONE Sonnet call (Read/Glob/Grep/Write/Edit, cwd = LIVE vault), cp -R snapshot net, usage-limit `--resume`, exact-row stamping.
- **`Proactive`:** judge (Sonnet, no tools, `--json-schema`) over flagged summaries past the `proactive` pointer → tier-1 scheduled reminder / tier-2 agentic briefing (vault + WebSearch → Briefings folder, deliberately OUTSIDE the vault). ≤1/day enforced in prompt AND code.
- **`VaultActivity` + `pushIfDirty()`** close the "nothing auto-pushes yet" gap (initial gen pushes too; flag clears only on push success). **Welcome briefing** ships with initial gen.

## Verification (all on this Mac)
- Build green · `incremental` self-test **11/11** · `skipping` **17/17** · `proactive` **5/5 live** (taste cap + pointer round-trip) · `daysend` **5/5 live** — real Sonnet folded 2 seeded memories into a fixture vault (8 turns, 34s), exact rows stamped, second run no-op.
- Context files (1, 2, 4) + codebase `Documentation/` updated in lockstep (the four-file truth rule).

**Not in scope (deliberate):** the condition-gate scheduler (handoff scope), all Phase-5 UI (per Aditya, mid-build).

## ⚠️ Post-merge migration (all three Macs)
The schema change auto-wipes your dev store on first launch. Your **vault on disk survives** — don't regenerate it. Instead:
1. **Start Analysis** (rebuilds the store; every summary lands unsynced).
2. Quit the app, then stamp the corpus as already-in-vault (it is — your vault was built from these same items):
   `sqlite3 ~/Library/Application\ Support/default.store "UPDATE ZSUMMARY SET ZSYNCEDTOVAULT = strftime('%s','now') - 978307200 WHERE ZSYNCEDTOVAULT IS NULL;"`
3. Relaunch. "Update Knowledge Base" now folds only what's new.

Skipping step 2 and pressing the button would push your ENTIRE re-analyzed corpus through the Sonnet daily-updater in one job — don't. (No vault on disk yet? Then just analyze + Create Knowledge Base as usual.)

