### PR TITLE
Constellation home + For You briefings UI

### DIFF
--- a/Sentient OS macOS/Documentation/Briefings Window (For You).md
+++ b/Sentient OS macOS/Documentation/Briefings Window (For You).md
@@ -1,0 +1,55 @@
+# The Briefings Window — For You ("The Offerings")
+
+The proactive-intelligence surface (Arch §9 naming: surface = **For You**, artifacts =
+**briefings**) — and the stage for the headline feature: every briefing is an **offer**.
+The AI already did the work (research / draft / plan) and asks one question — *"Should I
+send it for you?"* — clicking it is the user's fire (Privacy Constitution: we never act
+unbidden; we offer, they fire). Execution rides the user's own Codex CLI (browser use,
+computer use), armed with the vault's personal context.
+
+Three files:
+
+## `Views/Briefing.swift` — model + the demo six
+
+`Briefing` (kicker / serif title / preview body / full `letter` / copyable `draft` / the
+verb `offer` / `workLog` theater lines / done state / **`codexPrompt`**). Kind → accent
+(meeting cobalt · overdue amber · promise mint · deadline ember · plan orchid · welcome =
+the full gradient).
+
+**THE CODEX SEAM:** demo execution plays the scripted `workLog`; real execution replaces
+the loop in `ForYouModel.run` with `CodexCLI.run` on `codexPrompt`, streaming JSONL events
+into the same lines. One swap point, clearly marked.
+
+**All six cards are hard-coded showcase content** (Deepika/Outlander · Luis/Headline ·
+Dad's shoes · ZFellows · SF break plan · the welcome letter), mined from the real vault for
+authenticity. The proactive module generates real ones post-launch.
+
+## `Views/BriefingCard.swift` — the card's four lives
+
+`sealed` (welcome only: dark-paper envelope, 3D-swinging flap, gradient wax seal stamped
+with the orb mark — tap to open) → `offer` (kicker + serif headline + `OfferButton`, the
+accent-ringed verb CTA) → `working(n)` (the agentic theater: mono log lines typing in
+under a blinking cursor) → `done` (mint check; the model flies the card away after ~3s).
+`OfferButton` is shared with the expanded letter.
+
+## `Views/BriefingsView.swift` — the window
+
+- **The deal:** cards spring in from above the header, staggered 110ms apart, and settle
+  into organic slots (per-population layouts + stable per-id jitter/rotation — pinned, not
+  gridded).
+- **Flick physics:** drag any card; past a flick threshold (predicted translation > 320pt)
+  it flies off along the flick vector and the scatter **reflows** with springs.
+- **The letter:** detail links expand a full typeset reading view (paragraph + ✦-bullet
+  styling, accent-barred draft block with Copy, the offer button lives there too). Esc /
+  click-outside / ✕ closes; the scatter blurs behind.
+- Header greeting is hour-aware ("Good morning, Jesai." — name is `Demo.name` until the
+  vault portrait supplies it). Reminders whisper-strip + trust footer on the floor. Empty
+  state: *"All quiet." / YOUR AI LOOKS OUT FOR YOU*.
+- Scene: its own `Window` (`BriefingsView.windowID`), hidden title bar, 1180×800. Opened by
+  the Constellation's briefing satellite (which now shows the latest offer + a `+5` pill).
+
+## Still demo / future
+
+Real briefings from the proactive module · real reminders in the strip · `Demo.name` from
+the vault · trackpad two-finger swipe-to-dismiss (needs an NSEvent scroll monitor; drag-
+flick ships first) · menu-bar "newest briefing" entry.

--- a/Sentient OS macOS/Documentation/Constellation Home (UI).md
+++ b/Sentient OS macOS/Documentation/Constellation Home (UI).md
@@ -1,0 +1,63 @@
+# The Constellation Home (UI)
+
+The app's home screen (Arch §9; design bar: `UI_Inspiration/01` + its HTML motion mockup).
+Three files, three jobs:
+
+## `Views/Orb.swift` — the living orb (design-system primitive)
+
+The logo made dimensional: a dark glassy planet with the logo's white dot glowing as a
+*heart* inside it, wrapped in a tilted ring of orbiting light. Pure SwiftUI — no Metal
+files, no SceneKit.
+
+- **True 3D occlusion:** the ring is drawn by TWO Canvases sandwiching the planet — one
+  draws only the far half (`depth < 0`), one only the near half — so it genuinely passes
+  behind and in front.
+- **Physics, not UI:** ~230 seeded particles in two bands (with a Cassini-style gap) on
+  **Keplerian** orbits (inner faster, `ω ∝ r^-1.5`); two shimmer glints chase around the
+  band in opposite directions; the planet casts a shadow on the far side of the ring; the
+  whole plane wobbles on slow precession cycles (23s/29s); 5.5s breathing.
+- **Color geography is anchored to angle** (the sentient spectrum at deep-space brightness)
+  — colors stay put while matter flows through them.
+- **Modes:** `.idle` / `.processing` (fast + bright) / `.attention` (quiet amber). The
+  processing/attention hooks are ready for the home ⟷ processing morph (a later phase).
+- **Performance rules (learned the 8-fps way; the file header repeats them):** no @State
+  writes per frame (the ring clock is a pure function of wall time) · no per-frame blur
+  filters (halo = pre-rasterized texture that only rotates; nebula/heart = radial gradients)
+  · one Canvas glow pass per side · the planet's diameter is FIXED (vector-crisp — breathing
+  lives in the heart/halo/ring, never a whole-orb scaleEffect).
+- `OrbMark` = the tiny static header glyph.
+
+## `Views/ConstellationHome.swift` — the home screen
+
+Orb dead-center; serif-italic status ("All caught up." / "Ready to begin."); mono-caps
+whisper (real `LifetimeStats.analyzed`); compact **Analyze Now** on the shared `GlowHalo`;
+four satellite cards pinned at the corners (±1.4–2° rotations — pinned, not gridded), each a
+door-with-preview; dotted tether lines drawn from **real geometry** (`anchorPreference` →
+Canvas) so they survive any window size; trust footer; `DEV TOOLS` bottom-right.
+
+- **Real data:** things-understood count, vault note/domain counts (walks
+  `VaultGenerator.vaultRoot` on appear), source chips (live from the dev picker's prefs),
+  Copy MCP Link (real `MirrorClient.shared.shareURL` when the mirror is on).
+- **Showcase data:** everything hard-coded lives in the file-private `Demo` enum and ONLY
+  there (briefing card, Your AIs numbers, synced time, pending count, "last night" foot) —
+  wiring real data later is a search for `Demo.`.
+- Vault card opens the existing knowledge window; the briefing card's door opens the
+  briefings window when that phase lands.
+
+## `Views/DevToolsView.swift` — the dev cockpit (sheet)
+
+The pre-Constellation home, moved verbatim behind the DEV TOOLS button: Start Analysis,
+View knowledge, source picker + chat pickers, Reset store, Update Knowledge Base, FDA
+tools, VaultView. The Phase-6 "Release strip" re-hides it.
+
+- **`SourceSelection`** (top of the file) is the one shared reader of the `dbg.run.*`
+  prefs, so RootView's *Analyze Now* and the sheet's *Start Analysis* run exactly the same
+  selection. Its defaults must mirror the `@AppStorage` declarations (folders ON, DB
+  sources OFF). The `@AppStorage` copies inside `DevToolsView` exist for SwiftUI
+  reactivity; `SourceSelection` exists for everyone else.
+
+## `Views/RootView.swift` — the switchboard
+
+Constellation (idle) ⟷ ProcessingView (takeover), today a cross-fade — the cohesive
+"cards recede, orb rises, processing assembles" morph is its own upcoming phase, along with
+the briefings window and the vault viewer (in that order).

--- a/Sentient OS macOS/Sentient_OS_macOSApp.swift
+++ b/Sentient OS macOS/Sentient_OS_macOSApp.swift
@@ -45,7 +45,20 @@ struct SentientOSApp: App {
                 .environment(appState)
                 .preferredColorScheme(.dark)   // Sentient OS is dark-only — no light mode
         }
+        .windowStyle(.hiddenTitleBar)            // OLED black runs edge-to-edge; no gray trim
         .windowResizability(.contentMinSize)
+        .defaultSize(width: 1100, height: 760)   // the Constellation's intended canvas
+
+        // For You — the briefings ("offerings") window. Its own scene; the Constellation's
+        // briefing satellite and (later) the menu bar open it.
+        Window("", id: BriefingsView.windowID) {
+            BriefingsView()
+                .environment(appState)
+                .preferredColorScheme(.dark)
+        }
+        .windowStyle(.hiddenTitleBar)
+        .windowResizability(.contentMinSize)
+        .defaultSize(width: 1180, height: 800)
 
         // The knowledge inspector is its OWN resizable window (native traffic-light controls,
         // closed with the red button) — not a sheet. Single-instance; `openWindow` brings it up.

--- a/Sentient OS macOS/Views/Briefing.swift
+++ b/Sentient OS macOS/Views/Briefing.swift
@@ -1,0 +1,229 @@
+//
+//  Briefing.swift
+//  Sentient OS macOS
+//
+//  The briefing ("offering") model + the demo set for the For You window. A briefing is an
+//  OFFER: the AI already did the work (research / draft / plan) and asks one question —
+//  "Should I do this for you?" — clicking it is the user's fire (Privacy Constitution: we
+//  never act unbidden; we offer, they fire).
+//
+//  THE CODEX SEAM: `codexPrompt` is what real execution sends to the user's own Codex CLI
+//  (`CodexCLI.run` — browser use, computer use, the works — armed with the vault's personal
+//  context). The demo plays the hard-coded `workLog` theater instead; swapping in the real
+//  call is a one-line change at the seam in BriefingsView.
+//
+//  ALL content below is the hard-coded investor-demo set (mined from the real vault for
+//  authenticity). The proactive-intelligence module generates real ones post-launch.
+//
+
+import SwiftUI
+
+struct Briefing: Identifiable {
+    enum Kind {
+        case meeting, overdue, promise, deadline, plan, welcome
+
+        /// The kind's accent — used as the card's hairline tint and kicker color (jewelry rule:
+        /// one quiet color per card; the welcome letter alone wears the full gradient).
+        var accent: Color {
+            switch self {
+            case .meeting:  Color(red: 0.36, green: 0.55, blue: 1.00)   // cobalt
+            case .overdue:  Theme.Ink.amber
+            case .promise:  Theme.Ink.mint
+            case .deadline: Color(red: 1.00, green: 0.42, blue: 0.45)   // ember
+            case .plan:     Color(red: 0.72, green: 0.46, blue: 0.96)   // orchid
+            case .welcome:  Theme.Ink.amber
+            }
+        }
+    }
+
+    let id: String
+    let kind: Kind
+    let kicker: String          // mono-caps provenance whisper, e.g. "OVERDUE · 3 DAYS · GMAIL"
+    let title: String           // the serif headline
+    let body: String            // 2–3 line card preview
+    let letter: String?         // the full typeset letter (paragraphs split on \n\n; "✦ " = accent bullet)
+    let draft: String?          // a ready-to-send message, shown as a copyable draft block
+    let draftLabel: String?     // the draft block's tag, e.g. "DRAFT REPLY · IMESSAGE"
+    let detailLabel: String?    // the quiet open-the-letter link, e.g. "read the draft"
+    let offer: String?          // the verb CTA, e.g. "Should I send it for you?" (nil = no action)
+    let workLog: [String]       // the agentic theater lines (demo stand-in for live codex output)
+    let doneTitle: String
+    let doneBody: String
+    let codexPrompt: String?    // what real execution hands to CodexCLI (see THE CODEX SEAM above)
+
+    init(id: String, kind: Kind, kicker: String, title: String, body: String,
+         letter: String? = nil, draft: String? = nil, draftLabel: String? = nil,
+         detailLabel: String? = nil, offer: String? = nil, workLog: [String] = [],
+         doneTitle: String = "", doneBody: String = "", codexPrompt: String? = nil) {
+        self.id = id
+        self.kind = kind
+        self.kicker = kicker
+        self.title = title
+        self.body = body
+        self.letter = letter
+        self.draft = draft
+        self.draftLabel = draftLabel
+        self.detailLabel = detailLabel
+        self.offer = offer
+        self.workLog = workLog
+        self.doneTitle = doneTitle
+        self.doneBody = doneBody
+        self.codexPrompt = codexPrompt
+    }
+
+    // MARK: The demo six
+
+    static let demo: [Briefing] = [
+        Briefing(
+            id: "deepika", kind: .overdue,
+            kicker: "Overdue · 3 days · Gmail",
+            title: "Deepika is waiting.",
+            body: "She's connecting you with Jordan, Outlander's senior partner, about the ~$1.5M — and asked for a TLDR she can forward. I wrote it.",
+            letter: """
+            Deepika (Outlander VC) loved Sentient and is connecting you with Jordan, their senior partner, to talk through the ~$1.5M. She asked for a TLDR she could forward.
+
+            That was three days ago. Time to land it — the draft is below, written to be forwarded.
+            """,
+            draft: """
+            Hi Deepika,
+
+            So great speaking with you — and thank you for connecting me with Jordan! Here's a TLDR you can forward along:
+
+            Sentient OS is the private, on-device intelligence layer for your digital life. Your Mac reads everything you've saved — files, screenshots, WhatsApp, iMessage, Notes — entirely on your own hardware, and distills it into a knowledge vault every AI you use can plug into. Raw data never leaves the device. 2,500+ waitlist signups in 24 hours from a single Reddit post, a working product, and a public launch this month.
+
+            Would love to walk Jordan through a live demo whenever suits.
+
+            Best,
+            Jesai
+            """,
+            draftLabel: "Draft · Gmail",
+            detailLabel: "read the draft",
+            offer: "Should I send it for you?",
+            workLog: ["→ reading the thread with Deepika",
+                      "→ opening Gmail",
+                      "→ composing the forwardable TLDR…",
+                      "✓ sent"],
+            doneTitle: "Sent to Deepika.",
+            doneBody: "The TLDR is on its way to Jordan.",
+            codexPrompt: "Open Gmail and reply to the latest thread with Deepika (Outlander VC) using the approved draft in this briefing. Send it."),
+
+        Briefing(
+            id: "luis", kind: .meeting,
+            kicker: "Meeting · iMessage + Calendar",
+            title: "Luis wants Friday, 1 PM.",
+            body: "Luis Schmitz (Headline) proposed meeting next Friday. I checked your calendar — you're free at 1 PM. The reply is drafted.",
+            letter: """
+            Luis Schmitz from Headline proposed meeting next week — Friday at 1 PM. I checked your calendar: you're free, with nothing for two hours on either side.
+
+            Worth remembering: their HQ is 101 Montgomery Street in the Presidio — NOT the Montgomery in Downtown. I'll remind you that morning.
+            """,
+            draft: "Hi Luis! Friday at 1 PM works perfectly — see you at 101 Montgomery. Looking forward to it!",
+            draftLabel: "Draft reply · iMessage",
+            detailLabel: "read the draft",
+            offer: "Reply & add it to your calendar?",
+            workLog: ["→ opening Messages",
+                      "→ replying to Luis…",
+                      "→ adding Friday 1:00 PM to Calendar",
+                      "→ location: 101 Montgomery St — the Presidio",
+                      "✓ replied & scheduled"],
+            doneTitle: "Friday's locked in.",
+            doneBody: "Replied to Luis · calendar updated — the Presidio one.",
+            codexPrompt: "Reply to Luis Schmitz on iMessage with the approved draft, then create a calendar event Friday 1 PM at 101 Montgomery St (Presidio), title 'Luis — Headline'."),
+
+        Briefing(
+            id: "dad", kind: .promise,
+            kicker: "Promise · WhatsApp",
+            title: "Dad's running shoes, found.",
+            body: "You promised him shoe research. Done — a clear winner for daily runs and two backups. The message is ready to send.",
+            letter: """
+            You told your dad you'd research running shoes for him. Done — he needs stability shoes for daily walks and easy 5Ks, and this year the field has a clear winner.
+
+            ✦ The pick: ASICS Gel-Kayano 31 — the benchmark stability shoe; plush, supportive, kindest to knees. ₹13,999 on amazon.in.
+
+            ✦ Backup: Brooks Adrenaline GTS 24 — lighter, slightly firmer ride, same support. ₹11,500.
+
+            ✦ Budget: New Balance 860v14 — the value play, often discounted. ₹9,999.
+            """,
+            draft: "Appa — researched the shoes properly :) Get the ASICS Gel-Kayano 31 — best stability for daily runs and easiest on the knees. If the size is sold out, the Brooks Adrenaline GTS 24 is just as good. Sending links!",
+            draftLabel: "Draft · WhatsApp",
+            detailLabel: "view the full research",
+            offer: "Shall I send it to him?",
+            workLog: ["→ opening WhatsApp",
+                      "→ finding Dad",
+                      "→ sending the message + links…",
+                      "✓ delivered"],
+            doneTitle: "Dad has it.",
+            doneBody: "Delivered on WhatsApp, links and all.",
+            codexPrompt: "Send Dad the approved WhatsApp message from this briefing, followed by the three amazon.in product links from the research."),
+
+        Briefing(
+            id: "zfellows", kind: .deadline,
+            kicker: "Deadline · 8 days · Browser agent",
+            title: "ZFellows closes in 8 days.",
+            body: "You bookmarked the Dropout Graduation but never registered. The form needs your name, school, and what you're building — I have all three.",
+            letter: """
+            You bookmarked the ZFellows Dropout Graduation three weeks ago and never registered. It closes in 8 days.
+
+            The form is short: name, school, and what you're building. I have all three — say the word and an agent fills it while you watch.
+            """,
+            detailLabel: nil,
+            offer: "Want an agent to register you?",
+            workLog: ["→ launching a browser agent",
+                      "→ zfellows.com/dropout-graduation",
+                      "→ name: Jesai Tarun · school: UMass Amherst",
+                      "→ building: Sentient OS",
+                      "→ submitting the form…",
+                      "✓ registered — confirmation in your inbox"],
+            doneTitle: "You're registered.",
+            doneBody: "The ZFellows confirmation is in your inbox.",
+            codexPrompt: "Use the browser to open the ZFellows Dropout Graduation registration and submit it for Jesai Tarun, UMass Amherst, building Sentient OS."),
+
+        Briefing(
+            id: "sfbreak", kind: .plan,
+            kicker: "Plan · WhatsApp · Cofounders",
+            title: "Your perfect SF break.",
+            body: "You three were brainstorming attractions in the group chat. I built the day from everything I know about you — golden hour included.",
+            letter: """
+            The three of you were brainstorming a break day in the group chat. I built it from everything I know about you — the camera itch, the food list, the fog:
+
+            ✦ 9 AM — Tartine in the Mission. It's been sitting on your Food to Try list since April.
+
+            ✦ 11 AM — Marin Headlands. The Golden Gate from above, and the best photography light of the day.
+
+            ✦ 2 PM — Musée Mécanique and Pier 39 chaos, settled by an It's-It taste test.
+
+            ✦ 5 PM — Karl the Fog permitting: Twin Peaks at golden hour.
+
+            ✦ 8 PM — the Alcatraz night tour — the one booking that actually sells out. I can grab three tickets the moment you say yes.
+            """,
+            detailLabel: "view the plan",
+            offer: "Shall I post it to the chat?",
+            workLog: ["→ opening WhatsApp",
+                      "→ “Aditya, Aryaman & Jesai”",
+                      "→ posting the plan…",
+                      "✓ posted"],
+            doneTitle: "It's on the chat.",
+            doneBody: "Aditya and Aryaman are typing…",
+            codexPrompt: "Post the SF break-day plan from this briefing to the WhatsApp group 'Aditya, Aryaman & Jesai'."),
+
+        Briefing(
+            id: "welcome", kind: .welcome,
+            kicker: "Welcome · Read across your whole life",
+            title: "A gift — connections across your life.",
+            body: "Three patterns you might not have seen yourself — visible only with everything in one place.",
+            letter: """
+            I read **1,704 things** across your life last night. Three patterns you might not have seen yourself:
+
+            ✦ **You never accept defaults.** Your iPhone ran **iPadOS** — WIRED noticed. Macs got **Apple Intelligence** before Apple shipped it, because you ported it. Your playlists skip the charts — and now you're routing around **college** itself.
+
+            ✦ **You spec hardware in numbers and music in feelings.** RAM chosen by the gigabyte for local LLMs; playlists curated for **“mood, tears, goosebumps.”**
+
+            ✦ **Your optimization points outward.** The systems you engineer for yourself show up rebuilt as **study systems for Jacob**, 8,000 miles away.
+
+            I'll keep watch from here. — **your Sentient**
+            """,
+            detailLabel: "read it again",
+            offer: nil,
+            doneTitle: "", doneBody: ""),
+    ]
+}

--- a/Sentient OS macOS/Views/BriefingCard.swift
+++ b/Sentient OS macOS/Views/BriefingCard.swift
@@ -1,0 +1,313 @@
+//
+//  BriefingCard.swift
+//  Sentient OS macOS
+//
+//  One offering card in the For You window, through its four lives:
+//  sealed (the welcome envelope, wax-sealed with the orb) → offer (kicker + serif headline +
+//  the verb CTA, e.g. "Should I send it for you?") → working (the agentic theater: mono log
+//  lines typing in with a blinking cursor) → done (mint check; the model flies it away).
+//  `OfferButton` is shared with the expanded letter view in BriefingsView.
+//
+
+import SwiftUI
+
+enum BriefingPhase: Equatable {
+    case sealed            // welcome only: the unopened envelope
+    case offer
+    case working(Int)      // how many workLog lines are visible
+    case done
+}
+
+struct BriefingCard: View {
+    let briefing: Briefing
+    let phase: BriefingPhase
+    var onOffer: () -> Void
+    var onDetail: () -> Void
+    var onOpenEnvelope: () -> Void
+
+    @State private var hovering = false
+
+    static let width: CGFloat = 332
+
+    var body: some View {
+        Group {
+            if phase == .sealed {
+                EnvelopeFace(onOpened: onOpenEnvelope)
+            } else {
+                face
+            }
+        }
+        .scaleEffect(hovering ? 1.012 : 1)
+        .animation(.spring(response: 0.35, dampingFraction: 0.75), value: hovering)
+        .onHover { hovering = $0 }
+    }
+
+    // MARK: The card faces
+
+    private var face: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            switch phase {
+            case .sealed:
+                EmptyView()
+            case .offer:
+                offerFace.transition(.blurReplace)
+            case .working(let visible):
+                workingFace(visible).transition(.blurReplace)
+            case .done:
+                doneFace.transition(.blurReplace)
+            }
+        }
+        .padding(EdgeInsets(top: 16, leading: 18, bottom: 16, trailing: 18))
+        .frame(width: Self.width, alignment: .leading)
+        .background(Theme.Ink.cardBG, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: 14, style: .continuous)
+            .strokeBorder(border, lineWidth: 1))
+        .animation(.spring(response: 0.45, dampingFraction: 0.85), value: phase)
+    }
+
+    private var offerFace: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            MonoCaps(briefing.kicker, size: 9.5, tracking: 2.0, color: briefing.kind.accent.opacity(0.95))
+            Text(briefing.title)
+                .font(.system(size: 20, design: .serif)).foregroundStyle(.white)
+                .padding(.top, 8)
+            Text(briefing.body)
+                .font(.system(size: 12)).foregroundStyle(Theme.Ink.body).lineSpacing(3.2)
+                .padding(.top, 6)
+            HStack(spacing: 12) {
+                if let offer = briefing.offer {
+                    OfferButton(label: offer, accent: briefing.kind.accent, action: onOffer)
+                }
+                if let detail = briefing.detailLabel {
+                    Button(action: onDetail) {
+                        HStack(spacing: 4) {
+                            Text(detail).font(.system(size: 11.5))
+                            Image(systemName: "chevron.right").font(.system(size: 8, weight: .semibold))
+                        }
+                        .foregroundStyle(Theme.Ink.bright)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.top, 13)
+        }
+    }
+
+    private func workingFace(_ visible: Int) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 7) {
+                PulsingDot(color: briefing.kind.accent)
+                MonoCaps("Working", size: 9.5, tracking: 2.0, color: briefing.kind.accent)
+            }
+            Text(briefing.title)
+                .font(.system(size: 20, design: .serif)).foregroundStyle(.white.opacity(0.85))
+                .padding(.top, 8)
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(0..<min(visible, briefing.workLog.count), id: \.self) { i in
+                    let line = briefing.workLog[i]
+                    Text(line)
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundStyle(line.hasPrefix("✓") ? Theme.Ink.mint : .white.opacity(0.72))
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
+                if visible < briefing.workLog.count {
+                    BlinkingCursor(color: briefing.kind.accent)
+                }
+            }
+            .padding(.top, 10)
+        }
+    }
+
+    private var doneFace: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 24)).foregroundStyle(Theme.Ink.mint)
+            VStack(alignment: .leading, spacing: 5) {
+                Text(briefing.doneTitle)
+                    .font(.system(size: 20, design: .serif)).foregroundStyle(.white)
+                Text(briefing.doneBody)
+                    .font(.system(size: 12)).foregroundStyle(Theme.Ink.body)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.vertical, 6)
+    }
+
+    private var border: LinearGradient {
+        if briefing.kind == .welcome { return Self.welcomeGradient }
+        return LinearGradient(
+            colors: [briefing.kind.accent.opacity(hovering ? 0.55 : 0.40), .white.opacity(0.05)],
+            startPoint: .topLeading, endPoint: .bottomTrailing)
+    }
+
+    /// The full-spectrum hairline only the welcome letter wears (jewelry rule).
+    static let welcomeGradient = LinearGradient(
+        colors: [Color(red: 1.00, green: 0.37, blue: 0.43).opacity(0.55),
+                 Color(red: 1.00, green: 0.76, blue: 0.44).opacity(0.40),
+                 Color(red: 0.28, green: 0.84, blue: 0.67).opacity(0.40),
+                 Color(red: 0.36, green: 0.55, blue: 1.00).opacity(0.55)],
+        startPoint: .topLeading, endPoint: .bottomTrailing)
+}
+
+// MARK: - The verb CTA ("Should I send it for you?")
+
+struct OfferButton: View {
+    let label: String
+    let accent: Color
+    let action: () -> Void
+    @State private var hovering = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 7) {
+                Image(systemName: "sparkles").font(.system(size: 10.5, weight: .semibold))
+                Text(label).font(.system(size: 12.5, weight: .semibold))
+            }
+            .foregroundStyle(.white)
+            .padding(.horizontal, 15).padding(.vertical, 8)
+            .background(Capsule(style: .continuous).fill(.white.opacity(hovering ? 0.12 : 0.07)))
+            .overlay(Capsule(style: .continuous).strokeBorder(
+                LinearGradient(colors: [accent.opacity(0.9), accent.opacity(0.35)],
+                               startPoint: .topLeading, endPoint: .bottomTrailing), lineWidth: 1))
+            .contentShape(Capsule())
+        }
+        .buttonStyle(PressScaleStyle())
+        .shadow(color: accent.opacity(hovering ? 0.45 : 0.22), radius: hovering ? 12 : 7)
+        .animation(.easeInOut(duration: 0.2), value: hovering)
+        .onHover { hovering = $0 }
+    }
+}
+
+// MARK: - The welcome envelope
+
+/// The unopened welcome letter: dark paper, a flap that swings open in 3D, and a gradient
+/// wax seal carrying the orb mark. Tap anywhere → flap opens → `onOpened` (the parent then
+/// expands the letter and the card lives on as a normal welcome card).
+private struct EnvelopeFace: View {
+    var onOpened: () -> Void
+    @State private var open = false
+
+    var body: some View {
+        Button {
+            guard !open else { return }
+            withAnimation(.easeInOut(duration: 0.45)) { open = true }
+            Task {
+                try? await Task.sleep(for: .seconds(0.5))
+                onOpened()
+            }
+        } label: {
+            ZStack(alignment: .top) {
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(Color(red: 0.055, green: 0.051, blue: 0.071))
+                    .overlay(RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .strokeBorder(BriefingCard.welcomeGradient, lineWidth: 1))
+
+                VStack(spacing: 7) {
+                    MonoCaps("A letter from your Sentient", size: 9, tracking: 2.4, color: Theme.Ink.label)
+                    Text("For Jesai")   // demo: the recipient comes from the vault portrait later
+                        .font(.system(size: 22, design: .serif).italic())
+                        .foregroundStyle(Theme.Ink.statusInk)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.top, 128)
+
+                EnvelopeFlap()
+                    .fill(Color(red: 0.082, green: 0.076, blue: 0.106))
+                    .overlay(EnvelopeFlap().stroke(Color.white.opacity(0.08), lineWidth: 1))
+                    .frame(height: 94)
+                    .rotation3DEffect(.degrees(open ? -150 : 0),
+                                      axis: (x: 1, y: 0, z: 0), anchor: .top, perspective: 0.55)
+
+                seal
+                    .offset(y: 94 - 19)
+                    .opacity(open ? 0 : 1)
+            }
+            .frame(width: BriefingCard.width, height: 200)
+            .contentShape(RoundedRectangle(cornerRadius: 14))
+        }
+        .buttonStyle(PressScaleStyle())
+    }
+
+    /// The wax: an angular-gradient disc stamped with the logo's ring + dot.
+    private var seal: some View {
+        ZStack {
+            Circle()
+                .fill(AngularGradient(colors: [
+                    Color(red: 0.76, green: 0.30, blue: 0.36), Color(red: 0.80, green: 0.56, blue: 0.27),
+                    Color(red: 0.18, green: 0.58, blue: 0.51), Color(red: 0.30, green: 0.45, blue: 0.85),
+                    Color(red: 0.56, green: 0.34, blue: 0.67), Color(red: 0.76, green: 0.30, blue: 0.36),
+                ], center: .center))
+                .overlay(Circle().fill(Color.black.opacity(0.22)))   // wax depth
+                .frame(width: 38, height: 38)
+            Circle().strokeBorder(.white.opacity(0.92), lineWidth: 1.5)
+                .frame(width: 19, height: 19)
+            Circle().fill(.white).frame(width: 6.5, height: 6.5)
+        }
+        .shadow(color: Color(red: 0.56, green: 0.34, blue: 0.67).opacity(0.5), radius: 8)
+    }
+}
+
+private struct EnvelopeFlap: Shape {
+    func path(in rect: CGRect) -> Path {
+        var p = Path()
+        p.move(to: CGPoint(x: rect.minX, y: rect.minY))
+        p.addLine(to: CGPoint(x: rect.maxX, y: rect.minY))
+        p.addLine(to: CGPoint(x: rect.midX, y: rect.maxY))
+        p.closeSubpath()
+        return p
+    }
+}
+
+// MARK: - Tiny animated bits
+
+private struct PulsingDot: View {
+    let color: Color
+    @State private var on = false
+    var body: some View {
+        Circle().fill(color).frame(width: 5, height: 5)
+            .opacity(on ? 1 : 0.25)
+            .onAppear { withAnimation(.easeInOut(duration: 0.6).repeatForever(autoreverses: true)) { on = true } }
+    }
+}
+
+private struct BlinkingCursor: View {
+    let color: Color
+    @State private var on = false
+    var body: some View {
+        Text("▍").font(.system(size: 11, design: .monospaced)).foregroundStyle(color)
+            .opacity(on ? 0.9 : 0.15)
+            .onAppear { withAnimation(.easeInOut(duration: 0.5).repeatForever(autoreverses: true)) { on = true } }
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Offer") {
+    ZStack { Color.black
+        BriefingCard(briefing: Briefing.demo[0], phase: .offer,
+                     onOffer: {}, onDetail: {}, onOpenEnvelope: {})
+    }.frame(width: 420, height: 300)
+}
+
+#Preview("Working") {
+    ZStack { Color.black
+        BriefingCard(briefing: Briefing.demo[3], phase: .working(3),
+                     onOffer: {}, onDetail: {}, onOpenEnvelope: {})
+    }.frame(width: 420, height: 320)
+}
+
+#Preview("Done") {
+    ZStack { Color.black
+        BriefingCard(briefing: Briefing.demo[0], phase: .done,
+                     onOffer: {}, onDetail: {}, onOpenEnvelope: {})
+    }.frame(width: 420, height: 240)
+}
+
+#Preview("Sealed envelope") {
+    ZStack { Color.black
+        BriefingCard(briefing: Briefing.demo[5], phase: .sealed,
+                     onOffer: {}, onDetail: {}, onOpenEnvelope: {})
+    }.frame(width: 420, height: 300)
+}

