### PR TITLE
Back out the welcome briefing (For You/proactive territory)

### DIFF
--- a/Sentient OS macOS/CodexCLI.swift
+++ b/Sentient OS macOS/CodexCLI.swift
@@ -47,8 +47,8 @@ actor CodexCLI {
         var effort: Effort = .medium
         var sandbox: Sandbox = .readOnly
         var cwd: String? = nil                 // the agent's working root (vault/staging dir)
-        var addDirs: [String] = []             // extra writable roots (the Briefings folder)
-        var webSearch = false                  // native web_search tool (tier-2 briefings)
+        var addDirs: [String] = []             // extra writable roots beyond cwd
+        var webSearch = false                  // native web_search tool
         var outputSchema: String? = nil        // JSON Schema for the final message (the judge)
         var resumeSessionID: String? = nil     // continue a prior session (usage-limit recovery)
         var timeout: TimeInterval = 3_600      // agentic vault runs are long; default generous

--- a/Sentient OS macOS/Documentation/CodexCLI (codex exec Compute Spine).md
+++ b/Sentient OS macOS/Documentation/CodexCLI (codex exec Compute Spine).md
@@ -16,7 +16,7 @@ piggybacks on the user's own Codex CLI (their ChatGPT subscription pays). Replac
 
 `Invocation`: `prompt` (always over **stdin**, never argv) · `effort` (`.high` = initial gen,
 `.medium` = everything daily) · `sandbox` (`.readOnly` default / `.workspaceWrite`) · `cwd` ·
-`addDirs` (extra writable roots, e.g. Briefings) · `webSearch` · `outputSchema` (JSON-Schema
+`addDirs` (extra writable roots) · `webSearch` · `outputSchema` (JSON-Schema
 string → temp file → `--output-schema`) · `resumeSessionID` · `timeout` (default 1 h).
 
 `Envelope`: `result` (final agent message) · `sessionID` (thread id — the resume handle) ·
@@ -59,7 +59,7 @@ ChatGPT-plan limit message is still unverified — refine the markers during dog
 |---|---|
 | GUI-spawnable, sanitized env | `env -i HOME USER PATH=system` + absolute path → PIGGYBACK_OK. Auth = `~/.codex/auth.json` (file, not Keychain), no TTY. |
 | Agentic file-writing, headless | `-s workspace-write -C <dir>` wrote exact-content files, zero prompts; `file_change` events stream per-file progress |
-| `--add-dir` | wrote outside cwd into the add-dir'd folder (the Briefings pattern) |
+| `--add-dir` | wrote outside cwd into the add-dir'd folder (extra writable root) |
 | `--output-schema` | clean conforming JSON for the proactive `{time, text}` shape |
 | Resume | same thread id, full memory; workspace = process cwd (see above) |
 | Web search | `-c tools.web_search=true` → `web_search` items, correct live answer |

--- a/Sentient OS macOS/Documentation/Days-End Job (Living System).md
+++ b/Sentient OS macOS/Documentation/Days-End Job (Living System).md
@@ -54,14 +54,6 @@ Small `UNUserNotificationCenter` wrapper (`now(title:body:)` only, for now). Per
 requested lazily on first use (the real ask moves into onboarding); suppressed entirely under
 `SENTIENT_SELFTEST`. Quiet by design — no-op runs never notify.
 
-## The welcome briefing
-
-Initial generation's second act (`VaultGenerator.writeWelcomeBriefing()`): a cheap medium-effort pass
-over the freshly built vault that writes "What I learned about you" (portrait + 3–5
-cross-domain connections + what happens next) into the **Briefings folder**
-(`~/Library/Application Support/SentientOS/Briefings/` — deliberately OUTSIDE the vault, so
-For You artifacts never ride the mirror push). Best-effort, off the UI path, fired alongside
-the post-gen mirror push.
 
 ## Self-test (a real cloud call — it spends a little budget)
 

--- a/Sentient OS macOS/VaultGenerator.swift
+++ b/Sentient OS macOS/VaultGenerator.swift
@@ -16,25 +16,11 @@
 //  Key methods:
 //   - generate(summaries:resume:onProgress:)  → the agentic build, returns stats
 //   - vaultRoot                               → ~/Sentient OS -- The Vault
-//   - writeWelcomeBriefing()                  → initial gen's second act (For You day one)
 //
 //  Doc: Documentation/Vault Generation (Stage 2).md
 //
 
 import Foundation
-
-/// Where For You artifacts live — `~/Library/Application Support/SentientOS/Briefings/`
-/// [STARTING POINT], deliberately outside the vault (briefings are artifacts we generate,
-/// not the user's knowledge base — they must never ride the mirror push). Written by the
-/// welcome briefing today; proactive intelligence (rebuilt separately) writes here next.
-enum Briefings {
-    static var dir: URL {
-        let d = URL.applicationSupportDirectory
-            .appendingPathComponent("SentientOS/Briefings", isDirectory: true)
-        try? FileManager.default.createDirectory(at: d, withIntermediateDirectories: true)
-        return d
-    }
-}
 
 actor VaultGenerator {
 
@@ -168,48 +154,6 @@ actor VaultGenerator {
                       inputTokens: envelope.inputTokens ?? 0,
                       outputTokens: envelope.outputTokens ?? 0,
                       vaultPath: root.path)
-    }
-
-    /// The welcome briefing — initial gen's second act ("here's what I learned about you"),
-    /// For You's day-one artifact. A cheap medium-effort pass over the freshly built vault that lands
-    /// ONE .md in the Briefings folder (outside the vault — it never rides the mirror push).
-    /// Best-effort: a failure logs and moves on; the vault itself is already safe on disk.
-    func writeWelcomeBriefing() async {
-        let date: String = {
-            let f = ISO8601DateFormatter(); f.formatOptions = [.withFullDate]
-            return f.string(from: Date())
-        }()
-        let file = Briefings.dir.appendingPathComponent("\(date) — What I learned about you.md")
-
-        var inv = CodexCLI.Invocation(prompt: """
-            You just finished organizing a person's entire digital life into the Obsidian-style \
-            knowledge vault that is your working directory. Now write them a welcome.
-
-            Read the root README.md first, then explore a handful of the most interesting notes \
-            (be selective, not exhaustive). Then write ONE markdown briefing to \
-            this exact path:
-            \(file.path)
-
-            Shape: title "What I learned about you". Open with a warm, specific portrait of who \
-            they are — a few real paragraphs, addressed to them as "you" (never "the user"). \
-            Then 3–5 delightful cross-domain connections you noticed that they might not have \
-            seen themselves (the screenshot trail that matches a note, the plan echoed across \
-            chats…). Close with one short paragraph on what happens next: their vault now stays \
-            current automatically, and their other AIs can read it the moment they connect. \
-            Specific beats flattering; true beats complete. Never include raw private specifics.
-
-            When the briefing is written, reply with one line: DONE.
-            """)
-        inv.sandbox = .workspaceWrite
-        inv.cwd = Self.vaultRoot.path
-        inv.addDirs = [Briefings.dir.path]
-        inv.timeout = 600
-        do {
-            _ = try await CodexCLI.shared.run(inv)
-            Log("VaultGenerator: welcome briefing → \(file.lastPathComponent)")
-        } catch {
-            Log("VaultGenerator: welcome briefing failed — \(error)")
-        }
     }
 
     /// Count the .md notes (and folders containing them) under a directory.

--- a/Sentient OS macOS/Views/VaultView.swift
+++ b/Sentient OS macOS/Views/VaultView.swift
@@ -54,11 +54,9 @@ final class VaultModel {
             // they supersede) — anything newer stays queued for the iterative updater.
             await store.markCorpusSynced(summaries)
             phase = .done
-            // The vault changed → mirror push (if enabled), plus the day-one welcome briefing.
-            // Both best-effort and off the UI path.
+            // The vault changed → mirror push (if enabled), best-effort and off the UI path.
             VaultActivity.shared.vaultDirty = true
             Task.detached(priority: .utility) {
-                await VaultGenerator().writeWelcomeBriefing()
                 _ = await DaysEndJob.shared.pushIfDirty()
             }
         } catch let VaultGenerator.VaultError.usageLimit(message, resume) {


### PR DESCRIPTION
Aditya's call: the welcome briefing is initial-gen/For-You/onboarding work, not the updater spine — same logic as the proactive back-out. Removed `writeWelcomeBriefing()`, the `Briefings` helper (zero consumers left), and the post-gen call; **the post-gen mirror push is untouched**. Docs + TODO updated (item back to unchecked under Jesai, with a pointer to the minable implementation at `17d5ad2` — rebuild against CodexCLI when the time comes). Build green on this head.