### PR TITLE
Dev UI cleanup: one selection surface, no hold-back, initial wipes the vault

### DIFF
--- a/Sentient OS macOS/Ingestion/IterativeRun.swift
+++ b/Sentient OS macOS/Ingestion/IterativeRun.swift
@@ -26,21 +26,24 @@ struct IterativeRun {
     private static let maxReloadsWithoutProgress = 4
 
     @discardableResult
-    func runInitial(_ connector: any Connector,
+    func runInitial(_ connectors: [any Connector],
                     onProgress: @Sendable @escaping (PipelineProgress) -> Void = { _ in }) async -> PipelineProgress {
-        await run(connector, mode: .initial, onProgress: onProgress)
+        await run(connectors, mode: .initial, onProgress: onProgress)
     }
 
     @discardableResult
-    func runIterative(_ connector: any Connector,
+    func runIterative(_ connectors: [any Connector],
                       onProgress: @Sendable @escaping (PipelineProgress) -> Void = { _ in }) async -> PipelineProgress {
-        await run(connector, mode: .iterative, onProgress: onProgress)
+        await run(connectors, mode: .iterative, onProgress: onProgress)
     }
 
-    private func run(_ connector: any Connector, mode: Mode,
+    /// Runs each connector's buckets through ONE engine (sized to the biggest connector). The dev
+    /// buttons pass every selected source at once; per-connector load + kind ride along per bucket.
+    private func run(_ connectors: [any Connector], mode: Mode,
                      onProgress: @Sendable @escaping (PipelineProgress) -> Void) async -> PipelineProgress {
         var p = PipelineProgress()
-        let engine = Engine(modelPath: modelPath, maxNumTokens: connector.maxTokens)
+        guard !connectors.isEmpty else { return p }
+        let engine = Engine(modelPath: modelPath, maxNumTokens: connectors.map(\.maxTokens).max() ?? 4096)
         do { try await engine.load() } catch {
             Log("IterativeRun: engine load failed — \(error)")
             return p
@@ -60,7 +63,7 @@ struct IterativeRun {
         }
 
         // One full attempt at one item: load → generate → decide → (survivor ⇒ recordNote).
-        func attempt(_ cand: Candidate, bucketKey: String) async -> Bool {
+        func attempt(_ cand: Candidate, connector: any Connector, bucketKey: String) async -> Bool {
             do {
                 let artifact = try autoreleasepool { try connector.load(cand) }
                 let result = try await engine.generate(
@@ -99,58 +102,62 @@ struct IterativeRun {
         // Initial wants everything (we clear + reprocess) → pass [:]. Iterative passes the real
         // marks so connectors can query efficiently; the run still filters/advances authoritatively.
         let marks = mode == .initial ? [:] : await store.allPointers()
-        let buckets: [Bucket]
-        do { buckets = try connector.buckets(since: marks) }
-        catch { Log("IterativeRun: buckets() failed — \(error)"); await engine.unload(); return p }
 
-        bucketLoop: for bucket in buckets {
+        runLoop: for connector in connectors {
             if Task.isCancelled { break }
-            let work: [(key: ItemKey, item: Candidate)]
-            switch mode {
-            case .initial:
-                await store.clearBucket(bucket.key)
-                work = bucket.items                                            // newest → oldest
-            case .iterative:
-                guard let mark = await store.pointer(bucket.key) else {
-                    Log("IterativeRun: \(bucket.key) has no pointer — run initial first; skipping.")
-                    continue
-                }
-                work = bucket.items.filter { $0.key > mark }.sorted { $0.key < $1.key }   // oldest → newest
-            }
+            let buckets: [Bucket]
+            do { buckets = try connector.buckets(since: marks) }
+            catch { Log("IterativeRun: buckets() failed for \(connector.kind) — \(error)"); continue }
 
-            p.total += work.count
-            onProgress(p)
-
-            var finished = true
-            for w in work {
-                if Task.isCancelled { finished = false; break bucketLoop }
-                if sinceReload >= Self.preemptiveReloadEvery { await reloadEngine() }
-
-                p.lastPath = w.item.metadata["displayPath"] ?? w.item.metadata["name"]
-                p.lastFilePath = w.item.metadata["path"]
-
-                var ok = await attempt(w.item, bucketKey: bucket.key)
-                if !ok {
-                    consecutiveFailures += 1
-                    if consecutiveFailures >= Self.failuresBeforeReload {
-                        guard reloadsWithoutProgress < Self.maxReloadsWithoutProgress else {
-                            Log("IterativeRun: engine not recovering after \(reloadsWithoutProgress) reloads — stopping.")
-                            finished = false; break bucketLoop
-                        }
-                        await reloadEngine(); reloadsWithoutProgress += 1; consecutiveFailures = 0
-                        ok = await attempt(w.item, bucketKey: bucket.key)
+            for bucket in buckets {
+                if Task.isCancelled { break runLoop }
+                let work: [(key: ItemKey, item: Candidate)]
+                switch mode {
+                case .initial:
+                    await store.clearBucket(bucket.key)
+                    work = bucket.items                                            // newest → oldest
+                case .iterative:
+                    guard let mark = await store.pointer(bucket.key) else {
+                        Log("IterativeRun: \(bucket.key) has no pointer — run initial first; skipping.")
+                        continue
                     }
+                    work = bucket.items.filter { $0.key > mark }.sorted { $0.key < $1.key }   // oldest → newest
                 }
-                if ok { consecutiveFailures = 0; reloadsWithoutProgress = 0 } else { p.failed += 1 }
 
-                if mode == .iterative { await store.setPointer(bucket.key, w.key) }   // climb per item
-                sinceReload += 1; p.done += 1
+                p.total += work.count
                 onProgress(p)
-            }
 
-            // INITIAL completed this bucket's full descent → everything ≤ newest is done → set mark.
-            if mode == .initial, finished, let newest = bucket.items.first?.key {
-                await store.setPointer(bucket.key, newest)
+                var finished = true
+                for w in work {
+                    if Task.isCancelled { finished = false; break runLoop }
+                    if sinceReload >= Self.preemptiveReloadEvery { await reloadEngine() }
+
+                    p.lastPath = w.item.metadata["displayPath"] ?? w.item.metadata["name"]
+                    p.lastFilePath = w.item.metadata["path"]
+
+                    var ok = await attempt(w.item, connector: connector, bucketKey: bucket.key)
+                    if !ok {
+                        consecutiveFailures += 1
+                        if consecutiveFailures >= Self.failuresBeforeReload {
+                            guard reloadsWithoutProgress < Self.maxReloadsWithoutProgress else {
+                                Log("IterativeRun: engine not recovering after \(reloadsWithoutProgress) reloads — stopping.")
+                                finished = false; break runLoop
+                            }
+                            await reloadEngine(); reloadsWithoutProgress += 1; consecutiveFailures = 0
+                            ok = await attempt(w.item, connector: connector, bucketKey: bucket.key)
+                        }
+                    }
+                    if ok { consecutiveFailures = 0; reloadsWithoutProgress = 0 } else { p.failed += 1 }
+
+                    if mode == .iterative { await store.setPointer(bucket.key, w.key) }   // climb per item
+                    sinceReload += 1; p.done += 1
+                    onProgress(p)
+                }
+
+                // INITIAL completed this bucket's full descent → everything ≤ newest done → set mark.
+                if mode == .initial, finished, let newest = bucket.items.first?.key {
+                    await store.setPointer(bucket.key, newest)
+                }
             }
         }
         await engine.unload()

--- a/Sentient OS macOS/Self Tests - Temp/SelfTest_FileSkipping.swift
+++ b/Sentient OS macOS/Self Tests - Temp/SelfTest_FileSkipping.swift
@@ -23,8 +23,7 @@ enum SelfTestFileSkipping {
         // stamps "now"), and just-created files would all be freshness-held-back. Dates in this
         // harness are therefore mtime-only, with no hold-back.
         FilesSource.testIgnoreDateAdded = true
-        FilesSource.testZeroHoldBack = true
-        defer { FilesSource.testIgnoreDateAdded = false; FilesSource.testZeroHoldBack = false }
+        defer { FilesSource.testIgnoreDateAdded = false }
 
         let fm = FileManager.default
         var base = URL(fileURLWithPath: NSTemporaryDirectory())

--- a/Sentient OS macOS/Self Tests - Temp/SelfTest_Incremental.swift
+++ b/Sentient OS macOS/Self Tests - Temp/SelfTest_Incremental.swift
@@ -29,8 +29,7 @@ enum SelfTestIncremental {
 
     static func run(emit: (String) -> Void) async {
         FilesSource.testIgnoreDateAdded = true
-        FilesSource.testZeroHoldBack = true
-        defer { FilesSource.testIgnoreDateAdded = false; FilesSource.testZeroHoldBack = false }
+        defer { FilesSource.testIgnoreDateAdded = false }
 
         let fm = FileManager.default
         var base = URL(fileURLWithPath: NSTemporaryDirectory())

--- a/Sentient OS macOS/Sources/DataSource.swift
+++ b/Sentient OS macOS/Sources/DataSource.swift
@@ -31,17 +31,6 @@ enum SourceKind: String, Codable, Sendable, CaseIterable {
     case notes
 }
 
-/// Freshness hold-back shared by every source: items newer than this are left for the NEXT
-/// run, so a document mid-editing-session / an actively-flowing conversation / a note being
-/// typed isn't summarized between keystrokes. Pointers never advance past `now − holdBack`
-/// by construction (held-back items are never candidates).
-///
-/// ⚠️ TEMPORARILY 2 minutes (June 12, for dogfooding) — so a freshly-added file/message is
-/// eligible almost immediately when you click Analyze, instead of after an hour, while still
-/// skipping something you're actively mid-edit on. RESTORE `3_600` before launch (or make it a
-/// Settings toggle): the hold-back is what stops us summarizing a doc mid-edit or a
-/// conversation mid-sentence.
-let sourceFreshnessHoldBack: TimeInterval = 120
 
 /// Cheap unit produced by `scan` — enough to order and process without reading content.
 /// `metadata` carries light context (displayPath, name, created…).

--- a/Sentient OS macOS/Sources/FilesSource.swift
+++ b/Sentient OS macOS/Sources/FilesSource.swift
@@ -17,8 +17,7 @@
 //  A file's date is max(dateAdded, dateModified, nearest moved-in ancestor's dateAdded) —
 //  dateAdded catches downloads with old mtimes, dateModified catches edits, and the ancestor
 //  propagation catches whole folders dragged into a root (their files keep old dates).
-//  Guards: 60-min freshness hold-back (mid-edit files wait for the next run) and a future-date
-//  clamp (clock weirdness can't poison the pointer). Ordering: incremental runs ascend
+//  Guards: a future-date clamp (clock weirdness can't poison the pointer). Ordering: incremental runs ascend
 //  (oldest-first); a root's FIRST run (no pointer yet) is a BACKFILL — newest-first descent
 //  tracked by a BackfillCursor [lo, hi] interval, resumable, with the root cap as a TOTAL
 //  budget across interruptions. New files arriving mid-backfill process before the dig resumes.
@@ -58,12 +57,9 @@ struct FilesSource: DataSource, Sendable {
     private static let pdfPageLimit = 3
     private static let imageMaxPixel = 1_280   // ≈ 720p short edge on 16:9
 
-    // Test seams (DEBUG self-tests only — production never touches these): fixtures can't
-    // backdate dateAdded on a real filesystem, so date-sensitive assertions couldn't run
-    // otherwise. `testIgnoreDateAdded` makes file dates mtime-only; `testZeroHoldBack`
-    // disables the freshness hold-back (just-created fixtures would all be held back).
+    // Test seam (DEBUG self-tests only — production never touches it): fixtures can't backdate
+    // dateAdded on a real filesystem, so `testIgnoreDateAdded` makes file dates mtime-only.
     nonisolated(unsafe) static var testIgnoreDateAdded = false
-    nonisolated(unsafe) static var testZeroHoldBack = false
 
     // MARK: Skipping (code repos / dependency caches / datasets — Spotlight-style)
 
@@ -191,7 +187,6 @@ struct FilesSource: DataSource, Sendable {
         let hiPointer = backfill.flatMap { Self.parsePointer($0.hi) }
         let loPointer = backfill.flatMap { Self.parsePointer($0.lo) }
         let now = Date()
-        let holdBack = Self.testZeroHoldBack ? now : now.addingTimeInterval(-sourceFreshnessHoldBack)
 
         let keys: Set<URLResourceKey> = [.isRegularFileKey, .isDirectoryKey,
                                          .contentModificationDateKey, .creationDateKey,
@@ -231,7 +226,6 @@ struct FilesSource: DataSource, Sendable {
             // file (clock weirdness) is treated as "now" instead of poisoning the pointer.
             let date = min(max(mtime, added, parentEff), now)
 
-            guard date <= holdBack else { continue }                          // freshness hold-back
             // Keep only rows the current pointer state could consume: incremental = past the
             // plain pointer; backfill resume = above hi OR below lo; backfill start = everything.
             let (d, p) = (date.timeIntervalSince1970, url.path)

--- a/Sentient OS macOS/Sources/NotesSource.swift
+++ b/Sentient OS macOS/Sources/NotesSource.swift
@@ -38,8 +38,7 @@ struct NotesSource: DataSource, Sendable {
 
     /// Pointer (June 11 rewrite + June 12 backfill): one cursor, key "notes", value
     /// "(modEpochSeconds|noteUUID)" (UUID = same-second tiebreak). An edited note's mod-date
-    /// moves past the pointer → it's re-summarized as a new version. The one-hour hold-back
-    /// keeps a note that's being typed out of the run. Ordering: incremental runs ascend; the
+    /// moves past the pointer → it's re-summarized as a new version. Ordering: incremental runs ascend; the
     /// FIRST run is a newest-first backfill descent (BackfillCursor, resumable, the newest-1000
     /// cap as a total budget) — notes edited mid-backfill jump above `hi` and process first.
     func scan(since cursors: [String: String]) throws -> ScanResult {
@@ -48,8 +47,6 @@ struct NotesSource: DataSource, Sendable {
         let pointer = backfill == nil ? Self.parsePointer(raw) : nil   // plain pointer (incremental)
         let hiPointer = backfill.flatMap { Self.parsePointer($0.hi) }
         let loPointer = backfill.flatMap { Self.parsePointer($0.lo) }
-        let holdBackFloor = Date().addingTimeInterval(-sourceFreshnessHoldBack)
-            .timeIntervalSinceReferenceDate
 
         let (dbURL, tempDir) = try SQLiteDB.walSafeCopy(of: dbPath)
         defer { try? FileManager.default.removeItem(at: tempDir) }   // delete the plaintext copy immediately
@@ -74,7 +71,6 @@ struct NotesSource: DataSource, Sendable {
             """) { r in
             guard let id = r.text(0) else { return }
             let modified = r.double(2)
-            guard modified <= holdBackFloor else { return }                       // being typed right now
             // Keep only rows the current pointer state could consume: incremental = past the
             // plain pointer; backfill resume = above hi OR below lo; backfill start = everything.
             if backfill != nil {

--- a/Sentient OS macOS/Sources/WhatsAppSource.swift
+++ b/Sentient OS macOS/Sources/WhatsAppSource.swift
@@ -12,7 +12,7 @@
 //  chat-flavored prompt). The model sees the chat name, DM-vs-group, and per-message sender.
 //
 //  Requires Full Disk Access (Permissions.swift). Incrementality: a per-chat Z_PK pointer
-//  ("whatsapp:<jid>" in SourceCursor) + a one-hour tail hold-back — the initial backfill and
+//  ("whatsapp:<jid>" in SourceCursor) — the initial backfill and
 //  the daily delta are the same scan. See Documentation/Pointer Architecture (Kill the Ledger).md.
 //
 
@@ -154,9 +154,6 @@ struct WhatsAppSource: DataSource, Sendable {
         for chat in chats.values {
             states[chat.pk] = ChatCursorState.decode(cursors["whatsapp:\(chat.jid)"])
         }
-        // Tail hold-back: an actively-flowing conversation isn't chopped mid-thought — the last
-        // hour's messages are windowed next run (they stay past the pointer until consumed).
-        let tailFloor = Date().addingTimeInterval(-sourceFreshnessHoldBack).timeIntervalSinceReferenceDate
 
         // Text messages within the limits (90-day floor AND newest-`maxMessages` cap over the
         // analyzed chats; the outer ORDER restores per-chat ascending iteration), oldest →
@@ -178,7 +175,6 @@ struct WhatsAppSource: DataSource, Sendable {
             fetched += 1
             guard let chat = chats[r.int(5)] else { return }
             guard states[chat.pk]?.wants(r.int(0)) ?? true else { return }   // already consumed
-            guard r.double(1) <= tailFloor else { return }                   // tail hold-back
             let isFromMe = r.int(2) == 1
             byChat[r.int(5), default: []].append(ChatMessage(
                 id: r.int(0),
@@ -242,7 +238,7 @@ struct WhatsAppSource: DataSource, Sendable {
     // MARK: Eligible windows (the iterative system's flat, pointer-free view)
 
     /// Current conversation windows per opted-in chat, for the iterative system (WhatsAppConnector).
-    /// Same DB read + windowing + caps (100k/90-day) + tail hold-back as `scan`, but with NO cursor/
+    /// Same DB read + windowing + caps (100k/90-day) as `scan`, but with NO cursor/
     /// backfill — IterativeRun's per-chat pointer (highest message Z_PK) decides new-vs-done. One
     /// bucket per chat ("whatsapp:<jid>"); each window keyed by its last (max) Z_PK; newest-first.
     /// (Reuses the static helpers + ChatWindowing; the read overlaps `scan` until the old path retires.)
@@ -262,7 +258,6 @@ struct WhatsAppSource: DataSource, Sendable {
         let analyzedPKs = chats.values.filter { chatJIDs == nil || chatJIDs!.contains($0.jid) }.map(\.pk)
         guard !analyzedPKs.isEmpty else { return [] }
 
-        let tailFloor = Date().addingTimeInterval(-sourceFreshnessHoldBack).timeIntervalSinceReferenceDate
         let floor = ChatWindowing.lookbackFloor.timeIntervalSinceReferenceDate
         var byChat: [Int64: [ChatMessage]] = [:]
         try reader.forEachRow("""
@@ -275,7 +270,6 @@ struct WhatsAppSource: DataSource, Sendable {
             ORDER BY m.ZCHATSESSION, m.Z_PK
             """) { r in
             guard let chat = chats[r.int(5)] else { return }
-            guard r.double(1) <= tailFloor else { return }                   // tail hold-back
             let isFromMe = r.int(2) == 1
             byChat[r.int(5), default: []].append(ChatMessage(
                 id: r.int(0),

--- a/Sentient OS macOS/Sources/iMessageSource.swift
+++ b/Sentient OS macOS/Sources/iMessageSource.swift
@@ -16,7 +16,7 @@
 //  Key methods: listChats() (picker rows) · scan(since:) · load(_:). Limits per ChatWindowing:
 //  90-day floor AND newest-100k cap. Tapbacks (associated_message_type != 0) and system items
 //  (item_type != 0) are filtered in SQL — they'd spam every window otherwise. Incrementality:
-//  a per-chat ROWID pointer ("imessage:<guid>" in SourceCursor) + a one-hour tail hold-back.
+//  a per-chat ROWID pointer ("imessage:<guid>" in SourceCursor).
 //
 
 import Foundation
@@ -127,7 +127,7 @@ struct iMessageSource: DataSource, Sendable {
 
     /// Pointer (June 11 rewrite + June 12 backfill): ONE cursor per opted-in chat — key
     /// "imessage:<guid>", value = the highest consumed `ROWID` (or a BackfillCursor while the
-    /// chat's first run is in flight) — plus a one-hour tail hold-back. Per-chat (not one
+    /// chat's first run is in flight). Per-chat (not one
     /// global ROWID pointer) because chats interleave in ROWID space; see WhatsAppSource.scan
     /// for the full rationale. Ordering: incremental windows ascend per chat; a chat's first
     /// run digs newest-window-first, with every chat's NEW windows emitted before any dig.
@@ -151,8 +151,6 @@ struct iMessageSource: DataSource, Sendable {
         for chat in chats.values {
             states[chat.rowid] = ChatCursorState.decode(cursors["imessage:\(chat.guid)"])
         }
-        let tailFloorNS = Int64(Date().addingTimeInterval(-sourceFreshnessHoldBack)
-            .timeIntervalSinceReferenceDate * 1e9)
 
         // Messages within the limits (90-day floor AND newest-`maxMessages` cap over the
         // analyzed chats; the outer ORDER restores per-chat ascending iteration), decoded
@@ -172,7 +170,6 @@ struct iMessageSource: DataSource, Sendable {
             fetched += 1
             guard let chat = chats[r.int(5)] else { return }
             guard states[chat.rowid]?.wants(r.int(0)) ?? true else { return }   // already consumed
-            guard r.int(1) <= tailFloorNS else { return }                       // tail hold-back
 
             let body = r.text(3) ?? r.blob(4).flatMap(Self.typedstreamText)
             guard let body, !body.trimmingCharacters(in: .whitespaces).isEmpty else { return }
@@ -243,7 +240,7 @@ struct iMessageSource: DataSource, Sendable {
     // MARK: Eligible windows (the iterative system's flat, pointer-free view)
 
     /// Current conversation windows per opted-in chat, for the iterative system (iMessageConnector).
-    /// Same DB read + typedstream decode + windowing + caps + tail hold-back as `scan`, but with NO
+    /// Same DB read + typedstream decode + windowing + caps as `scan`, but with NO
     /// cursor/backfill — IterativeRun's per-chat pointer (highest ROWID) decides new-vs-done. One
     /// bucket per chat ("imessage:<guid>"); each window keyed by its last (max) ROWID; newest-first.
     func eligibleWindows() throws -> [Bucket] {
@@ -256,8 +253,6 @@ struct iMessageSource: DataSource, Sendable {
         let analyzedROWIDs = chats.values.filter { chatGUIDs == nil || chatGUIDs!.contains($0.guid) }.map(\.rowid)
         guard !analyzedROWIDs.isEmpty else { return [] }
 
-        let tailFloorNS = Int64(Date().addingTimeInterval(-sourceFreshnessHoldBack)
-            .timeIntervalSinceReferenceDate * 1e9)
         var byChat: [Int64: [ChatMessage]] = [:]
         try reader.forEachRow("""
             SELECT m.ROWID, m.date, m.is_from_me, m.text, m.attributedBody, m.chat_id, h.id
@@ -270,7 +265,6 @@ struct iMessageSource: DataSource, Sendable {
             ORDER BY m.chat_id, m.ROWID
             """) { r in
             guard let chat = chats[r.int(5)] else { return }
-            guard r.int(1) <= tailFloorNS else { return }                       // tail hold-back
             let body = r.text(3) ?? r.blob(4).flatMap(Self.typedstreamText)
             guard let body, !body.trimmingCharacters(in: .whitespaces).isEmpty else { return }
             let isFromMe = r.int(2) == 1

--- a/Sentient OS macOS/Views/DevToolsView.swift
+++ b/Sentient OS macOS/Views/DevToolsView.swift
@@ -68,15 +68,6 @@ final class DevRunModel {
     var status: [String: String] = [:]      // action id → live/final line
 }
 
-/// Which connector the INITIAL/ITERATIVE buttons drive (one at a time, per the dev cockpit).
-enum DevConnector: String, CaseIterable, Identifiable {
-    case files = "Files"
-    case notes = "Apple Notes"
-    case whatsapp = "WhatsApp"
-    case imessage = "iMessage"
-    var id: String { rawValue }
-}
-
 struct DevToolsView: View {
     let store: Store
     @Binding var customRoots: [URL]
@@ -84,7 +75,6 @@ struct DevToolsView: View {
     var onStartAnalysis: () -> Void
 
     @Environment(\.dismiss) private var dismiss
-    @Environment(\.openWindow) private var openWindow
 
     private static let modelPath = ModelLocator.resolve()
 
@@ -99,7 +89,6 @@ struct DevToolsView: View {
     @AppStorage("dbg.run.notes")     private var runNotes = false
 
     @State private var run = DevRunModel()
-    @State private var devConnector: DevConnector = .files
     @State private var showChatPicker = false
     @State private var showIMessagePicker = false
     @State private var showSummaries = false
@@ -141,7 +130,6 @@ struct DevToolsView: View {
                             .multilineTextAlignment(.center).fixedSize(horizontal: false, vertical: true)
                     }
 
-                    connectorPicker
                     columns
                     viewSummariesButton
                     moreSection
@@ -173,25 +161,6 @@ struct DevToolsView: View {
     }
 
     // MARK: The two columns
-
-    private var connectorHint: String {
-        switch devConnector {
-        case .files: return "Runs the selected file folders above."
-        case .notes: return "Runs all Apple Notes (needs Full Disk Access)."
-        case .whatsapp, .imessage: return "Runs the selected \(devConnector.rawValue) chats above (needs Full Disk Access)."
-        }
-    }
-
-    private var connectorPicker: some View {
-        VStack(spacing: 6) {
-            Text("ON-DEVICE CONNECTOR").font(.caption2.weight(.bold)).tracking(2).foregroundStyle(Theme.faint)
-            Picker("", selection: $devConnector) {
-                ForEach(DevConnector.allCases) { Text($0.rawValue).tag($0) }
-            }
-            .pickerStyle(.segmented).labelsHidden().frame(maxWidth: 320)
-            Text(connectorHint).font(.caption2).foregroundStyle(Theme.faint)
-        }
-    }
 
     private var columns: some View {
         HStack(alignment: .top, spacing: 16) {
@@ -277,33 +246,32 @@ struct DevToolsView: View {
 
     private func runOnDevice(mode: IterativeRun.Mode, progress: @escaping @Sendable (String) -> Void) async -> String {
         guard let mp = Self.modelPath else { return "✗ model not found" }
-        let connector: any Connector
-        switch devConnector {
-        case .files:
-            let roots = selectedFileRoots
-            guard !roots.isEmpty else { return "✗ select a file folder above" }
-            connector = FilesConnector(roots: roots)
-        case .notes:
-            guard fdaGranted else { return "✗ grant Full Disk Access (More ▾) for Notes" }
-            connector = NotesConnector()
-        case .whatsapp:
-            guard fdaGranted else { return "✗ grant Full Disk Access (More ▾) for WhatsApp" }
-            let jids = selectedChatJIDs
-            guard !jids.isEmpty else { return "✗ pick WhatsApp chats (chip above)" }
-            connector = WhatsAppConnector(chatJIDs: jids)
-        case .imessage:
-            guard fdaGranted else { return "✗ grant Full Disk Access (More ▾) for iMessage" }
-            let guids = selectedIMessageGUIDs
-            guard !guids.isEmpty else { return "✗ pick iMessage chats (chip above)" }
-            connector = iMessageConnector(chatGUIDs: guids)
+        // Build connectors straight from the SOURCES selection (SourceSelection already FDA-gates the
+        // chat/Notes sources): all selected file folders → one FilesConnector; each opted chat / Notes
+        // → its connector. The buttons run everything that's lit, in one pass.
+        let roots = selectedFileRoots
+        var connectors: [any Connector] = roots.isEmpty ? [] : [FilesConnector(roots: roots)]
+        for src in selectedSources {
+            switch src {
+            case .whatsapp(let jids): connectors.append(WhatsAppConnector(chatJIDs: jids))
+            case .imessage(let guids): connectors.append(iMessageConnector(chatGUIDs: guids))
+            case .notes:               connectors.append(NotesConnector())
+            case .files:               break   // folded into FilesConnector(roots:)
+            }
         }
-        let runner = IterativeRun(modelPath: mp)
+        guard !connectors.isEmpty else { return "✗ select a source above (folder / chat / Apple Notes)" }
+        if mode == .initial {
+            // Fresh start: immediately wipe the existing on-device knowledge base (the vault).
+            try? FileManager.default.removeItem(at: VaultGenerator.vaultRoot)
+            Log("DevTools: INITIAL — wiped the on-device vault at \(VaultGenerator.vaultRoot.path)")
+        }
         let onProg: @Sendable (PipelineProgress) -> Void = { p in
             progress("… \(p.done)/\(p.total) · kept \(p.survivors)")
         }
+        let runner = IterativeRun(modelPath: mp)
         let p = mode == .initial
-            ? await runner.runInitial(connector, onProgress: onProg)
-            : await runner.runIterative(connector, onProgress: onProg)
+            ? await runner.runInitial(connectors, onProgress: onProg)
+            : await runner.runIterative(connectors, onProgress: onProg)
         return "✓ \(p.survivors) kept · \(p.junk) junk · \(p.sensitive) sensitive · \(p.failed) failed"
     }
 
@@ -379,7 +347,7 @@ struct DevToolsView: View {
             }
             .frame(maxWidth: 460)
 
-            Text("The INITIAL / ITERATIVE buttons act on the selected FILE folders. WhatsApp · iMessage · Apple Notes still run the old pipeline (home’s Analyze Now / “More” below).")
+            Text("The INITIAL / ITERATIVE buttons run every selected source (folders + opted chats + Apple Notes) through the iterative core. Select only one to test it alone.")
                 .font(.caption2).foregroundStyle(Theme.faint)
                 .multilineTextAlignment(.center).fixedSize(horizontal: false, vertical: true)
         }
@@ -471,14 +439,8 @@ struct DevToolsView: View {
 
             if showMore {
                 VStack(spacing: 12) {
-                    HStack(spacing: 10) {
-                        Button("Start Analysis (legacy)") { onStartAnalysis() }
-                            .buttonStyle(.bordered)
-                        Button { openWindow(id: DatabaseView.windowID) } label: {
-                            Label("View knowledge (old store)", systemImage: "sparkles.rectangle.stack")
-                        }
-                        .buttonStyle(.bordered).tint(Theme.accent)
-                    }
+                    Button("Start Analysis (legacy)") { onStartAnalysis() }
+                        .buttonStyle(.bordered)
 
                     VStack(spacing: 4) {
                         Button(role: .destructive) { Task { await runReset() } } label: {


### PR DESCRIPTION
Cleanup pass on the iterative dev cockpit + removes the freshness hold-back everywhere.

## Changes
- **Removed the redundant ON-DEVICE CONNECTOR picker.** It overlapped the SOURCES chips. INITIAL/ITERATIVE now run **every lit SOURCES chip in one pass** (select just one to test it alone). `IterativeRun` now takes `[any Connector]` and runs them through one engine sized to the biggest (chats need 16384).
- **Removed the legacy "View knowledge (old store)" button** (it pointed at the old `Store`, separate from the new `CycleStore` — confusing). The home's vault window is unaffected.
- **INITIAL "start on device" now immediately wipes the on-device vault** (`~/Sentient OS -- The Vault/`) so a fresh initial truly starts from scratch.
- **Ripped out the freshness hold-back from everything:** the new connectors (`eligibleWindows`; files/notes never had it) **and** the old belt (`FilesSource`/`NotesSource`/`WhatsApp`/`iMessage` `scan`). Deleted the shared `sourceFreshnessHoldBack` constant, the `testZeroHoldBack` test seam, its two self-test usages, and the stale comments. Ingestion now processes everything **right up to now** — no 2-minute / 1-hour wait, any source.

## Verify
Build green. Deterministic self-tests: **fileiter 18/18 · incremental 22/22 · skipping 17/17** (the old file path still works without the test seam). WhatsApp connector was validated earlier on real data (77 chats / 237 windows).

Untouched: home, old `Store`/`Pipeline`/`DataSource` shapes. **Out of scope (future):** home rewire to `IterativeRun`, scheduler, retiring the old belt.