### PR TITLE
NotesConnector: Apple Notes on the iterative core (PR B)

### DIFF
--- a/Sentient OS macOS/Documentation/Iterative Core (Connectors).md
+++ b/Sentient OS macOS/Documentation/Iterative Core (Connectors).md
@@ -48,10 +48,16 @@ Connector-agnostic; operates on `CycleStore.notes()` regardless of source (`Clou
 - **`FilesConnector`** (`Ingestion/Connectors/FilesConnector.swift`) ✅ — one bucket per `FileRoot`
   (`file:<root.id>`), key `(dateAdded, path)`, item = a file. Wraps `FilesSource.eligibleFiles`
   (skip rules + caps) + `FilesSource.loadArtifact`.
-- **NotesConnector** (next) — single bucket `"notes"`, key `(createdDate, uuid)`, item = a note;
-  reuse `NotesSource.decodeBody`. Created-date key ⇒ edited notes are **not** re-summarized.
-- **ChatConnector** (after) — per chat (`whatsapp:<jid>` / `imessage:<guid>`), key `(rowID, "")`,
+- **`NotesConnector`** (`Ingestion/Connectors/NotesConnector.swift`) ✅ — single bucket `"notes"`,
+  key `(createdDate, "notes:<uuid>")`, item = a note; wraps `NotesSource.eligibleNotes` (reuses the
+  gunzip/protobuf `decodeBody`). **Created-date** key ⇒ edited notes are **not** re-summarized.
+  Needs Full Disk Access.
+- **ChatConnector** (next) — per chat (`whatsapp:<jid>` / `imessage:<guid>`), key `(rowID, "")`,
   item = a `ChatWindowing` window; reuse `ChatWindowing` / `SQLiteDB` / `AddressBookNames`.
+
+The dev cockpit (`DevToolsView`) has an **ON-DEVICE CONNECTOR** picker (Files / Apple Notes) that
+routes the INITIAL/ITERATIVE buttons to the chosen connector. "tell cloud" / proactive operate on
+all of `CycleStore.notes()` regardless of connector.
 
 ## What was deleted (folded into the core)
 `FileKey` / `FileStore` / `FileRun` / `FileVaultCloud` / `FileNotesView` → `ItemKey` / `CycleStore` /
@@ -63,4 +69,6 @@ Connector-agnostic; operates on `CycleStore.notes()` regardless of source (`Clou
 ## Verify
 `SENTIENT_SELFTEST=fileiter` — deterministic, no model/codex: ItemKey tiebreak · the newer-than-mark
 partition (twin at the boundary) · CycleStore round-trip · `FilesConnector.buckets` skip/keep.
-Engine-driven + cloud end-to-end is exercised via the dev buttons on real folders.
+`SENTIENT_SELFTEST=notesiter` — runs the real `NotesConnector` against the live Notes DB (structural
+invariants); needs Full Disk Access (skips gracefully without it). Engine-driven + cloud end-to-end
+is exercised via the dev buttons on real folders / Apple Notes.

--- a/Sentient OS macOS/Ingestion/Connectors/NotesConnector.swift
+++ b/Sentient OS macOS/Ingestion/Connectors/NotesConnector.swift
@@ -1,0 +1,27 @@
+//
+//  NotesConnector.swift
+//  Sentient OS macOS
+//
+//  Apple Notes adapter for the iterative core. A SINGLE bucket ("notes"), keyed on
+//  (createdDate, "notes:<uuid>") — created-date so an edited note is NOT re-summarized; the uuid
+//  is the tiebreak. One note = one item, through the FILE Triage prompt (a note is a document the
+//  user wrote). Wraps `NotesSource.eligibleNotes` (WAL-safe read + gunzip/protobuf decode + cap);
+//  the body is already decoded at list time, so `load` just wraps it. Requires Full Disk Access.
+//
+
+import Foundation
+
+struct NotesConnector: Connector {
+    let kind = SourceKind.notes
+
+    func buckets(since marks: [String: ItemKey]) throws -> [Bucket] {
+        let items = try NotesSource().eligibleNotes().map { c in
+            (key: ItemKey(date: c.itemDate, tiebreak: c.id), item: c)   // c.id = "notes:<uuid>" (unique)
+        }
+        return [Bucket(key: "notes", items: items)]   // single bucket, newest-created first
+    }
+
+    func load(_ item: Candidate) throws -> Artifact {
+        Artifact(candidate: item, text: item.metadata["noteText"] ?? "")
+    }
+}

--- a/Sentient OS macOS/Self Tests - Temp/SelfTest_NotesIter.swift
+++ b/Sentient OS macOS/Self Tests - Temp/SelfTest_NotesIter.swift
@@ -1,0 +1,63 @@
+//
+//  SelfTest_NotesIter.swift
+//  Sentient OS macOS
+//
+//  SENTIENT_SELFTEST=notesiter — runs the REAL NotesConnector against the live Notes DB and checks
+//  structural invariants: a single "notes" bucket, every item .notes, ids unique + "notes:<uuid>",
+//  bodies non-empty, keys strictly ordered (no dup keys) and newest-created first, load() returns
+//  the decoded body. Needs Full Disk Access + some notes; reports "skipped" gracefully without them.
+//  (The generic core itself — ItemKey/CycleStore/partition — is covered by `fileiter`.)
+//
+
+import Foundation
+
+enum SelfTestNotesIter {
+
+    static func run(emit: (String) -> Void) async {
+        var passed = 0, failed = 0
+        func check(_ label: String, _ cond: Bool) {
+            if cond { passed += 1; emit("  ✓ \(label)") }
+            else { failed += 1; emit("  ✗ FAIL — \(label)") }
+        }
+
+        emit("=== notesiter: NotesConnector against the live Notes DB ===")
+        let connector = NotesConnector()
+        let buckets: [Bucket]
+        do { buckets = try connector.buckets(since: [:]) }
+        catch {
+            emit("  ⚠️ couldn't read NoteStore.sqlite (\(error)) — grant Full Disk Access to this build.")
+            emit("\n=== notesiter: skipped (no DB access) ===")
+            return
+        }
+
+        check("at most one bucket (single \"notes\" bucket)", buckets.count <= 1)
+        guard let bucket = buckets.first, !bucket.items.isEmpty else {
+            emit("  (0 notes — empty store or no Full Disk Access. Structural checks skipped.)")
+            emit("\n=== notesiter: \(passed) passed · \(failed) failed (0 items) ===")
+            return
+        }
+        check("bucket key is \"notes\"", bucket.key == "notes")
+
+        let items = bucket.items
+        emit("  \(items.count) notes")
+        check("every item kind == .notes", items.allSatisfy { $0.item.kind == .notes })
+        check("ids are unique and \"notes:<uuid>\"",
+              Set(items.map { $0.item.id }).count == items.count
+              && items.allSatisfy { $0.item.id.hasPrefix("notes:") })
+        check("every body is non-empty", items.allSatisfy { !($0.item.metadata["noteText"] ?? "").isEmpty })
+
+        let keysSorted = items.map(\.key).sorted()
+        check("keys strictly ordered when sorted (no dup keys)",
+              zip(keysSorted, keysSorted.dropFirst()).allSatisfy { $0.0 < $0.1 })
+        let keys = items.map(\.key)
+        check("listed newest-created first (descending)",
+              zip(keys, keys.dropFirst()).allSatisfy { $0.0 > $0.1 })
+
+        if let first = items.first {
+            let art = try? connector.load(first.item)
+            check("load() returns the decoded body", (art?.text?.isEmpty == false))
+        }
+
+        emit("\n=== notesiter: \(passed) passed · \(failed) failed ===")
+    }
+}

--- a/Sentient OS macOS/Self Tests - Temp/SelfTest_Triage_Pipeline_and_Vault.swift
+++ b/Sentient OS macOS/Self Tests - Temp/SelfTest_Triage_Pipeline_and_Vault.swift
@@ -95,6 +95,9 @@ enum SelfTest {
         // newer-than-mark partition (twin at the boundary) · CycleStore round-trip · FilesConnector.
         if mode == "fileiter" { await SelfTestFileIter.run(emit: emit); return }
 
+        // NotesConnector against the live Notes DB — structural invariants (needs Full Disk Access).
+        if mode == "notesiter" { await SelfTestNotesIter.run(emit: emit); return }
+
         // CodexCLI mode: no model needed — discovery, ping, and one tiny run through the REAL
         // codex exec spine (binary → env → stdin → JSONL envelope). Verifies the compute
         // waterfall's tier-1 path end to end on this Mac.

--- a/Sentient OS macOS/Sources/NotesSource.swift
+++ b/Sentient OS macOS/Sources/NotesSource.swift
@@ -167,6 +167,56 @@ struct NotesSource: DataSource, Sendable {
         Artifact(candidate: candidate, text: candidate.metadata["noteText"] ?? "")
     }
 
+    // MARK: Eligible notes (the iterative system's flat, pointer-free view)
+
+    /// The current eligible notes for the iterative system (NotesConnector). Same decode + cap as
+    /// `scan`, but keyed on **creation date** (so an edited note is NOT re-summarized — created-date
+    /// never moves), with NO cursor/backfill/hold-back — IterativeRun's pointer decides new-vs-done.
+    /// Each Candidate's `itemDate` IS its creation date (so ItemKey = (createdDate, "notes:<uuid>")).
+    /// Newest-created first. Reuses `decodeBody` (fail-closed: undecodable → skipped).
+    func eligibleNotes() throws -> [Candidate] {
+        let (dbURL, tempDir) = try SQLiteDB.walSafeCopy(of: dbPath)
+        defer { try? FileManager.default.removeItem(at: tempDir) }   // delete the plaintext copy immediately
+        let reader = try SQLiteReader(path: dbURL.path)
+
+        var folders: [Int64: String] = [:]
+        try reader.forEachRow("SELECT Z_PK, ZTITLE2 FROM ZICCLOUDSYNCINGOBJECT WHERE ZTITLE2 IS NOT NULL") { r in
+            if let t = r.text(1) { folders[r.int(0)] = t }
+        }
+
+        var out: [Candidate] = []
+        try reader.forEachRow("""
+            SELECT o.ZIDENTIFIER, o.ZTITLE1,
+                   COALESCE(o.ZCREATIONDATE3, o.ZCREATIONDATE2, o.ZCREATIONDATE1, o.ZCREATIONDATE) AS created,
+                   o.ZFOLDER, d.ZDATA
+            FROM ZICCLOUDSYNCINGOBJECT o JOIN ZICNOTEDATA d ON o.ZNOTEDATA = d.Z_PK
+            WHERE o.ZISPASSWORDPROTECTED IS NOT 1 AND o.ZMARKEDFORDELETION IS NOT 1
+            ORDER BY created DESC LIMIT \(Self.maxNotes)
+            """) { r in
+            guard let id = r.text(0) else { return }
+            guard let blob = r.blob(4), let decoded = Self.decodeBody(blob) else { return }   // fail-closed
+            let body = decoded.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !body.isEmpty else { return }                                                 // attachment-only / blank
+
+            let title = r.text(1) ?? String(body.prefix(40))
+            let folder = folders[r.int(3)] ?? "Notes"
+            let created = Date(timeIntervalSinceReferenceDate: r.double(2))
+
+            out.append(Candidate(
+                id: "notes:\(id)", kind: .notes,
+                cursorKey: "notes", cursorValue: "",   // vestigial — the iterative core keys on ItemKey
+                itemDate: created,
+                metadata: [
+                    "folder": folder,
+                    "name": title,
+                    "displayPath": "Apple Notes · \(folder) · \(title)",
+                    "created": Self.dateString(created),
+                    "noteText": String(body.prefix(Self.maxContentChars)),
+                ]))
+        }
+        return out   // newest-created first (the SQL ORDER)
+    }
+
     // MARK: Body decode — gunzip, then protobuf fields 2 → 3 → 2
 
     /// ZICNOTEDATA.ZDATA → the note's plain text. nil = not decodable (skip the note).

--- a/Sentient OS macOS/Views/DevToolsView.swift
+++ b/Sentient OS macOS/Views/DevToolsView.swift
@@ -68,6 +68,13 @@ final class DevRunModel {
     var status: [String: String] = [:]      // action id → live/final line
 }
 
+/// Which connector the INITIAL/ITERATIVE buttons drive (one at a time, per the dev cockpit).
+enum DevConnector: String, CaseIterable, Identifiable {
+    case files = "Files"
+    case notes = "Apple Notes"
+    var id: String { rawValue }
+}
+
 struct DevToolsView: View {
     let store: Store
     @Binding var customRoots: [URL]
@@ -90,6 +97,7 @@ struct DevToolsView: View {
     @AppStorage("dbg.run.notes")     private var runNotes = false
 
     @State private var run = DevRunModel()
+    @State private var devConnector: DevConnector = .files
     @State private var showChatPicker = false
     @State private var showIMessagePicker = false
     @State private var showSummaries = false
@@ -131,6 +139,7 @@ struct DevToolsView: View {
                             .multilineTextAlignment(.center).fixedSize(horizontal: false, vertical: true)
                     }
 
+                    connectorPicker
                     columns
                     viewSummariesButton
                     moreSection
@@ -162,6 +171,19 @@ struct DevToolsView: View {
     }
 
     // MARK: The two columns
+
+    private var connectorPicker: some View {
+        VStack(spacing: 6) {
+            Text("ON-DEVICE CONNECTOR").font(.caption2.weight(.bold)).tracking(2).foregroundStyle(Theme.faint)
+            Picker("", selection: $devConnector) {
+                ForEach(DevConnector.allCases) { Text($0.rawValue).tag($0) }
+            }
+            .pickerStyle(.segmented).labelsHidden().frame(maxWidth: 320)
+            Text(devConnector == .notes ? "Runs all Apple Notes (needs Full Disk Access)."
+                                        : "Runs the selected file folders above.")
+                .font(.caption2).foregroundStyle(Theme.faint)
+        }
+    }
 
     private var columns: some View {
         HStack(alignment: .top, spacing: 16) {
@@ -247,10 +269,17 @@ struct DevToolsView: View {
 
     private func runOnDevice(mode: IterativeRun.Mode, progress: @escaping @Sendable (String) -> Void) async -> String {
         guard let mp = Self.modelPath else { return "✗ model not found" }
-        let roots = selectedFileRoots
-        guard !roots.isEmpty else { return "✗ select a file folder above" }
+        let connector: any Connector
+        switch devConnector {
+        case .files:
+            let roots = selectedFileRoots
+            guard !roots.isEmpty else { return "✗ select a file folder above" }
+            connector = FilesConnector(roots: roots)
+        case .notes:
+            guard fdaGranted else { return "✗ grant Full Disk Access (More ▾) for Notes" }
+            connector = NotesConnector()
+        }
         let runner = IterativeRun(modelPath: mp)
-        let connector = FilesConnector(roots: roots)
         let onProg: @Sendable (PipelineProgress) -> Void = { p in
             progress("… \(p.done)/\(p.total) · kept \(p.survivors)")
         }


### PR DESCRIPTION
**PR B** — the second connector. Apple Notes plugs into the generic core (PR A) with **no new engine/store/cloud code**.

- **`NotesSource.eligibleNotes()`** — query + gunzip/protobuf `decodeBody` + newest-1,000 cap, **no backfill**, keyed on **creation date** (edited notes are *not* re-summarized). Reuses the proven decoder.
- **`NotesConnector`** — single bucket `"notes"`, key `(createdDate, "notes:<uuid>")`, item = a note, **file** Triage prompt.
- **`DevToolsView`** — new **ON-DEVICE CONNECTOR** picker (Files / Apple Notes) routes the INITIAL/ITERATIVE buttons to the chosen connector (FDA-gated for Notes). "tell cloud" / proactive still operate on all of `CycleStore.notes()`.
- **`SENTIENT_SELFTEST=notesiter`** — structural checks against the live Notes DB (single bucket · all `.notes` · unique ids · non-empty bodies · keys ordered & newest-first · `load` decodes). Needs Full Disk Access; **skips gracefully** without it.

## Verify
`fileiter` **18/18** (no regression), build green. `notesiter` validates on a Mac with FDA granted to the build, or via the dev button (the headless binary launched from a shell doesn't inherit FDA). Untouched: home, old belt, WhatsApp/iMessage.

**Next:** PR C — `ChatConnector` (WhatsApp + iMessage, per-chat buckets, `(rowID, "")`, reuse `ChatWindowing`).