### PR TITLE
Fix codex discovery (nvm installs) + honest day's-end status + e2e harness

### DIFF
--- a/Sentient OS macOS/CodexCLI.swift
+++ b/Sentient OS macOS/CodexCLI.swift
@@ -109,22 +109,35 @@ actor CodexCLI {
             return cached
         }
         let home = fm.homeDirectoryForCurrentUser.path
-        let known = [
+        var known = [
             "\(home)/.local/bin/codex",        // the standalone installer's symlink
             "/opt/homebrew/bin/codex",         // brew / npm -g (Apple Silicon)
             "/usr/local/bin/codex",
         ]
+        // npm-under-nvm (`npm i -g @openai/codex` with nvm-managed node): the binary lives in
+        // a VERSIONED dir invisible to fixed paths AND to non-interactive shells (nvm inits in
+        // .zshrc). Newest node version first. [MEASURED on Aditya's Mac — the app saw
+        // "notInstalled" for a fully working, logged-in codex.]
+        let nvmBin = "\(home)/.nvm/versions/node"
+        if let versions = try? fm.contentsOfDirectory(atPath: nvmBin) {
+            known += versions.sorted(by: >).map { "\(nvmBin)/\($0)/bin/codex" }
+        }
         let found = known.first(where: { fm.isExecutableFile(atPath: $0) }) ?? whichViaLoginShell()
         if let found { UserDefaults.standard.set(found, forKey: pathCacheKey) }
         return found
     }
 
+    /// `zsh -lic` (INTERACTIVE login shell — `-lc` never sources .zshrc, where nvm/asdf/volta
+    /// init). Interactive shells print theme noise, so the output is scanned line-by-line for
+    /// something that is actually an executable path. Watchdog-bounded; can't hang.
     private static func whichViaLoginShell() -> String? {
-        guard let out = try? execute(binary: "/bin/zsh", args: ["-lc", "which codex"],
-                                     stdinText: nil, cwd: nil, timeout: 5),
-              out.status == 0 else { return nil }
-        let path = out.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
-        return FileManager.default.isExecutableFile(atPath: path) ? path : nil
+        guard let out = try? execute(binary: "/bin/zsh", args: ["-lic", "which codex"],
+                                     stdinText: nil, cwd: nil, timeout: 5) else { return nil }
+        let fm = FileManager.default
+        return (out.stdout + "\n" + out.stderr)
+            .split(separator: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .first { $0.hasPrefix("/") && fm.isExecutableFile(atPath: $0) }
     }
 
     // MARK: Validation
@@ -314,7 +327,11 @@ actor CodexCLI {
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: binary)
         proc.arguments = args
-        var env: [String: String] = ["PATH": "/usr/bin:/bin:/usr/sbin:/sbin"]
+        // The binary's OWN directory leads the sanitized PATH: npm installs are
+        // `#!/usr/bin/env node` shims, and (in the nvm layout) `node` sits right next to
+        // them — without this, the shim exec-fails even when found.
+        let binDir = (binary as NSString).deletingLastPathComponent
+        var env: [String: String] = ["PATH": "\(binDir):/usr/bin:/bin:/usr/sbin:/sbin"]
         let current = ProcessInfo.processInfo.environment
         for key in ["HOME", "USER"] where current[key] != nil { env[key] = current[key] }
         proc.environment = env

--- a/Sentient OS macOS/DaysEndJob.swift
+++ b/Sentient OS macOS/DaysEndJob.swift
@@ -47,24 +47,35 @@ actor DaysEndJob {
         //    re-enter the queue and the run continues to the push step (vaultDirty may still
         //    be set from an earlier change).
         var folded = 0
+        var failed = false
         do {
             folded = try await VaultUpdater.shared.runDailyUpdate(store: store)
             // N = summaries the updater REVIEWED (and stamped) — it folds in only what's
             // worth keeping; reviewing everything and changing nothing is a valid outcome.
             parts.append(folded == 0 ? "nothing new to fold" : "reviewed \(folded) new memories")
         } catch {
+            failed = true
             parts.append((error as? LocalizedError)?.errorDescription ?? "\(error)")
         }
 
         // 2) Mirror push — any run that ends with a dirty vault and the mirror enabled.
         parts.append(await pushIfDirty())
 
-        // 3) Quiet by design: notify only when there was something to review.
+        // 3) Quiet by design: notify only when there was something to review — and never
+        //    block the run's completion on it: the first notification ever triggers the
+        //    system permission dialog, and awaiting that (it resolves only when the user
+        //    answers) would hang this status return — i.e. a forever-spinning dev button.
         if folded > 0 {
-            await Notify.now(title: "Your knowledge base is up to date",
-                             body: "Caught up on \(folded) new \(folded == 1 ? "memory" : "memories") while your Mac rested.")
+            let n = folded
+            Task.detached(priority: .utility) {
+                await Notify.now(title: "Your knowledge base is up to date",
+                                 body: "Caught up on \(n) new \(n == 1 ? "memory" : "memories") while your Mac rested.")
+            }
         }
-        let status = "Done — " + parts.joined(separator: " · ")
+        // "Failed —" / "Done —" prefixes are load-bearing: the dev button colors results by
+        // prefix, and a failure wearing "Done" reads as success (measured: the missing-vault
+        // error showed green).
+        let status = (failed ? "Failed — " : "Done — ") + parts.joined(separator: " · ")
         Log("DaysEndJob: \(status)")
         return status
     }

--- a/Sentient OS macOS/Documentation/CodexCLI (codex exec Compute Spine).md
+++ b/Sentient OS macOS/Documentation/CodexCLI (codex exec Compute Spine).md
@@ -8,7 +8,7 @@ piggybacks on the user's own Codex CLI (their ChatGPT subscription pays). Replac
 ## Surface
 
 - `CodexCLI.locateBinary()` — known paths (`~/.local/bin/codex`, `/opt/homebrew/bin/codex`,
-  `/usr/local/bin/codex`) then `zsh -lc "which codex"`; cached in UserDefaults
+  `/usr/local/bin/codex`) then `zsh -lic (interactive — .zshrc is where nvm/asdf init) "which codex"`; cached in UserDefaults
   (`codexcli.binaryPath`), re-verified on every read.
 - `validate(force:)` — ping (`Reply with exactly: PIGGYBACK_OK`, 30 s), cached per app launch;
   `force: true` re-probes (the installer flow).