--- a/Sentient OS macOS/Views/BriefingsView.swift
+++ b/Sentient OS macOS/Views/BriefingsView.swift
@@ -1,0 +1,438 @@
+//
+//  BriefingsView.swift
+//  Sentient OS macOS
+//
+//  The For You window — "The Offerings". The orb deals the briefing cards onto the black
+//  with staggered physics; they settle into a loose scatter (placed, not gridded). Each card
+//  is an OFFER the user can fire (BriefingCard plays the agentic theater, then the card
+//  flies away), flick-dismiss with drag physics (the scatter reflows), or expand into a full
+//  typeset letter. A faint reminders strip + trust footer hold the floor; the empty state
+//  whispers "Your AI looks out for you."
+//
+//  Doc: Documentation/Briefings Window (For You).md · Demo content + the CodexCLI seam:
+//  Briefing.swift.
+//
+
+import SwiftUI
+import AppKit
+
+struct BriefingsView: View {
+    static let windowID = "foryou"
+
+    @State private var model = ForYouModel()
+    // The letter layer is ALWAYS mounted and driven purely by opacity/scale from plain
+    // @State — view INSERTION (`if let` overlays) can miss a redraw on macOS hidden-titlebar
+    // windows (the "appears only after a resize" bug); opacity changes cannot.
+    @State private var letter: Briefing?
+    @State private var letterShown = false
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack {
+                Theme.bg.ignoresSafeArea()
+
+                Group {
+                    header
+                    scatter(geo)
+                    bottomStrip
+                    if model.entries.isEmpty { emptyState.transition(.opacity) }
+                }
+                .blur(radius: letterShown ? 7 : 0)
+                .opacity(letterShown ? 0.4 : 1)
+
+                letterLayer(geo)
+            }
+        }
+        .frame(minWidth: 1020, minHeight: 720)
+        .background(Theme.bg)
+        .onAppear {                        // every visit starts fresh: sealed envelope, full deal
+            letter = nil
+            letterShown = false
+            model.beginVisit()
+        }
+        .animation(.easeInOut(duration: 0.5), value: model.entries.isEmpty)
+    }
+
+    // MARK: Header
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            HStack(spacing: 9) {
+                OrbMark(size: 15)
+                MonoCaps("For You", size: 10, tracking: 2.6, color: Theme.Ink.label)
+            }
+            Text(greeting)
+                .font(.system(size: 30, design: .serif).italic())
+                .foregroundStyle(Theme.Ink.statusInk)
+            MonoCaps(Demo.readLine(count: model.entries.count), size: 9.5, tracking: 2.2,
+                     color: Theme.Ink.deepMuted)
+        }
+        .padding(.leading, 36).padding(.top, 28)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private var greeting: String {
+        let hour = Calendar.current.component(.hour, from: Date())
+        let part = hour < 5 ? "Up late" : hour < 12 ? "Good morning"
+                 : hour < 18 ? "Good afternoon" : "Good evening"
+        return "\(part), \(Demo.name)."
+    }
+
+    // MARK: The scatter
+
+    private func scatter(_ geo: GeometryProxy) -> some View {
+        let slots = Self.slots(count: model.entries.count, in: geo.size)
+        return ZStack {
+            ForEach(Array(model.entries.enumerated()), id: \.element.id) { item in
+                DealtCard(
+                    entry: item.element,
+                    slot: slots[min(item.offset, slots.count - 1)],
+                    dealFrom: CGPoint(x: geo.size.width / 2, y: -160),
+                    onOffer: { model.run(item.element.id) },
+                    onDetail: { openLetter(item.element.b) },
+                    onOpenEnvelope: {
+                        model.unsealWelcome()
+                        openLetter(item.element.b)
+                    },
+                    onFling: { model.dismiss(item.element.id, toward: $0) })
+            }
+        }
+    }
+
+    /// Organic slot positions per population — pinned, not gridded; reflows as cards leave.
+    private static func slots(count: Int, in size: CGSize) -> [CGPoint] {
+        let f: [(CGFloat, CGFloat)]
+        switch count {
+        case 6...: f = [(0.21, 0.40), (0.50, 0.36), (0.79, 0.40), (0.21, 0.74), (0.50, 0.78), (0.79, 0.74)]
+        case 5:    f = [(0.22, 0.40), (0.50, 0.37), (0.78, 0.40), (0.34, 0.75), (0.66, 0.75)]
+        case 4:    f = [(0.28, 0.40), (0.72, 0.40), (0.28, 0.75), (0.72, 0.75)]
+        case 3:    f = [(0.24, 0.57), (0.50, 0.51), (0.76, 0.57)]
+        case 2:    f = [(0.35, 0.55), (0.65, 0.55)]
+        default:   f = [(0.50, 0.55)]
+        }
+        return f.map { CGPoint(x: $0.0 * size.width, y: $0.1 * size.height) }
+    }
+
+    // MARK: Floor — reminders whisper + trust footer
+
+    private var bottomStrip: some View {
+        VStack(spacing: 9) {
+            MonoCaps(Demo.reminders, size: 9, tracking: 1.6, color: Theme.Ink.deepMuted)
+            HStack(spacing: 8) {
+                Image(systemName: "shield").font(.system(size: 11)).foregroundStyle(Theme.Ink.label)
+                Text("Private by design. Your files never leave this Mac.")
+                    .font(.system(size: 12)).foregroundStyle(Theme.Ink.label)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+        .padding(.bottom, 14)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 13) {
+            OrbMark(size: 26)
+            Text("All quiet.")
+                .font(.system(size: 22, design: .serif).italic())
+                .foregroundStyle(Theme.Ink.statusInk)
+            MonoCaps("Your AI looks out for you", size: 9.5, tracking: 2.4, color: Theme.Ink.deepMuted)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: The expanded letter (always-mounted layer; see the note at the top)
+
+    private func letterLayer(_ geo: GeometryProxy) -> some View {
+        ZStack {
+            Color.black.opacity(0.5).ignoresSafeArea()
+                .onTapGesture { closeLetter() }
+            if let b = letter {
+                LetterView(briefing: b,
+                           phase: model.entry(b.id)?.phase ?? .offer,
+                           onOffer: {
+                               closeLetter()
+                               model.run(b.id)   // the theater plays out on the card
+                           },
+                           onClose: closeLetter)
+                    .frame(width: 660)
+                    .frame(maxHeight: geo.size.height * 0.86)
+                    .scaleEffect(letterShown ? 1 : 0.94)
+            }
+        }
+        .opacity(letterShown ? 1 : 0)
+        .allowsHitTesting(letterShown)
+    }
+
+    private func openLetter(_ b: Briefing) {
+        letter = b   // content lands while the layer is still invisible
+        withAnimation(.easeInOut(duration: 0.32)) { letterShown = true }
+    }
+
+    private func closeLetter() {
+        withAnimation(.easeInOut(duration: 0.26)) { letterShown = false }
+    }
+}
+
+// MARK: - The model (deal · run · dismiss)
+
+@MainActor @Observable
+final class ForYouModel {
+    struct Entry: Identifiable {
+        let b: Briefing
+        var phase: BriefingPhase
+        var dealt = false
+        var flight: CGSize?       // set = the card is flying off-screen
+        var id: String { b.id }
+    }
+
+    var entries: [Entry] = []
+    /// Bumped per window visit — in-flight Tasks from a previous visit check it and bail,
+    /// so a re-deal can never be mutated by stale theater/dismiss timers.
+    private var visit = 0
+
+    func entry(_ id: String) -> Entry? { entries.first { $0.id == id } }
+
+    private func update(_ id: String, _ mutate: (inout Entry) -> Void) {
+        guard let i = entries.firstIndex(where: { $0.id == id }) else { return }
+        mutate(&entries[i])
+    }
+
+    /// A fresh visit: full demo deck, welcome re-sealed, letter closed — then the orb deals
+    /// the cards with staggered springs from above the header.
+    func beginVisit() {
+        visit += 1
+        let v = visit
+        entries = Briefing.demo.map { Entry(b: $0, phase: $0.kind == .welcome ? .sealed : .offer) }
+        for (i, e) in entries.enumerated() {
+            Task {
+                try? await Task.sleep(for: .seconds(0.25 + Double(i) * 0.11))
+                guard self.visit == v else { return }
+                withAnimation(.spring(response: 0.62, dampingFraction: 0.74)) {
+                    self.update(e.id) { $0.dealt = true }
+                }
+            }
+        }
+    }
+
+    /// The welcome envelope opened: the card lives on un-sealed (the view opens the letter).
+    func unsealWelcome() {
+        guard let e = entries.first(where: { $0.b.kind == .welcome }) else { return }
+        update(e.id) { $0.phase = .offer }
+    }
+
+    /// Fire the offer. THE CODEX SEAM: real execution replaces the scripted loop below with
+    /// `CodexCLI.shared.run(...)` on `briefing.codexPrompt`, streaming JSONL events into the
+    /// same `working(n)` lines. The demo plays the briefing's hard-coded theater.
+    func run(_ id: String) {
+        guard let e = entry(id), e.phase == .offer, e.b.offer != nil else { return }
+        let v = visit
+        Task {
+            withAnimation(.easeInOut(duration: 0.3)) { update(id) { $0.phase = .working(0) } }
+            for n in 1...e.b.workLog.count {
+                try? await Task.sleep(for: .seconds(n == 1 ? 0.55 : Double.random(in: 0.7...1.15)))
+                guard self.visit == v else { return }
+                withAnimation(.easeOut(duration: 0.22)) { update(id) { $0.phase = .working(n) } }
+            }
+            try? await Task.sleep(for: .seconds(0.8))
+            guard self.visit == v else { return }
+            withAnimation(.spring(response: 0.5, dampingFraction: 0.8)) { update(id) { $0.phase = .done } }
+            try? await Task.sleep(for: .seconds(3.0))
+            guard self.visit == v else { return }
+            dismiss(id, toward: CGSize(width: CGFloat.random(in: 250...520),
+                                       height: -CGFloat.random(in: 350...560)))
+        }
+    }
+
+    /// Send a card flying along `v` (a flick's predicted translation), then reflow the scatter.
+    func dismiss(_ id: String, toward v: CGSize) {
+        guard entry(id) != nil else { return }
+        let token = visit
+        let mag = max(hypot(v.width, v.height), 1)
+        let flight = CGSize(width: v.width / mag * 1200, height: v.height / mag * 1200)
+        withAnimation(.easeIn(duration: 0.38)) { update(id) { $0.flight = flight } }
+        Task {
+            try? await Task.sleep(for: .seconds(0.42))
+            guard self.visit == token else { return }
+            withAnimation(.spring(response: 0.55, dampingFraction: 0.8)) {
+                entries.removeAll { $0.id == id }
+            }
+        }
+    }
+}
+
+// MARK: - One dealt card: position + jitter + drag/flick physics
+
+private struct DealtCard: View {
+    let entry: ForYouModel.Entry
+    let slot: CGPoint
+    let dealFrom: CGPoint
+    var onOffer: () -> Void
+    var onDetail: () -> Void
+    var onOpenEnvelope: () -> Void
+    var onFling: (CGSize) -> Void
+
+    @State private var drag: CGSize = .zero
+
+    var body: some View {
+        let j = Self.jitter(entry.id)
+        BriefingCard(briefing: entry.b, phase: entry.phase,
+                     onOffer: onOffer, onDetail: onDetail, onOpenEnvelope: onOpenEnvelope)
+            .rotationEffect(.degrees(j.rot + drag.width / 24))
+            .scaleEffect(entry.dealt ? 1 : 0.7)
+            .position(entry.dealt ? CGPoint(x: slot.x + j.dx, y: slot.y + j.dy) : dealFrom)
+            .offset(x: drag.width + (entry.flight?.width ?? 0),
+                    y: drag.height + (entry.flight?.height ?? 0))
+            .opacity(entry.flight != nil ? 0 : (entry.dealt ? 1 : 0))
+            // simultaneous, NOT .gesture: a plain ancestor DragGesture can win macOS click
+            // arbitration and eat the card's buttons ("read it again", the envelope).
+            .simultaneousGesture(DragGesture(minimumDistance: 12)
+                .onChanged { drag = $0.translation }
+                .onEnded { g in
+                    let p = g.predictedEndTranslation
+                    if hypot(p.width, p.height) > 320 {
+                        onFling(p)                       // flick → the model flies it away
+                    } else {
+                        withAnimation(.spring(response: 0.45, dampingFraction: 0.7)) { drag = .zero }
+                    }
+                })
+    }
+
+    /// Stable per-card scatter personality (offset + rotation) from the briefing id.
+    private static func jitter(_ id: String) -> (dx: CGFloat, dy: CGFloat, rot: Double) {
+        var h = UInt64(5381)
+        for b in id.utf8 { h = (h &* 33) ^ UInt64(b) }
+        let r1 = Double(h % 1000) / 1000
+        let r2 = Double((h >> 10) % 1000) / 1000
+        let r3 = Double((h >> 20) % 1000) / 1000
+        return (CGFloat(r1 * 20 - 10), CGFloat(r2 * 16 - 8), r3 * 5.2 - 2.6)
+    }
+}
+
+// MARK: - The typeset letter (expanded view)
+
+private struct LetterView: View {
+    let briefing: Briefing
+    let phase: BriefingPhase
+    var onOffer: () -> Void
+    var onClose: () -> Void
+
+    @State private var copied = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(alignment: .top) {
+                MonoCaps(briefing.kicker, size: 10, tracking: 2.2, color: briefing.kind.accent)
+                Spacer()
+                Button(action: onClose) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(Theme.Ink.label)
+                        .padding(6)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .keyboardShortcut(.cancelAction)   // Esc closes
+            }
+            Text(briefing.title)
+                .font(.system(size: 30, design: .serif)).foregroundStyle(.white)
+                .padding(.top, 8)
+
+            ScrollView(showsIndicators: false) {
+                VStack(alignment: .leading, spacing: 14) {
+                    paragraphs
+                    if let draft = briefing.draft { draftBlock(draft) }
+                }
+                .padding(.top, 18)
+                .padding(.bottom, 4)
+            }
+
+            if let offer = briefing.offer, phase == .offer {
+                OfferButton(label: offer, accent: briefing.kind.accent, action: onOffer)
+                    .padding(.top, 16)
+            }
+        }
+        .padding(28)
+        .background(Theme.Ink.cardBG, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: 18, style: .continuous)
+            .strokeBorder(briefing.kind == .welcome ? BriefingCard.welcomeGradient
+                          : LinearGradient(colors: [briefing.kind.accent.opacity(0.45), .white.opacity(0.06)],
+                                           startPoint: .topLeading, endPoint: .bottomTrailing),
+                          lineWidth: 1))
+        .shadow(color: .black.opacity(0.6), radius: 40, y: 18)
+    }
+
+    @ViewBuilder
+    private var paragraphs: some View {
+        let parts = (briefing.letter ?? briefing.body).components(separatedBy: "\n\n")
+        ForEach(Array(parts.enumerated()), id: \.offset) { item in
+            let text = item.element.trimmingCharacters(in: .whitespacesAndNewlines)
+            if text.hasPrefix("✦ ") {
+                HStack(alignment: .firstTextBaseline, spacing: 9) {
+                    Text("✦").font(.system(size: 12)).foregroundStyle(briefing.kind.accent)
+                    Text(Self.inline(String(text.dropFirst(2))))
+                        .font(.system(size: 13.5)).foregroundStyle(.white.opacity(0.84)).lineSpacing(4.5)
+                }
+            } else {
+                Text(Self.inline(text))
+                    .font(.system(size: 14)).foregroundStyle(.white.opacity(0.84)).lineSpacing(5)
+            }
+        }
+    }
+
+    /// Inline-markdown parse (**bold** etc.) so letters can carry a skimmable bold rail.
+    private static func inline(_ s: String) -> AttributedString {
+        (try? AttributedString(markdown: s,
+                               options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)))
+            ?? AttributedString(s)
+    }
+
+    private func draftBlock(_ draft: String) -> some View {
+        HStack(alignment: .top, spacing: 0) {
+            RoundedRectangle(cornerRadius: 1)
+                .fill(LinearGradient(colors: [briefing.kind.accent, briefing.kind.accent.opacity(0.15)],
+                                     startPoint: .top, endPoint: .bottom))
+                .frame(width: 2)
+            VStack(alignment: .leading, spacing: 9) {
+                HStack {
+                    MonoCaps(briefing.draftLabel ?? "Draft", size: 9, tracking: 2.0, color: Theme.Ink.label)
+                    Spacer()
+                    Button {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(draft, forType: .string)
+                        copied = true
+                        Task { try? await Task.sleep(for: .seconds(2)); copied = false }
+                    } label: {
+                        HStack(spacing: 5) {
+                            Image(systemName: copied ? "checkmark" : "doc.on.doc").font(.system(size: 9.5))
+                            Text(copied ? "Copied" : "Copy").font(.system(size: 11))
+                        }
+                        .foregroundStyle(copied ? Theme.Ink.mint : Theme.Ink.bright)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                }
+                Text(draft)
+                    .font(.system(size: 13)).foregroundStyle(.white.opacity(0.88)).lineSpacing(4)
+                    .textSelection(.enabled)
+            }
+            .padding(14)
+        }
+        .background(Color.white.opacity(0.04), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: 10, style: .continuous)
+            .strokeBorder(Color.white.opacity(0.07), lineWidth: 1))
+    }
+}
+
+// MARK: - Demo data (the window's own showcase strings — cards live in Briefing.demo)
+
+private enum Demo {
+    static let name = "Jesai"   // later: the vault portrait's first name
+    static let reminders = "Reminders · Luis @ Headline — Fri 1 PM · ZFellows — 8 days · Workout — tonight 8 PM"
+    static func readLine(count: Int) -> String {
+        "While you slept, I read 1,704 things · \(count) offering\(count == 1 ? "" : "s")"
+    }
+}
+
+#Preview("For You — the offerings") {
+    BriefingsView()
+        .frame(width: 1180, height: 800)
+}

