### PR TITLE
Initial vault gen runs at xhigh reasoning effort

### DIFF
--- a/Sentient OS macOS/CodexCLI.swift
+++ b/Sentient OS macOS/CodexCLI.swift
@@ -28,8 +28,9 @@ actor CodexCLI {
     // MARK: Types
 
     /// Every job runs GPT-5.5 (1M context; 400k input through codex). Tiers differ only in
-    /// reasoning effort: `.high` for the initial vault build, `.medium` for everything daily.
+    /// reasoning effort: `.xhigh` for the initial vault build, `.medium` for everything daily.
     enum Effort: String, Sendable {
+        case xhigh                               // [MEASURED June 11] accepted live by codex 0.139.0
         case high
         case medium
     }

--- a/Sentient OS macOS/Documentation/CodexCLI (codex exec Compute Spine).md
+++ b/Sentient OS macOS/Documentation/CodexCLI (codex exec Compute Spine).md
@@ -14,8 +14,9 @@ piggybacks on the user's own Codex CLI (their ChatGPT subscription pays). Replac
   `force: true` re-probes (the installer flow).
 - `run(Invocation) → Envelope` — one headless call, typed errors.
 
-`Invocation`: `prompt` (always over **stdin**, never argv) · `effort` (`.high` = initial gen,
-`.medium` = everything daily) · `sandbox` (`.readOnly` default / `.workspaceWrite`) · `cwd` ·
+`Invocation`: `prompt` (always over **stdin**, never argv) · `effort` (`.xhigh` = initial gen
+[MEASURED June 11: accepted live by codex 0.139.0], `.medium` = everything daily, `.high`
+available but currently unused) · `sandbox` (`.readOnly` default / `.workspaceWrite`) · `cwd` ·
 `addDirs` (extra writable roots) · `webSearch` · `outputSchema` (JSON-Schema
 string → temp file → `--output-schema`) · `resumeSessionID` · `timeout` (default 1 h).
 

--- a/Sentient OS macOS/Documentation/Vault Generation (Stage 2).md
+++ b/Sentient OS macOS/Documentation/Vault Generation (Stage 2).md
@@ -2,7 +2,7 @@
 
 `VaultGenerator.generate(summaries:resume:onProgress:)` turns the on-device survivor
 summaries into the markdown vault at `~/Sentient OS -- The Vault/`, through ONE route:
-`codex exec` via the `CodexCLI` spine — GPT-5.5 **high effort**, `workspace-write` sandbox,
+`codex exec` via the `CodexCLI` spine — GPT-5.5 **xhigh effort**, `workspace-write` sandbox,
 cwd = a staging dir; the model writes the `.md` files itself with its file tools. Without a
 working codex the run throws `CodexCLI`'s `.notAvailable` (no fallback — the free tier is
 the eventual answer for no-codex users; the old direct-Anthropic-API route and its

--- a/Sentient OS macOS/VaultGenerator.swift
+++ b/Sentient OS macOS/VaultGenerator.swift
@@ -109,7 +109,7 @@ actor VaultGenerator {
         }
 
         var invocation = CodexCLI.Invocation(prompt: prompt)
-        invocation.effort = .high                            // the initial build gets the deep pass
+        invocation.effort = .xhigh                           // the initial build gets the deepest pass
         invocation.sandbox = .workspaceWrite                 // writes confined to the staging dir
         invocation.cwd = staging.path
         invocation.resumeSessionID = resume?.sessionID

--- a/Sentient OS macOS/VaultUpdater.swift
+++ b/Sentient OS macOS/VaultUpdater.swift
@@ -4,7 +4,7 @@
 //
 //  The iterative vault updater (Part II §B) — the day's-end cloud job that folds NEW survivor
 //  summaries into the EXISTING vault. One `codex exec` call (medium effort — daily updates
-//  are cheap; high effort stays reserved for initial generation): the vault's skeleton tree
+//  are cheap; xhigh effort stays reserved for initial generation): the vault's skeleton tree
 //  + the unsynced summaries go in over stdin, the agent explores only the notes it needs
 //  and rewrites only what changed, working directly on the LIVE vault — no staging dir,
 //  because the inputs are tiny and edits are surgical. A cp -R snapshot is the safety net:


### PR DESCRIPTION
## What

The initial vault build now runs GPT-5.5 at **`xhigh`** reasoning effort instead of `high`. Daily updates, the proactive judge, and briefings stay `medium` — untouched.

## Changes

- **`CodexCLI.swift`** — `Effort` enum gains `case xhigh`. `.high` stays (valid tier, currently unused).
- **`VaultGenerator.swift`** — initial-gen invocation `.high` → `.xhigh`.
- **Docs kept true** — `VaultUpdater` header comment + `Documentation/CodexCLI (codex exec Compute Spine).md` + `Documentation/Vault Generation (Stage 2).md` updated to match. (File 2 §5/§6 in `Our_Stuff` updated too — rides Obsidian Sync, not this PR.)

## Receipt

`xhigh` was NOT in the June 11 receipts (only `high`/`medium` were measured), so it was verified live before hardcoding — codex-cli 0.139.0, Jesai's Mac, sanitized env:

```
codex exec -m gpt-5.5 -c model_reasoning_effort="xhigh" …  →  clean envelope, XHIGH_OK
```

Project builds green (Xcode MCP `BuildProject`).

## Watch during dogfood

xhigh = more reasoning tokens + longer wall clock on initial gen → burns the user's subscription window faster on big corpora. The usage-limit resume machinery already covers it; just expect the limit markers to fire a bit more often at full scale.