--- a/Sentient OS macOS/Self Tests - Temp/SelfTest_E2E.swift
+++ b/Sentient OS macOS/Self Tests - Temp/SelfTest_E2E.swift
@@ -1,0 +1,150 @@
+//
+//  SelfTest_E2E.swift — the full incremental loop, headless (analysis → updater → repeat)
+//  Sentient OS macOS
+//
+//  The end-to-end proof of the iterative system on REAL machinery: the actual on-device
+//  Engine summarizes a fixture folder through the actual Pipeline (pointers and all), then
+//  the actual DaysEndJob folds the survivors into a fixture vault via codex. Then a NEW file
+//  appears, and the loop runs again — asserting the pointer picks up ONLY the new file and
+//  the updater reviews ONLY the new summaries. No 1-hour wait: the FilesSource test seams
+//  (`testZeroHoldBack` / `testIgnoreDateAdded`) disable the freshness hold-back.
+//
+//    SENTIENT_SELFTEST=e2e SENTIENT_VAULT_ROOT=/tmp/scratch-vault
+//
+//  Spends: ~4 on-device inferences (seconds each) + 2 codex medium calls (~30s each).
+//  REQUIRES the vault-root override (protects the real vault) and refuses to run if the
+//  mirror is enabled without SENTIENT_MIRROR_BASE (the push would clobber the real mirror).
+//
+
+#if DEBUG
+import Foundation
+import SwiftData
+
+enum SelfTestE2E {
+
+    static func run(emit: (String) -> Void) async {
+        let env = ProcessInfo.processInfo.environment
+
+        // Gates: model on disk, codex working, scratch vault root, mirror safety.
+        guard let modelPath = ModelLocator.resolve() else {
+            emit("SKIP — on-device model not found (set SENTIENT_MODEL_PATH)"); return
+        }
+        let codex = await CodexCLI.shared.validate()
+        guard case .available = codex else { emit("SKIP — Codex unavailable: \(codex)"); return }
+        let home = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Sentient OS -- The Vault").path
+        guard let scratch = env["SENTIENT_VAULT_ROOT"], !scratch.isEmpty, scratch != home else {
+            emit("SET SENTIENT_VAULT_ROOT to a scratch dir (NOT the real vault) and re-run."); return
+        }
+        if await MirrorClient.shared.isEnabled && env["SENTIENT_MIRROR_BASE"] == nil {
+            emit("ABORT — mirror enabled without SENTIENT_MIRROR_BASE; the push step would "
+                 + "replace your real hosted mirror. Disable the mirror or set the override."); return
+        }
+
+        FilesSource.testIgnoreDateAdded = true
+        FilesSource.testZeroHoldBack = true
+        defer { FilesSource.testIgnoreDateAdded = false; FilesSource.testZeroHoldBack = false }
+
+        var pass = 0, fail = 0
+        func check(_ name: String, _ ok: Bool, _ detail: String = "") {
+            if ok { pass += 1 } else { fail += 1 }
+            emit("\(ok ? "✅" : "❌") \(name)\(detail.isEmpty ? "" : "  (\(detail))")")
+        }
+
+        let fm = FileManager.default
+
+        // Fixture source folder — content concrete enough that triage keeps it.
+        let folder = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("sentient-e2e-\(UUID().uuidString.prefix(8))")
+        try? fm.createDirectory(at: folder, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: folder) }
+        func drop(_ name: String, _ body: String, mtimeAgo: TimeInterval) {
+            let p = folder.appendingPathComponent(name)
+            try? body.write(to: p, atomically: true, encoding: .utf8)
+            let then = Date().addingTimeInterval(-mtimeAgo)
+            try? fm.setAttributes([.creationDate: then, .modificationDate: then], ofItemAtPath: p.path)
+        }
+        drop("Lisbon Trip Plan.md",
+             "Booked flights to Lisbon July 18–25. Staying in Alfama. Shortlist: Memmo Alfama vs "
+             + "Santiago de Alfama. Need to reserve Sintra day-trip tickets before July 1.",
+             mtimeAgo: 7_200)
+        drop("Espresso Setup.md",
+             "Ordered the Gaggia Classic Pro. Dial-in plan: 18g in, 36g out, 25–30s. Grinder is the "
+             + "DF64. First service: replace the steam wand with the IMS tip.",
+             mtimeAgo: 5_400)
+        drop("Marathon Training.md",
+             "Registered for the CIM marathon on December 6. 16-week block starts August 17: 4 runs "
+             + "a week, long run Sundays, goal 3:25.",
+             mtimeAgo: 3_600)
+
+        // Fixture vault (the updater's target — we don't spend a high-effort initial gen here).
+        let vault = URL(fileURLWithPath: scratch, isDirectory: true)
+        try? fm.removeItem(at: vault)
+        try? fm.createDirectory(at: vault.appendingPathComponent("Life"), withIntermediateDirectories: true)
+        try? "# README\nFixture human: an SF engineer who travels, lifts, and tinkers.\n## Map\n- Life/\n"
+            .write(to: vault.appendingPathComponent("README.md"), atomically: true, encoding: .utf8)
+        try? "---\ntitle: Hobbies\n---\n# Hobbies\nThe user enjoys coffee and running.\n"
+            .write(to: vault.appendingPathComponent("Life/Hobbies.md"), atomically: true, encoding: .utf8)
+
+        // Real store (in-memory), real engine, real pipeline.
+        let container: ModelContainer
+        do {
+            container = try ModelContainer(for: Summary.self, SourceCursor.self,
+                                           configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+        } catch { emit("ModelContainer FAILED: \(error)"); return }
+        let store = Store(modelContainer: container)
+        let source = FilesSource(root: folder, label: "Fixture", cursorKey: "file:e2e")
+        let engine = Engine(modelPath: modelPath, maxNumTokens: 4096)
+        do { try await engine.load() } catch { emit("engine load FAILED: \(error)"); return }
+        defer { Task { await engine.unload() } }
+        let pipeline = Pipeline(engine: engine, store: store)
+
+        // ── Round 1: initial analysis + first fold ───────────────────────────────
+        emit("ROUND 1 — analyzing 3 fixture files on-device…")
+        let p1: PipelineProgress
+        do { p1 = try await pipeline.run(source: source, currentDate: Date()) }
+        catch { emit("pipeline FAILED: \(error)"); return }
+        let survivors1 = await store.unsyncedSummaries().count
+        check("analyzed all 3 files", p1.done == 3, "done \(p1.done)")
+        check("at least 1 survivor (triage kept real content)", survivors1 >= 1,
+              "survivors \(survivors1) · junk \(p1.junk)")
+
+        emit("ROUND 1 — running DaysEndJob (real codex call)…")
+        let s1 = await DaysEndJob.shared.run(store: store)
+        emit("status: \(s1)")
+        check("round-1 status is a Done", s1.hasPrefix("Done"), s1)
+        check("round-1 reviewed the survivors", s1.contains("reviewed \(survivors1)"), s1)
+        check("round-1 stamped exactly the queue", await store.unsyncedSummaries().isEmpty)
+
+        // ── Round 2: ONE new file → pointer picks up only it → second fold ──────
+        drop("Dentist Appointment.md",
+             "Dentist cleaning booked for June 24 at 2:30 PM with Dr. Yu at SF Dental on Mission. "
+             + "Bring the new insurance card.",
+             mtimeAgo: 1_800)
+        emit("\nROUND 2 — one NEW file added; re-analyzing…")
+        let p2: PipelineProgress
+        do { p2 = try await pipeline.run(source: source, currentDate: Date()) }
+        catch { emit("pipeline FAILED: \(error)"); return }
+        let survivors2 = await store.unsyncedSummaries().count
+        check("pointer picked up ONLY the new file", p2.done == 1, "done \(p2.done)")
+
+        let s2 = await DaysEndJob.shared.run(store: store)
+        emit("status: \(s2)")
+        if survivors2 >= 1 {
+            check("round-2 reviewed only the new summaries", s2.contains("reviewed \(survivors2)"), s2)
+            check("round-2 stamped them", await store.unsyncedSummaries().isEmpty)
+        } else {
+            check("round-2 no-op (triage junked the new file)", s2.contains("nothing new to fold"), s2)
+        }
+
+        // ── Round 3: nothing changed → full no-op ────────────────────────────────
+        let p3 = (try? await pipeline.run(source: source, currentDate: Date()))
+        let s3 = await DaysEndJob.shared.run(store: store)
+        check("round-3 analysis is a no-op", (p3?.done ?? -1) == 0, "done \(p3?.done ?? -1)")
+        check("round-3 update is a no-op", s3.contains("nothing new to fold"), s3)
+
+        emit("\nvault skeleton after:\n\(VaultUpdater.skeleton(of: vault))")
+        emit("\n# \(fail == 0 ? "✅ ALL PASS" : "❌ FAILURES") — \(pass) passed · \(fail) failed")
+    }
+}
+#endif

