### PR TITLE
ChatConnector: WhatsApp + iMessage on the iterative core (PR C)

### DIFF
--- a/Sentient OS macOS/Documentation/Iterative Core (Connectors).md
+++ b/Sentient OS macOS/Documentation/Iterative Core (Connectors).md
@@ -52,8 +52,15 @@ Connector-agnostic; operates on `CycleStore.notes()` regardless of source (`Clou
   key `(createdDate, "notes:<uuid>")`, item = a note; wraps `NotesSource.eligibleNotes` (reuses the
   gunzip/protobuf `decodeBody`). **Created-date** key ⇒ edited notes are **not** re-summarized.
   Needs Full Disk Access.
-- **ChatConnector** (next) — per chat (`whatsapp:<jid>` / `imessage:<guid>`), key `(rowID, "")`,
-  item = a `ChatWindowing` window; reuse `ChatWindowing` / `SQLiteDB` / `AddressBookNames`.
+- **`WhatsAppConnector` / `iMessageConnector`** (`Ingestion/Connectors/ChatConnectors.swift`) ✅ —
+  per chat (`whatsapp:<jid>` / `imessage:<guid>`), key `(rowID, "")` (row id is unique + monotonic →
+  no tiebreak), item = a `ChatWindowing` window (so `maxTokens` 16384), chat Triage prompt (DM vs
+  group). Wrap each source's `eligibleWindows()` (reuses `ChatWindowing` / `SQLiteDB` /
+  `AddressBookNames` / the typedstream decode). Per-chat opt-in via the dev picker's chat selection.
+
+All three on-device source families now run on the core. **Remaining (out of scope here):** rewire
+the home's Analyze Now to `IterativeRun`, add the scheduler, then delete the old belt
+(`DataSource`/`Pipeline`/old `Store` + the sources' `scan` paths). Gmail/Calendar are the later cloud family.
 
 The dev cockpit (`DevToolsView`) has an **ON-DEVICE CONNECTOR** picker (Files / Apple Notes) that
 routes the INITIAL/ITERATIVE buttons to the chosen connector. "tell cloud" / proactive operate on
@@ -70,5 +77,8 @@ all of `CycleStore.notes()` regardless of connector.
 `SENTIENT_SELFTEST=fileiter` — deterministic, no model/codex: ItemKey tiebreak · the newer-than-mark
 partition (twin at the boundary) · CycleStore round-trip · `FilesConnector.buckets` skip/keep.
 `SENTIENT_SELFTEST=notesiter` — runs the real `NotesConnector` against the live Notes DB (structural
-invariants); needs Full Disk Access (skips gracefully without it). Engine-driven + cloud end-to-end
-is exercised via the dev buttons on real folders / Apple Notes.
+invariants); needs Full Disk Access (skips gracefully without it).
+`SENTIENT_SELFTEST=chatiter` — runs the real WhatsApp + iMessage connectors over all chats (per-chat
+buckets · right kind · windows have text · keys unique + newest-first per chat); WhatsApp's group
+container is readable without FDA (validated on 77 chats / 237 windows), iMessage's `chat.db` needs
+FDA. Engine-driven + cloud end-to-end is exercised via the dev buttons.

--- a/Sentient OS macOS/Ingestion/Connectors/ChatConnectors.swift
+++ b/Sentient OS macOS/Ingestion/Connectors/ChatConnectors.swift
@@ -1,0 +1,39 @@
+//
+//  ChatConnectors.swift
+//  Sentient OS macOS
+//
+//  WhatsApp + iMessage adapters for the iterative core — one shape: per-chat buckets
+//  ("whatsapp:<jid>" / "imessage:<guid>"), key `(rowID, "")` (the message row id is unique +
+//  monotonic, so no tiebreak), item = a `ChatWindowing` window through the chat Triage prompt
+//  (DM vs group via the `isGroup` metadata). Big windows ⇒ `maxTokens` 16384. They wrap each
+//  source's `eligibleWindows()` (which reuses the existing windowing / name-resolution / decode).
+//  Per-chat opt-in via the JIDs/GUIDs the dev picker supplies. Require Full Disk Access.
+//
+
+import Foundation
+
+struct WhatsAppConnector: Connector {
+    let kind = SourceKind.whatsapp
+    let chatJIDs: Set<String>
+    var maxTokens: Int { 16384 }
+
+    func buckets(since marks: [String: ItemKey]) throws -> [Bucket] {
+        try WhatsAppSource(chatJIDs: chatJIDs).eligibleWindows()
+    }
+    func load(_ item: Candidate) throws -> Artifact {
+        Artifact(candidate: item, text: item.metadata["windowText"] ?? "")
+    }
+}
+
+struct iMessageConnector: Connector {
+    let kind = SourceKind.imessage
+    let chatGUIDs: Set<String>
+    var maxTokens: Int { 16384 }
+
+    func buckets(since marks: [String: ItemKey]) throws -> [Bucket] {
+        try iMessageSource(chatGUIDs: chatGUIDs).eligibleWindows()
+    }
+    func load(_ item: Candidate) throws -> Artifact {
+        Artifact(candidate: item, text: item.metadata["windowText"] ?? "")
+    }
+}

--- a/Sentient OS macOS/Self Tests - Temp/SelfTest_ChatIter.swift
+++ b/Sentient OS macOS/Self Tests - Temp/SelfTest_ChatIter.swift
@@ -1,0 +1,56 @@
+//
+//  SelfTest_ChatIter.swift
+//  Sentient OS macOS
+//
+//  SENTIENT_SELFTEST=chatiter — runs the REAL WhatsApp + iMessage connectors against the live DBs
+//  (over ALL chats) and checks structural invariants: per-chat buckets keyed by source, every item
+//  the right kind, every window has text, keys unique + newest-first within each chat, load() returns
+//  the window text. Needs Full Disk Access + some chats; reports "skipped" gracefully without them.
+//  (The generic core — ItemKey/CycleStore/partition — is covered by `fileiter`.)
+//
+
+import Foundation
+
+enum SelfTestChatIter {
+
+    static func run(emit: (String) -> Void) async {
+        var passed = 0, failed = 0
+        func check(_ label: String, _ cond: Bool) {
+            if cond { passed += 1; emit("  ✓ \(label)") }
+            else { failed += 1; emit("  ✗ FAIL — \(label)") }
+        }
+
+        emit("=== chatiter: WhatsApp + iMessage connectors against the live DBs ===")
+        validate("WhatsApp", prefix: "whatsapp:", kind: .whatsapp, check: check, emit: emit) {
+            let jids = Set((try WhatsAppSource().listChats()).map(\.id))
+            return try WhatsAppConnector(chatJIDs: jids).buckets(since: [:])
+        }
+        validate("iMessage", prefix: "imessage:", kind: .imessage, check: check, emit: emit) {
+            let guids = Set((try iMessageSource().listChats()).map(\.id))
+            return try iMessageConnector(chatGUIDs: guids).buckets(since: [:])
+        }
+        emit("\n=== chatiter: \(passed) passed · \(failed) failed ===")
+    }
+
+    private static func validate(_ name: String, prefix: String, kind: SourceKind,
+                                 check: (String, Bool) -> Void, emit: (String) -> Void,
+                                 buckets: () throws -> [Bucket]) {
+        let bs: [Bucket]
+        do { bs = try buckets() }
+        catch { emit("  ⚠️ \(name): couldn't read (Full Disk Access?) — \(error). Skipping."); return }
+
+        let items = bs.flatMap { $0.items }
+        emit("  \(name): \(bs.count) chats · \(items.count) windows")
+        guard !items.isEmpty else { emit("  (\(name): 0 windows — no opted chats / no FDA / empty.)"); return }
+
+        check("\(name): bucket keys are \(prefix)<id>", bs.allSatisfy { $0.key.hasPrefix(prefix) })
+        check("\(name): every item kind == .\(kind)", items.allSatisfy { $0.item.kind == kind })
+        check("\(name): every window has text", items.allSatisfy { !($0.item.metadata["windowText"] ?? "").isEmpty })
+        check("\(name): per-chat keys unique + newest-first", bs.allSatisfy { b in
+            let ks = b.items.map(\.key)
+            let unique = Set(ks).count == ks.count
+            let descending = zip(ks, ks.dropFirst()).allSatisfy { $0.0 > $0.1 }
+            return unique && descending
+        })
+    }
+}

--- a/Sentient OS macOS/Self Tests - Temp/SelfTest_Triage_Pipeline_and_Vault.swift
+++ b/Sentient OS macOS/Self Tests - Temp/SelfTest_Triage_Pipeline_and_Vault.swift
@@ -98,6 +98,9 @@ enum SelfTest {
         // NotesConnector against the live Notes DB — structural invariants (needs Full Disk Access).
         if mode == "notesiter" { await SelfTestNotesIter.run(emit: emit); return }
 
+        // WhatsApp + iMessage connectors against the live DBs — structural invariants (needs FDA).
+        if mode == "chatiter" { await SelfTestChatIter.run(emit: emit); return }
+
         // CodexCLI mode: no model needed — discovery, ping, and one tiny run through the REAL
         // codex exec spine (binary → env → stdin → JSONL envelope). Verifies the compute
         // waterfall's tier-1 path end to end on this Mac.

--- a/Sentient OS macOS/Sources/WhatsAppSource.swift
+++ b/Sentient OS macOS/Sources/WhatsAppSource.swift
@@ -239,6 +239,71 @@ struct WhatsAppSource: DataSource, Sendable {
         Artifact(candidate: candidate, text: candidate.metadata["windowText"] ?? "")
     }
 
+    // MARK: Eligible windows (the iterative system's flat, pointer-free view)
+
+    /// Current conversation windows per opted-in chat, for the iterative system (WhatsAppConnector).
+    /// Same DB read + windowing + caps (100k/90-day) + tail hold-back as `scan`, but with NO cursor/
+    /// backfill — IterativeRun's per-chat pointer (highest message Z_PK) decides new-vs-done. One
+    /// bucket per chat ("whatsapp:<jid>"); each window keyed by its last (max) Z_PK; newest-first.
+    /// (Reuses the static helpers + ChatWindowing; the read overlaps `scan` until the old path retires.)
+    func eligibleWindows() throws -> [Bucket] {
+        let (dbURL, tempDir) = try SQLiteDB.walSafeCopy(of: dbPath)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let reader = try SQLiteReader(path: dbURL.path)
+
+        let members = Self.activeMemberNames(reader)
+        var chats: [Int64: Chat] = [:]
+        try reader.forEachRow("SELECT s.Z_PK, s.ZPARTNERNAME, s.ZCONTACTJID FROM ZWACHATSESSION s WHERE \(Self.sessionFilter)") { r in
+            let jid = r.text(2) ?? ""
+            chats[r.int(0)] = Chat(pk: r.int(0), jid: jid,
+                                   name: Self.displayName(r.text(1), jid: jid, members: members[r.int(0)]),
+                                   isGroup: jid.hasSuffix("@g.us"))
+        }
+        let analyzedPKs = chats.values.filter { chatJIDs == nil || chatJIDs!.contains($0.jid) }.map(\.pk)
+        guard !analyzedPKs.isEmpty else { return [] }
+
+        let tailFloor = Date().addingTimeInterval(-sourceFreshnessHoldBack).timeIntervalSinceReferenceDate
+        let floor = ChatWindowing.lookbackFloor.timeIntervalSinceReferenceDate
+        var byChat: [Int64: [ChatMessage]] = [:]
+        try reader.forEachRow("""
+            SELECT m.Z_PK, m.ZMESSAGEDATE, m.ZISFROMME, m.ZTEXT, m.ZPUSHNAME, m.ZCHATSESSION, gm.ZCONTACTNAME, gm.ZFIRSTNAME
+            FROM (SELECT * FROM ZWAMESSAGE
+                  WHERE ZTEXT IS NOT NULL AND length(ZTEXT) > 0 AND ZMESSAGEDATE >= \(floor)
+                        AND ZCHATSESSION IN (\(analyzedPKs.sorted().map(String.init).joined(separator: ",")))
+                  ORDER BY ZMESSAGEDATE DESC LIMIT \(ChatWindowing.maxMessages)) m
+            LEFT JOIN ZWAGROUPMEMBER gm ON m.ZGROUPMEMBER = gm.Z_PK
+            ORDER BY m.ZCHATSESSION, m.Z_PK
+            """) { r in
+            guard let chat = chats[r.int(5)] else { return }
+            guard r.double(1) <= tailFloor else { return }                   // tail hold-back
+            let isFromMe = r.int(2) == 1
+            byChat[r.int(5), default: []].append(ChatMessage(
+                id: r.int(0),
+                date: Date(timeIntervalSinceReferenceDate: r.double(1)),
+                sender: isFromMe ? "Me" : Self.sender(pushName: r.text(4), memberName: r.text(6) ?? r.text(7), chat: chat),
+                isFromMe: isFromMe,
+                text: String((r.text(3) ?? "").prefix(ChatWindowing.maxMessageChars))))
+        }
+
+        return byChat.compactMap { (chatPK, msgs) -> Bucket? in
+            guard let chat = chats[chatPK] else { return nil }
+            let items = ChatWindowing.windows(of: msgs).filter { !$0.isEmpty }.map { win -> (key: ItemKey, item: Candidate) in
+                let cand = Candidate(
+                    id: "whatsapp:c\(chatPK):\(win.first!.id)-\(win.last!.id)", kind: .whatsapp,
+                    cursorKey: "whatsapp:\(chat.jid)", cursorValue: "",   // vestigial — core keys on ItemKey
+                    itemDate: win.last!.date,
+                    metadata: [
+                        "folder": chat.name, "name": chat.name,
+                        "displayPath": "WhatsApp · \(chat.name)",
+                        "isGroup": chat.isGroup ? "1" : "0", "msgCount": "\(win.count)",
+                        "windowText": ChatWindowing.format(chatName: chat.name, isGroup: chat.isGroup, messages: win),
+                    ])
+                return (key: ItemKey(rowID: win.last!.id), item: cand)
+            }
+            return items.isEmpty ? nil : Bucket(key: "whatsapp:\(chat.jid)", items: items.sorted { $0.key > $1.key })
+        }
+    }
+
     // MARK: Sender labels
 
     private static func sender(pushName: String?, memberName: String?, chat: Chat) -> String {

--- a/Sentient OS macOS/Sources/iMessageSource.swift
+++ b/Sentient OS macOS/Sources/iMessageSource.swift
@@ -240,6 +240,68 @@ struct iMessageSource: DataSource, Sendable {
         Artifact(candidate: candidate, text: candidate.metadata["windowText"] ?? "")
     }
 
+    // MARK: Eligible windows (the iterative system's flat, pointer-free view)
+
+    /// Current conversation windows per opted-in chat, for the iterative system (iMessageConnector).
+    /// Same DB read + typedstream decode + windowing + caps + tail hold-back as `scan`, but with NO
+    /// cursor/backfill — IterativeRun's per-chat pointer (highest ROWID) decides new-vs-done. One
+    /// bucket per chat ("imessage:<guid>"); each window keyed by its last (max) ROWID; newest-first.
+    func eligibleWindows() throws -> [Bucket] {
+        let (dbURL, tempDir) = try SQLiteDB.walSafeCopy(of: dbPath)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let reader = try SQLiteReader(path: dbURL.path)
+
+        let chats = try Self.chats(reader)
+        let contacts = AddressBookNames.loadMap()
+        let analyzedROWIDs = chats.values.filter { chatGUIDs == nil || chatGUIDs!.contains($0.guid) }.map(\.rowid)
+        guard !analyzedROWIDs.isEmpty else { return [] }
+
+        let tailFloorNS = Int64(Date().addingTimeInterval(-sourceFreshnessHoldBack)
+            .timeIntervalSinceReferenceDate * 1e9)
+        var byChat: [Int64: [ChatMessage]] = [:]
+        try reader.forEachRow("""
+            SELECT m.ROWID, m.date, m.is_from_me, m.text, m.attributedBody, m.chat_id, h.id
+            FROM (SELECT message.ROWID, date, is_from_me, text, attributedBody, handle_id, cmj.chat_id
+                  FROM message JOIN chat_message_join cmj ON cmj.message_id = message.ROWID
+                  WHERE date >= \(Self.floorNS) AND \(Self.messageFilter)
+                        AND cmj.chat_id IN (\(analyzedROWIDs.sorted().map(String.init).joined(separator: ",")))
+                  ORDER BY date DESC LIMIT \(ChatWindowing.maxMessages)) m
+            LEFT JOIN handle h ON h.ROWID = m.handle_id
+            ORDER BY m.chat_id, m.ROWID
+            """) { r in
+            guard let chat = chats[r.int(5)] else { return }
+            guard r.int(1) <= tailFloorNS else { return }                       // tail hold-back
+            let body = r.text(3) ?? r.blob(4).flatMap(Self.typedstreamText)
+            guard let body, !body.trimmingCharacters(in: .whitespaces).isEmpty else { return }
+            let isFromMe = r.int(2) == 1
+            let sender: String
+            if isFromMe { sender = "Me" }
+            else if chat.isGroup { sender = Self.resolved(r.text(6) ?? "", contacts) }
+            else { sender = chat.name }
+            byChat[r.int(5), default: []].append(ChatMessage(
+                id: r.int(0), date: Self.date(fromAppleNS: r.int(1)), sender: sender,
+                isFromMe: isFromMe, text: String(body.prefix(ChatWindowing.maxMessageChars))))
+        }
+
+        return byChat.compactMap { (chatROWID, msgs) -> Bucket? in
+            guard let chat = chats[chatROWID] else { return nil }
+            let items = ChatWindowing.windows(of: msgs).filter { !$0.isEmpty }.map { win -> (key: ItemKey, item: Candidate) in
+                let cand = Candidate(
+                    id: "imessage:c\(chatROWID):\(win.first!.id)-\(win.last!.id)", kind: .imessage,
+                    cursorKey: "imessage:\(chat.guid)", cursorValue: "",   // vestigial — core keys on ItemKey
+                    itemDate: win.last!.date,
+                    metadata: [
+                        "folder": chat.name, "name": chat.name,
+                        "displayPath": "iMessage · \(chat.name)",
+                        "isGroup": chat.isGroup ? "1" : "0", "msgCount": "\(win.count)",
+                        "windowText": ChatWindowing.format(chatName: chat.name, isGroup: chat.isGroup, messages: win),
+                    ])
+                return (key: ItemKey(rowID: win.last!.id), item: cand)
+            }
+            return items.isEmpty ? nil : Bucket(key: "imessage:\(chat.guid)", items: items.sorted { $0.key > $1.key })
+        }
+    }
+
     // MARK: The typedstream heuristic — deliberately NOT a full parser (Arch §4)
 
     /// Extract the message body from an `attributedBody` typedstream blob: find the NSString /

--- a/Sentient OS macOS/Views/DevToolsView.swift
+++ b/Sentient OS macOS/Views/DevToolsView.swift
@@ -72,6 +72,8 @@ final class DevRunModel {
 enum DevConnector: String, CaseIterable, Identifiable {
     case files = "Files"
     case notes = "Apple Notes"
+    case whatsapp = "WhatsApp"
+    case imessage = "iMessage"
     var id: String { rawValue }
 }
 
@@ -172,6 +174,14 @@ struct DevToolsView: View {
 
     // MARK: The two columns
 
+    private var connectorHint: String {
+        switch devConnector {
+        case .files: return "Runs the selected file folders above."
+        case .notes: return "Runs all Apple Notes (needs Full Disk Access)."
+        case .whatsapp, .imessage: return "Runs the selected \(devConnector.rawValue) chats above (needs Full Disk Access)."
+        }
+    }
+
     private var connectorPicker: some View {
         VStack(spacing: 6) {
             Text("ON-DEVICE CONNECTOR").font(.caption2.weight(.bold)).tracking(2).foregroundStyle(Theme.faint)
@@ -179,9 +189,7 @@ struct DevToolsView: View {
                 ForEach(DevConnector.allCases) { Text($0.rawValue).tag($0) }
             }
             .pickerStyle(.segmented).labelsHidden().frame(maxWidth: 320)
-            Text(devConnector == .notes ? "Runs all Apple Notes (needs Full Disk Access)."
-                                        : "Runs the selected file folders above.")
-                .font(.caption2).foregroundStyle(Theme.faint)
+            Text(connectorHint).font(.caption2).foregroundStyle(Theme.faint)
         }
     }
 
@@ -278,6 +286,16 @@ struct DevToolsView: View {
         case .notes:
             guard fdaGranted else { return "✗ grant Full Disk Access (More ▾) for Notes" }
             connector = NotesConnector()
+        case .whatsapp:
+            guard fdaGranted else { return "✗ grant Full Disk Access (More ▾) for WhatsApp" }
+            let jids = selectedChatJIDs
+            guard !jids.isEmpty else { return "✗ pick WhatsApp chats (chip above)" }
+            connector = WhatsAppConnector(chatJIDs: jids)
+        case .imessage:
+            guard fdaGranted else { return "✗ grant Full Disk Access (More ▾) for iMessage" }
+            let guids = selectedIMessageGUIDs
+            guard !guids.isEmpty else { return "✗ pick iMessage chats (chip above)" }
+            connector = iMessageConnector(chatGUIDs: guids)
         }
         let runner = IterativeRun(modelPath: mp)
         let onProg: @Sendable (PipelineProgress) -> Void = { p in


### PR DESCRIPTION
**PR C** — the last on-device connector family. WhatsApp + iMessage plug into the generic core (PR A) with **no new engine/store/cloud code** — one shape: per-chat buckets, `(rowID, "")` key, **window = item**.

- **`WhatsAppSource.eligibleWindows()` / `iMessageSource.eligibleWindows()`** — same DB read + `ChatWindowing` + caps (100k/90-day) + tail hold-back as `scan`, but **no cursor/backfill** (IterativeRun's per-chat rowID pointer decides new-vs-done). Each window keyed by its last (max) rowID; one bucket per chat; newest-first. Reuses every existing helper (windowing, name resolution, typedstream decode).
- **`WhatsAppConnector` / `iMessageConnector`** — thin adapters; `maxTokens` 16384 (big windows).
- **`DevToolsView`** — connector picker gains WhatsApp + iMessage (FDA-gated; uses the existing chat pickers + selections).
- **`SENTIENT_SELFTEST=chatiter`** — structural checks against the live DBs (per-chat buckets · right kind · windows have text · keys unique + newest-first per chat).

## Verify
- `fileiter` **18/18** (no regression), build green.
- `chatiter`: **WhatsApp validated on real data — 77 chats / 237 windows, all checks pass** (its group container reads without FDA). iMessage skips gracefully without FDA (validates on a Mac with it / via the dev button).

All three on-device source families now run on the core. **Out of scope (future):** rewire the home's Analyze Now to `IterativeRun`, add the scheduler, then delete the old belt. Gmail/Calendar are the later cloud family.