### PR TITLE
Newest-first backfill: a key's first run descends from NOW, resumable

### DIFF
--- a/Sentient OS macOS/Documentation/Pointer Architecture (Kill the Ledger).md
+++ b/Sentient OS macOS/Documentation/Pointer Architecture (Kill the Ledger).md
@@ -1,15 +1,16 @@
-# Pointer Architecture — Kill the Ledger (June 11)
+# Pointer Architecture — Kill the Ledger (June 11) + Newest-First Backfill (June 12)
 
 The dedup/incrementality rewrite. The old `LedgerEntry` table (one permanent row per item ever
 analyzed, plus tombstones for junk/sensitive) is **gone**. The only question the system ever
 asks is *"what's new since last time?"* — so every source keeps **pointers**: "I have processed
-everything up to HERE." A run scans past the pointers, processes oldest-first, and advances
-each pointer after its item durably saves.
+everything up to HERE." An incremental run scans past the pointers, processes oldest-first, and
+advances each pointer after its item durably saves.
 
 **The payoff:** initial processing and incremental processing are the SAME code path. Pointer
-absent → everything (connector caps still apply) = the initial pass. Pointer present → only the
-new stuff. And the privacy story got stronger: junk/sensitive items now leave **zero trace** —
-judged on-device, discarded, gone (no tombstones anywhere; `LifetimeStats` keeps only counters).
+absent → everything, **newest first** (the backfill — see below; connector caps still apply) =
+the initial pass. Pointer present → only the new stuff, ascending. And the privacy story got
+stronger: junk/sensitive items now leave **zero trace** — judged on-device, discarded, gone
+(no tombstones anywhere; `LifetimeStats` keeps only counters).
 
 ## The pointers (all rows in `SourceCursor`, key → value)
 