--- a/Sentient OS macOS/Self Tests - Temp/SelfTest_Triage_Pipeline_and_Vault.swift
+++ b/Sentient OS macOS/Self Tests - Temp/SelfTest_Triage_Pipeline_and_Vault.swift
@@ -95,6 +95,11 @@ enum SelfTest {
         // "daysend" needs SENTIENT_VAULT_ROOT (fixture vault).
         if mode == "daysend" { await SelfTestDaysEnd.daysend(emit: emit); return }
 
+        // Full incremental loop, headless (SelfTest_E2E.swift): REAL engine analysis of a
+        // fixture folder → REAL codex updater → new file → pointer-only re-analysis → fold →
+        // no-op. Needs the model + codex + SENTIENT_VAULT_ROOT.
+        if mode == "e2e" { await SelfTestE2E.run(emit: emit); return }
+
         // CodexCLI mode: no model needed — discovery, ping, and one tiny run through the REAL
         // codex exec spine (binary → env → stdin → JSONL envelope). Verifies the compute
         // waterfall's tier-1 path end to end on this Mac.

--- a/Sentient OS macOS/VaultGenerator.swift
+++ b/Sentient OS macOS/VaultGenerator.swift
@@ -115,6 +115,7 @@ actor VaultGenerator {
         invocation.resumeSessionID = resume?.sessionID
         invocation.timeout = 3_600
 
+        Log("VaultGenerator: \(resume == nil ? "starting" : "RESUMING") initial generation — \(summaries.count) summaries → \(staging.lastPathComponent)")
         onProgress(.calling)
 
         // Progress = the files themselves: poll the staging dir's .md count. Honest, and
@@ -133,12 +134,18 @@ actor VaultGenerator {
             envelope = try await CodexCLI.shared.run(invocation)
         } catch let CodexCLI.CLIError.usageLimit(message, sessionID) {
             // Staging is deliberately KEPT — the resume token points at it.
+            Log("VaultGenerator: ⚠️ usage limit mid-generation (session \(sessionID ?? "nil"), staging kept) — \(message.prefix(160))")
             throw VaultError.usageLimit(message: message,
                                         resume: ResumeToken(sessionID: sessionID, stagingPath: staging.path))
+        } catch {
+            // Any other failure: vault untouched; staging kept on disk for post-mortems.
+            Log("VaultGenerator: ❌ generation failed (staging kept at \(staging.lastPathComponent)) — \(error)")
+            throw error
         }
         poller.cancel()
 
         let (notes, folders) = Self.census(of: staging)
+        Log("VaultGenerator: codex finished (turns \(envelope.numTurns ?? -1), \(envelope.durationMS ?? -1)ms) — \(notes) notes / \(folders) folders in staging")
         guard notes > 0 else {
             try? fm.removeItem(at: staging)
             throw VaultError.empty
@@ -149,6 +156,7 @@ actor VaultGenerator {
         let root = Self.vaultRoot
         try? fm.removeItem(at: root)
         try fm.moveItem(at: staging, to: root)
+        Log("VaultGenerator: ✅ vault swapped into place — \(notes) notes at \(root.path)")
 
         return Result(notes: notes, folders: folders,
                       inputTokens: envelope.inputTokens ?? 0,

--- a/Sentient OS macOS/VaultUpdater.swift
+++ b/Sentient OS macOS/VaultUpdater.swift
@@ -33,7 +33,7 @@ actor VaultUpdater {
         var errorDescription: String? {
             switch self {
             case .noVault:
-                return "No vault on disk yet — run the initial generation first."
+                return "No knowledge base on disk yet — click Create Knowledge Base first."
             case .usageLimit(let m, _):
                 return "Your AI hit its usage limit — the next run resumes where it left off. (\(m.prefix(160)))"
             case .cloudFailed(let m):

--- a/Sentient OS macOS/Views/RootView.swift
+++ b/Sentient OS macOS/Views/RootView.swift
@@ -348,7 +348,7 @@ struct RootView: View {
                 Text(result)
                     .font(.system(.footnote, design: .monospaced))
                     .foregroundStyle(result.hasPrefix(passPrefix) ? .green
-                                     : result.contains("FAIL") ? .red : Theme.secondary)
+                                     : result.localizedCaseInsensitiveContains("fail") ? .red : Theme.secondary)
                     .multilineTextAlignment(.leading)
                     .textSelection(.enabled)
                     .frame(maxWidth: 460)


### PR DESCRIPTION
**Root cause of Aditya's broken end-to-end test:** on a Mac where codex was installed via npm-under-nvm, `CodexCLI.locateBinary()` returned **notInstalled** for a fully working, logged-in codex — the versioned nvm dir isn't in the fixed paths, and the `zsh -lc` fallback never sources `.zshrc` (where nvm inits). Every cloud feature silently failed on that machine since the migration; initial generation died instantly with zero log output, so no vault existed, and 'Update Knowledge Base' then (correctly) reported no-vault — wearing a green 'Done —' prefix.

**Fixes**
1. Discovery: scan `~/.nvm/versions/node/*/bin/codex` (newest first) + interactive `zsh -lic` fallback with defensive parsing. Execution: the binary's own dir leads the child PATH (npm bins are `#!/usr/bin/env node` shims; node sits beside them in nvm's layout).
2. `DaysEndJob`: failures return `Failed — …` (the dev button no longer paints errors green), and the post-fold notification fires detached — `requestAuthorization` awaiting an unanswered system dialog was a forever-spinning button.
3. `VaultGenerator` agentic path now logs start/envelope/census/swap + every error path (it was completely silent).
4. New `SENTIENT_SELFTEST=e2e`: real Gemma analysis of a fixture folder → real codex fold → add one file → pointer-only re-analysis → fold → double no-op. **10/10 live** on the previously-broken Mac (`codexcli` ping now SPINE_OK through the nvm binary, 4.2s).