### PR TITLE
Files pointer: drop the unused interval, keep a single high-water mark

### DIFF
--- a/Sentient OS macOS/Documentation/Files Iterative System.md
+++ b/Sentient OS macOS/Documentation/Files Iterative System.md
@@ -8,13 +8,17 @@ with `BackfillCursor`) and will migrate to this system later.
 It is **self-contained** (new `File Ingestion/` group + its own SwiftData store) and driven entirely
 from the **DEV TOOLS sheet** (`DevToolsView`) — the hand-drawn INITIAL | ITERATIVE mockup.
 
-## The one durable idea: a per-folder processed interval
+## The one durable idea: a per-folder high-water mark
 
-The only thing that survives a cycle is, per file root, the **processed interval `[lo, hi]`** of the
-**date-added** timeline. Each bound is a `FileKey = (dateAdded, path)`:
+The only thing that survives a cycle is, per file root, a single **high-water mark** = the **newest
+file processed**, stored as a `FileKey = (dateAdded, path)`. Invariant: everything ≤ the mark is
+done; everything newer is new (the next ITERATIVE run starts *above* it). INITIAL sets it = newest
+once its descent completes; ITERATIVE climbs it up, per item.
 
-- **`hi`** = newest file processed. The anchor the next ITERATIVE run starts *above*.
-- **`lo`** = oldest file processed. An INITIAL top→bottom descent slides it down.
+*(There is no `[lo, hi]` interval — an earlier design tracked the descent's low end too, but it was
+write-only: nothing ever read it. The mark alone is sufficient. The trade is that a stopped INITIAL
+restarts rather than resumes — fine, since initial is the one-time, foreground, watched run, and the
+ongoing ITERATIVE flow is single-mark crash-resumable.)*
 
 **Why `(dateAdded, path)` and not just a date** (`FileKey.swift`): `kMDItemDateAdded` is only
 second-precise and real folders have files sharing the exact same second (two screenshots at
@@ -29,7 +33,7 @@ reprocess edited files.
 A cycle = *on-device summarize → cloud (make/update KB) → cloud (proactive) → wipe summaries → next
 cycle starts clean*. So **`FileNote`s are ephemeral** — they live only for one cycle. That means
 "tell cloud" just sends whatever notes currently exist (no "which are new?" bookkeeping), and the
-**proactive button ends the cycle by wiping all notes**. The interval pointer persists; the
+**proactive button ends the cycle by wiping all notes**. The high-water mark persists; the
 summaries do not.
 
 ## Components (`File Ingestion/`)
@@ -37,17 +41,15 @@ summaries do not.
 - **`FileKey.swift`** — the `(dateAdded, path)` ordered key (the tiebreak, in one place).
 - **`FileStore.swift`** — `@ModelActor` over its **own** on-disk container (`FileIngestion.store`,
   isolated from the old `Store`'s `default.store` so adding these models never schema-wipes the dev
-  DB). Models: `FolderPointer` (durable interval) + `FileNote` (ephemeral survivor). API:
-  `interval/setInterval/clearFolder · recordNote/notes/reminderNotes/wipeAllNotes · counts`.
+  DB). Models: `FolderPointer` (durable high-water mark) + `FileNote` (ephemeral survivor). API:
+  `pointer/setPointer/clearFolder · recordNote/notes/reminderNotes/wipeAllNotes · counts`.
 - **`FileRun.swift`** — the on-device orchestrator. Reuses `Engine` + `Triage` + `FilesSource`
   (`eligibleFiles` + `load`); mirrors `Pipeline`'s GPU-wedge resilience.
