### PR TITLE
Dev UI: rich processing takeover for on-device runs + dummy proactive button

### DIFF
--- a/Sentient OS macOS/Ingestion/VaultCloud.swift
+++ b/Sentient OS macOS/Ingestion/VaultCloud.swift
@@ -141,29 +141,11 @@ actor VaultCloud {
 
     // MARK: Proactive — placeholder scaffold
 
-    /// Send the reminder-flagged notes to a proactive pass and return how many were sent. The real
-    /// proactive intelligence system isn't built yet — this is a deliberate scaffold (CodexCLI,
-    /// read-only sandbox) that proves the wiring end to end.
+    /// DUMMY proactive pass — the real proactive intelligence system isn't built yet. It just reports
+    /// how many reminder-flagged notes WOULD be sent; **nothing goes to Codex.**
     /// TODO: real proactive (cloud judge → tier-1 reminders / tier-2 briefings).
-    @discardableResult
-    func proactive(reminderNotes: [CloudNote]) async throws -> Int {
-        guard !reminderNotes.isEmpty else {
-            Log("VaultCloud.proactive: no reminder-flagged notes — nothing to send.")
-            return 0
-        }
-        var inv = CodexCLI.Invocation(prompt: Self.proactivePrompt(reminderNotes))
-        inv.effort = .medium
-        inv.sandbox = .readOnly
-        inv.timeout = 600
-        Log("VaultCloud.proactive: sending \(reminderNotes.count) reminder candidate(s) to codex (placeholder)…")
-        do {
-            let envelope = try await CodexCLI.shared.run(inv)
-            Log("VaultCloud.proactive: ✅ sent \(reminderNotes.count) — \(envelope.result.prefix(120))")
-        } catch let CodexCLI.CLIError.usageLimit(message, _) {
-            throw CloudError.usageLimit(message)
-        } catch {
-            throw CloudError.failed("\(error)")
-        }
+    func proactive(reminderNotes: [CloudNote]) -> Int {
+        Log("VaultCloud.proactive: filtered \(reminderNotes.count) reminder candidate(s) (dummy — not sent).")
         return reminderNotes.count
     }
 
@@ -251,23 +233,4 @@ actor VaultCloud {
         """
     }
 
-    /// Placeholder proactive prompt — proves the codex wiring; replaced when the real proactive
-    /// system lands.
-    private static func proactivePrompt(_ notes: [CloudNote]) -> String {
-        var lines: [String] = []
-        for (i, n) in notes.enumerated() {
-            let title = (n.title?.isEmpty == false) ? n.title! : "(untitled)"
-            lines.append("#\(i + 1) \(title) — \(n.text)")
-        }
-        return """
-        [PLACEHOLDER — Sentient OS proactive intelligence is not built yet. This is a wiring test.]
-
-        Below are on-device "potential reminder" candidates the local model flagged as possibly \
-        time-sensitive or worth the user's attention. The real proactive system (a cloud judge that \
-        decides which deserve a reminder or a briefing) will replace this prompt. For now, simply \
-        acknowledge receipt and reply with ONE line: the number of candidates you received.
-
-        \(lines.joined(separator: "\n"))
-        """
-    }
 }

--- a/Sentient OS macOS/Views/DevToolsView.swift
+++ b/Sentient OS macOS/Views/DevToolsView.swift
@@ -68,6 +68,13 @@ final class DevRunModel {
     var status: [String: String] = [:]      // action id → live/final line
 }
 
+/// A queued on-device run for the start-on-device buttons — drives the rich ProcessingView takeover.
+struct DeviceJob: Identifiable {
+    let id = UUID()
+    let connectors: [any Connector]
+    let mode: IterativeRun.Mode
+}
+
 struct DevToolsView: View {
     let store: Store
     @Binding var customRoots: [URL]
@@ -89,6 +96,7 @@ struct DevToolsView: View {
     @AppStorage("dbg.run.notes")     private var runNotes = false
 
     @State private var run = DevRunModel()
+    @State private var deviceJob: DeviceJob?
     @State private var showChatPicker = false
     @State private var showIMessagePicker = false
     @State private var showSummaries = false
@@ -141,6 +149,12 @@ struct DevToolsView: View {
         .frame(width: 720, height: 780)
         .background(Theme.bg)
         .sheet(isPresented: $showSummaries) { SummariesView() }
+        .sheet(item: $deviceJob) { job in
+            ProcessingView(modelPath: Self.modelPath ?? "", connectors: job.connectors, mode: job.mode) {
+                deviceJob = nil
+            }
+            .frame(minWidth: 600, minHeight: 680)
+        }
         .sheet(isPresented: $showChatPicker) {
             ChatPicker(sourceName: "WhatsApp",
                        loadChats: { try WhatsAppSource().listChats() },
@@ -165,9 +179,7 @@ struct DevToolsView: View {
     private var columns: some View {
         HStack(alignment: .top, spacing: 16) {
             columnView("INITIAL") {
-                actionButton("init.device", "start on device\n(top → bottom)", "arrow.down.to.line", tint: .green) { progress in
-                    await runOnDevice(mode: .initial, progress: progress)
-                }
+                deviceButton("init.device", "start on device\n(top → bottom)", .initial)
                 actionButton("init.cloud", "tell cloud:\n“go make knowledge base exist”", "cloud.fill", tint: .purple) { progress in
                     await cloudCreate(progress: progress)
                 }
@@ -177,9 +189,7 @@ struct DevToolsView: View {
             }
             Divider().frame(maxHeight: 320).overlay(Theme.stroke)
             columnView("ITERATIVE") {
-                actionButton("iter.device", "start on device\n(bottom → top)", "arrow.up.to.line", tint: .green) { progress in
-                    await runOnDevice(mode: .iterative, progress: progress)
-                }
+                deviceButton("iter.device", "start on device\n(bottom → top)", .iterative)
                 actionButton("iter.cloud", "tell cloud:\n“go update knowledge base”", "cloud.fill", tint: .purple) { _ in
                     await cloudUpdate()
                 }
@@ -244,11 +254,29 @@ struct DevToolsView: View {
 
     // MARK: The actions (all on the NEW files-iterative stack)
 
-    private func runOnDevice(mode: IterativeRun.Mode, progress: @escaping @Sendable (String) -> Void) async -> String {
-        guard let mp = Self.modelPath else { return "✗ model not found" }
-        // Build connectors straight from the SOURCES selection (SourceSelection already FDA-gates the
-        // chat/Notes sources): all selected file folders → one FilesConnector; each opted chat / Notes
-        // → its connector. The buttons run everything that's lit, in one pass.
+    /// One of the two "start on device" buttons — presents the rich ProcessingView takeover.
+    private func deviceButton(_ id: String, _ title: String, _ mode: IterativeRun.Mode) -> some View {
+        VStack(spacing: 5) {
+            Button { startOnDevice(id: id, mode: mode) } label: {
+                HStack(spacing: 7) {
+                    Image(systemName: mode == .initial ? "arrow.down.to.line" : "arrow.up.to.line")
+                    Text(title).font(.caption.weight(.medium)).multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .frame(maxWidth: .infinity, minHeight: 44)
+            }
+            .buttonStyle(.bordered).tint(.green)
+            .disabled(deviceJob != nil || Self.modelPath == nil)
+            if let s = run.status[id] {   // only set for "✗ …" guidance (no source selected, etc.)
+                Text(s).font(.system(.caption2, design: .monospaced)).foregroundStyle(.red)
+                    .multilineTextAlignment(.center).fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    /// Build the connectors from the lit SOURCES + (initial) wipe the vault, then present ProcessingView.
+    private func startOnDevice(id: String, mode: IterativeRun.Mode) {
+        guard Self.modelPath != nil else { run.status[id] = "✗ model not found"; return }
         let roots = selectedFileRoots
         var connectors: [any Connector] = roots.isEmpty ? [] : [FilesConnector(roots: roots)]
         for src in selectedSources {
@@ -259,20 +287,16 @@ struct DevToolsView: View {
             case .files:               break   // folded into FilesConnector(roots:)
             }
         }
-        guard !connectors.isEmpty else { return "✗ select a source above (folder / chat / Apple Notes)" }
+        guard !connectors.isEmpty else {
+            run.status[id] = "✗ select a source above (folder / chat / Apple Notes)"; return
+        }
         if mode == .initial {
             // Fresh start: immediately wipe the existing on-device knowledge base (the vault).
             try? FileManager.default.removeItem(at: VaultGenerator.vaultRoot)
             Log("DevTools: INITIAL — wiped the on-device vault at \(VaultGenerator.vaultRoot.path)")
         }
-        let onProg: @Sendable (PipelineProgress) -> Void = { p in
-            progress("… \(p.done)/\(p.total) · kept \(p.survivors)")
-        }
-        let runner = IterativeRun(modelPath: mp)
-        let p = mode == .initial
-            ? await runner.runInitial(connectors, onProgress: onProg)
-            : await runner.runIterative(connectors, onProgress: onProg)
-        return "✓ \(p.survivors) kept · \(p.junk) junk · \(p.sensitive) sensitive · \(p.failed) failed"
+        run.status[id] = nil
+        deviceJob = DeviceJob(connectors: connectors, mode: mode)
     }
 
     private func cloudCreate(progress: @escaping @Sendable (String) -> Void) async -> String {
@@ -308,13 +332,9 @@ struct DevToolsView: View {
     /// summaries (the cycle ends; the next on-device run starts fresh).
     private func runProactive() async -> String {
         let reminders = await CycleStore.shared.reminderNotes().map(CloudNote.init)
-        do {
-            let n = try await VaultCloud.shared.proactive(reminderNotes: reminders)
-            await CycleStore.shared.wipeAllNotes()
-            return "✓ sent \(n) reminder\(n == 1 ? "" : "s") · summaries wiped"
-        } catch {
-            return "✗ \((error as? LocalizedError)?.errorDescription ?? "\(error)")"
-        }
+        let n = await VaultCloud.shared.proactive(reminderNotes: reminders)   // dummy — no Codex
+        await CycleStore.shared.wipeAllNotes()
+        return "✓ filtered to send \(n) reminder\(n == 1 ? "" : "s") · summaries wiped"
     }
 
     // MARK: Source picker (which folders/connections the buttons act on)

--- a/Sentient OS macOS/Views/ProcessingView.swift
+++ b/Sentient OS macOS/Views/ProcessingView.swift
@@ -38,11 +38,25 @@ enum RunSource: Hashable {
 }
 
 struct ProcessingView: View {
-    let store: Store
+    let store: Store?
     let modelPath: String
     let sources: [RunSource]   // one pass per source, in order
     let limit: Int?
     var onDone: () -> Void
+    /// When set, run the new IterativeRun over these connectors instead of the old pipeline.
+    private let iterative: (connectors: [any Connector], mode: IterativeRun.Mode)?
+
+    /// Old pipeline takeover (home's Analyze Now): runs `sources` through Pipeline → old Store.
+    init(store: Store, modelPath: String, sources: [RunSource], limit: Int?, onDone: @escaping () -> Void) {
+        self.store = store; self.modelPath = modelPath; self.sources = sources
+        self.limit = limit; self.onDone = onDone; self.iterative = nil
+    }
+
+    /// Iterative takeover (dev start-on-device): runs the connectors through IterativeRun → CycleStore.
+    init(modelPath: String, connectors: [any Connector], mode: IterativeRun.Mode, onDone: @escaping () -> Void) {
+        self.store = nil; self.modelPath = modelPath; self.sources = []
+        self.limit = nil; self.onDone = onDone; self.iterative = (connectors, mode)
+    }
 
     private enum UIState: Equatable { case loadingModel, processing, completed, failed(String) }
     @State private var state: UIState = .loadingModel
@@ -55,6 +69,7 @@ struct ProcessingView: View {
     @State private var engine: Engine?
     @State private var started = false
     @State private var pipelineTask: Task<PipelineProgress, Error>?
+    @State private var iterativeTask: Task<PipelineProgress, Never>?
 
     var body: some View {
         ZStack {
@@ -78,7 +93,7 @@ struct ProcessingView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .task { await startIfNeeded() }
-        .onDisappear { let e = engine; Task { await e?.unload() } }
+        .onDisappear { iterativeTask?.cancel(); let e = engine; Task { await e?.unload() } }
     }
 
     // MARK: States
@@ -265,6 +280,7 @@ struct ProcessingView: View {
     private func stop() {
         stopped = true
         pipelineTask?.cancel()
+        iterativeTask?.cancel()
         onDone()
     }
 
@@ -281,9 +297,32 @@ struct ProcessingView: View {
     }
 
     private func run() async {
-        state = .loadingModel
         stopped = false
         totals = PipelineProgress()
+
+        // Iterative takeover (dev start-on-device): stream IterativeRun's progress into the same UI.
+        if let iterative {
+            state = .loadingModel
+            let (stream, continuation) = AsyncStream.makeStream(
+                of: PipelineProgress.self, bufferingPolicy: .bufferingNewest(1))
+            let task = Task {
+                defer { continuation.finish() }
+                let runner = IterativeRun(modelPath: modelPath)
+                return iterative.mode == .initial
+                    ? await runner.runInitial(iterative.connectors) { continuation.yield($0) }
+                    : await runner.runIterative(iterative.connectors) { continuation.yield($0) }
+            }
+            iterativeTask = task
+            for await p in stream {
+                if state == .loadingModel { withAnimation { state = .processing } }
+                progress = p
+            }
+            progress = await task.value
+            withAnimation { state = .completed }
+            return
+        }
+
+        state = .loadingModel
         guard !sources.isEmpty else { state = .failed("No sources selected to analyze."); return }
         do {
             // Chat windows are big (and prompt scaffolding is sizeable); size the KV cache with
@@ -294,7 +333,7 @@ struct ProcessingView: View {
             self.engine = engine
             withAnimation { state = .processing }
 
-            let pipeline = Pipeline(engine: engine, store: store)
+            let pipeline = Pipeline(engine: engine, store: store!)
             rootCount = sources.count
 
             // One pass per source (its own progress bar); verdict counts accumulate for the summary.


### PR DESCRIPTION
Follow-on to #27 (merged).

## What
- **ProcessingView** now shows the full per-item takeover (title / description / junk-or-not) for **both INITIAL and ITERATIVE** on-device runs — same rich UI the old belt used, streamed via `AsyncStream` (loadingModel → processing on first event → completed at end).
- **DevToolsView** — the on-device run is driven by the single SOURCES selection surface; INITIAL wipes the existing vault first; legacy "View knowledge (old store)" button removed.
- **Proactive button is a no-Codex dummy** — `VaultCloud.proactive(reminderNotes:) -> Int` just logs + returns the count; `runProactive()` filters reminder-flagged cycle notes, reports `✓ filtered to send N reminder(s) · summaries wiped`, and wipes all cycle summaries. The real proactive system is still to build.

## Verification
- `BuildProject` green.
- No `project.pbxproj` / signing changes included.