--- a/Sentient OS macOS/Views/ConstellationHome.swift
+++ b/Sentient OS macOS/Views/ConstellationHome.swift
@@ -1,0 +1,496 @@
+//
+//  ConstellationHome.swift
+//  Sentient OS macOS
+//
+//  The Constellation — the app's home screen (Arch §9; design bar: UI_Inspiration/01 + the
+//  HTML motion mockup). The living Orb at the center of the user's universe; four satellite
+//  cards pinned (not gridded) at the corners, faintly tethered to the orb by dotted
+//  constellation lines; serif-italic status over a mono-caps whisper; the Analyze Now glow
+//  CTA; the trust footer on the floor; Dev Tools tucked bottom-right. Pure presentation —
+//  real numbers come in through the initializer; every hard-coded showcase string lives in
+//  `Demo` (search "Demo." when wiring real data).
+//
+
+import SwiftUI
+import AppKit
+
+struct ConstellationHome: View {
+    /// Which sources are armed to run (drives the Sources satellite's chips).
+    struct SourcesState {
+        var files = true
+        var whatsapp = false
+        var imessage = false
+        var notes = false
+    }
+
+    let thingsUnderstood: Int
+    let analyzeEnabled: Bool
+    let modelMissing: Bool
+    let sources: SourcesState
+    let onAnalyze: () -> Void
+    let onOpenVault: () -> Void
+    let onOpenBriefings: () -> Void
+    let onShowDevTools: () -> Void
+
+    @State private var vaultCounts: (notes: Int, domains: Int)?
+    @State private var mcpCopied = false
+    @State private var mcpUnavailable = false
+
+    var body: some View {
+        ZStack {
+            centerColumn
+            satellites
+            chrome
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .backgroundPreferenceValue(TetherKey.self) { tethers($0) }
+        .background(Theme.bg)
+        .task { vaultCounts = Self.countVault() }
+    }
+
+    // MARK: Center — the orb, the status, the CTA
+
+    private var centerColumn: some View {
+        VStack(spacing: 0) {
+            Orb(size: 132)
+                .anchorPreference(key: TetherKey.self, value: .bounds) { ["orb": $0] }
+            Text(statusLine)
+                .font(.system(size: 21, design: .serif).italic())
+                .foregroundStyle(C.statusInk)
+                .padding(.top, 12)
+            MonoCaps(statusSub, size: 10, tracking: 2.4, color: C.deepMuted)
+                .padding(.top, 8)
+            analyzeCTA
+                .padding(.top, 22)
+            if analyzeEnabled {
+                MonoCaps("\(Demo.pending) pending", size: 10, tracking: 1.6, color: C.deepMuted)
+                    .padding(.top, 13)
+            }
+            Text(whisper)
+                .font(.system(size: 13.5, design: .serif).italic())
+                .foregroundStyle(C.label)
+                .padding(.top, 7)
+        }
+        .offset(y: -14)
+    }
+
+    private var statusLine: String {
+        thingsUnderstood > 0 ? "All caught up." : "Ready to begin."
+    }
+    private var statusSub: String {
+        switch thingsUnderstood {
+        case 0:  "awaiting first analysis"
+        case 1:  "1 thing understood"
+        default: "\(thingsUnderstood.formatted()) things understood"
+        }
+    }
+    private var whisper: String {
+        modelMissing ? "The on-device model is missing — see Dev Tools"
+                     : "Will run when your Mac rests"
+    }
+
+    private var analyzeCTA: some View {
+        Button(action: onAnalyze) {
+            Text("Analyze Now")
+                .font(.system(size: 13.5, weight: .semibold))
+                .foregroundStyle(analyzeEnabled ? .black : .white.opacity(0.35))
+                .padding(.horizontal, 30).padding(.vertical, 11)
+                .background(Capsule(style: .continuous)
+                    .fill(analyzeEnabled ? Color.white : Color.white.opacity(0.08)))
+                .overlay(Capsule(style: .continuous)
+                    .stroke(analyzeEnabled ? .clear : Color.white.opacity(0.1), lineWidth: 1))
+                .contentShape(Capsule())
+        }
+        .buttonStyle(PressScaleStyle())
+        .background(GlowHalo(active: analyzeEnabled))
+        .disabled(!analyzeEnabled)
+    }
+
+    // MARK: The four satellites (exactly four, forever — doors with previews)
+
+    private var satellites: some View {
+        ZStack {
+            briefingCard
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                .padding(.leading, 48).padding(.top, 70)
+            aisCard
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
+                .padding(.trailing, 48).padding(.top, 78)
+            vaultCard
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
+                .padding(.leading, 48).padding(.bottom, 86)
+            sourcesCard
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+                .padding(.trailing, 56).padding(.bottom, 80)
+        }
+    }
+
+    /// For You's front door — sells proactive intelligence as a category (your AI worked
+    /// overnight, plural, consent-gated), never one contextless headline. Opens the window.
+    private var briefingCard: some View {
+        SatelliteCard(id: "briefing", width: 300, rotation: -2, style: .gradientNew,
+                      action: onOpenBriefings) {
+            HStack(spacing: 8) {
+                Image(systemName: "sparkles").font(.system(size: 9)).foregroundStyle(C.label)
+                MonoCaps("For You", size: 9.5, tracking: 2.3, color: C.label)
+                NewPill()
+                Spacer(minLength: 0)
+            }
+            Text("Let's get stuff done.")
+                .font(.system(size: 21, design: .serif)).foregroundStyle(.white)
+                .padding(.top, 9)
+            VStack(alignment: .leading, spacing: 7) {
+                ForEach(Demo.forYouTeasers, id: \.text) { t in
+                    HStack(spacing: 8) {
+                        Image(systemName: "arrow.right")
+                            .font(.system(size: 9, weight: .bold)).foregroundStyle(t.kind.accent)
+                        Text(t.text)
+                            .font(.system(size: 12.5, weight: .semibold))
+                            .foregroundStyle(.white.opacity(0.92)).lineLimit(1)
+                    }
+                }
+            }
+            .padding(.top, 10)
+            MonoCaps(Demo.forYouFoot, size: 9, tracking: 1.6, color: C.deepMuted)
+                .padding(.top, 11)
+        }
+    }
+
+    private var aisCard: some View {
+        SatelliteCard(id: "ais", width: 290, rotation: 1.6) {
+            MonoCaps("Your AIs", size: 9.5, tracking: 2.3, color: C.label)
+            (Text("Read ") + Text("\(Demo.aiNotesRead) notes").italic() + Text(" yesterday."))
+                .font(.system(size: 20, design: .serif)).foregroundStyle(.white)
+                .padding(.top, 8)
+            HStack(spacing: 0) {
+                Text("CHATGPT · ").foregroundStyle(C.label)
+                Text(Demo.aiLog).foregroundStyle(C.body)
+            }
+            .font(.system(size: 10, design: .monospaced))
+            .padding(.top, 6)
+            mcpButton
+                .padding(.top, 11)
+        }
+    }
+
+    private var mcpButton: some View {
+        Button(action: copyMCPLink) {
+            HStack(spacing: 6) {
+                Image(systemName: mcpCopied ? "checkmark" : "link").font(.system(size: 10))
+                Text(mcpCopied ? "Copied" : mcpUnavailable ? "Mirror is off" : "Copy MCP Link")
+                    .font(.system(size: 11.5))
+            }
+            .foregroundStyle(mcpCopied ? C.mint : C.bright)
+            .padding(.horizontal, 14).padding(.vertical, 6)
+            .overlay(Capsule().strokeBorder(Color(red: 0.165, green: 0.165, blue: 0.188), lineWidth: 1))
+            .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+    }
+
+    /// Copies the real share URL when the mirror is on; the mirror opt-in UI itself is a
+    /// later phase (onboarding step ⑨).
+    private func copyMCPLink() {
+        Task { @MainActor in
+            if let url = await MirrorClient.shared.shareURL {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(url, forType: .string)
+                mcpCopied = true
+            } else {
+                mcpUnavailable = true
+            }
+            try? await Task.sleep(for: .seconds(2))
+            mcpCopied = false
+            mcpUnavailable = false
+        }
+    }
+
+    private var vaultCard: some View {
+        SatelliteCard(id: "vault", width: 322, rotation: 1.4, action: onOpenVault) {
+            HStack {
+                MonoCaps("The Vault", size: 9.5, tracking: 2.3, color: C.label)
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12, weight: .medium)).foregroundStyle(C.deepMuted)
+            }
+            HStack(alignment: .center, spacing: 14) {
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(vaultHeadline)
+                        .font(.system(size: 21, design: .serif)).foregroundStyle(.white)
+                        .lineLimit(1).minimumScaleFactor(0.75)
+                        .padding(.top, 8)
+                    MonoCaps(vaultFoot, size: 9.5, tracking: 1.8, color: C.deepMuted)
+                        .lineLimit(1).minimumScaleFactor(0.85)
+                        .padding(.top, 10)
+                }
+                Spacer(minLength: 0)
+                MiniGraph().frame(width: 94, height: 58)
+            }
+        }
+    }
+
+    private var vaultHeadline: String {
+        if let v = vaultCounts, v.notes > 0 { return "\(v.notes) notes · \(v.domains) domains" }
+        return "No vault yet"
+    }
+    private var vaultFoot: String {
+        (vaultCounts?.notes ?? 0) > 0 ? Demo.vaultFoot : "Your first analysis builds it"
+    }
+
+    /// Counts the real vault on disk (notes = .md files, domains = top-level folders).
+    private static func countVault() -> (notes: Int, domains: Int)? {
+        let fm = FileManager.default
+        let root = VaultGenerator.vaultRoot
+        guard let walker = fm.enumerator(at: root, includingPropertiesForKeys: nil) else { return nil }
+        var notes = 0
+        for case let url as URL in walker where url.pathExtension == "md" { notes += 1 }
+        let domains = (try? fm.contentsOfDirectory(at: root, includingPropertiesForKeys: [.isDirectoryKey])
+            .filter {
+                !$0.lastPathComponent.hasPrefix(".")
+                    && (try? $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
+            }.count) ?? 0
+        return (notes, domains)
+    }
+
+    private var sourcesCard: some View {
+        SatelliteCard(id: "sources", width: 296, rotation: -1.8) {
+            MonoCaps("Sources", size: 9.5, tracking: 2.3, color: C.label)
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 8) {
+                    SourceChip("Files", on: sources.files)
+                    SourceChip("WhatsApp", on: sources.whatsapp)
+                    SourceChip("iMessage", on: sources.imessage)
+                }
+                HStack(spacing: 8) {
+                    SourceChip("Notes", on: sources.notes)
+                    SourceChip("Gmail", on: false, soon: true)
+                }
+            }
+            .padding(.top, 11)
+        }
+    }
+
+    // MARK: Chrome — header, trust footer, dev tools
+
+    private var chrome: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 10) {
+                OrbMark(size: 18)
+                Text("Sentient OS")
+                    .font(.system(size: 13.5, weight: .semibold)).foregroundStyle(.white)
+                Spacer()
+                MonoCaps(Demo.synced, size: 9, tracking: 1.8, color: C.mint)
+                    .padding(.horizontal, 12).padding(.vertical, 5)
+                    .overlay(Capsule().strokeBorder(C.mint.opacity(0.3), lineWidth: 1))
+            }
+            .padding(.horizontal, 28).padding(.top, 18)
+            Spacer()
+            ZStack {
+                HStack(spacing: 8) {
+                    Image(systemName: "shield").font(.system(size: 11)).foregroundStyle(C.label)
+                    Text("Private by design. Your files never leave this Mac.")
+                        .font(.system(size: 12)).foregroundStyle(C.label)
+                }
+                HStack {
+                    Spacer()
+                    devToolsButton
+                }
+                .padding(.trailing, 20)
+            }
+            .padding(.bottom, 16)
+        }
+    }
+
+    /// DX continuity: the pre-Constellation dev cockpit, one click away (Release strip re-hides it).
+    private var devToolsButton: some View {
+        Button(action: onShowDevTools) {
+            HStack(spacing: 5) {
+                Image(systemName: "wrench.and.screwdriver").font(.system(size: 8.5))
+                Text("DEV TOOLS")
+                    .font(.system(size: 9, weight: .medium, design: .monospaced)).tracking(1.6)
+            }
+            .foregroundStyle(C.deepMuted)
+            .padding(.horizontal, 10).padding(.vertical, 5)
+            .overlay(Capsule().strokeBorder(Color.white.opacity(0.10), lineWidth: 1))
+            .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: Tethers — the faint dotted lines that make it a constellation
+
+    private func tethers(_ anchors: [String: Anchor<CGRect>]) -> some View {
+        GeometryReader { proxy in
+            Canvas { ctx, _ in
+                guard let orbAnchor = anchors["orb"] else { return }
+                let orbRect = proxy[orbAnchor]
+                let orbCenter = CGPoint(x: orbRect.midX, y: orbRect.midY)
+                for id in ["briefing", "ais", "vault", "sources"] {
+                    guard let anchor = anchors[id] else { continue }
+                    let rect = proxy[anchor]
+                    var path = Path()
+                    path.move(to: orbCenter)
+                    path.addLine(to: CGPoint(x: rect.midX, y: rect.midY))
+                    ctx.stroke(path, with: .color(.white.opacity(0.07)),
+                               style: StrokeStyle(lineWidth: 1, dash: [2, 5]))
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Satellite card (door-with-preview)
+
+private struct SatelliteCard<Content: View>: View {
+    enum Style { case standard, gradientNew }
+
+    let id: String
+    let width: CGFloat
+    let rotation: Double
+    var style: Style = .standard
+    var action: (() -> Void)? = nil
+    let content: Content
+    @State private var hovering = false
+
+    init(id: String, width: CGFloat, rotation: Double, style: Style = .standard,
+         action: (() -> Void)? = nil, @ViewBuilder content: () -> Content) {
+        self.id = id
+        self.width = width
+        self.rotation = rotation
+        self.style = style
+        self.action = action
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) { content }
+            .padding(EdgeInsets(top: 15, leading: 18, bottom: 16, trailing: 18))
+            .frame(width: width, alignment: .leading)
+            .background(C.cardBG, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .overlay(RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .strokeBorder(border, lineWidth: 1))
+            .anchorPreference(key: TetherKey.self, value: .bounds) { [id: $0] }
+            .rotationEffect(.degrees(rotation))
+            .scaleEffect(hovering ? 1.015 : 1)
+            .animation(.spring(response: 0.35, dampingFraction: 0.75), value: hovering)
+            .onHover { hovering = $0 }
+            .onTapGesture { action?() }
+    }
+
+    private var border: LinearGradient {
+        switch style {
+        case .standard:
+            LinearGradient(colors: [.white.opacity(hovering ? 0.16 : 0.10), .white.opacity(0.04)],
+                           startPoint: .topLeading, endPoint: .bottomTrailing)
+        case .gradientNew:   // the NEW briefing wears the gradient like jewelry
+            LinearGradient(colors: [Color(red: 1.00, green: 0.37, blue: 0.43).opacity(0.55),
+                                    Color(red: 1.00, green: 0.76, blue: 0.44).opacity(0.35),
+                                    Color(red: 0.36, green: 0.55, blue: 1.00).opacity(0.55)],
+                           startPoint: .topLeading, endPoint: .bottomTrailing)
+        }
+    }
+}
+
+// MARK: - Small pieces
+
+private struct NewPill: View {
+    var body: some View {
+        Text("NEW")
+            .font(.system(size: 9, weight: .medium, design: .monospaced)).tracking(1.6)
+            .foregroundStyle(C.amber)
+            .padding(.horizontal, 8).padding(.vertical, 2)
+            .overlay(Capsule().strokeBorder(C.amber.opacity(0.5), lineWidth: 1))
+    }
+}
+
+private struct SourceChip: View {
+    let name: String
+    let on: Bool
+    var soon = false
+
+    init(_ name: String, on: Bool, soon: Bool = false) {
+        self.name = name
+        self.on = on
+        self.soon = soon
+    }
+
+    var body: some View {
+        HStack(spacing: 5) {
+            if on { Text("✓").foregroundStyle(C.mint) }
+            Text(name).foregroundStyle(soon ? C.deepMuted : on ? C.chipInk : .white.opacity(0.28))
+        }
+        .font(.system(size: 9, weight: .medium, design: .monospaced))
+        .tracking(0.8)
+        .padding(.horizontal, 9).padding(.vertical, 4)
+        .overlay(Capsule().strokeBorder(C.chipBorder,
+                                        style: StrokeStyle(lineWidth: 1, dash: soon ? [3, 3] : [])))
+    }
+}
+
+/// The vault card's constellation thumbnail — static placeholder geometry until the live
+/// graph render lands with the vault window (a later build phase).
+private struct MiniGraph: View {
+    private static let nodes: [(x: CGFloat, y: CGFloat, r: CGFloat)] = [
+        (10, 40, 2.6), (34, 14, 3.8), (60, 30, 3.0), (84, 12, 2.4), (50, 48, 2.4)]
+    private static let edges: [(Int, Int)] = [(0, 1), (1, 2), (2, 3), (1, 4), (2, 4), (0, 4)]
+
+    var body: some View {
+        Canvas { ctx, _ in
+            for (a, b) in Self.edges {
+                var path = Path()
+                path.move(to: CGPoint(x: Self.nodes[a].x, y: Self.nodes[a].y))
+                path.addLine(to: CGPoint(x: Self.nodes[b].x, y: Self.nodes[b].y))
+                ctx.stroke(path, with: .color(.white.opacity(0.25)), lineWidth: 1)
+            }
+            for n in Self.nodes {
+                ctx.fill(Path(ellipseIn: CGRect(x: n.x - n.r, y: n.y - n.r,
+                                                width: n.r * 2, height: n.r * 2)),
+                         with: .color(.white))
+            }
+        }
+    }
+}
+
+/// Card + orb bounds, collected so the tether lines can be drawn from real geometry.
+private struct TetherKey: PreferenceKey {
+    static let defaultValue: [String: Anchor<CGRect>] = [:]
+    static func reduce(value: inout [String: Anchor<CGRect>],
+                       nextValue: () -> [String: Anchor<CGRect>]) {
+        value.merge(nextValue()) { $1 }
+    }
+}
+
+// MARK: - Palette alias & showcase data
+
+private typealias C = Theme.Ink   // the shared editorial palette (Theme.swift)
+
+/// Hard-coded showcase content (the investor-demo state). Every fake string lives HERE and
+/// only here — wiring real data later is a search for "Demo.". The briefing + Your AIs cards
+/// stay showcase until the briefings window and access-log polling land.
+private enum Demo {
+    static let synced = "Synced · 3:41 AM"
+    static let pending = 214
+    static let forYouTeasers: [(kind: Briefing.Kind, text: String)] = [
+        (.overdue,  "Send your reply to Outlander VC?"),
+        (.promise,  "Text Dad his running-shoe research?"),
+        (.deadline, "Register you for ZFellows?"),
+    ]
+    static let forYouFoot = "6 offerings · one click each"
+    static let aiNotesRead = 5
+    static let aiLog = "Tokyo Trip, Visa…"
+    static let vaultFoot = "Last night · 6 changed"
+}
+
+#Preview("Constellation — caught up") {
+    ConstellationHome(thingsUnderstood: 12438, analyzeEnabled: true, modelMissing: false,
+                      sources: .init(files: true, whatsapp: true, imessage: true, notes: true),
+                      onAnalyze: {}, onOpenVault: {}, onOpenBriefings: {}, onShowDevTools: {})
+        .frame(width: 1100, height: 760)
+}
+
+#Preview("Constellation — fresh install") {
+    ConstellationHome(thingsUnderstood: 0, analyzeEnabled: true, modelMissing: false,
+                      sources: .init(files: true, whatsapp: false, imessage: false, notes: false),
+                      onAnalyze: {}, onOpenVault: {}, onOpenBriefings: {}, onShowDevTools: {})
+        .frame(width: 1100, height: 760)
+}

--- a/Sentient OS macOS/Views/DevToolsView.swift
+++ b/Sentient OS macOS/Views/DevToolsView.swift
@@ -1,0 +1,394 @@
+//
+//  DevToolsView.swift
+//  Sentient OS macOS
+//
+//  The dev cockpit — the pre-Constellation home screen, now living in a sheet behind the
+//  home's DEV TOOLS button (DX continuity until real Settings/onboarding ship; the Phase-6
+//  "Release strip" re-hides it). Start Analysis, View knowledge, the source picker (folders +
+//  chat pickers + Notes), Reset store, Update Knowledge Base, FDA tools, and the Stage-2
+//  VaultView. `SourceSelection` is the one shared reader of the dbg.run.* prefs so Analyze
+//  Now (RootView) and Start Analysis (here) run EXACTLY the same selection.
+//
+
+import SwiftUI
+import AppKit
+
+/// One-shot reader of the dev source-picker prefs (the same keys as the @AppStorage
+/// declarations below — defaults must match: folder toggles ON, DB sources OFF). RootView
+/// uses it for Analyze Now; this sheet uses it for Start Analysis. The @AppStorage copies in
+/// DevToolsView exist for SwiftUI reactivity; this exists for everyone else.
+enum SourceSelection {
+    static var chatJIDs: Set<String> {
+        Set((UserDefaults.standard.string(forKey: "dbg.whatsapp.chats") ?? "")
+            .split(separator: ",").map(String.init))
+    }
+    static var imessageGUIDs: Set<String> {
+        Set((UserDefaults.standard.string(forKey: "dbg.imessage.chats") ?? "")
+            .split(separator: ",").map(String.init))
+    }
+
+    static func current(customRoots: [URL], fdaGranted: Bool) -> [RunSource] {
+        var s: [RunSource] = []
+        if bool("dbg.run.downloads", default: true) { s.append(.files(.downloads)) }
+        if bool("dbg.run.desktop", default: true) { s.append(.files(.desktop)) }
+        if bool("dbg.run.documents", default: true) { s.append(.files(.documents)) }
+        s.append(contentsOf: customRoots.map { .files(.custom($0)) })
+        // Never run a DB source without FDA + a chat selection.
+        if bool("dbg.run.whatsapp", default: false) && fdaGranted && !chatJIDs.isEmpty {
+            s.append(.whatsapp(chatJIDs: chatJIDs))
+        }
+        if bool("dbg.run.imessage", default: false) && fdaGranted && !imessageGUIDs.isEmpty {
+            s.append(.imessage(chatGUIDs: imessageGUIDs))
+        }
+        if bool("dbg.run.notes", default: false) && fdaGranted { s.append(.notes) }
+        return s
+    }
+
+    private static func bool(_ key: String, default def: Bool) -> Bool {
+        (UserDefaults.standard.object(forKey: key) as? Bool) ?? def
+    }
+}
+
+struct DevToolsView: View {
+    let store: Store
+    @Binding var customRoots: [URL]
+    /// Closes the sheet and hands off to the processing takeover.
+    var onStartAnalysis: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.openWindow) private var openWindow
+
+    private static let modelPath = ModelLocator.resolve()
+
+    // The dev source picker: which folders analysis runs over. Named-folder toggles persist
+    // across launches; custom folders are session-only (re-pick after a relaunch). Same keys
+    // as SourceSelection above.
+    @AppStorage("dbg.run.downloads") private var runDownloads = true
+    @AppStorage("dbg.run.desktop")   private var runDesktop = true
+    @AppStorage("dbg.run.documents") private var runDocuments = true
+    @AppStorage("dbg.run.whatsapp")  private var runWhatsApp = false   // is WhatsApp active this run (chip lit)
+    @AppStorage("dbg.whatsapp.chats") private var selectedChatsCSV = ""  // opt-in chat JIDs, comma-joined
+    @AppStorage("dbg.run.imessage")  private var runIMessage = false   // is iMessage active this run (chip lit)
+    @AppStorage("dbg.imessage.chats") private var selectedIMessageChatsCSV = ""  // opt-in chat GUIDs, comma-joined
+    @AppStorage("dbg.run.notes")     private var runNotes = false      // Apple Notes (no picker — all notes, capped)
+
+    @State private var showChatPicker = false
+    @State private var showIMessagePicker = false
+    @State private var resetResult: String?
+    @State private var isResetting = false
+    @State private var daysEndResult: String?
+    @State private var isDaysEndRunning = false
+    // "More Options" — advanced debug (Full Disk Access + the DB sources), tucked away so the
+    // main debug area stays uncluttered.
+    @State private var showMoreOptions = false
+    @State private var fdaGranted = false
+
+    private var selectedSources: [RunSource] {
+        SourceSelection.current(customRoots: customRoots, fdaGranted: fdaGranted)
+    }
+    private var selectedChatJIDs: Set<String> {
+        Set(selectedChatsCSV.split(separator: ",").map(String.init))
+    }
+    private var selectedIMessageGUIDs: Set<String> {
+        Set(selectedIMessageChatsCSV.split(separator: ",").map(String.init))
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("DEV TOOLS").font(.caption2.weight(.bold)).tracking(2).foregroundStyle(Theme.faint)
+                Spacer()
+                Button("Done") { dismiss() }.controlSize(.small)
+            }
+            .padding(.horizontal, 18).padding(.vertical, 12)
+
+            ScrollView {
+                VStack(spacing: 18) {
+                    GlowButton(title: "Start Analysis", systemImage: "sparkles",
+                               active: !selectedSources.isEmpty && Self.modelPath != nil) {
+                        onStartAnalysis()
+                    }
+                    .frame(maxWidth: 300)
+
+                    if Self.modelPath == nil {
+                        Text("On-device model not found — place \(ModelLocator.fileName) next to the .xcodeproj, or set SENTIENT_MODEL_PATH.")
+                            .font(.caption2).foregroundStyle(Theme.faint)
+                            .multilineTextAlignment(.center)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    Button { openWindow(id: DatabaseView.windowID) } label: {
+                        Label("View knowledge", systemImage: "sparkles.rectangle.stack")
+                    }
+                    .buttonStyle(.bordered).controlSize(.large).tint(Theme.accent)
+
+                    devControls
+
+                    VaultView(store: store)
+                        .padding(.top, 14)
+                }
+                .padding(30)
+                .frame(maxWidth: .infinity)
+            }
+        }
+        .frame(width: 660, height: 740)
+        .background(Theme.bg)
+        .sheet(isPresented: $showChatPicker) {
+            ChatPicker(sourceName: "WhatsApp",
+                       loadChats: { try WhatsAppSource().listChats() },
+                       initialSelection: selectedChatJIDs) { newSel in
+                selectedChatsCSV = newSel.sorted().joined(separator: ",")
+                runWhatsApp = !newSel.isEmpty   // lit only if at least one chat is chosen
+            }
+        }
+        .sheet(isPresented: $showIMessagePicker) {
+            ChatPicker(sourceName: "iMessage",
+                       loadChats: { try iMessageSource().listChats() },
+                       initialSelection: selectedIMessageGUIDs) { newSel in
+                selectedIMessageChatsCSV = newSel.sorted().joined(separator: ",")
+                runIMessage = !newSel.isEmpty
+            }
+        }
+    }
+
+    private var devControls: some View {
+        VStack(spacing: 14) {
+            Divider().overlay(Theme.stroke).padding(.vertical, 10)
+
+            sourcePicker
+
+            debugTest(title: "Reset store", systemImage: "trash",
+                      isRunning: isResetting, result: resetResult, passPrefix: "Cleared",
+                      action: { Task { await runReset() } })
+
+            // The scheduler's stand-in [DECIDED]: this button IS the day's-end trigger until
+            // the condition-gate loop lands — which will call exactly the same entry point
+            // (iterative updater → mirror push → notify). Proactive intelligence gets its
+            // own separate trigger when it lands.
+            debugTest(title: "Update Knowledge Base", systemImage: "arrow.triangle.2.circlepath",
+                      isRunning: isDaysEndRunning, result: daysEndResult, passPrefix: "Done",
+                      action: { Task { await runDaysEnd() } })
+
+            Button {
+                withAnimation { showMoreOptions.toggle() }
+                if showMoreOptions { fdaGranted = Permissions.hasFullDiskAccess() }
+            } label: {
+                Label("More Options", systemImage: showMoreOptions ? "chevron.down" : "chevron.right")
+                    .font(.caption.weight(.medium))
+            }
+            .buttonStyle(.plain).foregroundStyle(Theme.secondary)
+
+            if showMoreOptions { moreOptions }
+        }
+    }
+
+    // MARK: More Options (advanced DEBUG: Full Disk Access + DB sources)
+
+    private var moreOptions: some View {
+        VStack(spacing: 12) {
+            HStack(spacing: 8) {
+                Image(systemName: fdaGranted ? "checkmark.shield.fill" : "exclamationmark.shield.fill")
+                    .foregroundStyle(fdaGranted ? Theme.verdictColor(.survivor) : .orange)
+                Text(fdaGranted ? "Full Disk Access granted" : "Full Disk Access needed")
+                    .font(.caption.weight(.medium)).foregroundStyle(.white)
+                Spacer()
+                Button("Re-check") { fdaGranted = Permissions.hasFullDiskAccess() }
+                    .buttonStyle(.borderless).controlSize(.small).tint(Theme.accent)
+            }
+
+            if !fdaGranted {
+                Text("The database sources (WhatsApp · iMessage · Notes) read protected databases. Grant Full Disk Access, then restart.")
+                    .font(.caption2).foregroundStyle(Theme.faint)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                HStack(spacing: 10) {
+                    Button("Grant Full Disk Access…") { Permissions.openFullDiskAccessSettings() }
+                        .buttonStyle(.bordered).tint(Theme.accent)
+                    Button("Restart app") { Permissions.relaunch() }
+                        .buttonStyle(.bordered).tint(.white)
+                }
+            } else {
+                Text("Database sources (WhatsApp · iMessage · Notes) are unlocked — pick them up in SOURCES above.")
+                    .font(.caption2).foregroundStyle(Theme.faint)
+                    .multilineTextAlignment(.center).fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(14)
+        .frame(maxWidth: 460)
+        .glassCard()
+    }
+
+    // MARK: Source picker (DEBUG) — pick which folders analysis runs over
+
+    private var sourcePicker: some View {
+        VStack(spacing: 9) {
+            Text("SOURCES").font(.caption2.weight(.bold)).tracking(2).foregroundStyle(Theme.faint)
+
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 116), spacing: 8)], spacing: 8) {
+                sourceChip("Downloads", selected: runDownloads) { runDownloads.toggle() }
+                sourceChip("Desktop",   selected: runDesktop)   { runDesktop.toggle() }
+                sourceChip("Documents", selected: runDocuments) { runDocuments.toggle() }
+                ForEach(customRoots, id: \.self) { url in
+                    sourceChip(url.lastPathComponent, selected: true, removable: true) {
+                        customRoots.removeAll { $0 == url }
+                    }
+                }
+                chooseFolderChip
+                // DB sources — enabled once Full Disk Access is granted (see More Options).
+                chatSourceChip("WhatsApp", systemImage: "message.fill",
+                               isOn: runWhatsApp && fdaGranted && !selectedChatJIDs.isEmpty,
+                               count: selectedChatJIDs.count,
+                               turnOff: { runWhatsApp = false },
+                               openPicker: { showChatPicker = true })
+                chatSourceChip("iMessage", systemImage: "bubble.left.fill",
+                               isOn: runIMessage && fdaGranted && !selectedIMessageGUIDs.isEmpty,
+                               count: selectedIMessageGUIDs.count,
+                               turnOff: { runIMessage = false },
+                               openPicker: { showIMessagePicker = true })
+                notesChip
+            }
+            .frame(maxWidth: 420)
+
+            if selectedSources.isEmpty {
+                Text("Select at least one source to analyze.")
+                    .font(.caption2).foregroundStyle(Theme.faint)
+            }
+            if !fdaGranted {
+                Text("WhatsApp, iMessage & Apple Notes need Full Disk Access — grant it in More Options below.")
+                    .font(.caption2).foregroundStyle(Theme.faint)
+            }
+        }
+        .onAppear { fdaGranted = Permissions.hasFullDiskAccess() }
+    }
+
+    /// Apple Notes chip — a plain FDA-gated toggle (no picker: all notes go in, capped inside
+    /// the source). Same look as the chat chips, minus the count.
+    private var notesChip: some View {
+        let on = runNotes && fdaGranted
+        return HStack(spacing: 6) {
+            Image(systemName: on ? "checkmark.circle.fill" : "note.text").font(.system(size: 11))
+            Text("Apple Notes").font(.caption.weight(.medium)).lineLimit(1)
+        }
+        .foregroundStyle(on ? .black : (fdaGranted ? Theme.secondary : Theme.faint))
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 11).padding(.vertical, 6)
+        .background(on ? Theme.accent : Color.white.opacity(0.06), in: Capsule())
+        .overlay(Capsule().strokeBorder(on ? .clear : Theme.stroke, lineWidth: 1))
+        .contentShape(Capsule())
+        .onTapGesture {
+            guard fdaGranted else { return }
+            runNotes.toggle()
+        }
+    }
+
+    /// A chat-DB source chip (WhatsApp / iMessage). Tap when OFF → opens that source's chat
+    /// picker → Done lights it up (with the chat count). Tap when ON → turns it off (keeps the
+    /// selection for next time).
+    private func chatSourceChip(_ name: String, systemImage: String, isOn: Bool, count: Int,
+                                turnOff: @escaping () -> Void,
+                                openPicker: @escaping () -> Void) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: isOn ? "checkmark.circle.fill" : systemImage).font(.system(size: 11))
+            Text(isOn ? "\(name) · \(count)" : name).font(.caption.weight(.medium)).lineLimit(1)
+        }
+        .foregroundStyle(isOn ? .black : (fdaGranted ? Theme.secondary : Theme.faint))
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 11).padding(.vertical, 6)
+        .background(isOn ? Theme.accent : Color.white.opacity(0.06), in: Capsule())
+        .overlay(Capsule().strokeBorder(isOn ? .clear : Theme.stroke, lineWidth: 1))
+        .contentShape(Capsule())
+        .onTapGesture {
+            guard fdaGranted else { return }
+            if isOn { turnOff() }          // ON → off (selection kept)
+            else { openPicker() }          // OFF → choose chats
+        }
+    }
+
+    private func sourceChip(_ label: String, selected: Bool, removable: Bool = false,
+                            _ tap: @escaping () -> Void) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: removable ? "xmark.circle.fill"
+                              : (selected ? "checkmark.circle.fill" : "circle"))
+                .font(.system(size: 11))
+            Text(label).font(.caption.weight(.medium)).lineLimit(1).truncationMode(.middle)
+        }
+        .foregroundStyle(selected ? .black : Theme.secondary)
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 11).padding(.vertical, 6)
+        .background(selected ? Theme.accent : Color.white.opacity(0.06), in: Capsule())
+        .overlay(Capsule().strokeBorder(selected ? .clear : Theme.stroke, lineWidth: 1))
+        .contentShape(Capsule())
+        .onTapGesture(perform: tap)
+    }
+
+    private var chooseFolderChip: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "folder.badge.plus").font(.system(size: 11))
+            Text("Choose folder…").font(.caption.weight(.medium)).lineLimit(1)
+        }
+        .foregroundStyle(Theme.accent)
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 11).padding(.vertical, 6)
+        .background(Color.white.opacity(0.06), in: Capsule())
+        .overlay(Capsule().strokeBorder(Theme.accent.opacity(0.4), lineWidth: 1))
+        .contentShape(Capsule())
+        .onTapGesture(perform: chooseFolder)
+    }
+
+    /// Pick any folder(s) to add as custom sources for this session.
+    private func chooseFolder() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = true
+        panel.prompt = "Add"
+        panel.message = "Add a folder for Sentient OS to analyze."
+        guard panel.runModal() == .OK else { return }
+        for url in panel.urls where !customRoots.contains(url) { customRoots.append(url) }
+    }
+
+    @ViewBuilder
+    private func debugTest(title: String, systemImage: String, isRunning: Bool,
+                           result: String?, passPrefix: String,
+                           action: @escaping () -> Void) -> some View {
+        VStack(spacing: 8) {
+            Button(action: action) {
+                if isRunning { ProgressView().controlSize(.small) }
+                Label(title, systemImage: systemImage)
+            }
+            .disabled(isRunning)
+
+            if let result {
+                Text(result)
+                    .font(.system(.footnote, design: .monospaced))
+                    .foregroundStyle(result.hasPrefix(passPrefix) ? .green
+                                     : result.localizedCaseInsensitiveContains("fail") ? .red : Theme.secondary)
+                    .multilineTextAlignment(.leading)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: 460)
+            }
+        }
+    }
+
+    @MainActor
+    private func runDaysEnd() async {
+        isDaysEndRunning = true
+        defer { isDaysEndRunning = false }
+        daysEndResult = await DaysEndJob.shared.run(store: store)
+    }
+
+    @MainActor
+    private func runReset() async {
+        isResetting = true
+        defer { isResetting = false }
+        do {
+            try await store.reset()
+            LifetimeStats.reset()
+            let counts = await store.counts()
+            resetResult = "Cleared ✓  summaries=\(counts.versions)  pointers=\(counts.cursors)"
+        } catch {
+            resetResult = "Reset FAIL: \(error)"
+        }
+    }
+}