@@ -30,6 +31,35 @@ interleave in Z_PK/ROWID space. With one global pointer, saving chat B's window 
 pointer past chat A's still-unprocessed older messages — a crash there silently loses them.
 Per-chat keys make every chat independently crash-safe (same shape as Files' per-root keys).
 
+## The backfill — a key's first run digs newest-first (June 12)
+
+A user watching the first run should see the app understanding what's happening NOW — not
+chewing through ancient files first. So a key with **no pointer at all** runs as a **backfill**:
+the capped selection is consumed **newest-first**, and the consumed region is the closed
+interval **[lo, hi]** instead of "everything ≤ pointer":
+
+- The cursor's value during a backfill is a JSON-encoded **`BackfillCursor`**
+  (`{"hi":…,"lo":…,"remaining":n}`, DataSource.swift) in the same `SourceCursor` row — a `{`
+  prefix is unambiguous (plain values start with a digit), so Store/Pipeline stay encoding-blind.
+- **`hi`** = the newest consumed value (the eventual plain pointer). **`lo`** = the descent
+  watermark; every durable save rewrites the full state, so an interrupted backfill resumes
+  digging strictly below `lo` — exactly the crash-resume property, mirrored.
+- **Items arriving mid-backfill** land above `hi` and are emitted FIRST on later runs
+  (ascending, sweeping `hi` up) before the descent resumes — day 2 of an unfinished backfill
+  still shows today's life before history.
+- **Termination:** `remaining` carries the connector cap as a TOTAL budget across interrupted
+  runs (files: 1,000/root · notes: 1,000); the item that spends the last of it writes the plain
+  `hi` pointer. Chats are unbudgeted (`remaining` nil) — the rolling 90-day floor ends the dig.
+  A dig that comes up empty (aged out, files deleted) completes via `ScanResult.completions`:
+  the scan reports "this key is done", and the Pipeline collapses it to the plain `hi` before
+  processing. Chat sources never complete on a scan that hit the global 100k cap — an empty dig
+  there may be the clip, not the end (`mayBeClipped`, ChatWindowing.chatCandidates).
+- Once collapsed, the key behaves exactly as before: plain pointer, ascending, done.
+
+The failure policy mirrors too: during a descent, a permanently-failing item is passed by the
+next success BELOW it (its slot lands inside [lo, hi] without a summary) — same
+no-poison-pills, no-bookkeeping property as the ascending case.
+
 ## The file date
 
 `date = min(max(mtime, dateAdded, movedInAncestorDate), now)`
@@ -46,9 +76,10 @@ Per-chat keys make every chat independently crash-safe (same shape as Files' per
   for the next run — a doc mid-editing-session, an actively-flowing conversation, or a note
   being typed is never summarized between keystrokes. Pointers can't advance past `now − 1h`
   by construction.
-- **Ordering contract (`DataSource.scan`):** candidates come back ascending per `cursorKey`;
-  the pipeline advances each candidate's cursor only after its durable save. Crash = resume,
-  never skip. (Selection is still newest-N for the caps; *consumption* is oldest-first.)
+- **Ordering contract (`DataSource.scan`):** incremental keys come back ascending; backfilling
+  keys come back new-items-first (ascending) then descending below `lo`. The pipeline advances
+  each candidate's cursor only after its durable save. Crash = resume, never skip. (Selection
+  is always newest-N for the caps; *consumption* direction depends on the key's state.)
 - **Junk/sensitive advance the pointer with nothing else saved** — the cursor write IS the
   durable record (`Store.record` does the summary insert + cursor upsert in one transaction).
 
@@ -73,8 +104,10 @@ updater's queue **self-populating** — nothing to reset, ever.
 
 ## Self-tests
 
-- `SENTIENT_SELFTEST=incremental` — the pointer-lifecycle proof, no model (11 checks): full
-  pass → no-op → new file only → edited file as `— Edit` version → corpus stamping → junk
-  advances with zero trace.
+- `SENTIENT_SELFTEST=incremental` — the pointer-lifecycle proof, no model (22 checks):
+  newest-first backfill → collapse to plain → no-op → new file only → edited file as `— Edit`
+  version → corpus stamping → junk advances with zero trace → interrupted backfill (mid-flight
+  BackfillCursor, mid-backfill arrivals first, resumed descent, budget collapse) → emptied dig
+  completing via the scan's completion report.
 - `skipping` (17 checks) still green — fixtures use the `testIgnoreDateAdded` /
   `testZeroHoldBack` seams on `FilesSource` (real filesystems can't backdate dateAdded).

--- a/Sentient OS macOS/Pipeline.swift
+++ b/Sentient OS macOS/Pipeline.swift
@@ -3,11 +3,13 @@
 //  Sentient OS macOS
 //
 //  The loop that ties Sources + Engine + Store together (Arch §2.1). Fetches the pointer map,
-//  scans each source for items PAST its pointers, and processes them in scan order (ascending
-//  per pointer — the pointer contract): load content → Engine.generate → Triage.decide →
+//  scans each source for items PAST its pointers, and processes them in scan order (the
+//  pointer contract, DataSource.swift: incremental keys ascend; a key's FIRST run is a
+//  newest-first backfill descent): load content → Engine.generate → Triage.decide →
 //  Store.record (summary version for survivors + the pointer advance, one transaction).
-//  Initial run and incremental run are the SAME code path — an empty pointer map simply means
-//  "everything" (connector caps still apply inside each source's scan).
+//  Initial run and incremental run are the SAME code path — a missing pointer simply means
+//  "backfill everything, newest first" (connector caps still apply inside each source's scan).
+//  Finished backfills reported by the scan collapse to plain pointers before processing.
 //
 //  Failure policy (pointer architecture, June 11): a failed item is retried ONCE on a fresh
 //  engine when its failure triggered a reactive reload; an item that still fails is given up —
@@ -54,7 +56,13 @@ actor Pipeline {
         onProgress: @Sendable (PipelineProgress) -> Void = { _ in }
     ) async throws -> PipelineProgress {
         let cursors = await store.cursors()
-        var todo = try source.scan(since: cursors)
+        let scan = try source.scan(since: cursors)
+        // Backfills the scan found to be finished collapse to plain pointers first, so this
+        // run's candidates (if any) write against the collapsed state the scan assumed.
+        for (key, value) in scan.completions {
+            try await store.advanceCursor(value, forKey: key)
+        }
+        var todo = scan.candidates
         if let limit, todo.count > limit { todo = Array(todo.prefix(limit)) }
 
         var p = PipelineProgress(total: todo.count)

--- a/Sentient OS macOS/Self Tests - Temp/SelfTest_FileSkipping.swift
+++ b/Sentient OS macOS/Self Tests - Temp/SelfTest_FileSkipping.swift
@@ -60,7 +60,7 @@ enum SelfTestFileSkipping {
         func counts(_ source: FilesSource) -> [String: Int] {
             let rootPath = source.root.path + "/"
             var by: [String: Int] = [:]
-            for c in (try? source.scan(since: [:])) ?? [] {
+            for c in (try? source.scan(since: [:]).candidates) ?? [] {
                 guard let p = c.metadata["path"], p.hasPrefix(rootPath) else { continue }
                 by[String(p.dropFirst(rootPath.count).split(separator: "/").first ?? "?"), default: 0] += 1
             }
@@ -165,7 +165,7 @@ enum SelfTestFileSkipping {
             }
 
             // What survives, and which directories contribute the most.
-            let candidates = (try? source.scan(since: [:])) ?? []
+            let candidates = (try? source.scan(since: [:]).candidates) ?? []
             var byDir: [String: Int] = [:]
             for c in candidates {
                 byDir[((c.metadata["path"] ?? "?") as NSString).deletingLastPathComponent, default: 0] += 1

--- a/Sentient OS macOS/Self Tests - Temp/SelfTest_Incremental.swift
+++ b/Sentient OS macOS/Self Tests - Temp/SelfTest_Incremental.swift
@@ -1,16 +1,22 @@
 //
-//  SelfTest_Incremental.swift — pointer-architecture proof (Kill the Ledger, June 11)
+//  SelfTest_Incremental.swift — pointer-architecture proof (Kill the Ledger, June 11 +
+//  newest-first backfill, June 12)
 //  Sentient OS macOS
 //
 //  Deterministic, no model. Dispatched from SelfTest.runIfRequested():
 //    SENTIENT_SELFTEST=incremental
 //  Drives the REAL FilesSource + Store (in-memory container) through the pointer lifecycle:
-//    1. full pass consumes everything, oldest-first
+//    1. the first run is a BACKFILL: everything consumes NEWEST-first, then the cursor
+//       collapses to a plain pointer
 //    2. immediate re-run is a complete no-op (nothing past the pointer)
-//    3. a new file → only the new file processes
+//    3. a new file → only the new file processes (ascending incremental)
 //    4. an edited file → re-processes as a NEW summary version with a " — Edit" title
 //    5. a junk verdict advances the pointer while persisting NOTHING (zero trace)
 //    6. markCorpusSynced stamps the queue; new versions re-enter it
+//    7. an INTERRUPTED backfill resumes: mid-flight cursor is a BackfillCursor, files arriving
+//       mid-backfill process BEFORE the dig resumes, the dig descends, the budget's last item
+//       collapses the cursor
+//    8. a backfill whose below-lo items vanish completes via the scan's completion report
 //
 //  Uses the mtime-only/zero-hold-back test seams (fixtures can't backdate dateAdded).
 //
@@ -27,9 +33,14 @@ enum SelfTestIncremental {
         defer { FilesSource.testIgnoreDateAdded = false; FilesSource.testZeroHoldBack = false }
 
         let fm = FileManager.default
-        let base = URL(fileURLWithPath: NSTemporaryDirectory())
+        var base = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("sentient-incremental-\(UUID().uuidString.prefix(8))")
         try? fm.createDirectory(at: base, withIntermediateDirectories: true)
+        // The enumerator yields canonical /private/var/… paths while NSTemporaryDirectory()
+        // hands out the /var/… symlink form — canonicalize so the pointer-suffix checks match.
+        if let canon = try? base.resourceValues(forKeys: [.canonicalPathKey]).canonicalPath {
+            base = URL(fileURLWithPath: canon, isDirectory: true)
+        }
         defer { try? fm.removeItem(at: base) }
 
         var pass = 0, fail = 0
@@ -37,8 +48,9 @@ enum SelfTestIncremental {
             if ok { pass += 1 } else { fail += 1 }
             emit("\(ok ? "✅" : "❌") \(name)\(detail.isEmpty ? "" : "  (\(detail))")")
         }
-        func touch(_ name: String, mtimeAgo: TimeInterval) {
-            let p = base.appendingPathComponent(name).path
+        func touch(_ dir: URL, _ name: String, mtimeAgo: TimeInterval) {
+            try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
+            let p = dir.appendingPathComponent(name).path
             if !fm.fileExists(atPath: p) { fm.createFile(atPath: p, contents: Data("x".utf8)) }
             let then = Date().addingTimeInterval(-mtimeAgo)
             try? fm.setAttributes([.creationDate: then, .modificationDate: then], ofItemAtPath: p)
@@ -50,13 +62,18 @@ enum SelfTestIncremental {
                                            configurations: ModelConfiguration(isStoredInMemoryOnly: true))
         } catch { emit("ModelContainer FAILED: \(error)"); return }
         let store = Store(modelContainer: container)
-        let source = FilesSource(root: base, label: "Fixture", cursorKey: "file:fixture")
 
-        /// One simulated pipeline pass: scan past the pointers, "judge" each candidate with the
-        /// given verdict, record (summary + pointer advance — the real Store path). Returns the
-        /// processed file names in processing order.
-        func runPass(verdict: Verdict = .survivor) async -> [String] {
-            let cands = (try? source.scan(since: await store.cursors())) ?? []
+        /// One simulated pipeline pass: scan past the pointers, apply completions (as the real
+        /// Pipeline does), "judge" up to `limit` candidates with the given verdict, record
+        /// (summary + pointer advance — the real Store path). Returns names in processing order.
+        func runPass(_ source: FilesSource, verdict: Verdict = .survivor, limit: Int? = nil) async -> [String] {
+            let scan = (try? source.scan(since: await store.cursors()))
+                ?? ScanResult(candidates: [])
+            for (key, value) in scan.completions {
+                try? await store.advanceCursor(value, forKey: key)
+            }
+            var cands = scan.candidates
+            if let limit, cands.count > limit { cands = Array(cands.prefix(limit)) }
             for c in cands {
                 guard let artifact = try? source.load(c) else { continue }
                 let draft = verdict == .survivor
@@ -68,24 +85,32 @@ enum SelfTestIncremental {
             return cands.map { $0.metadata["name"] ?? "?" }
         }
 
-        // 1) Initial pass: everything, oldest-first.
-        touch("a.md", mtimeAgo: 7_200)
-        touch("b.md", mtimeAgo: 3_600)
-        let first = await runPass()
-        check("initial pass consumes everything oldest-first", first == ["a.md", "b.md"], "\(first)")
+        // ── A. The straight-through lifecycle ───────────────────────────────────
+        let rootA = base.appendingPathComponent("a")
+        let sourceA = FilesSource(root: rootA, label: "Fixture", cursorKey: "file:fixture")
+
+        // 1) Backfill: everything, NEWEST-first; a completed backfill collapses to a plain pointer.
+        touch(rootA, "a.md", mtimeAgo: 7_200)
+        touch(rootA, "b.md", mtimeAgo: 3_600)
+        let first = await runPass(sourceA)
+        check("backfill consumes everything newest-first", first == ["b.md", "a.md"], "\(first)")
+        let cursorA = await store.cursor(forKey: "file:fixture") ?? ""
+        check("completed backfill collapsed to a plain pointer",
+              !cursorA.isEmpty && !cursorA.hasPrefix("{"), cursorA)
+        check("plain pointer sits at the NEWEST item", cursorA.hasSuffix("|" + rootA.appendingPathComponent("b.md").path))
 
         // 2) Immediate re-run: complete no-op.
-        let second = await runPass()
+        let second = await runPass(sourceA)
         check("re-run is a no-op", second.isEmpty, "\(second)")
 
-        // 3) New file: only the new file.
-        touch("c.md", mtimeAgo: 1_800)
-        let third = await runPass()
+        // 3) New file: only the new file (ascending incremental).
+        touch(rootA, "c.md", mtimeAgo: 1_800)
+        let third = await runPass(sourceA)
         check("only the NEW file processes", third == ["c.md"], "\(third)")
 
         // 4) Edited file: re-processes as a new VERSION with the " — Edit" title suffix.
-        touch("a.md", mtimeAgo: 900)   // mtime moves past the pointer
-        let fourth = await runPass()
+        touch(rootA, "a.md", mtimeAgo: 900)   // mtime moves past the pointer
+        let fourth = await runPass(sourceA)
         check("only the EDITED file re-processes", fourth == ["a.md"], "\(fourth)")
         let all = await store.allSummaries()
         let aVersions = all.filter { $0.sourceID.hasSuffix("/a.md") }
@@ -103,14 +128,59 @@ enum SelfTestIncremental {
 
         // 6) Junk advances the pointer and leaves ZERO trace.
         let before = await store.counts()
-        touch("d.md", mtimeAgo: 600)
-        let fifth = await runPass(verdict: .junk)
+        touch(rootA, "d.md", mtimeAgo: 600)
+        let fifth = await runPass(sourceA, verdict: .junk)
         check("junk item was scanned once", fifth == ["d.md"], "\(fifth)")
-        let sixth = await runPass()
+        let sixth = await runPass(sourceA)
         check("junk never re-scans (pointer passed it)", sixth.isEmpty, "\(sixth)")
         let after = await store.counts()
         check("junk persisted nothing", after.versions == before.versions,
               "versions \(before.versions) → \(after.versions)")
+
+        // ── B. The interrupted backfill: resume digs down; mid-backfill arrivals go first ──
+        let rootB = base.appendingPathComponent("b")
+        let sourceB = FilesSource(root: rootB, label: "Fixture2", cursorKey: "file:fixture2")
+        touch(rootB, "w.md", mtimeAgo: 8_000)
+        touch(rootB, "x.md", mtimeAgo: 6_000)
+        touch(rootB, "y.md", mtimeAgo: 4_000)
+        touch(rootB, "z.md", mtimeAgo: 2_000)
+
+        let b1 = await runPass(sourceB, limit: 2)   // "stopped midway"
+        check("interrupted backfill consumed the newest first", b1 == ["z.md", "y.md"], "\(b1)")
+        let midCursor = BackfillCursor.decode(await store.cursor(forKey: "file:fixture2"))
+        check("mid-backfill cursor is a BackfillCursor", midCursor != nil)
+        check("…with hi at the newest item and 2 budget left",
+              midCursor?.remaining == 2
+              && (midCursor?.hi.hasSuffix("|" + rootB.appendingPathComponent("z.md").path) ?? false),
+              "remaining \(midCursor?.remaining ?? -1)")
+
+        touch(rootB, "n.md", mtimeAgo: 1_000)       // arrives mid-backfill, newer than hi
+        let b2 = await runPass(sourceB)
+        check("resume: the NEW file first, then the dig descends",
+              b2 == ["n.md", "x.md", "w.md"], "\(b2)")
+        let doneCursor = await store.cursor(forKey: "file:fixture2") ?? ""
+        check("spent budget collapsed the cursor to the swept-up hi",
+              doneCursor.hasSuffix("|" + rootB.appendingPathComponent("n.md").path)
+              && !doneCursor.hasPrefix("{"), doneCursor)
+        let b3 = await runPass(sourceB)
+        check("post-backfill re-run is a no-op", b3.isEmpty, "\(b3)")
+
+        // ── C. A starved dig completes via the scan's completion report ─────────
+        let rootC = base.appendingPathComponent("c")
+        let sourceC = FilesSource(root: rootC, label: "Fixture3", cursorKey: "file:fixture3")
+        touch(rootC, "t1.md", mtimeAgo: 6_000)
+        touch(rootC, "t2.md", mtimeAgo: 4_000)
+        touch(rootC, "t3.md", mtimeAgo: 2_000)
+        let c1 = await runPass(sourceC, limit: 1)
+        check("backfill interrupted after the newest item", c1 == ["t3.md"], "\(c1)")
+        try? fm.removeItem(at: rootC.appendingPathComponent("t1.md"))
+        try? fm.removeItem(at: rootC.appendingPathComponent("t2.md"))
+        let c2 = await runPass(sourceC)
+        let cCursor = await store.cursor(forKey: "file:fixture3") ?? ""
+        check("emptied dig yields no candidates", c2.isEmpty, "\(c2)")
+        check("…and the scan completion collapsed the cursor",
+              cCursor.hasSuffix("|" + rootC.appendingPathComponent("t3.md").path)
+              && !cCursor.hasPrefix("{"), cCursor)
 
         emit("\n# \(fail == 0 ? "✅ ALL PASS" : "❌ FAILURES") — \(pass) passed · \(fail) failed")
     }

--- a/Sentient OS macOS/Self Tests - Temp/SelfTest_Triage_Pipeline_and_Vault.swift
+++ b/Sentient OS macOS/Self Tests - Temp/SelfTest_Triage_Pipeline_and_Vault.swift
@@ -287,7 +287,7 @@ enum SelfTest {
         if mode == "tokens" {
             let source = WhatsAppSource(chatJIDs: chatFilter((try? WhatsAppSource().listChats()) ?? []))
             let candidates: [Candidate]
-            do { candidates = try source.scan(since: [:]) }
+            do { candidates = try source.scan(since: [:]).candidates }
             catch { emit("scan FAILED: \(error)"); return }
             emit("windows in backlog: \(candidates.count) · current byte budget: \(ChatWindowing.maxWindowBytes)\n")
             guard !candidates.isEmpty else { return }
@@ -400,7 +400,7 @@ enum SelfTest {
         }
 
         let candidates: [Candidate]
-        do { candidates = try source.scan(since: [:]) }
+        do { candidates = try source.scan(since: [:]).candidates }
         catch { emit("scan FAILED: \(error)"); return }
         emit("scanned \(candidates.count) candidates; dumping first \(min(count, candidates.count))\n")
         guard !candidates.isEmpty else { emit("nothing to dump."); return }

--- a/Sentient OS macOS/Sources/ChatWindowing.swift
+++ b/Sentient OS macOS/Sources/ChatWindowing.swift
@@ -8,7 +8,10 @@
 //  the pipeline as one Artifact. Key pieces:
 //    ChatMessage          — one decoded message, normalized across sources
 //    ChatInfo             — a row for the opt-in chat picker
+//    ChatCursorState      — a chat's decoded pointer (incremental / backfill / first run)
 //    ChatWindowing.windows(of:)  — greedy byte-budget batching
+//    ChatWindowing.chatCandidates(...) — one chat's windows under its pointer state (the
+//                                  backfill/incremental ordering logic, shared verbatim)
 //    ChatWindowing.format(...)   — frames a window for the model (chat name, group/DM,
 //                                  "you sent N of M" participation anchor, per-message senders)
 //  Limits (TODO plan): chat connectors read the last `lookbackDays` 90 days OR the newest
@@ -36,6 +39,32 @@ struct ChatInfo: Sendable, Identifiable {
     let isGroup: Bool
     let messageCount: Int
     let lastActive: Date
+}
+
+/// One chat's pointer state, decoded from its SourceCursor value (WhatsApp Z_PK / iMessage
+/// ROWID — both monotonic Int64 row ids). `.backfill` carries the consumed interval [lo, hi];
+/// chats are unbudgeted (remaining nil) — the rolling 90-day floor terminates the dig.
+enum ChatCursorState: Sendable {
+    case backfillStart                                  // no pointer yet — first run for this chat
+    case backfill(BackfillCursor, hi: Int64, lo: Int64)
+    case incremental(Int64)
+
+    static func decode(_ raw: String?) -> ChatCursorState {
+        if let bf = BackfillCursor.decode(raw), let hi = Int64(bf.hi), let lo = Int64(bf.lo) {
+            return .backfill(bf, hi: hi, lo: lo)
+        }
+        if let v = raw.flatMap(Int64.init) { return .incremental(v) }
+        return .backfillStart
+    }
+
+    /// Should a message row with this id be fetched under this state?
+    func wants(_ id: Int64) -> Bool {
+        switch self {
+        case .backfillStart:                return true
+        case .backfill(_, let hi, let lo):  return id > hi || id < lo
+        case .incremental(let v):           return id > v
+        }
+    }
 }
 
 enum ChatWindowing {
@@ -79,6 +108,61 @@ enum ChatWindowing {
 
     /// UTF-8 byte size of a formatted line — the upper bound on its token count.
     private static func msgBytes(_ m: ChatMessage) -> Int { m.text.utf8.count + 28 }   // + date/sender label overhead
+
+    // MARK: One chat's candidates under its pointer state (shared by WhatsApp + iMessage)
+
+    /// Window `msgs` (ascending by row id, already state-filtered by the source's fetch) and
+    /// assign each window's pointer write per the backfill contract (DataSource.swift):
+    ///   now — new windows (above hi / past the plain pointer), ascending
+    ///   dig — backfill descent windows, NEWEST first; each write records [window min, hi]
+    ///   completion — the plain pointer value when this chat's backfill just finished
+    /// `make` builds the source-specific Candidate from (window, cursorValue).
+    /// `mayBeClipped`: when the connector-wide newest-`maxMessages` cap was hit, an empty dig
+    /// might be the clip rather than a finished backfill — never complete on a clipped scan
+    /// (the state lingers and completes on a quieter run; collapsing early would skip the
+    /// chat's remaining history forever).
+    static func chatCandidates(
+        msgs: [ChatMessage], state: ChatCursorState, mayBeClipped: Bool,
+        make: ([ChatMessage], String) -> Candidate
+    ) -> (now: [Candidate], dig: [Candidate], completion: String?) {
+        switch state {
+        case .backfillStart:
+            let wins = windows(of: msgs).filter { !$0.isEmpty }
+            guard let hi = wins.last?.last?.id else { return ([], [], nil) }
+            let dig = wins.reversed().map { win in
+                make(win, BackfillCursor(hi: "\(hi)", lo: "\(win.first!.id)", remaining: nil).encoded)
+            }
+            return ([], dig, nil)
+
+        case .backfill(let bf, let hi, let lo):
+            let aboveWins = windows(of: msgs.filter { $0.id > hi }).filter { !$0.isEmpty }
+            let belowWins = windows(of: msgs.filter { $0.id < lo }).filter { !$0.isEmpty }
+            if belowWins.isEmpty {
+                if mayBeClipped {   // dig starved by the cap, not finished — keep the state
+                    let now = aboveWins.map { win in
+                        make(win, BackfillCursor(hi: "\(win.last!.id)", lo: bf.lo, remaining: nil).encoded)
+                    }
+                    return (now, [], nil)
+                }
+                // Backfill over — collapse to a plain pointer; new windows proceed as
+                // ordinary incrementals.
+                return (aboveWins.map { make($0, "\($0.last!.id)") }, [], bf.hi)
+            }
+            // The dig's writes must carry the hi the now-group will have swept up to.
+            let hiFinal = aboveWins.last.map { "\($0.last!.id)" } ?? bf.hi
+            let now = aboveWins.map { win in
+                make(win, BackfillCursor(hi: "\(win.last!.id)", lo: bf.lo, remaining: nil).encoded)
+            }
+            let dig = belowWins.reversed().map { win in
+                make(win, BackfillCursor(hi: hiFinal, lo: "\(win.first!.id)", remaining: nil).encoded)
+            }
+            return (now, dig, nil)
+
+        case .incremental:
+            let wins = windows(of: msgs).filter { !$0.isEmpty }
+            return (wins.map { make($0, "\($0.last!.id)") }, [], nil)
+        }
+    }
 
     // MARK: Formatting — frame the window for the model
 

--- a/Sentient OS macOS/Sources/DataSource.swift
+++ b/Sentient OS macOS/Sources/DataSource.swift
@@ -8,11 +8,17 @@
 //    load(_:)     -> Artifact      // expensive: extract text/image for a chosen candidate
 //  Candidate & Artifact are Sendable value types; live @Model objects never cross actors.
 //
-//  THE POINTER CONTRACT (June 11 pointer rewrite — Documentation/Pointer Architecture…):
-//  every candidate names the cursor it advances (`cursorKey` → `cursorValue`). The pipeline
-//  processes candidates in scan order and advances each candidate's cursor only after its
-//  durable save — so scan() MUST return candidates ascending per cursorKey (oldest first).
-//  A crash resumes exactly where it stopped; pointer nil = "everything" = the initial run.
+//  THE POINTER CONTRACT (June 11 pointer rewrite + June 12 backfill — Documentation/Pointer
+//  Architecture…): every candidate names the cursor it advances (`cursorKey` → `cursorValue`).
+//  The pipeline processes candidates in scan order and advances each candidate's cursor only
+//  after its durable save — a crash resumes exactly where it stopped. Ordering per cursorKey:
+//   - Key has a PLAIN pointer → incremental: candidates ascend (oldest first), pointer sweeps up.
+//   - Key has NO pointer → BACKFILL (first run for that key): candidates DESCEND (newest first —
+//     the user watches it understand NOW, not 2019), and each cursorValue is a `BackfillCursor`
+//     encoding the consumed interval [lo, hi]. New items arriving mid-backfill sit above `hi`
+//     and are emitted FIRST (ascending) on later runs, before the descent resumes below `lo`.
+//   - scan() reports finished backfills via `ScanResult.completions`; the pipeline collapses
+//     those keys to plain pointers before processing.
 //
 
 import Foundation
@@ -50,6 +56,59 @@ struct Candidate: Sendable, Identifiable {
         self.itemDate = itemDate
         self.metadata = metadata
     }
+
+    /// Same candidate with a different pointer write — backfill encodings depend on each item's
+    /// position in the consumption order, so sources assign them after selection/sorting.
+    func replacingCursorValue(_ value: String) -> Candidate {
+        Candidate(id: id, kind: kind, cursorKey: cursorKey, cursorValue: value,
+                  itemDate: itemDate, metadata: metadata)
+    }
+}
+
+/// What one scan hands the pipeline: the candidates to process (in consumption order) plus any
+/// backfills the scan discovered to be FINISHED (budget spent or nothing left below `lo`) —
+/// `completions` maps cursorKey → the final plain pointer value, applied before processing.
+struct ScanResult: Sendable {
+    var candidates: [Candidate]
+    var completions: [String: String] = [:]
+}
+
+/// A key's pointer value while its first run (the backfill) is still in flight: the consumed
+/// region is the closed interval **[lo, hi]** instead of "everything ≤ pointer".
+///   hi — the newest consumed value; new items land above it and move it up. Becomes the plain
+///        pointer when the backfill completes.
+///   lo — the descent watermark ("dug down to here"); resuming digs strictly below it.
+///   remaining — descent budget left (files/notes honor their connector cap as a TOTAL across
+///        interrupted runs); nil for chats, where the rolling 90-day floor terminates the dig.
+/// Stored JSON-encoded in the same SourceCursor.value string — a `{` prefix is unambiguous
+/// (plain values always start with a digit), so the Store/Pipeline stay encoding-blind.
+struct BackfillCursor: Codable, Sendable {
+    var hi: String
+    var lo: String
+    var remaining: Int?
+
+    /// nil input (no pointer yet) or a plain value both decode to nil — only an in-flight
+    /// backfill returns a value.
+    static func decode(_ raw: String?) -> BackfillCursor? {
+        guard let raw, raw.hasPrefix("{") else { return nil }
+        return try? JSONDecoder().decode(BackfillCursor.self, from: Data(raw.utf8))
+    }
+
+    var encoded: String {
+        String(data: (try? JSONEncoder().encode(self)) ?? Data(), encoding: .utf8) ?? ""
+    }
+
+    /// Assign backfill encodings to a newest-first descent batch (files + notes — the budgeted
+    /// sources): each item's write records the consumed interval [its value, hi] plus the budget
+    /// left after it. The item that spends the last of the budget writes the plain `hi` pointer —
+    /// completing the backfill in its own durable transaction.
+    static func descent(_ kept: [Candidate], hi: String, budget: Int) -> [Candidate] {
+        kept.enumerated().map { i, c in
+            let left = budget - (i + 1)
+            return c.replacingCursorValue(
+                left <= 0 ? hi : BackfillCursor(hi: hi, lo: c.cursorValue, remaining: left).encoded)
+        }
+    }
 }
 
 /// A loaded item = a Candidate plus its extracted content (text and/or image bytes).
@@ -79,9 +138,10 @@ struct Artifact: Sendable, Identifiable {
 protocol DataSource {
     var kind: SourceKind { get }
     /// Enumerate items past the pointers — NO content extraction. `cursors` is the full pointer
-    /// map (a source reads only its own keys; empty map = initial run = everything, connector
-    /// caps still apply). Returned candidates MUST be ascending per cursorKey (see contract above).
-    func scan(since cursors: [String: String]) throws -> [Candidate]
+    /// map (a source reads only its own keys; missing key = backfill = everything, connector
+    /// caps still apply). Candidate ordering per cursorKey follows the contract above:
+    /// incremental keys ascend, backfilling keys descend (new-above-hi items first, ascending).
+    func scan(since cursors: [String: String]) throws -> ScanResult
     /// Expensive content extraction for a candidate the pipeline chose to process.
     func load(_ candidate: Candidate) throws -> Artifact
 }

--- a/Sentient OS macOS/Sources/FilesSource.swift
+++ b/Sentient OS macOS/Sources/FilesSource.swift
@@ -12,13 +12,16 @@
 //  The model is given the home-relative path (e.g. ~/Downloads/Useless Stuff/x.jpg) + creation
 //  date — the folder structure alone is strong signal for junk/intent.
 //
-//  POINTER (June 11 rewrite — Documentation/Pointer Architecture (Kill the Ledger).md):
+//  POINTER (June 11 rewrite + June 12 backfill — Documentation/Pointer Architecture…):
 //  one "(epochSeconds|path)" pointer per folder root (cursorKey = "file:<FileRoot.id>").
 //  A file's date is max(dateAdded, dateModified, nearest moved-in ancestor's dateAdded) —
 //  dateAdded catches downloads with old mtimes, dateModified catches edits, and the ancestor
 //  propagation catches whole folders dragged into a root (their files keep old dates).
 //  Guards: 60-min freshness hold-back (mid-edit files wait for the next run) and a future-date
-//  clamp (clock weirdness can't poison the pointer). Scan returns candidates OLDEST-FIRST.
+//  clamp (clock weirdness can't poison the pointer). Ordering: incremental runs ascend
+//  (oldest-first); a root's FIRST run (no pointer yet) is a BACKFILL — newest-first descent
+//  tracked by a BackfillCursor [lo, hi] interval, resumable, with the root cap as a TOTAL
+//  budget across interruptions. New files arriving mid-backfill process before the dig resumes.
 //
 //  Skipping & caps (see Documentation/Files Source (Skipping & Caps).md): code repos and
 //  machine-generated datasets are pruned at the walk level (`pruneReason`), and `scan` bounds
@@ -172,10 +175,21 @@ struct FilesSource: DataSource, Sendable {
         return date > pointer.date || (date == pointer.date && path > pointer.path)
     }
 
+    /// Strictly below the backfill descent watermark — the dig's mirror of `isPast`.
+    /// (nil = fail-closed: an unparseable `lo` digs nothing rather than re-digging everything.)
+    private static func isBelow(_ pointer: (date: Double, path: String)?, date: Double, path: String) -> Bool {
+        guard let pointer else { return false }
+        return date < pointer.date || (date == pointer.date && path < pointer.path)
+    }
+
     // MARK: Scan (cheap — stat only, recurses subfolders)
 
-    func scan(since cursors: [String: String]) throws -> [Candidate] {
-        let pointer = Self.parsePointer(cursors[cursorKey])
+    func scan(since cursors: [String: String]) throws -> ScanResult {
+        let raw = cursors[cursorKey]
+        let backfill = BackfillCursor.decode(raw)
+        let pointer = backfill == nil ? Self.parsePointer(raw) : nil   // plain pointer (incremental)
+        let hiPointer = backfill.flatMap { Self.parsePointer($0.hi) }
+        let loPointer = backfill.flatMap { Self.parsePointer($0.lo) }
         let now = Date()
         let holdBack = Self.testZeroHoldBack ? now : now.addingTimeInterval(-sourceFreshnessHoldBack)
 
@@ -185,7 +199,7 @@ struct FilesSource: DataSource, Sendable {
         guard let enumerator = FileManager.default.enumerator(
             at: root, includingPropertiesForKeys: Array(keys),
             options: [.skipsHiddenFiles, .skipsPackageDescendants]
-        ) else { return [] }
+        ) else { return ScanResult(candidates: []) }
 
         // Effective "moved-in" date per directory: a folder dragged into the root carries files
         // with OLD dates — the folder's own dateAdded (propagated down the tree) rescues them.
@@ -218,7 +232,14 @@ struct FilesSource: DataSource, Sendable {
             let date = min(max(mtime, added, parentEff), now)
 
             guard date <= holdBack else { continue }                          // freshness hold-back
-            guard Self.isPast(pointer, date: date.timeIntervalSince1970, path: url.path) else { continue }
+            // Keep only rows the current pointer state could consume: incremental = past the
+            // plain pointer; backfill resume = above hi OR below lo; backfill start = everything.
+            let (d, p) = (date.timeIntervalSince1970, url.path)
+            if backfill != nil {
+                guard Self.isPast(hiPointer, date: d, path: p) || Self.isBelow(loPointer, date: d, path: p) else { continue }
+            } else {
+                guard Self.isPast(pointer, date: d, path: p) else { continue }
+            }
 
             var meta: [String: String] = [
                 "path": url.path,
@@ -234,15 +255,59 @@ struct FilesSource: DataSource, Sendable {
                                       itemDate: date, metadata: meta)
             rows.append((candidate, date.timeIntervalSince1970))
         }
-        // Newest first, then the caps (connector-limits decision, June 10–11):
-        //  • optional age cutoff (Downloads: 1 year — downloads age into junk; keepers elsewhere don't)
-        //  • per-directory cap (300, every root) — the bulk-dump backstop
-        //  • per-root cap (newest 1,000, every root)
+        // ── Backfill resume: new-above-hi first (ascending), then dig below lo (descending) ──
+        if let backfill {
+            let aboveRows = rows.filter {
+                Self.isPast(hiPointer, date: $0.sortKey, path: $0.candidate.metadata["path"] ?? "")
+            }
+            let aboveAsc = cappedNewestFirst(aboveRows, budget: Self.perRootCap, now: now)
+                .sorted { ($0.itemDate, $0.id) < ($1.itemDate, $1.id) }
+            let belowRows = rows.filter {
+                Self.isBelow(loPointer, date: $0.sortKey, path: $0.candidate.metadata["path"] ?? "")
+            }
+            let budget = backfill.remaining ?? 0
+            let dig = budget > 0
+                ? cappedNewestFirst(belowRows, budget: min(budget, Self.perRootCap), now: now) : []
+            if dig.isEmpty {
+                // Backfill over (budget spent, everything below aged out, or nothing left) —
+                // collapse to a plain pointer; the new items proceed as ordinary incrementals.
+                return ScanResult(candidates: aboveAsc, completions: [cursorKey: backfill.hi])
+            }
+            // The dig's writes must carry the hi the above-group will have swept up to.
+            let hiFinal = aboveAsc.last?.cursorValue ?? backfill.hi
+            let aboveCands = aboveAsc.map {
+                $0.replacingCursorValue(BackfillCursor(hi: $0.cursorValue, lo: backfill.lo,
+                                                       remaining: budget).encoded)
+            }
+            return ScanResult(candidates: aboveCands + BackfillCursor.descent(dig, hi: hiFinal, budget: budget))
+        }
+
+        // ── Backfill start (no pointer at all): newest-first descent over the capped selection ──
+        if raw == nil {
+            let kept = cappedNewestFirst(rows, budget: Self.perRootCap, now: now)
+            guard let hi = kept.first?.cursorValue else { return ScanResult(candidates: []) }
+            return ScanResult(candidates: BackfillCursor.descent(kept, hi: hi, budget: kept.count))
+        }
+
+        // ── Incremental (plain pointer): newest-N selection, OLDEST-FIRST consumption — the
+        // pointer sweeps forward and a stopped run resumes exactly here. Unchanged behavior. ──
+        let kept = cappedNewestFirst(rows, budget: Self.perRootCap, now: now)
+        return ScanResult(candidates: kept.sorted {
+            ($0.itemDate, $0.id) < ($1.itemDate, $1.id)   // id = "file:<path>" → path tiebreak
+        })
+    }
+
+    /// Newest-first selection under the connector caps (June 10–11 decisions):
+    ///  • optional age cutoff (Downloads: 1 year — downloads age into junk; keepers elsewhere don't)
+    ///  • per-directory cap (300, every root) — the bulk-dump backstop
+    ///  • `budget` — the per-root cap, or what's left of a backfill's descent budget
+    private func cappedNewestFirst(_ rows: [(candidate: Candidate, sortKey: Double)],
+                                   budget: Int, now: Date) -> [Candidate] {
         let cutoff = maxAge.map { now.timeIntervalSince1970 - $0 }
         var perDir: [String: Int] = [:]
         var kept: [Candidate] = []
         for row in rows.sorted(by: { $0.sortKey > $1.sortKey }) {
-            if kept.count >= Self.perRootCap { break }
+            if kept.count >= budget { break }
             if let cutoff, row.sortKey < cutoff { break }   // sorted → every later row is older
             guard let path = row.candidate.metadata["path"] else { continue }
             let dir = (path as NSString).deletingLastPathComponent
@@ -250,11 +315,7 @@ struct FilesSource: DataSource, Sendable {
             perDir[dir, default: 0] += 1
             kept.append(row.candidate)
         }
-        // Process OLDEST-FIRST (the pointer contract): selection is newest-N, consumption is
-        // ascending, so the pointer sweeps forward and a stopped run resumes exactly here.
-        return kept.sorted {
-            ($0.itemDate, $0.id) < ($1.itemDate, $1.id)   // id = "file:<path>" → path tiebreak
-        }
+        return kept
     }
 
     // MARK: Load (expensive — extract content)

--- a/Sentient OS macOS/Sources/NotesSource.swift
+++ b/Sentient OS macOS/Sources/NotesSource.swift
@@ -36,12 +36,18 @@ struct NotesSource: DataSource, Sendable {
 
     // MARK: Scan — copy → query → decode → delete
 
-    /// Pointer (June 11 rewrite): one cursor, key "notes", value "(modEpochSeconds|noteUUID)"
-    /// (UUID = same-second tiebreak). An edited note's mod-date moves past the pointer → it's
-    /// re-summarized as a new version. The one-hour hold-back keeps a note that's being typed
-    /// out of the run. Candidates are emitted OLDEST-FIRST (the pointer contract).
-    func scan(since cursors: [String: String]) throws -> [Candidate] {
-        let pointer = Self.parsePointer(cursors["notes"])
+    /// Pointer (June 11 rewrite + June 12 backfill): one cursor, key "notes", value
+    /// "(modEpochSeconds|noteUUID)" (UUID = same-second tiebreak). An edited note's mod-date
+    /// moves past the pointer → it's re-summarized as a new version. The one-hour hold-back
+    /// keeps a note that's being typed out of the run. Ordering: incremental runs ascend; the
+    /// FIRST run is a newest-first backfill descent (BackfillCursor, resumable, the newest-1000
+    /// cap as a total budget) — notes edited mid-backfill jump above `hi` and process first.
+    func scan(since cursors: [String: String]) throws -> ScanResult {
+        let raw = cursors["notes"]
+        let backfill = BackfillCursor.decode(raw)
+        let pointer = backfill == nil ? Self.parsePointer(raw) : nil   // plain pointer (incremental)
+        let hiPointer = backfill.flatMap { Self.parsePointer($0.hi) }
+        let loPointer = backfill.flatMap { Self.parsePointer($0.lo) }
         let holdBackFloor = Date().addingTimeInterval(-sourceFreshnessHoldBack)
             .timeIntervalSinceReferenceDate
 
@@ -57,7 +63,7 @@ struct NotesSource: DataSource, Sendable {
 
         // Newest notes first (the cap selects the newest `maxNotes`); locked/deleted skipped in
         // SQL. Creation-date column name varies across macOS versions → COALESCE the variants.
-        var out: [Candidate] = []
+        var rows: [(cand: Candidate, modified: Int64, uuid: String)] = []
         try reader.forEachRow("""
             SELECT o.ZIDENTIFIER, o.ZTITLE1, o.ZMODIFICATIONDATE1,
                    COALESCE(o.ZCREATIONDATE3, o.ZCREATIONDATE2, o.ZCREATIONDATE1, o.ZCREATIONDATE),
@@ -69,7 +75,14 @@ struct NotesSource: DataSource, Sendable {
             guard let id = r.text(0) else { return }
             let modified = r.double(2)
             guard modified <= holdBackFloor else { return }                       // being typed right now
-            guard Self.isPast(pointer, modified: Int64(modified), uuid: id) else { return }   // already consumed
+            // Keep only rows the current pointer state could consume: incremental = past the
+            // plain pointer; backfill resume = above hi OR below lo; backfill start = everything.
+            if backfill != nil {
+                guard Self.isPast(hiPointer, modified: Int64(modified), uuid: id)
+                   || Self.isBelow(loPointer, modified: Int64(modified), uuid: id) else { return }
+            } else {
+                guard Self.isPast(pointer, modified: Int64(modified), uuid: id) else { return }
+            }
             guard let blob = r.blob(5),
                   let decoded = Self.decodeBody(blob) else { return }   // no/undecodable body → skip (fail-closed)
             let body = decoded.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -80,7 +93,7 @@ struct NotesSource: DataSource, Sendable {
             let createdTS = r.double(3)
             let created = Date(timeIntervalSinceReferenceDate: createdTS > 0 ? createdTS : modified)
 
-            out.append(Candidate(
+            rows.append((Candidate(
                 id: "notes:\(id)",
                 kind: .notes,
                 cursorKey: "notes",
@@ -92,10 +105,43 @@ struct NotesSource: DataSource, Sendable {
                     "displayPath": "Apple Notes · \(folder) · \(title)",
                     "created": Self.dateString(created),
                     "noteText": String(body.prefix(Self.maxContentChars)),
-                ]))
+                ]), Int64(modified), id))
         }
-        // Selection was newest-first (the cap); consumption is oldest-first (the pointer contract).
-        return out.sorted { ($0.itemDate, $0.id) < ($1.itemDate, $1.id) }
+        // `rows` is newest-first (the SQL ORDER). Assemble per pointer state:
+
+        // ── Backfill resume: edited/new notes first (ascending), then dig below lo (descending) ──
+        if let backfill {
+            let aboveAsc = rows
+                .filter { Self.isPast(hiPointer, modified: $0.modified, uuid: $0.uuid) }
+                .map(\.cand)
+                .sorted { ($0.itemDate, $0.id) < ($1.itemDate, $1.id) }
+            let budget = backfill.remaining ?? 0
+            let dig = Array(rows
+                .filter { Self.isBelow(loPointer, modified: $0.modified, uuid: $0.uuid) }
+                .map(\.cand)
+                .prefix(budget))
+            if dig.isEmpty {
+                // Backfill over (budget spent or nothing left below lo) — collapse to a plain
+                // pointer; the new/edited notes proceed as ordinary incrementals.
+                return ScanResult(candidates: aboveAsc, completions: ["notes": backfill.hi])
+            }
+            let hiFinal = aboveAsc.last?.cursorValue ?? backfill.hi
+            let aboveCands = aboveAsc.map {
+                $0.replacingCursorValue(BackfillCursor(hi: $0.cursorValue, lo: backfill.lo,
+                                                       remaining: budget).encoded)
+            }
+            return ScanResult(candidates: aboveCands + BackfillCursor.descent(dig, hi: hiFinal, budget: budget))
+        }
+
+        // ── Backfill start (no pointer at all): newest-first descent over the capped selection ──
+        if raw == nil {
+            let kept = rows.map(\.cand)
+            guard let hi = kept.first?.cursorValue else { return ScanResult(candidates: []) }
+            return ScanResult(candidates: BackfillCursor.descent(kept, hi: hi, budget: kept.count))
+        }
+
+        // ── Incremental: selection was newest-first (the cap); consumption is oldest-first. ──
+        return ScanResult(candidates: rows.map(\.cand).sorted { ($0.itemDate, $0.id) < ($1.itemDate, $1.id) })
     }
 
     // MARK: Pointer encoding — "(modEpochSeconds|noteUUID)"
@@ -108,6 +154,13 @@ struct NotesSource: DataSource, Sendable {
     private static func isPast(_ pointer: (modified: Int64, uuid: String)?, modified: Int64, uuid: String) -> Bool {
         guard let pointer else { return true }
         return modified > pointer.modified || (modified == pointer.modified && uuid > pointer.uuid)
+    }
+
+    /// Strictly below the backfill descent watermark — the dig's mirror of `isPast`.
+    /// (nil = fail-closed: an unparseable `lo` digs nothing rather than re-digging everything.)
+    private static func isBelow(_ pointer: (modified: Int64, uuid: String)?, modified: Int64, uuid: String) -> Bool {
+        guard let pointer else { return false }
+        return modified < pointer.modified || (modified == pointer.modified && uuid < pointer.uuid)
     }
 
     func load(_ candidate: Candidate) throws -> Artifact {

--- a/Sentient OS macOS/Sources/WhatsAppSource.swift
+++ b/Sentient OS macOS/Sources/WhatsAppSource.swift
@@ -116,13 +116,15 @@ struct WhatsAppSource: DataSource, Sendable {
 
     // MARK: Scan — copy → query → window → delete
 
-    /// Pointer (June 11 rewrite): ONE cursor per opted-in chat — key "whatsapp:<jid>", value =
-    /// the highest consumed `Z_PK`. Per-chat (not one global Z_PK pointer) because chats
+    /// Pointer (June 11 rewrite + June 12 backfill): ONE cursor per opted-in chat — key
+    /// "whatsapp:<jid>", value = the highest consumed `Z_PK` (or a BackfillCursor while the
+    /// chat's first run is in flight). Per-chat (not one global Z_PK pointer) because chats
     /// interleave in Z_PK space: with a single pointer, saving chat B's window would move the
     /// pointer past chat A's still-unprocessed older messages and a crash would lose them.
     /// Per-chat keys make every chat independently crash-safe — same shape as Files' per-root
-    /// pointers. Windows are emitted ascending per chat (the pointer contract).
-    func scan(since cursors: [String: String]) throws -> [Candidate] {
+    /// pointers. Ordering: incremental windows ascend per chat; a chat's first run digs
+    /// newest-window-first, with every chat's NEW windows emitted before any chat's dig.
+    func scan(since cursors: [String: String]) throws -> ScanResult {
         let (dbURL, tempDir) = try SQLiteDB.walSafeCopy(of: dbPath)
         defer { try? FileManager.default.removeItem(at: tempDir) }   // delete the plaintext copy immediately
         let reader = try SQLiteReader(path: dbURL.path)
@@ -145,12 +147,12 @@ struct WhatsAppSource: DataSource, Sendable {
         let analyzedPKs = chats.values
             .filter { chatJIDs == nil || chatJIDs!.contains($0.jid) }
             .map(\.pk)
-        guard !analyzedPKs.isEmpty else { return [] }
+        guard !analyzedPKs.isEmpty else { return ScanResult(candidates: []) }
 
-        // Each analyzed chat's pointer (no row = chat never consumed = everything qualifies).
-        var pointers: [Int64: Int64] = [:]
+        // Each analyzed chat's pointer state (no row = backfill start = everything qualifies).
+        var states: [Int64: ChatCursorState] = [:]
         for chat in chats.values {
-            if let v = cursors["whatsapp:\(chat.jid)"].flatMap(Int64.init) { pointers[chat.pk] = v }
+            states[chat.pk] = ChatCursorState.decode(cursors["whatsapp:\(chat.jid)"])
         }
         // Tail hold-back: an actively-flowing conversation isn't chopped mid-thought — the last
         // hour's messages are windowed next run (they stay past the pointer until consumed).
@@ -161,6 +163,7 @@ struct WhatsAppSource: DataSource, Sendable {
         // newest per chat.
         let floor = ChatWindowing.lookbackFloor.timeIntervalSinceReferenceDate
         var byChat: [Int64: [ChatMessage]] = [:]
+        var fetched = 0   // raw rows the capped query returned (cap hit = a dig may be starved)
         // LEFT JOIN the group-member row (indexed on Z_PK → near-free) so senders without a
         // push-name resolve to their saved contact name instead of a raw JID/LID.
         try reader.forEachRow("""
@@ -172,9 +175,10 @@ struct WhatsAppSource: DataSource, Sendable {
             LEFT JOIN ZWAGROUPMEMBER gm ON m.ZGROUPMEMBER = gm.Z_PK
             ORDER BY m.ZCHATSESSION, m.Z_PK
             """) { r in
+            fetched += 1
             guard let chat = chats[r.int(5)] else { return }
-            guard r.int(0) > pointers[chat.pk] ?? -1 else { return }   // already consumed
-            guard r.double(1) <= tailFloor else { return }             // tail hold-back
+            guard states[chat.pk]?.wants(r.int(0)) ?? true else { return }   // already consumed
+            guard r.double(1) <= tailFloor else { return }                   // tail hold-back
             let isFromMe = r.int(2) == 1
             byChat[r.int(5), default: []].append(ChatMessage(
                 id: r.int(0),
@@ -186,33 +190,49 @@ struct WhatsAppSource: DataSource, Sendable {
                 text: String((r.text(3) ?? "").prefix(ChatWindowing.maxMessageChars))))
         }
 
-        // Window each chat to the byte budget; one window = one Artifact. A window's cursor
-        // value is its newest Z_PK — messages arrive ascending, so consuming windows in order
-        // sweeps the chat's pointer forward.
-        var perChat: [(lastActive: Date, candidates: [Candidate])] = []
+        // Window each chat to the byte budget; one window = one Artifact. The shared
+        // ChatWindowing.chatCandidates applies the chat's pointer state (incremental ascend /
+        // backfill descent / completion).
+        let mayBeClipped = fetched >= ChatWindowing.maxMessages
+        var perChat: [(lastActive: Date, now: [Candidate], dig: [Candidate])] = []
+        var completions: [String: String] = [:]
         for (chatPK, msgs) in byChat {
             guard let chat = chats[chatPK] else { continue }
-            var wins: [Candidate] = []
-            for win in ChatWindowing.windows(of: msgs) where !win.isEmpty {
-                let meta: [String: String] = [
-                    "folder": chat.name,                         // per-chat tag → folder pills in the viewer
-                    "name": chat.name,
-                    "displayPath": "WhatsApp · \(chat.name)",
-                    "isGroup": chat.isGroup ? "1" : "0",         // → group vs DM bouncer prompt
-                    "msgCount": "\(win.count)",
-                    "windowText": ChatWindowing.format(chatName: chat.name, isGroup: chat.isGroup, messages: win),
-                ]
-                wins.append(Candidate(id: "whatsapp:c\(chatPK):\(win.first!.id)-\(win.last!.id)",
-                                      kind: .whatsapp,
-                                      cursorKey: "whatsapp:\(chat.jid)",
-                                      cursorValue: "\(win.last!.id)",
-                                      itemDate: win.last!.date,
-                                      metadata: meta))
+            let (now, dig, completion) = ChatWindowing.chatCandidates(
+                msgs: msgs, state: states[chatPK] ?? .backfillStart, mayBeClipped: mayBeClipped
+            ) { win, cursorValue in
+                Candidate(id: "whatsapp:c\(chatPK):\(win.first!.id)-\(win.last!.id)",
+                          kind: .whatsapp,
+                          cursorKey: "whatsapp:\(chat.jid)",
+                          cursorValue: cursorValue,
+                          itemDate: win.last!.date,
+                          metadata: [
+                              "folder": chat.name,                 // per-chat tag → folder pills in the viewer
+                              "name": chat.name,
+                              "displayPath": "WhatsApp · \(chat.name)",
+                              "isGroup": chat.isGroup ? "1" : "0", // → group vs DM bouncer prompt
+                              "msgCount": "\(win.count)",
+                              "windowText": ChatWindowing.format(chatName: chat.name, isGroup: chat.isGroup, messages: win),
+                          ])
             }
-            if !wins.isEmpty { perChat.append((msgs.last!.date, wins)) }
+            if let completion { completions["whatsapp:\(chat.jid)"] = completion }
+            if !(now.isEmpty && dig.isEmpty) { perChat.append((msgs.last!.date, now, dig)) }
         }
-        // Active chats first; windows within a chat stay ascending (the pointer contract).
-        return perChat.sorted { $0.lastActive > $1.lastActive }.flatMap(\.candidates)
+        // A backfilling chat with NO fetched messages has nothing above hi and nothing left
+        // below lo (within the floor) — its backfill is over. Never collapse on a clipped scan.
+        if !mayBeClipped {
+            for chat in chats.values where chatJIDs?.contains(chat.jid) ?? true {
+                if case .backfill(let bf, _, _) = states[chat.pk] ?? .backfillStart,
+                   byChat[chat.pk] == nil {
+                    completions["whatsapp:\(chat.jid)"] = bf.hi
+                }
+            }
+        }
+        // Every chat's NEW windows first (what's happening now), then the backfill digs —
+        // active chats first within each group.
+        let ordered = perChat.sorted { $0.lastActive > $1.lastActive }
+        return ScanResult(candidates: ordered.flatMap(\.now) + ordered.flatMap(\.dig),
+                          completions: completions)
     }
 
     func load(_ candidate: Candidate) throws -> Artifact {

--- a/Sentient OS macOS/Sources/iMessageSource.swift
+++ b/Sentient OS macOS/Sources/iMessageSource.swift
@@ -125,11 +125,13 @@ struct iMessageSource: DataSource, Sendable {
 
     // MARK: Scan — copy → query → decode → window → delete
 
-    /// Pointer (June 11 rewrite): ONE cursor per opted-in chat — key "imessage:<guid>", value =
-    /// the highest consumed `ROWID` — plus a one-hour tail hold-back. Per-chat (not one global
-    /// ROWID pointer) because chats interleave in ROWID space; see WhatsAppSource.scan for the
-    /// full rationale. Windows are emitted ascending per chat (the pointer contract).
-    func scan(since cursors: [String: String]) throws -> [Candidate] {
+    /// Pointer (June 11 rewrite + June 12 backfill): ONE cursor per opted-in chat — key
+    /// "imessage:<guid>", value = the highest consumed `ROWID` (or a BackfillCursor while the
+    /// chat's first run is in flight) — plus a one-hour tail hold-back. Per-chat (not one
+    /// global ROWID pointer) because chats interleave in ROWID space; see WhatsAppSource.scan
+    /// for the full rationale. Ordering: incremental windows ascend per chat; a chat's first
+    /// run digs newest-window-first, with every chat's NEW windows emitted before any dig.
+    func scan(since cursors: [String: String]) throws -> ScanResult {
         let (dbURL, tempDir) = try SQLiteDB.walSafeCopy(of: dbPath)
         defer { try? FileManager.default.removeItem(at: tempDir) }   // delete the plaintext copy immediately
         let reader = try SQLiteReader(path: dbURL.path)
@@ -142,12 +144,12 @@ struct iMessageSource: DataSource, Sendable {
         let analyzedROWIDs = chats.values
             .filter { chatGUIDs == nil || chatGUIDs!.contains($0.guid) }
             .map(\.rowid)
-        guard !analyzedROWIDs.isEmpty else { return [] }
+        guard !analyzedROWIDs.isEmpty else { return ScanResult(candidates: []) }
 
-        // Each analyzed chat's pointer (no row = chat never consumed = everything qualifies).
-        var pointers: [Int64: Int64] = [:]
+        // Each analyzed chat's pointer state (no row = backfill start = everything qualifies).
+        var states: [Int64: ChatCursorState] = [:]
         for chat in chats.values {
-            if let v = cursors["imessage:\(chat.guid)"].flatMap(Int64.init) { pointers[chat.rowid] = v }
+            states[chat.rowid] = ChatCursorState.decode(cursors["imessage:\(chat.guid)"])
         }
         let tailFloorNS = Int64(Date().addingTimeInterval(-sourceFreshnessHoldBack)
             .timeIntervalSinceReferenceDate * 1e9)
@@ -156,6 +158,7 @@ struct iMessageSource: DataSource, Sendable {
         // analyzed chats; the outer ORDER restores per-chat ascending iteration), decoded
         // text ?? typedstream, grouped per chat.
         var byChat: [Int64: [ChatMessage]] = [:]
+        var fetched = 0   // raw rows the capped query returned (cap hit = a dig may be starved)
         try reader.forEachRow("""
             SELECT m.ROWID, m.date, m.is_from_me, m.text, m.attributedBody, m.chat_id, h.id
             FROM (SELECT message.ROWID, date, is_from_me, text, attributedBody, handle_id, cmj.chat_id
@@ -166,9 +169,10 @@ struct iMessageSource: DataSource, Sendable {
             LEFT JOIN handle h ON h.ROWID = m.handle_id
             ORDER BY m.chat_id, m.ROWID
             """) { r in
+            fetched += 1
             guard let chat = chats[r.int(5)] else { return }
-            guard r.int(0) > pointers[chat.rowid] ?? -1 else { return }   // already consumed
-            guard r.int(1) <= tailFloorNS else { return }                 // tail hold-back
+            guard states[chat.rowid]?.wants(r.int(0)) ?? true else { return }   // already consumed
+            guard r.int(1) <= tailFloorNS else { return }                       // tail hold-back
 
             let body = r.text(3) ?? r.blob(4).flatMap(Self.typedstreamText)
             guard let body, !body.trimmingCharacters(in: .whitespaces).isEmpty else { return }
@@ -187,32 +191,49 @@ struct iMessageSource: DataSource, Sendable {
                 text: String(body.prefix(ChatWindowing.maxMessageChars))))
         }
 
-        // Window each chat to the byte budget; one window = one Artifact. A window's cursor
-        // value is its newest ROWID — consuming windows in order sweeps the chat's pointer.
-        var perChat: [(lastActive: Date, candidates: [Candidate])] = []
+        // Window each chat to the byte budget; one window = one Artifact. The shared
+        // ChatWindowing.chatCandidates applies the chat's pointer state (incremental ascend /
+        // backfill descent / completion).
+        let mayBeClipped = fetched >= ChatWindowing.maxMessages
+        var perChat: [(lastActive: Date, now: [Candidate], dig: [Candidate])] = []
+        var completions: [String: String] = [:]
         for (chatROWID, msgs) in byChat {
             guard let chat = chats[chatROWID] else { continue }
-            var wins: [Candidate] = []
-            for win in ChatWindowing.windows(of: msgs) where !win.isEmpty {
-                let meta: [String: String] = [
-                    "folder": chat.name,                         // per-chat tag → folder pills in the viewer
-                    "name": chat.name,
-                    "displayPath": "iMessage · \(chat.name)",
-                    "isGroup": chat.isGroup ? "1" : "0",         // → group vs DM bouncer prompt
-                    "msgCount": "\(win.count)",
-                    "windowText": ChatWindowing.format(chatName: chat.name, isGroup: chat.isGroup, messages: win),
-                ]
-                wins.append(Candidate(id: "imessage:c\(chatROWID):\(win.first!.id)-\(win.last!.id)",
-                                      kind: .imessage,
-                                      cursorKey: "imessage:\(chat.guid)",
-                                      cursorValue: "\(win.last!.id)",
-                                      itemDate: win.last!.date,
-                                      metadata: meta))
+            let (now, dig, completion) = ChatWindowing.chatCandidates(
+                msgs: msgs, state: states[chatROWID] ?? .backfillStart, mayBeClipped: mayBeClipped
+            ) { win, cursorValue in
+                Candidate(id: "imessage:c\(chatROWID):\(win.first!.id)-\(win.last!.id)",
+                          kind: .imessage,
+                          cursorKey: "imessage:\(chat.guid)",
+                          cursorValue: cursorValue,
+                          itemDate: win.last!.date,
+                          metadata: [
+                              "folder": chat.name,                 // per-chat tag → folder pills in the viewer
+                              "name": chat.name,
+                              "displayPath": "iMessage · \(chat.name)",
+                              "isGroup": chat.isGroup ? "1" : "0", // → group vs DM bouncer prompt
+                              "msgCount": "\(win.count)",
+                              "windowText": ChatWindowing.format(chatName: chat.name, isGroup: chat.isGroup, messages: win),
+                          ])
             }
-            if !wins.isEmpty { perChat.append((msgs.last!.date, wins)) }
+            if let completion { completions["imessage:\(chat.guid)"] = completion }
+            if !(now.isEmpty && dig.isEmpty) { perChat.append((msgs.last!.date, now, dig)) }
         }
-        // Active chats first; windows within a chat stay ascending (the pointer contract).
-        return perChat.sorted { $0.lastActive > $1.lastActive }.flatMap(\.candidates)
+        // A backfilling chat with NO fetched messages has nothing above hi and nothing left
+        // below lo (within the floor) — its backfill is over. Never collapse on a clipped scan.
+        if !mayBeClipped {
+            for chat in chats.values where chatGUIDs?.contains(chat.guid) ?? true {
+                if case .backfill(let bf, _, _) = states[chat.rowid] ?? .backfillStart,
+                   byChat[chat.rowid] == nil {
+                    completions["imessage:\(chat.guid)"] = bf.hi
+                }
+            }
+        }
+        // Every chat's NEW windows first (what's happening now), then the backfill digs —
+        // active chats first within each group.
+        let ordered = perChat.sorted { $0.lastActive > $1.lastActive }
+        return ScanResult(candidates: ordered.flatMap(\.now) + ordered.flatMap(\.dig),
+                          completions: completions)
     }
 
     func load(_ candidate: Candidate) throws -> Artifact {

--- a/Sentient OS macOS/Store/Store.swift
+++ b/Sentient OS macOS/Store/Store.swift
@@ -142,8 +142,10 @@ actor Store {
     // MARK: Stage 2 — the cloud vault & the iterative updater
 
     /// The corpus for FULL vault generations (initial gen / Regenerate): the LATEST version per
-    /// source, oldest first (stable ordering → stable `#index` refs). A 50-version file
-    /// contributes exactly one entry.
+    /// source, in the artifact's own chronology (stable ordering → stable `#index` refs). The
+    /// sort keys on `itemDate` — processing order means nothing now that backfills run
+    /// newest-first; the cloud model should read a life in the order it was lived. A 50-version
+    /// file contributes exactly one entry.
     func survivorSummaries() -> [SummaryItem] {
         let all = (try? modelContext.fetch(
             FetchDescriptor<Summary>(sortBy: [SortDescriptor(\.createdAt, order: .forward)])
@@ -151,7 +153,10 @@ actor Store {
         var latest: [String: Summary] = [:]
         for s in all { latest[s.sourceID] = s }       // ascending walk → last write wins
         return latest.values
-            .sorted { $0.createdAt < $1.createdAt }
+            .sorted {
+                let a = $0.itemDate ?? $0.createdAt, b = $1.itemDate ?? $1.createdAt
+                return a == b ? $0.createdAt < $1.createdAt : a < b
+            }
             .map(item(from:))
     }
 


### PR DESCRIPTION
## What

A pointer key's **first run** (no cursor row) now consumes its capped selection **newest-first** instead of oldest-first — the user watching the first analysis sees the app understanding what's happening NOW, not crawling through ancient files. Incremental behavior (plain pointer, ascending) is byte-for-byte unchanged.

## How

- **`BackfillCursor`** (`DataSource.swift`): while a key backfills, its `SourceCursor.value` is a JSON `{hi, lo, remaining}` — the consumed region is the closed interval **[lo, hi]**. Every durable save rewrites the full state through the existing one-transaction `Store.record` path, so **no Store/schema changes**. A `{` prefix vs digit prefix keeps plain and backfill values unambiguous.
- **Resume:** an interrupted backfill digs strictly below `lo` next run. **Items arriving mid-backfill** sit above `hi` and are emitted FIRST (ascending) before the descent continues — day 2 of an unfinished backfill still shows today's life first.
- **Termination:** `remaining` carries the connector cap as a TOTAL budget across interruptions (files 1,000/root, notes 1,000); the item spending the last of it writes the plain `hi` pointer. Chats are unbudgeted — the rolling 90-day floor ends the dig. An emptied dig (aged out / deleted files) completes via the new **`ScanResult.completions`**, applied by the Pipeline before processing. Chat sources never complete on a scan that hit the global 100k cap (`mayBeClipped`) — an empty dig there may be the clip, not the end.
- **Per-key, not global:** a custom folder added in August or a chat opted-in next month gets the same newest-first treatment automatically — initial and incremental stay ONE code path.
- **Shared machinery:** `ChatCursorState` + `ChatWindowing.chatCandidates` (WhatsApp + iMessage use them verbatim); `BackfillCursor.descent` (files + notes).
- **Corpus ordering:** `survivorSummaries()` now sorts by `itemDate` — codex reads a life in the order it was lived, since processing order is now meaningless.

## Tests

- `SENTIENT_SELFTEST=incremental` grown 11 → **22 checks**: newest-first backfill → collapse → no-op → new/edited/junk lifecycle → interrupted backfill (mid-flight BackfillCursor state, mid-backfill arrival processes first, descent resumes, budget collapse) → emptied dig completing via the scan report. **22/22 green.**
- `SENTIENT_SELFTEST=skipping` — **17/17 still green.**
- Docs updated: codebase `Pointer Architecture` doc + arch file 2 §4/§11 (same PR, per the dev law).

## Failure-policy note

The no-poison-pill property mirrors during a descent: a permanently-failing item is passed by the next success *below* it. Same zero-bookkeeping design as ascending.