-  - `runInitial(roots:)` — top→bottom: `clearFolder`, pin `hi` at the newest, walk newest→oldest,
-    slide `lo` down.
-  - `runIterative(roots:)` — bottom→top: take files with `key > hi`, walk oldest→newest, slide `hi`
-    up. (No interval yet ⇒ "run initial first", skipped.)
-  - The interval advances after **every** item (survivor / junk / sensitive / given-up) so it stays
-    contiguous and a stopped run resumes; survivors write a `FileNote`, junk/sensitive store nothing
-    (zero trace).
+  - `runInitial(roots:)` — top→bottom: `clearFolder`, walk newest→oldest, then on completion set the
+    mark = newest. (Interrupted ⇒ mark stays unset ⇒ iterative says "run initial first".)
+  - `runIterative(roots:)` — bottom→top: take files with `key > mark`, walk oldest→newest, climbing
+    the mark per item (so a stopped run resumes). No mark yet ⇒ "run initial first", skipped.
+  - Survivors write a `FileNote`; junk/sensitive store nothing (zero trace).
 - **`FileVaultCloud.swift`** — the three Codex calls + the `CloudNote` value type (decouples the
   cloud prompts from the old `Store`'s `SummaryItem`/`PersistentIdentifier`):
   - `create` — reuses `VaultGenerator.generate(notes:)` (staging + atomic swap + usage-limit resume).

--- a/Sentient OS macOS/File Ingestion/FileKey.swift
+++ b/Sentient OS macOS/File Ingestion/FileKey.swift
@@ -8,8 +8,8 @@
 //  point, so the per-folder pointer (FolderPointer) can name EXACTLY one boundary file and
 //  "is this file past the line?" is never ambiguous when a folder is re-scanned on a later run.
 //
-//  Used by FolderPointer (the processed interval [lo, hi]) and FileRun (direction-sorting the
-//  eligible files: initial descends from hi, iterative ascends above hi).
+//  Used by FolderPointer (the per-folder high-water mark) and FileRun (direction-sorting the
+//  eligible files: initial descends from the newest, iterative ascends above the mark).
 //
 
 import Foundation

--- a/Sentient OS macOS/File Ingestion/FileRun.swift
+++ b/Sentient OS macOS/File Ingestion/FileRun.swift
@@ -4,16 +4,17 @@
 //
 //  The files-iterative on-device orchestrator — what the dev UI's "start on device" buttons call.
 //  Reuses Engine + Triage + FilesSource (eligibleFiles + load), writing survivor summaries and the
-//  processed interval into FileStore. Two directions:
+//  per-folder high-water mark into FileStore. Two directions:
 //
-//   • runInitial   (top→bottom): clear the root, pin `hi` at the NEWEST file, walk newest→oldest,
-//                   sliding `lo` down. The user watches it understand NOW first.
-//   • runIterative (bottom→top): take only files NEWER than `hi`, walk oldest→newest, sliding `hi`
-//                   up to today's newest. (No interval yet ⇒ "run initial first", skipped.)
+//   • runInitial   (top→bottom): clear the root, walk the eligible files newest→oldest, then on
+//                   completion set the mark = newest. The user watches it understand NOW first.
+//                   (Interrupted ⇒ mark stays unset ⇒ iterative says "run initial first".)
+//   • runIterative (bottom→top): take only files NEWER than the mark, walk oldest→newest, and
+//                   climb the mark up per item (so a stopped run resumes, not skips). No mark yet
+//                   ⇒ "run initial first", skipped.
 //
-//  The interval advances after EVERY item (survivor / junk / sensitive / given-up alike) so it
-//  stays contiguous and a stopped run resumes rather than skips; survivors also write a FileNote,
-//  while junk/sensitive store nothing (zero trace). GPU-wedge resilience mirrors Pipeline's policy.
+//  Survivors write a FileNote; junk/sensitive store nothing (zero trace). GPU-wedge resilience
+//  mirrors Pipeline's policy.
 //
 
 import Foundation
@@ -115,33 +116,28 @@ struct FileRun {
             guard let source = root.source else { continue }
             let rootKey = source.cursorKey
 
-            // Build this root's ordered work + the interval bounds for the chosen direction.
+            // Build this root's ordered work for the chosen direction.
             let all = source.eligibleFiles().map { (cand: $0, key: fileKey($0)) }   // newest-first
             let work: [(cand: Candidate, key: FileKey)]
-            let pinnedHi: FileKey?    // initial: the pinned top; iterative: nil
-            let fixedLo: FileKey?     // iterative: the existing lo; initial: nil (lo slides)
 
             switch mode {
             case .initial:
-                await store.clearFolder(rootKey: rootKey)
-                guard let top = all.first?.key else { continue }
-                await store.setInterval(forKey: rootKey, lo: top, hi: top)   // pin hi at the newest
-                work = all                                                   // already top→bottom
-                pinnedHi = top; fixedLo = nil
+                await store.clearFolder(rootKey: rootKey)   // fresh start; the mark is set on completion
+                work = all                                  // newest → oldest (top→bottom)
             case .iterative:
-                guard let iv = await store.interval(forKey: rootKey) else {
-                    Log("FileRun: \(rootKey) has no interval — run initial first; skipping.")
+                guard let mark = await store.pointer(forKey: rootKey) else {
+                    Log("FileRun: \(rootKey) has no pointer — run initial first; skipping.")
                     continue
                 }
-                work = all.filter { $0.key > iv.hi }.sorted { $0.key < $1.key }   // bottom→top
-                pinnedHi = nil; fixedLo = iv.lo
+                work = all.filter { $0.key > mark }.sorted { $0.key < $1.key }   // oldest → newest (bottom→top)
             }
 
             p.total += work.count
             onProgress(p)
 
+            var finished = true
             for w in work {
-                if Task.isCancelled { break rootLoop }
+                if Task.isCancelled { finished = false; break rootLoop }
                 if sinceReload >= Self.preemptiveReloadEvery { await reloadEngine() }
 
                 p.lastPath = w.cand.metadata["displayPath"] ?? w.cand.metadata["name"]
@@ -153,7 +149,7 @@ struct FileRun {
                     if consecutiveFailures >= Self.failuresBeforeReload {
                         guard reloadsWithoutProgress < Self.maxReloadsWithoutProgress else {
                             Log("FileRun: engine not recovering after \(reloadsWithoutProgress) reloads — stopping.")
-                            break rootLoop
+                            finished = false; break rootLoop
                         }
                         await reloadEngine(); reloadsWithoutProgress += 1; consecutiveFailures = 0
                         ok = await attempt(w.cand, source: source, rootKey: rootKey, dateAdded: w.key.dateAdded)
@@ -161,14 +157,19 @@ struct FileRun {
                 }
                 if ok { consecutiveFailures = 0; reloadsWithoutProgress = 0 } else { p.failed += 1 }
 
-                // Advance the interval past this item — contiguous, every verdict, so a stopped run
-                // resumes exactly here. Initial slides lo down (hi pinned); iterative slides hi up.
-                switch mode {
-                case .initial:   await store.setInterval(forKey: rootKey, lo: w.key, hi: pinnedHi!)
-                case .iterative: await store.setInterval(forKey: rootKey, lo: fixedLo!, hi: w.key)
-                }
+                // ITERATIVE climbs the mark up per item (ascending → everything ≤ this is now done,
+                // so a stopped run resumes here, not skips). INITIAL leaves it untouched mid-run —
+                // its mark is set only once the whole descent finishes (below).
+                if mode == .iterative { await store.setPointer(forKey: rootKey, w.key) }
                 sinceReload += 1; p.done += 1
                 onProgress(p)
+            }
+
+            // INITIAL finished this root's full descent → everything ≤ newest is done → set the mark.
+            // (Interrupted/aborted → break rootLoop skips this → the mark stays unset, so iterative
+            // correctly says "run initial first".)
+            if mode == .initial, finished, let newest = all.first?.key {
+                await store.setPointer(forKey: rootKey, newest)
             }
         }
         await engine.unload()

--- a/Sentient OS macOS/File Ingestion/FileStore.swift
+++ b/Sentient OS macOS/File Ingestion/FileStore.swift
@@ -6,16 +6,15 @@
 //  (its own on-disk SwiftData container, so adding these models never schema-wipes the existing
 //  dev DB, and the two systems can't entangle). Two models:
 //
-//   - FolderPointer  DURABLE. One row per file root. The processed interval [lo, hi] of the
-//                    date-added timeline. `hi` = newest processed (the anchor the next ITERATIVE
-//                    run starts above); `lo` = oldest processed (an INITIAL top→bottom descent
-//                    slides it down). This is the ONLY state that survives a cycle.
+//   - FolderPointer  DURABLE. One row per file root. The HIGH-WATER MARK — the newest file
+//                    processed. Everything ≤ it is done; everything newer is new (the next
+//                    ITERATIVE run starts above it). The ONLY state that survives a cycle.
 //   - FileNote       EPHEMERAL. One survivor summary per file, wiped at the end of every cycle
 //                    (the proactive button clears them). Junk/sensitive files store NOTHING — the
 //                    pointer simply moves past them (zero trace).
 //
 //  Only this actor touches the @Model objects; callers get/pass Sendable value types (FileKey,
-//  FileNoteItem). Methods: interval/setInterval/clearFolder · recordNote/notes/reminderNotes/
+//  FileNoteItem). Methods: pointer/setPointer/clearFolder · recordNote/notes/reminderNotes/
 //  wipeAllNotes · counts.
 //
 
@@ -24,27 +23,24 @@ import SwiftData
 
 // MARK: - Models
 
-/// DURABLE — one per file root. The processed interval as two (epoch, path) bounds.
+/// DURABLE — one per file root. The HIGH-WATER MARK: the newest file processed, `(epoch, path)`.
+/// Invariant: everything ≤ mark is done, everything newer is new. Set when an INITIAL descent
+/// completes; an ITERATIVE run climbs it up, per item.
 @Model
 final class FolderPointer {
     @Attribute(.unique) var key: String   // "file:<FileRoot.id>"
-    var loEpoch: Double
-    var loPath: String
-    var hiEpoch: Double
-    var hiPath: String
+    var markEpoch: Double
+    var markPath: String
     var updatedAt: Date
 
-    init(key: String, lo: FileKey, hi: FileKey, updatedAt: Date = Date()) {
+    init(key: String, mark: FileKey, updatedAt: Date = Date()) {
         self.key = key
-        self.loEpoch = lo.dateAdded.timeIntervalSince1970
-        self.loPath = lo.path
-        self.hiEpoch = hi.dateAdded.timeIntervalSince1970
-        self.hiPath = hi.path
+        self.markEpoch = mark.dateAdded.timeIntervalSince1970
+        self.markPath = mark.path
         self.updatedAt = updatedAt
     }
 
-    var lo: FileKey { FileKey(dateAdded: Date(timeIntervalSince1970: loEpoch), path: loPath) }
-    var hi: FileKey { FileKey(dateAdded: Date(timeIntervalSince1970: hiEpoch), path: hiPath) }
+    var mark: FileKey { FileKey(dateAdded: Date(timeIntervalSince1970: markEpoch), path: markPath) }
 }
 
 /// EPHEMERAL — one survivor summary for one file, this cycle only.
@@ -99,21 +95,22 @@ actor FileStore {
 
     // MARK: Pointers (durable)
 
-    /// The processed interval for a root, or nil if it has never had an initial run.
-    func interval(forKey key: String) -> (lo: FileKey, hi: FileKey)? {
-        guard let row = pointerRow(key) else { return nil }
-        return (row.lo, row.hi)
+    /// The high-water mark for a root (newest file processed), or nil if it's never completed an
+    /// initial run.
+    func pointer(forKey key: String) -> FileKey? {
+        pointerRow(key)?.mark
     }
 
-    /// Set/advance a root's processed interval (initial sets hi then slides lo down; iterative
-    /// slides hi up). Called once per processed item so a crash resumes rather than skips.
-    func setInterval(forKey key: String, lo: FileKey, hi: FileKey) {
+    /// Set/advance a root's high-water mark — initial sets it = newest once its descent completes;
+    /// iterative climbs it up per item (ascending → everything ≤ it is done, so a stopped run
+    /// resumes rather than skips).
+    func setPointer(forKey key: String, _ mark: FileKey) {
         if let row = pointerRow(key) {
-            row.loEpoch = lo.dateAdded.timeIntervalSince1970; row.loPath = lo.path
-            row.hiEpoch = hi.dateAdded.timeIntervalSince1970; row.hiPath = hi.path
+            row.markEpoch = mark.dateAdded.timeIntervalSince1970
+            row.markPath = mark.path
             row.updatedAt = Date()
         } else {
-            modelContext.insert(FolderPointer(key: key, lo: lo, hi: hi))
+            modelContext.insert(FolderPointer(key: key, mark: mark))
         }
         try? modelContext.save()
     }

--- a/Sentient OS macOS/Self Tests - Temp/SelfTest_FileIter.swift
+++ b/Sentient OS macOS/Self Tests - Temp/SelfTest_FileIter.swift
@@ -7,7 +7,7 @@
 //    • FileKey ordering — the (dateAdded, path) tiebreak.
 //    • The iterative "newer than hi" partition, with a same-second TWIN straddling the boundary
 //      (the exact case the tiebreak exists for: the twin below the line is NOT reprocessed).
-//    • FileStore round-trip — interval set/get, clearFolder, recordNote/notes/reminderNotes,
+//    • FileStore round-trip — pointer set/get, clearFolder, recordNote/notes/reminderNotes,
 //      wipeAllNotes.
 //    • FilesSource.eligibleFiles — keeps allowed files, skips a disallowed extension, prunes a
 //      .git repo.
@@ -47,13 +47,11 @@ enum SelfTestFileIter {
         emit("\n=== fileiter: FileStore round-trip (in-memory) ===")
         let store = inMemoryStore()
         let key = "file:__fileiter__"
-        check("interval nil before any initial run", await store.interval(forKey: key) == nil)
-        // Initial: pin hi at the newest (c), then slide lo down to the oldest (a).
-        await store.setInterval(forKey: key, lo: c, hi: c)
-        await store.setInterval(forKey: key, lo: a, hi: c)
-        let iv = await store.interval(forKey: key)
-        check("interval persists hi = c (the iterative anchor)", iv?.hi == c)
-        check("interval persists lo = a (descent watermark)", iv?.lo == a)
+        check("pointer nil before any initial run", await store.pointer(forKey: key) == nil)
+        // Iterative climbs the mark up per item — simulate two ascending advances (a then c).
+        await store.setPointer(forKey: key, a)
+        await store.setPointer(forKey: key, c)
+        check("pointer persists the high-water mark (c)", await store.pointer(forKey: key) == c)
 
         await store.recordNote(rootKey: key, folder: "Fix", path: "/d/a.png", dateAdded: a.dateAdded,
                                text: "summary a", title: "A", reminderFlagged: true)
@@ -65,7 +63,7 @@ enum SelfTestFileIter {
         check("exactly one reminder-flagged", await store.reminderNotes().count == 1)
 
         await store.clearFolder(rootKey: key)
-        check("clearFolder drops the pointer", await store.interval(forKey: key) == nil)
+        check("clearFolder drops the pointer", await store.pointer(forKey: key) == nil)
         check("clearFolder removes that root's notes", await store.counts().notes == 0)
 
         await store.recordNote(rootKey: "file:other", folder: "Other", path: "/x/y.txt",


### PR DESCRIPTION
Follow-up cleanup to the files-iterative system. The processed interval `[lo, hi]` was **write-only** — `lo` (the descent low end) was set during initial but **never read** for any decision; iterative only ever filters on `hi`. Dead state, so it's gone.

`FolderPointer` is now a single **high-water mark** = the newest file processed, `(dateAdded, path)`.

- **FileStore**: one mark; `interval/setInterval` → `pointer/setPointer`.
- **FileRun**: initial walks newest→oldest and sets the mark = newest **once on completion** (interrupted ⇒ mark unset ⇒ iterative says "run initial first"); iterative filters `> mark` and **climbs the mark per item** (still crash-resumable). No per-item write during initial, no `lo`.
- **Self-test** `fileiter` → **18/18**.
- Doc updated + renamed (single mark, not an interval).

**Behavior is identical** to before (`lo` was never read). The only property we lack — resuming an *interrupted initial* — we already lacked (initial restarts), and initial is the one-time foreground run; ongoing iterative stays single-pointer crash-resumable.