--- a/Sentient OS macOS/Views/Orb.swift
+++ b/Sentient OS macOS/Views/Orb.swift
@@ -1,0 +1,412 @@
+//
+//  Orb.swift
+//  Sentient OS macOS
+//
+//  The living orb — the brand's heartbeat and the literal center of the Constellation home
+//  (Arch §9; design bar: UI_Inspiration/01 + README). The logo, made dimensional: a dark
+//  glassy planet with the white dot glowing as a heart inside it, wrapped in a tilted ring of
+//  orbiting light. The ring is truly 3D — depth-sorted across two Canvases sandwiching the
+//  planet (it passes behind AND in front), Keplerian (inner particles orbit faster), with two
+//  shimmer glints chasing around the band, the planet's shadow dimming the far side, and a
+//  slow precession wobble. Modes: .idle (slow spin + 5.5s breathing) · .processing (fast,
+//  bright) · .attention (quiet amber). `OrbMark` is the tiny static header glyph.
+//
+//  PERFORMANCE RULES (learned the 8-fps way — keep these true):
+//   · No @State writes per frame — the ring phase is a pure function of wall time.
+//   · No blur filters per frame: the halo is pre-rasterized (.drawingGroup) and only
+//     ROTATED; nebula clouds + the heart are radial gradients, not blurred circles.
+//   · One Canvas glow pass per side, not two.
+//   · The planet's diameter is FIXED (vector-crisp); breathing lives in the heart's glow,
+//     the halo, and the ring — never in a scaleEffect over the whole orb (bitmap fuzz).
+//
+
+import SwiftUI
+
+enum OrbMode { case idle, processing, attention }
+
+struct Orb: View {
+    var mode: OrbMode = .idle
+    var size: CGFloat = 132          // planet diameter; the frame is wider (the ring overflows it)
+
+    var body: some View {
+        ZStack {
+            haloLayer
+            TimelineView(.animation(minimumInterval: 1.0 / 60.0)) { ctx in
+                let t = ctx.date.timeIntervalSinceReferenceDate
+                let breath = (sin(t * 2 * .pi / 5.5) + 1) / 2     // 0…1, the 5.5s heartbeat
+                ZStack {
+                    ringCanvas(front: false, t: t, breath: breath)
+                    planet(t: t, breath: breath)
+                    ringCanvas(front: true, t: t, breath: breath)
+                }
+            }
+        }
+        .frame(width: size * 2.05, height: size * 1.5)
+        .allowsHitTesting(false)
+    }
+
+    // MARK: Ambient halo — a cached texture, spun and breathed (never re-blurred)
+
+    private var haloLayer: some View {
+        TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { ctx in
+            let t = ctx.date.timeIntervalSinceReferenceDate
+            let breath = (sin(t * 2 * .pi / 5.5) + 1) / 2
+            HaloTexture(size: size, mode: mode)
+                .rotationEffect(.radians(t * 2 * .pi / 18))
+                .scaleEffect(1 + 0.035 * breath)
+                .opacity(mode == .processing ? 0.40 : 0.23 + 0.07 * breath)
+        }
+    }
+
+    /// Stable inputs → SwiftUI never re-renders the (expensive) blur; the rasterized layer
+    /// is then rotated/scaled by the compositor for free.
+    private struct HaloTexture: View {
+        let size: CGFloat
+        let mode: OrbMode
+        var body: some View {
+            Circle()
+                .fill(AngularGradient(colors: Orb.haloColors(for: mode), center: .center))
+                .frame(width: size * 1.8, height: size * 1.8)
+                .blur(radius: size * 0.30)
+                .drawingGroup()
+        }
+    }
+
+    private static func haloColors(for mode: OrbMode) -> [Color] {
+        if mode == .attention {
+            return [Color(red: 0.55, green: 0.36, blue: 0.10), Color(red: 0.72, green: 0.48, blue: 0.16),
+                    Color(red: 0.45, green: 0.26, blue: 0.08), Color(red: 0.55, green: 0.36, blue: 0.10)]
+        }
+        return ringStops.map { Color(red: $0.r, green: $0.g, blue: $0.b) }
+    }
+
+    // MARK: The planet (fixed diameter — always vector-crisp)
+
+    private func planet(t: Double, breath: Double) -> some View {
+        ZStack {
+            // The dark glassy sphere, lit from the upper left.
+            Circle().fill(RadialGradient(
+                colors: [Color(red: 0.20, green: 0.20, blue: 0.27), Color(red: 0.012, green: 0.012, blue: 0.025)],
+                center: UnitPoint(x: 0.36, y: 0.30), startRadius: 0, endRadius: size * 0.85))
+
+            nebula(t: t)
+            grain
+
+            // The white heart — the logo's dot, glowing through the glass (radial falloff
+            // does the soft-edge work a blur used to do).
+            Circle()
+                .fill(RadialGradient(colors: [.white, .white.opacity(0)], center: .center,
+                                     startRadius: 0, endRadius: size * 0.31))
+                .frame(width: size * 0.62, height: size * 0.62)
+                .opacity(0.50 + 0.22 * breath)
+            Circle()
+                .fill(RadialGradient(
+                    stops: [.init(color: .white, location: 0), .init(color: .white, location: 0.72),
+                            .init(color: .white.opacity(0), location: 1)],
+                    center: .center, startRadius: 0, endRadius: size * 0.12))
+                .frame(width: size * 0.24, height: size * 0.24)
+                .opacity(0.90 + 0.10 * breath)
+
+            // Limb darkening — the sphere falls away into shadow at its edges.
+            Circle().fill(RadialGradient(
+                stops: [.init(color: .clear, location: 0.55), .init(color: .black.opacity(0.62), location: 1.0)],
+                center: UnitPoint(x: 0.40, y: 0.34), startRadius: 0, endRadius: size * 0.62))
+
+            // Rim light along the lit edge.
+            Circle().strokeBorder(
+                LinearGradient(colors: [.white.opacity(0.55), .white.opacity(0.06), .clear],
+                               startPoint: .topLeading, endPoint: .bottomTrailing), lineWidth: 1)
+        }
+        .frame(width: size, height: size)
+    }
+
+    /// Slow "weather" inside the sphere — four deep-color clouds drifting on different
+    /// orbits. Radial-gradient blobs (soft by construction, no blur filter).
+    private func nebula(t: Double) -> some View {
+        let a = t * 2 * .pi / 60   // base drift: one lap per minute
+        return ZStack {
+            nebulaBlob(Color(red: 0.24, green: 0.22, blue: 0.50), w: 0.74, angle: a, orbit: 0.20)
+            nebulaBlob(Color(red: 0.08, green: 0.34, blue: 0.37), w: 0.66, angle: a * 1.31 + 2.1, orbit: 0.24)
+            nebulaBlob(Color(red: 0.40, green: 0.15, blue: 0.31), w: 0.60, angle: -a * 0.83 + 4.2, orbit: 0.22)
+            nebulaBlob(Color(red: 0.10, green: 0.22, blue: 0.45), w: 0.54, angle: a * 1.72 + 1.0, orbit: 0.26)
+        }
+        .frame(width: size, height: size)
+        .opacity(0.72)
+        .mask(Circle())
+    }
+
+    private func nebulaBlob(_ c: Color, w: Double, angle: Double, orbit: Double) -> some View {
+        Circle()
+            .fill(RadialGradient(colors: [c.opacity(0.85), c.opacity(0)], center: .center,
+                                 startRadius: 0, endRadius: size * w * 0.5))
+            .frame(width: size * w, height: size * w)
+            .offset(x: cos(angle) * size * orbit, y: sin(angle) * size * orbit * 0.7)
+    }
+
+    /// Fine mineral grain dusted over the glass — breaks gradient banding and gives the
+    /// surface a texture to catch the eye.
+    private var grain: some View {
+        Canvas { ctx, sz in
+            let c = CGPoint(x: sz.width / 2, y: sz.height / 2)
+            let R = size / 2 * 0.97
+            for g in Self.grains {
+                let s = g.s
+                ctx.fill(Path(ellipseIn: CGRect(x: c.x + g.x * R - s / 2, y: c.y + g.y * R - s / 2,
+                                                width: s, height: s)),
+                         with: .color(.white.opacity(g.a)))
+            }
+        }
+        .frame(width: size, height: size)
+        .blendMode(.plusLighter)
+        .mask(Circle())
+    }
+
+    private static let grains: [(x: Double, y: Double, s: Double, a: Double)] = {
+        var rng = SplitMix64(seed: 0xD175)
+        return (0..<450).map { _ in
+            let r = sqrt(Double.random(in: 0...1, using: &rng))   // sqrt → uniform over the disc
+            let th = Double.random(in: 0..<(2 * .pi), using: &rng)
+            return (r * cos(th), r * sin(th),
+                    Double.random(in: 0.4...1.1, using: &rng),
+                    Double.random(in: 0.02...0.09, using: &rng))
+        }
+    }()
+
+    // MARK: The ring (the showpiece)
+
+    /// The ring clock is a pure function of wall time — no per-frame state. (A mode change
+    /// steps the pace; if a visible glide ever matters — e.g. the processing morph — bring
+    /// back accumulation OUTSIDE the render loop.)
+    private func ringPhase(_ t: Double) -> Double {
+        t * (mode == .processing ? 3.4 : 1.0)
+    }
+
+    private func ringCanvas(front: Bool, t: Double, breath: Double) -> some View {
+        Canvas { context, canvasSize in
+            var ctx = context
+            let frame = RingFrame(
+                center: CGPoint(x: canvasSize.width / 2, y: canvasSize.height / 2),
+                r: (size / 2) * (1 + 0.018 * breath),   // the ring carries the breath
+                geo: Self.ringGeometry(t: t),
+                phase: ringPhase(t),
+                t: t,
+                front: front,
+                bright: mode == .processing ? 1.3 : 1.0,
+                amber: mode == .attention ? 0.7 : 0.0)
+
+            // ONE additive glow pass, then the crisp pass on top.
+            ctx.drawLayer { layer in
+                layer.addFilter(.blur(radius: 5))
+                layer.blendMode = .plusLighter
+                Self.drawBand(&layer, frame, lineWidth: 3.4, gain: 0.8)
+                Self.drawParticles(&layer, frame, minSize: 1.55, gain: 0.9)
+            }
+            Self.drawBand(&ctx, frame, lineWidth: 1.1, gain: 1.0)
+            Self.drawParticles(&ctx, frame, minSize: 0, gain: 1.0)
+        }
+    }
+
+    /// Everything one ring pass needs, bundled so the draw helpers stay tidy.
+    private struct RingFrame {
+        let center: CGPoint
+        let r: CGFloat          // planet radius in points (ring radii are in planet-radius units)
+        let geo: RingGeometry
+        let phase: Double       // the ring clock
+        let t: Double           // wall time (twinkles)
+        let front: Bool         // which depth half this canvas draws
+        let bright: Double
+        let amber: Double
+    }
+
+    /// The ring plane's pose: a tilted circle, leaned slightly in-plane, both breathing on
+    /// slow precession cycles so the ring never feels mechanical.
+    private struct RingGeometry {
+        let tilt: Double
+        let leanSin: Double
+        let leanCos: Double
+
+        func project(radius: Double, angle: Double, r: CGFloat, center: CGPoint) -> (pos: CGPoint, depth: Double) {
+            let x = cos(angle) * radius
+            let depth = sin(angle)                 // +1 = nearest the viewer (front, lower half)
+            let y = depth * tilt * radius
+            let px = x * leanCos - y * leanSin
+            let py = x * leanSin + y * leanCos
+            return (CGPoint(x: center.x + CGFloat(px) * r, y: center.y + CGFloat(py) * r), depth)
+        }
+    }
+
+    private static func ringGeometry(t: Double) -> RingGeometry {
+        let tilt = 0.30 + 0.035 * sin(t * 2 * .pi / 23)
+        let lean = (-9 + 2.5 * sin(t * 2 * .pi / 29)) * .pi / 180
+        return RingGeometry(tilt: tilt, leanSin: sin(lean), leanCos: cos(lean))
+    }
+
+    /// The two gradient threads that define the band (inner band's heart + outer band's edge),
+    /// drawn as short depth-shaded segments with shimmer glints chasing around them.
+    private static func drawBand(_ ctx: inout GraphicsContext, _ f: RingFrame,
+                                 lineWidth: CGFloat, gain: Double) {
+        let seg = 84
+        for (radius, radiusGain) in [(1.33, 1.0), (1.585, 0.62)] {
+            for i in 0..<seg {
+                let a0 = Double(i) / Double(seg) * 2 * .pi
+                let a1 = Double(i + 1) / Double(seg) * 2 * .pi + 0.004   // hairline overlap, no seams
+                let am = (a0 + a1) / 2
+                let depth = sin(am)
+                guard (depth >= 0) == f.front else { continue }
+
+                let (p0, _) = f.geo.project(radius: radius, angle: a0, r: f.r, center: f.center)
+                let (p1, _) = f.geo.project(radius: radius, angle: a1, r: f.r, center: f.center)
+
+                let dn = (depth + 1) / 2
+                var b = (0.30 + 0.55 * dn) * radiusGain * f.bright * gain
+                if !f.front { b *= planetShadow(x: p0.x, center: f.center, r: f.r) }
+
+                // Two glints orbiting in opposite directions — they meet, cross, and part.
+                let boost = 1.7 * glint(am, at: f.phase * 0.50, width: 0.42)
+                          + 1.0 * glint(am, at: -f.phase * 0.34 + .pi, width: 0.60)
+                b *= 0.75 + boost
+
+                var path = Path()
+                path.move(to: p0)
+                path.addLine(to: p1)
+                ctx.stroke(path,
+                           with: .color(ringColor(at: am / (2 * .pi), brightness: min(b, 1.55),
+                                                  amber: f.amber, whiteMix: min(0.55, boost * 0.30))),
+                           style: StrokeStyle(lineWidth: lineWidth * (0.8 + 0.4 * dn), lineCap: .round))
+            }
+        }
+    }
+
+    private static func drawParticles(_ ctx: inout GraphicsContext, _ f: RingFrame,
+                                      minSize: Double, gain: Double) {
+        for p in particles where p.size >= minSize {   // the glow pass only blooms the bigger motes
+            let angle = p.angle0 + p.speed * f.phase
+            let (pt, depth) = f.geo.project(radius: p.radius, angle: angle, r: f.r, center: f.center)
+            guard (depth >= 0) == f.front else { continue }
+
+            let dn = (depth + 1) / 2
+            var b = (0.35 + 0.65 * dn) * gain * f.bright
+            if !f.front { b *= planetShadow(x: pt.x, center: f.center, r: f.r) }
+            b *= 0.62 + 0.38 * sin(f.t * p.twinkleSpeed + p.twinklePhase)
+
+            let s = p.size * (0.85 + 0.35 * dn)
+            let color = ringColor(at: angle / (2 * .pi), brightness: min(b * 1.15, 1.5),
+                                  amber: f.amber, whiteMix: 0.12)
+            ctx.fill(Path(ellipseIn: CGRect(x: pt.x - s / 2, y: pt.y - s / 2, width: s, height: s)),
+                     with: .color(color.opacity(min(b + 0.2, 1))))
+        }
+    }
+
+    /// The planet's shadow falling on the far side of the ring — the cue that sells the 3D.
+    private static func planetShadow(x: CGFloat, center: CGPoint, r: CGFloat) -> Double {
+        Double(min(1, max(0.25, abs(x - center.x) / (r * 1.18))))
+    }
+
+    /// A soft bright packet centered at `packet`, by angular distance (wraps correctly).
+    private static func glint(_ angle: Double, at packet: Double, width: Double) -> Double {
+        let d = abs(atan2(sin(angle - packet), cos(angle - packet)))
+        return exp(-d * d / (2 * width * width))
+    }
+
+    // MARK: Ring color — the sentient spectrum at deep-space brightness
+
+    /// The color geography is anchored to ring angle, so the colors stay put while the matter
+    /// flows through them — like light catching different bands of ice.
+    private static let ringStops: [(loc: Double, r: Double, g: Double, b: Double)] = [
+        (0.00, 0.76, 0.30, 0.36),   // ember
+        (0.18, 0.80, 0.56, 0.27),   // burnished amber
+        (0.40, 0.18, 0.58, 0.51),   // viridian
+        (0.62, 0.30, 0.45, 0.85),   // cobalt
+        (0.82, 0.56, 0.34, 0.67),   // orchid
+        (1.00, 0.76, 0.30, 0.36),   // wrap → ember (smooth seam)
+    ]
+
+    private static func ringColor(at frac: Double, brightness: Double,
+                                  amber: Double, whiteMix: Double) -> Color {
+        let f = frac - floor(frac)
+        var i = 0
+        while i + 1 < ringStops.count - 1 && ringStops[i + 1].loc < f { i += 1 }
+        let s0 = ringStops[i], s1 = ringStops[i + 1]
+        let u = (f - s0.loc) / max(s1.loc - s0.loc, 1e-6)
+        var r = s0.r + (s1.r - s0.r) * u
+        var g = s0.g + (s1.g - s0.g) * u
+        var b = s0.b + (s1.b - s0.b) * u
+        if amber > 0 {   // attention: the spectrum settles into quiet amber
+            r += (0.82 - r) * amber; g += (0.55 - g) * amber; b += (0.20 - b) * amber
+        }
+        r *= brightness; g *= brightness; b *= brightness
+        if whiteMix > 0 {   // glints run hot — mix toward white
+            r += (1 - min(r, 1)) * whiteMix; g += (1 - min(g, 1)) * whiteMix; b += (1 - min(b, 1)) * whiteMix
+        }
+        return Color(red: min(r, 1), green: min(g, 1), blue: min(b, 1))
+    }
+
+    // MARK: The ring's matter (seeded once, stable across renders)
+
+    private struct Particle {
+        let radius: Double        // in planet radii
+        let angle0: Double
+        let speed: Double         // rad per ring-clock second
+        let size: Double
+        let twinklePhase: Double
+        let twinkleSpeed: Double
+    }
+
+    private static let particles: [Particle] = {
+        var rng = SplitMix64(seed: 0x05EA_51E0)
+        return (0..<230).map { i in
+            // Two bands with a clean gap between them (the Cassini division).
+            let inner = i % 9 < 5
+            let radius = inner ? Double.random(in: 1.22...1.43, using: &rng)
+                               : Double.random(in: 1.52...1.70, using: &rng)
+            return Particle(
+                radius: radius,
+                angle0: .random(in: 0..<(2 * .pi), using: &rng),
+                speed: 0.38 * pow(1.22 / radius, 1.5),   // Keplerian: inner orbits run faster
+                size: .random(in: 0.7...2.1, using: &rng),
+                twinklePhase: .random(in: 0..<(2 * .pi), using: &rng),
+                twinkleSpeed: .random(in: 0.4...1.5, using: &rng))
+        }
+    }()
+}
+
+/// The tiny static orb glyph (header scale): the logo's ring + dot with a soft glow.
+struct OrbMark: View {
+    var size: CGFloat = 18
+    var body: some View {
+        ZStack {
+            Circle().strokeBorder(.white.opacity(0.92), lineWidth: max(1, size * 0.085))
+            Circle().fill(.white).frame(width: size * 0.38, height: size * 0.38)
+        }
+        .frame(width: size, height: size)
+        .shadow(color: Color(red: 0.69, green: 0.42, blue: 0.70).opacity(0.55), radius: size * 0.3)
+    }
+}
+
+/// Tiny deterministic RNG so the ring's matter is identical every launch.
+private struct SplitMix64: RandomNumberGenerator {
+    var state: UInt64
+    init(seed: UInt64) { state = seed }
+    mutating func next() -> UInt64 {
+        state &+= 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+}
+
+#Preview("Orb — idle") {
+    ZStack { Color.black.ignoresSafeArea(); Orb(size: 132) }
+        .frame(width: 480, height: 320)
+}
+
+#Preview("Orb — processing") {
+    ZStack { Color.black.ignoresSafeArea(); Orb(mode: .processing, size: 132) }
+        .frame(width: 480, height: 320)
+}
+
+#Preview("Orb — attention") {
+    ZStack { Color.black.ignoresSafeArea(); Orb(mode: .attention, size: 132) }
+        .frame(width: 480, height: 320)
+}

--- a/Sentient OS macOS/Views/RootView.swift
+++ b/Sentient OS macOS/Views/RootView.swift
@@ -2,72 +2,31 @@
 //  RootView.swift
 //  Sentient OS macOS
 //
-//  The home window. "Start Analysis" (the glow CTA) hands off to the full-screen ProcessingView;
-//  "View knowledge" opens the Database viewer. Below: the dev controls (source picker +
-//  Reset store) — visible in ALL build configs until real Settings/onboarding ship
-//  (re-hide is part of the Phase-6 "Release strip" task). Dark, on-brand.
+//  The home window's switchboard: the Constellation home (idle) ⟷ the full-screen
+//  ProcessingView takeover (the fancy morph between them is a coming build phase — today
+//  they cross-fade). Analyze Now runs whatever the dev source picker has armed (read via
+//  SourceSelection); the picker itself and all debug controls live in DevToolsView, a sheet
+//  behind the home's DEV TOOLS button.
 //
 
 import SwiftUI
-import AppKit
 
 struct RootView: View {
     let store: Store
-    @Environment(AppState.self) private var appState
     @Environment(\.openWindow) private var openWindow
 
     @State private var isProcessing = false
+    @State private var showDevTools = false
+    @State private var customRoots: [URL] = []   // session-only custom folders (dev picker)
+    @State private var fdaGranted = Permissions.hasFullDiskAccess()
 
     // Resolved at launch (env → bundle → App Support → repo root); nil = model not on this Mac.
     private static let modelPath = ModelLocator.resolve()
-    private static let processingLimit: Int? = nil   // nil = process the whole folder
+    private static let processingLimit: Int? = nil   // nil = process the whole selection
 
-    // The dev source picker: which folders "Start Analysis" runs over. Named-folder toggles
-    // persist across launches; custom folders are session-only (re-pick after a relaunch).
-    @AppStorage("dbg.run.downloads") private var runDownloads = true
-    @AppStorage("dbg.run.desktop")   private var runDesktop = true
-    @AppStorage("dbg.run.documents") private var runDocuments = true
-    @AppStorage("dbg.run.whatsapp")  private var runWhatsApp = false   // is WhatsApp active this run (chip lit)
-    @AppStorage("dbg.whatsapp.chats") private var selectedChatsCSV = ""  // opt-in chat JIDs, comma-joined
-    @AppStorage("dbg.run.imessage")  private var runIMessage = false   // is iMessage active this run (chip lit)
-    @AppStorage("dbg.imessage.chats") private var selectedIMessageChatsCSV = ""  // opt-in chat GUIDs, comma-joined
-    @AppStorage("dbg.run.notes")     private var runNotes = false      // Apple Notes (no picker — all notes, capped)
-    @State private var customRoots: [URL] = []
-    @State private var showChatPicker = false
-    @State private var showIMessagePicker = false
-    @State private var resetResult: String?
-    @State private var isResetting = false
-    @State private var daysEndResult: String?
-    @State private var isDaysEndRunning = false
-    // "More Options" — advanced debug (Full Disk Access + the DB sources), tucked away so the
-    // main debug area stays uncluttered.
-    @State private var showMoreOptions = false
-    @State private var fdaGranted = false
-
-    /// The sources "Start Analysis" will process: the picker's selection (folders + DB sources).
+    /// The sources Analyze Now will process — the dev picker's selection (folders + DB sources).
     private var selectedSources: [RunSource] {
-        var s: [RunSource] = []
-        if runDownloads { s.append(.files(.downloads)) }
-        if runDesktop   { s.append(.files(.desktop)) }
-        if runDocuments { s.append(.files(.documents)) }
-        s.append(contentsOf: customRoots.map { .files(.custom($0)) })
-        // Never run a DB source without FDA + a chat selection.
-        if runWhatsApp && fdaGranted && !selectedChatJIDs.isEmpty {
-            s.append(.whatsapp(chatJIDs: selectedChatJIDs))
-        }
-        if runIMessage && fdaGranted && !selectedIMessageGUIDs.isEmpty {
-            s.append(.imessage(chatGUIDs: selectedIMessageGUIDs))
-        }
-        if runNotes && fdaGranted { s.append(.notes) }
-        return s
-    }
-
-    /// The opt-in chats, decoded from the persisted comma-joined id lists (WhatsApp JIDs / iMessage GUIDs).
-    private var selectedChatJIDs: Set<String> {
-        Set(selectedChatsCSV.split(separator: ",").map(String.init))
-    }
-    private var selectedIMessageGUIDs: Set<String> {
-        Set(selectedIMessageChatsCSV.split(separator: ",").map(String.init))
+        SourceSelection.current(customRoots: customRoots, fdaGranted: fdaGranted)
     }
 
     var body: some View {
@@ -80,300 +39,35 @@ struct RootView: View {
                 }
                 .transition(.opacity)
             } else {
-                home.transition(.opacity)
+                constellation.transition(.opacity)
             }
         }
-        .frame(minWidth: 560, minHeight: 640)
-        .sheet(isPresented: $showChatPicker) {
-            ChatPicker(sourceName: "WhatsApp",
-                       loadChats: { try WhatsAppSource().listChats() },
-                       initialSelection: selectedChatJIDs) { newSel in
-                selectedChatsCSV = newSel.sorted().joined(separator: ",")
-                runWhatsApp = !newSel.isEmpty   // lit only if at least one chat is chosen
+        .frame(minWidth: 920, minHeight: 660)
+        .sheet(isPresented: $showDevTools) {
+            DevToolsView(store: store, customRoots: $customRoots) {
+                showDevTools = false
+                withAnimation(.easeInOut(duration: 0.3)) { isProcessing = true }
             }
         }
-        .sheet(isPresented: $showIMessagePicker) {
-            ChatPicker(sourceName: "iMessage",
-                       loadChats: { try iMessageSource().listChats() },
-                       initialSelection: selectedIMessageGUIDs) { newSel in
-                selectedIMessageChatsCSV = newSel.sorted().joined(separator: ",")
-                runIMessage = !newSel.isEmpty
-            }
+        .onChange(of: showDevTools) { _, open in
+            if !open { fdaGranted = Permissions.hasFullDiskAccess() }   // may have changed in the sheet
         }
     }
 
-    private var home: some View {
-        ScrollView {
-            VStack(spacing: 18) {
-                Spacer().frame(height: 36)
-
-                GlowButton(title: "Start Analysis", systemImage: "sparkles",
-                           active: !selectedSources.isEmpty && Self.modelPath != nil) {
-                    withAnimation(.easeInOut(duration: 0.3)) { isProcessing = true }
-                }
-                .frame(maxWidth: 300)
-
-                if Self.modelPath == nil {
-                    Text("On-device model not found — place \(ModelLocator.fileName) next to the .xcodeproj, or set SENTIENT_MODEL_PATH.")
-                        .font(.caption2).foregroundStyle(Theme.faint)
-                        .multilineTextAlignment(.center)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-
-                Button { openWindow(id: DatabaseView.windowID) } label: {
-                    Label("View knowledge", systemImage: "sparkles.rectangle.stack")
-                }
-                .buttonStyle(.bordered).controlSize(.large).tint(Theme.accent)
-
-                devControls
-
-                VaultView(store: store)
-                    .padding(.top, 14)
-            }
-            .padding(40)
-            .frame(maxWidth: .infinity)
-        }
-    }
-
-    private var devControls: some View {
-        VStack(spacing: 14) {
-            Divider().overlay(Theme.stroke).padding(.vertical, 10)
-            Text("DEV CONTROLS").font(.caption2.weight(.bold)).tracking(2).foregroundStyle(Theme.faint)
-
-            sourcePicker
-
-            debugTest(title: "Reset store", systemImage: "trash",
-                      isRunning: isResetting, result: resetResult, passPrefix: "Cleared",
-                      action: { Task { await runReset() } })
-
-            // The scheduler's stand-in [DECIDED]: this button IS the day's-end trigger until
-            // the condition-gate loop lands — which will call exactly the same entry point
-            // (iterative updater → mirror push → notify). Proactive intelligence gets its
-            // own separate trigger when it lands.
-            debugTest(title: "Update Knowledge Base", systemImage: "arrow.triangle.2.circlepath",
-                      isRunning: isDaysEndRunning, result: daysEndResult, passPrefix: "Done",
-                      action: { Task { await runDaysEnd() } })
-
-            Button {
-                withAnimation { showMoreOptions.toggle() }
-                if showMoreOptions { fdaGranted = Permissions.hasFullDiskAccess() }
-            } label: {
-                Label("More Options", systemImage: showMoreOptions ? "chevron.down" : "chevron.right")
-                    .font(.caption.weight(.medium))
-            }
-            .buttonStyle(.plain).foregroundStyle(Theme.secondary)
-
-            if showMoreOptions { moreOptions }
-        }
-    }
-
-    // MARK: More Options (advanced DEBUG: Full Disk Access + DB sources)
-
-    private var moreOptions: some View {
-        VStack(spacing: 12) {
-            HStack(spacing: 8) {
-                Image(systemName: fdaGranted ? "checkmark.shield.fill" : "exclamationmark.shield.fill")
-                    .foregroundStyle(fdaGranted ? Theme.verdictColor(.survivor) : .orange)
-                Text(fdaGranted ? "Full Disk Access granted" : "Full Disk Access needed")
-                    .font(.caption.weight(.medium)).foregroundStyle(.white)
-                Spacer()
-                Button("Re-check") { fdaGranted = Permissions.hasFullDiskAccess() }
-                    .buttonStyle(.borderless).controlSize(.small).tint(Theme.accent)
-            }
-
-            if !fdaGranted {
-                Text("The database sources (WhatsApp · iMessage · Notes) read protected databases. Grant Full Disk Access, then restart.")
-                    .font(.caption2).foregroundStyle(Theme.faint)
-                    .multilineTextAlignment(.center)
-                    .fixedSize(horizontal: false, vertical: true)
-
-                HStack(spacing: 10) {
-                    Button("Grant Full Disk Access…") { Permissions.openFullDiskAccessSettings() }
-                        .buttonStyle(.bordered).tint(Theme.accent)
-                    Button("Restart app") { Permissions.relaunch() }
-                        .buttonStyle(.bordered).tint(.white)
-                }
-            } else {
-                Text("Database sources (WhatsApp · iMessage · Notes) are unlocked — pick them up in SOURCES above.")
-                    .font(.caption2).foregroundStyle(Theme.faint)
-                    .multilineTextAlignment(.center).fixedSize(horizontal: false, vertical: true)
-            }
-        }
-        .padding(14)
-        .frame(maxWidth: 460)
-        .glassCard()
-    }
-
-    // MARK: Source picker (DEBUG) — pick which folders "Start Analysis" runs over
-
-    private var sourcePicker: some View {
-        VStack(spacing: 9) {
-            Text("SOURCES").font(.caption2.weight(.bold)).tracking(2).foregroundStyle(Theme.faint)
-
-            LazyVGrid(columns: [GridItem(.adaptive(minimum: 116), spacing: 8)], spacing: 8) {
-                sourceChip("Downloads", selected: runDownloads) { runDownloads.toggle() }
-                sourceChip("Desktop",   selected: runDesktop)   { runDesktop.toggle() }
-                sourceChip("Documents", selected: runDocuments) { runDocuments.toggle() }
-                ForEach(customRoots, id: \.self) { url in
-                    sourceChip(url.lastPathComponent, selected: true, removable: true) {
-                        customRoots.removeAll { $0 == url }
-                    }
-                }
-                chooseFolderChip
-                // DB sources — enabled once Full Disk Access is granted (see More Options).
-                chatSourceChip("WhatsApp", systemImage: "message.fill",
-                               isOn: runWhatsApp && fdaGranted && !selectedChatJIDs.isEmpty,
-                               count: selectedChatJIDs.count,
-                               turnOff: { runWhatsApp = false },
-                               openPicker: { showChatPicker = true })
-                chatSourceChip("iMessage", systemImage: "bubble.left.fill",
-                               isOn: runIMessage && fdaGranted && !selectedIMessageGUIDs.isEmpty,
-                               count: selectedIMessageGUIDs.count,
-                               turnOff: { runIMessage = false },
-                               openPicker: { showIMessagePicker = true })
-                notesChip
-            }
-            .frame(maxWidth: 420)
-
-            if selectedSources.isEmpty {
-                Text("Select at least one source to analyze.")
-                    .font(.caption2).foregroundStyle(Theme.faint)
-            }
-            if !fdaGranted {
-                Text("WhatsApp, iMessage & Apple Notes need Full Disk Access — grant it in More Options below.")
-                    .font(.caption2).foregroundStyle(Theme.faint)
-            }
-        }
-        .onAppear { fdaGranted = Permissions.hasFullDiskAccess() }
-    }
-
-    /// Apple Notes chip — a plain FDA-gated toggle (no picker: all notes go in, capped inside
-    /// the source). Same look as the chat chips, minus the count.
-    private var notesChip: some View {
-        let on = runNotes && fdaGranted
-        return HStack(spacing: 6) {
-            Image(systemName: on ? "checkmark.circle.fill" : "note.text").font(.system(size: 11))
-            Text("Apple Notes").font(.caption.weight(.medium)).lineLimit(1)
-        }
-        .foregroundStyle(on ? .black : (fdaGranted ? Theme.secondary : Theme.faint))
-        .frame(maxWidth: .infinity)
-        .padding(.horizontal, 11).padding(.vertical, 6)
-        .background(on ? Theme.accent : Color.white.opacity(0.06), in: Capsule())
-        .overlay(Capsule().strokeBorder(on ? .clear : Theme.stroke, lineWidth: 1))
-        .contentShape(Capsule())
-        .onTapGesture {
-            guard fdaGranted else { return }
-            runNotes.toggle()
-        }
-    }
-
-    /// A chat-DB source chip (WhatsApp / iMessage). Tap when OFF → opens that source's chat
-    /// picker → Done lights it up (with the chat count). Tap when ON → turns it off (keeps the
-    /// selection for next time).
-    private func chatSourceChip(_ name: String, systemImage: String, isOn: Bool, count: Int,
-                                turnOff: @escaping () -> Void,
-                                openPicker: @escaping () -> Void) -> some View {
-        HStack(spacing: 6) {
-            Image(systemName: isOn ? "checkmark.circle.fill" : systemImage).font(.system(size: 11))
-            Text(isOn ? "\(name) · \(count)" : name).font(.caption.weight(.medium)).lineLimit(1)
-        }
-        .foregroundStyle(isOn ? .black : (fdaGranted ? Theme.secondary : Theme.faint))
-        .frame(maxWidth: .infinity)
-        .padding(.horizontal, 11).padding(.vertical, 6)
-        .background(isOn ? Theme.accent : Color.white.opacity(0.06), in: Capsule())
-        .overlay(Capsule().strokeBorder(isOn ? .clear : Theme.stroke, lineWidth: 1))
-        .contentShape(Capsule())
-        .onTapGesture {
-            guard fdaGranted else { return }
-            if isOn { turnOff() }          // ON → off (selection kept)
-            else { openPicker() }          // OFF → choose chats
-        }
-    }
-
-    private func sourceChip(_ label: String, selected: Bool, removable: Bool = false,
-                            _ tap: @escaping () -> Void) -> some View {
-        HStack(spacing: 6) {
-            Image(systemName: removable ? "xmark.circle.fill"
-                              : (selected ? "checkmark.circle.fill" : "circle"))
-                .font(.system(size: 11))
-            Text(label).font(.caption.weight(.medium)).lineLimit(1).truncationMode(.middle)
-        }
-        .foregroundStyle(selected ? .black : Theme.secondary)
-        .frame(maxWidth: .infinity)
-        .padding(.horizontal, 11).padding(.vertical, 6)
-        .background(selected ? Theme.accent : Color.white.opacity(0.06), in: Capsule())
-        .overlay(Capsule().strokeBorder(selected ? .clear : Theme.stroke, lineWidth: 1))
-        .contentShape(Capsule())
-        .onTapGesture(perform: tap)
-    }
-
-    private var chooseFolderChip: some View {
-        HStack(spacing: 6) {
-            Image(systemName: "folder.badge.plus").font(.system(size: 11))
-            Text("Choose folder…").font(.caption.weight(.medium)).lineLimit(1)
-        }
-        .foregroundStyle(Theme.accent)
-        .frame(maxWidth: .infinity)
-        .padding(.horizontal, 11).padding(.vertical, 6)
-        .background(Color.white.opacity(0.06), in: Capsule())
-        .overlay(Capsule().strokeBorder(Theme.accent.opacity(0.4), lineWidth: 1))
-        .contentShape(Capsule())
-        .onTapGesture(perform: chooseFolder)
-    }
-
-    /// Pick any folder(s) to add as custom sources for this session.
-    private func chooseFolder() {
-        let panel = NSOpenPanel()
-        panel.canChooseFiles = false
-        panel.canChooseDirectories = true
-        panel.allowsMultipleSelection = true
-        panel.prompt = "Add"
-        panel.message = "Add a folder for Sentient OS to analyze."
-        guard panel.runModal() == .OK else { return }
-        for url in panel.urls where !customRoots.contains(url) { customRoots.append(url) }
-    }
-
-    @ViewBuilder
-    private func debugTest(title: String, systemImage: String, isRunning: Bool,
-                           result: String?, passPrefix: String,
-                           action: @escaping () -> Void) -> some View {
-        VStack(spacing: 8) {
-            Button(action: action) {
-                if isRunning { ProgressView().controlSize(.small) }
-                Label(title, systemImage: systemImage)
-            }
-            .disabled(isRunning)
-
-            if let result {
-                Text(result)
-                    .font(.system(.footnote, design: .monospaced))
-                    .foregroundStyle(result.hasPrefix(passPrefix) ? .green
-                                     : result.localizedCaseInsensitiveContains("fail") ? .red : Theme.secondary)
-                    .multilineTextAlignment(.leading)
-                    .textSelection(.enabled)
-                    .frame(maxWidth: 460)
-            }
-        }
-    }
-
-    @MainActor
-    private func runDaysEnd() async {
-        isDaysEndRunning = true
-        defer { isDaysEndRunning = false }
-        daysEndResult = await DaysEndJob.shared.run(store: store)
-    }
-
-    @MainActor
-    private func runReset() async {
-        isResetting = true
-        defer { isResetting = false }
-        do {
-            try await store.reset()
-            LifetimeStats.reset()
-            let counts = await store.counts()
-            resetResult = "Cleared ✓  summaries=\(counts.versions)  pointers=\(counts.cursors)"
-        } catch {
-            resetResult = "Reset FAIL: \(error)"
-        }
+    private var constellation: some View {
+        let sources = selectedSources
+        return ConstellationHome(
+            thingsUnderstood: LifetimeStats.analyzed,
+            analyzeEnabled: !sources.isEmpty && Self.modelPath != nil,
+            modelMissing: Self.modelPath == nil,
+            sources: .init(
+                files: sources.contains { if case .files = $0 { return true } else { return false } },
+                whatsapp: sources.contains { if case .whatsapp = $0 { return true } else { return false } },
+                imessage: sources.contains { if case .imessage = $0 { return true } else { return false } },
+                notes: sources.contains(.notes)),
+            onAnalyze: { withAnimation(.easeInOut(duration: 0.3)) { isProcessing = true } },
+            onOpenVault: { openWindow(id: DatabaseView.windowID) },
+            onOpenBriefings: { openWindow(id: BriefingsView.windowID) },
+            onShowDevTools: { showDevTools = true })
     }
 }

--- a/Sentient OS macOS/Views/Theme.swift
+++ b/Sentient OS macOS/Views/Theme.swift
@@ -48,6 +48,52 @@ enum Theme {
         colors: [Color(red: 1.0, green: 0.78, blue: 0.28), Color(red: 0.98, green: 0.42, blue: 0.52)],
         startPoint: .leading, endPoint: .trailing
     )
+
+    /// The editorial ink palette (from the Constellation mockup) — shared by the Constellation
+    /// home and the For You / briefings window.
+    enum Ink {
+        static let cardBG = Color(red: 0.047, green: 0.047, blue: 0.059)       // #0c0c0f
+        static let statusInk = Color(red: 0.914, green: 0.906, blue: 0.933)    // #e9e7ee
+        static let body = Color(red: 0.608, green: 0.604, blue: 0.627)         // #9b9aa0
+        static let label = Color(red: 0.431, green: 0.427, blue: 0.459)        // #6e6d75
+        static let deepMuted = Color(red: 0.337, green: 0.333, blue: 0.369)    // #56555e
+        static let bright = Color(red: 0.812, green: 0.804, blue: 0.839)       // #cfcdd6
+        static let mint = Color(red: 0.278, green: 0.843, blue: 0.675)         // #47d7ac
+        static let amber = Color(red: 1.0, green: 0.765, blue: 0.443)          // #ffc371
+        static let chipInk = Color(red: 0.541, green: 0.537, blue: 0.565)      // #8a8990
+        static let chipBorder = Color(red: 0.114, green: 0.114, blue: 0.133)   // #1d1d22
+    }
+}
+
+/// Monospace ALL-CAPS with wide tracking — the design language's whisper voice.
+struct MonoCaps: View {
+    let text: String
+    let size: CGFloat
+    let tracking: CGFloat
+    let color: Color
+
+    init(_ text: String, size: CGFloat, tracking: CGFloat, color: Color) {
+        self.text = text
+        self.size = size
+        self.tracking = tracking
+        self.color = color
+    }
+
+    var body: some View {
+        Text(text.uppercased())
+            .font(.system(size: size, weight: .medium, design: .monospaced))
+            .tracking(tracking)
+            .foregroundStyle(color)
+    }
+}
+
+/// Subtle scale-on-press for custom (non-bordered) buttons across the app.
+struct PressScaleStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.96 : 1)
+            .animation(.easeOut(duration: 0.18), value: configuration.isPressed)
+    }
 }
 
 extension Font {


### PR DESCRIPTION
The home screen stops looking like a dev tool and becomes **Sentient OS**: the living orb at the center of the four-satellite Constellation, and the For You window where proactive intelligence sells itself.

## 🪐 The orb (`Orb.swift`)
The logo, made dimensional — a dark glassy planet (drifting nebula + mineral grain + a glowing white heart) wrapped in a **truly 3D** ring: depth-sorted across two Canvases sandwiching the planet (it passes behind *and* in front), Keplerian particles (inner orbits faster), two shimmer glints, the planet's shadow on the far side, a slow precession wobble, 5.5s breathing. `idle / processing / attention` modes built in for the later morph.
- **Perf-tuned the hard way:** no per-frame `@State` writes (ring clock is a pure function of time), no per-frame blur filters (halo = cached rotating texture; nebula/heart = radial gradients), one glow pass per side, fixed planet diameter (vector-crisp). 60fps, sharp limb.

## ✨ The Constellation home (`ConstellationHome.swift`, `RootView.swift`)
Orb + serif-italic status + Analyze Now glow CTA + four pinned satellites (For You · Your AIs · The Vault · Sources), tethered by dotted lines drawn from **real geometry anchors**, trust footer. Real data where it's free (lifetime count, vault note/domain counts from disk, live source chips, real Copy MCP Link); every demo string quarantined in one `Demo` enum. Main window now uses a hidden title bar (OLED black edge-to-edge).

## 🔧 Dev cockpit preserved (`DevToolsView.swift`)
The prior dev home moved verbatim into a sheet behind the bottom-right DEV TOOLS button (Release-strip re-hides it). One shared `SourceSelection` reader means Analyze Now and Start Analysis run the exact same selection.

## ✉️ For You — "The Offerings" (`Briefing.swift`, `BriefingCard.swift`, `BriefingsView.swift`)
The proactive-intelligence headline: every briefing is an **offer** — the AI already did the work and asks *"Should I send it for you?"*. One click fires it (Privacy Constitution: we offer, they fire).
- The orb **deals** the cards into an organic scatter; **flick-to-dismiss** with drag physics and reflow; click an offer → **agentic-theater** working state (mono log lines typing in) → done → the card flies away.
- A **sealed welcome envelope** (3D-swinging flap + gradient wax seal) opens into a full typeset letter; detail links expand any briefing into a reading view with copyable draft blocks.
- Six demo offerings mined from the real vault (Outlander VC, Luis/Headline, Dad's shoes, ZFellows, SF plan, the welcome letter).
- **The CodexCLI seam** is marked in `ForYouModel.run`: real execution swaps the scripted theater for `CodexCLI.run` on each briefing's `codexPrompt` (browser/computer use, armed with the vault).

## Shared primitives (`Theme.swift`)
Extracted the editorial `Ink` palette + `MonoCaps` + `PressScaleStyle` so the home and briefings share one language.

## Notes
- All briefing content + the "Your AIs" / synced numbers are **hard-coded demo** (investor showcase). Doc files mark every demo-vs-real seam.
- Docs added: `Constellation Home (UI).md`, `Briefings Window (For You).md`.
- Build: ✅ green via xcodebuild, zero new warnings.

## Known follow-ups (not in this PR)
- Home ⟷ processing **morph** (today they cross-fade; the orb/processing-takeover assembly is the next animation phase).
- The vault viewer is still the existing placeholder.
- Trackpad two-finger swipe-to-dismiss (drag-flick ships here; scroll-monitor variant later).