### PR TITLE
Gmail connector — the cloud source via Codex

### DIFF
--- a/Sentient OS macOS/CodexCLI.swift
+++ b/Sentient OS macOS/CodexCLI.swift
@@ -27,11 +27,22 @@ actor CodexCLI {
 
     // MARK: Types
 
-    /// Every job runs GPT-5.5 (1M context; 400k input through codex). Tiers differ only in
-    /// reasoning effort: `.high` for the initial vault build, `.medium` for everything daily.
+    /// Reasoning-effort tier (codex `model_reasoning_effort`). All four are accepted by codex.
+    /// Per-call: Gmail connect-check = `.low`, Gmail processing = `.high`, knowledge-base work
+    /// (and everything else) = `.xhigh`.
     enum Effort: String, Sendable {
-        case high
+        case low
         case medium
+        case high
+        case xhigh
+    }
+
+    /// The model id passed to `codex exec -m`. NOTE: on a ChatGPT-account (subscription) auth only
+    /// gpt-5.5 and the gpt-5.4 family are available — gpt-5.4-spark / -codex / -mini-of-other-gens
+    /// are API-key-only [MEASURED June 15]. `gpt54mini` is the light model for the Gmail tier.
+    enum Model: String, Sendable {
+        case gpt55 = "gpt-5.5"           // knowledge-base work + everything else
+        case gpt54mini = "gpt-5.4-mini"  // Gmail connect-check + processing
     }
 
     /// OS-level (Seatbelt) confinement of everything the agent does — stronger than a tool
@@ -44,7 +55,8 @@ actor CodexCLI {
     /// One headless `codex exec` call, fully specified.
     struct Invocation: Sendable {
         var prompt: String
-        var effort: Effort = .medium
+        var model: Model = .gpt55              // gpt-5.5 for everything except the Gmail tier
+        var effort: Effort = .xhigh            // "everything else" default; Gmail overrides to low/high
         var sandbox: Sandbox = .readOnly
         var cwd: String? = nil                 // the agent's working root (vault/staging dir)
         var addDirs: [String] = []             // extra writable roots beyond cwd
@@ -208,7 +220,7 @@ actor CodexCLI {
         args += ["--json",
                  "--skip-git-repo-check",      // staging dirs and the vault aren't git repos
                  "--ignore-user-config",       // hermetic: personal config/plugins stay out of our jobs
-                 "-m", "gpt-5.5",
+                 "-m", inv.model.rawValue,
                  "-c", "model_reasoning_effort=\"\(inv.effort.rawValue)\""]
         if inv.resumeSessionID == nil {
             args += ["-s", inv.sandbox.rawValue]

--- a/Sentient OS macOS/Documentation/Gmail Connector (Codex).md
+++ b/Sentient OS macOS/Documentation/Gmail Connector (Codex).md
@@ -1,0 +1,72 @@
+# Gmail Connector (Codex)
+
+Gmail is the **lone cloud source**. It can't be read on-device (no local DB), so we both **fetch and
+summarize** it through the user's own **Codex Gmail connector** — OpenAI's account-level
+`codex_apps/gmail.*` tools, reached by `codex exec`. No on-device model touches Gmail.
+
+Code: `Ingestion/GmailConnect.swift` · UI: `Views/GmailConnectSheet.swift` + the Gmail chip in
+`Views/DevToolsView.swift`.
+
+## How a user connects
+1. **Gmail chip** in the dev SOURCES grid → opens the connect popup.
+2. **Connect Gmail** → opens OpenAI's hosted connector page
+   (`chatgpt.com/apps/gmail/connector_…`); the user links Google there. The connection lands in
+   their OpenAI account, so `codex exec` picks it up automatically.
+3. **I'm done** → 3 s settle, then `probeConnected()` — a `codex exec` that must reply exactly
+   `YES`/`NO`. YES lights up **Finish**; NO prompts a reconnect.
+4. **Finish** → marks Gmail connected + selected. The chip now behaves like any other source.
+
+## How reads work (rides the existing iterative stack)
+Gmail flows through the **same INITIAL / ITERATIVE buttons** as every other connector — it's just a
+source. The "start" button routes a selected Gmail to `GmailConnect` instead of the on-device takeover.
+
+- **Initial** (`runInitial`) — the last month as **4 weekly `codex exec` calls**, newest week first.
+  One dense **summary per week** (the user's decision). Weekly chunking is load-bearing: a heavy inbox
+  is ~430 threads/week and a whole month in one call would blow the model's input cap.
+- **Iterative** (`runIterative`) — one call covering everything since the high-water mark
+  (`after:<epoch>`), then the mark advances. Falls back to initial if never run.
+
+Each weekly/iterative summary becomes one ephemeral **`CycleNote`** in bucket `"gmail"`
+(`kind: .gmail`, `reminderFlagged = has_action_items`). The existing **"tell cloud"** buttons fold
+them into the vault — `VaultCloud` is source-agnostic. Pointer = run start (a few hours of overlap on
+the next run beats a boundary gap).
+
+## The weekly prompt is deliberately disciplined
+A naive "summarize this week" cost **220k tokens for a mere count** in testing — codex over-reads. So
+the prompt: searches on metadata/snippets via `gmail.search_emails`, **caps at the newest 300
+threads**, and only opens (`gmail.read_email`) the handful of threads that look genuinely important
+(a real ask, a deadline, a personal/financial/work matter — never newsletters/receipts). Output is one
+dense summary with an explicit **action-items** section, built to feed the proactive engine.
+
+Structured reply (`--output-schema`): `{ thread_count, notable, has_action_items, summary }`.
+
+## Models & effort (per the model tiers)
+The light model carries the Gmail tier; gpt-5.5 carries the knowledge base. Set via
+`CodexCLI.Invocation.model` + `.effort`:
+
+| Call | Model | Effort |
+|---|---|---|
+| Connect-check (`probeConnected`) | `gpt-5.4-mini` | `low` |
+| Gmail reads (`runInitial`/`runIterative`) | `gpt-5.4-mini` | `high` |
+| KB create/update + everything else | `gpt-5.5` | `xhigh` |
+
+⚠️ On a **ChatGPT-account** auth (no API key) only **gpt-5.5** and the **gpt-5.4** family are
+available — `gpt-5.4-spark`, `gpt-5.5-codex`, and the gpt-5/5.5 `-mini`s are all rejected. `gpt-5.4-mini`
+is the light model we landed on for Gmail [MEASURED June 15]. `.xhigh` is the new `Invocation` default.
+
+## Gotchas (measured live, June 15)
+- **`--ignore-user-config` does NOT block the connector.** The Gmail tools are account/server-side
+  (`codex_apps/gmail.*`), visible to `codex exec` even with the hermetic flag on. So **no CodexCLI
+  change was needed** — we keep the hermetic default *and* get Gmail.
+- **OpenAI strict output schemas require `"additionalProperties": false`** on the object *and* every
+  property in `required`, or `codex exec` fails with `invalid_json_schema`. The weekly schema has both.
+- **No `CodexCLI` change at all** — `probeConnected` and the reads use the existing
+  `CodexCLI.Invocation` (read-only sandbox; the connector works under it).
+
+## Not yet / next
+- **Proactive reconciliation:** proactive currently keys on *per-item* `reminderFlagged` summaries; a
+  weekly Gmail blob needs *mining* (extract its action items). The weekly summary is shaped for this
+  (explicit action-items section), but the proactive consumer isn't built yet.
+- **Connection detection** is a `codex exec` YES/NO probe (the user's chosen UX). A cheaper
+  `codex plugin list` poll exists but is unused by design.
+- Dev-only surface for now (the `dbg.*` prefs + DevToolsView); the real onboarding/connectors UI is Phase 5.

--- a/Sentient OS macOS/Ingestion/GmailConnect.swift
+++ b/Sentient OS macOS/Ingestion/GmailConnect.swift
@@ -1,0 +1,242 @@
+//
+//  GmailConnect.swift
+//  Sentient OS macOS
+//
+//  Gmail — the lone CLOUD source. Gmail can't be read on-device, so we both FETCH and SUMMARIZE
+//  through the user's own Codex Gmail connector (account-level `codex_apps/gmail.*`, visible to
+//  `codex exec` even under `--ignore-user-config` — measured live June 15, no CodexCLI change needed).
+//
+//  Connection: the user links Google on OpenAI's connector page (opened from the dev popup); we
+//  confirm with `probeConnected()` — a `codex exec` that returns exactly YES/NO.
+//
+//  Reads (each summary is ONE ephemeral CycleNote in bucket "gmail"; the existing "tell cloud"
+//  buttons fold them into the vault, same as every other source):
+//   • runInitial   — the last month as 4 WEEKLY `codex exec` calls, newest week first. Weekly
+//                    chunking keeps each context window bounded (a heavy inbox measured at ~430
+//                    threads/week; one month in a single call would blow GPT-5.5's 400k input cap).
+//   • runIterative — everything since the saved high-water mark, in one call, then advance the mark.
+//
+//  The weekly prompt is DELIBERATELY disciplined: a naive "summarize this week" cost 220k tokens for
+//  a mere count in testing (codex over-reads). It searches on metadata/snippets, caps at the newest
+//  300 threads, and only opens the handful of threads that look genuinely important.
+//
+//  Doc: Documentation/Gmail Connector (Codex).md
+//
+
+import Foundation
+
+enum GmailConnect {
+
+    /// The single iterative-store bucket for Gmail. Its pointer is the high-water mark (run start).
+    static let bucketKey = "gmail"
+
+    /// OpenAI's hosted Gmail connector page — opened from the dev popup's "Connect Gmail".
+    static let connectorURL = URL(string: "https://chatgpt.com/apps/gmail/connector_2128aebfecb84f64a069897515042a44")!
+
+    /// Newest-N threads per read (the connector-limits doc's cap; a heavy week exceeds it).
+    private static let threadCap = 300
+    private static let initialWeeks = 4
+
+    enum GmailError: LocalizedError {
+        case dateMath
+        var errorDescription: String? { "Gmail date math failed." }
+    }
+
+    /// Parsed weekly/iterative read result (from the structured codex reply).
+    private struct ReadResult {
+        let summary: String
+        let hasActionItems: Bool
+        let threadCount: Int
+    }
+
+    // MARK: - Connection probe (the "I'm done" YES/NO check)
+
+    /// One `codex exec`, read-only, that returns exactly YES/NO. Fail-closed (any error ⇒ false).
+    static func probeConnected() async -> Bool {
+        var inv = CodexCLI.Invocation(prompt: probePrompt)
+        inv.model = .gpt54mini               // light model for the connect-check
+        inv.effort = .low
+        inv.sandbox = .readOnly
+        inv.timeout = 120
+        do {
+            let env = try await CodexCLI.shared.run(inv)
+            let answer = env.result.uppercased()
+            let yes = answer.contains("YES") && !answer.contains("NO")
+            Log("GmailConnect.probe: codex → \"\(env.result.prefix(40))\" ⇒ \(yes ? "connected" : "NOT connected")")
+            return yes
+        } catch {
+            Log("GmailConnect.probe: ⚠️ \(error) — treating as NOT connected")
+            return false
+        }
+    }
+
+    // MARK: - Initial read (last month → 4 weekly summaries)
+
+    /// Fresh start: wipe the bucket, then read the last 4 weeks newest-first (one summary each).
+    /// Records each into CycleStore; sets the high-water mark to the run-start on completion.
+    @discardableResult
+    static func runInitial(onProgress: @Sendable @escaping (String) -> Void = { _ in }) async throws -> Int {
+        await CycleStore.shared.clearBucket(bucketKey)
+        let runStart = Date()
+        let cal = Calendar.current
+        let today = cal.startOfDay(for: runStart)
+        guard let tomorrow = cal.date(byAdding: .day, value: 1, to: today) else { throw GmailError.dateMath }
+
+        var recorded = 0
+        for week in 0..<initialWeeks {
+            // Window [tomorrow − 7·(week+1), tomorrow − 7·week): contiguous, no overlap, newest first.
+            guard let upper = cal.date(byAdding: .day, value: -7 * week, to: tomorrow),
+                  let lower = cal.date(byAdding: .day, value: -7 * (week + 1), to: tomorrow) else {
+                throw GmailError.dateMath
+            }
+            let weekLabel = "week of \(label(lower))"
+            onProgress("week \(week + 1)/\(initialWeeks) — reading \(weekLabel)…")
+            let query = "after:\(qDate(lower)) before:\(qDate(upper))"
+            if let r = try await read(query: query, label: weekLabel) {
+                let itemDate = cal.date(byAdding: .day, value: -1, to: upper) ?? lower
+                await record(r, itemDate: itemDate, label: weekLabel)
+                recorded += 1
+                onProgress("week \(week + 1)/\(initialWeeks) — \(r.threadCount) threads ✓")
+            } else {
+                onProgress("week \(week + 1)/\(initialWeeks) — nothing notable")
+            }
+        }
+        // High-water mark = run start. Iterative reads everything after it (a few hours of overlap
+        // is harmless — the cloud updater synthesizes — and beats a boundary gap).
+        await CycleStore.shared.setPointer(bucketKey, ItemKey(order: runStart.timeIntervalSince1970, tiebreak: ""))
+        Log("GmailConnect.runInitial: ✅ \(recorded)/\(initialWeeks) weekly summaries recorded; pointer → \(runStart)")
+        return recorded
+    }
+
+    // MARK: - Iterative read (since the high-water mark)
+
+    /// One summary covering everything since the saved mark, then advance the mark. Falls back to a
+    /// full initial read if Gmail has never been read on this Mac.
+    @discardableResult
+    static func runIterative(onProgress: @Sendable @escaping (String) -> Void = { _ in }) async throws -> Int {
+        guard let mark = await CycleStore.shared.pointer(bucketKey) else {
+            onProgress("no prior read — running initial…")
+            return try await runInitial(onProgress: onProgress)
+        }
+        let since = Date(timeIntervalSince1970: mark.order)
+        let runStart = Date()
+        onProgress("reading new email since \(label(since))…")
+        // Gmail's `after:` accepts an epoch-seconds boundary — precise, no day-rounding.
+        let query = "after:\(Int(since.timeIntervalSince1970))"
+        var recorded = 0
+        if let r = try await read(query: query, label: "since \(label(since))") {
+            await record(r, itemDate: runStart, label: "since \(label(since))")
+            recorded = 1
+            onProgress("\(r.threadCount) new threads ✓")
+        } else {
+            onProgress("no new email")
+        }
+        await CycleStore.shared.setPointer(bucketKey, ItemKey(order: runStart.timeIntervalSince1970, tiebreak: ""))
+        Log("GmailConnect.runIterative: ✅ \(recorded) summary since \(since); pointer → \(runStart)")
+        return recorded
+    }
+
+    // MARK: - One read (a single codex exec over a date window)
+
+    private static func read(query: String, label: String) async throws -> ReadResult? {
+        var inv = CodexCLI.Invocation(prompt: weeklyPrompt(query: query, label: label))
+        inv.model = .gpt54mini               // light model for the high-volume Gmail reads
+        inv.effort = .high
+        inv.sandbox = .readOnly              // we only read Gmail + return text (no file writes)
+        inv.outputSchema = weeklySchema
+        inv.timeout = 900                    // a heavy window with a few deep reads can run long
+        let env = try await CodexCLI.shared.run(inv)
+        return parse(env.result)
+    }
+
+    private static func record(_ r: ReadResult, itemDate: Date, label: String) async {
+        let sid = "gmail:\(Int(itemDate.timeIntervalSince1970))"          // unique per window
+        await CycleStore.shared.recordNote(
+            bucketKey: bucketKey, kind: .gmail, sourceID: sid, folder: "Gmail",
+            itemDate: itemDate, text: r.summary, title: "Email — \(label)",
+            reminderFlagged: r.hasActionItems)
+    }
+
+    /// Tolerant parse of the structured reply (output-schema makes `result` the JSON; still fence-safe).
+    private static func parse(_ result: String) -> ReadResult? {
+        let span: String
+        if let s = result.firstIndex(of: "{"), let e = result.lastIndex(of: "}"), s < e {
+            span = String(result[s...e])
+        } else { span = result }
+        guard let data = span.data(using: .utf8),
+              let obj = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+              let notable = obj["notable"] as? Bool else { return nil }
+        guard notable, let summary = obj["summary"] as? String,
+              !summary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+        return ReadResult(summary: summary,
+                          hasActionItems: obj["has_action_items"] as? Bool ?? false,
+                          threadCount: obj["thread_count"] as? Int ?? 0)
+    }
+
+    // MARK: - Date helpers
+
+    private static func qDate(_ d: Date) -> String {     // Gmail query date: yyyy/MM/dd
+        let f = DateFormatter(); f.dateFormat = "yyyy/MM/dd"; f.timeZone = .current
+        return f.string(from: d)
+    }
+    private static func label(_ d: Date) -> String {     // display: "Jun 8"
+        let f = DateFormatter(); f.dateFormat = "MMM d"; f.timeZone = .current
+        return f.string(from: d)
+    }
+
+    // MARK: - Prompts
+
+    private static let probePrompt = """
+    Using your Gmail connector tools, check whether you can read this account's Gmail inbox. \
+    Reply with EXACTLY YES if you can, or EXACTLY NO if the Gmail connector is not available. \
+    Output only that one word and nothing else.
+    """
+
+    /// The structured reply contract — one dense weekly summary plus the flags Sentient keys on.
+    private static let weeklySchema = """
+    {"type":"object","additionalProperties":false,"properties":{\
+    "thread_count":{"type":"integer"},\
+    "notable":{"type":"boolean"},\
+    "has_action_items":{"type":"boolean"},\
+    "summary":{"type":"string"}},\
+    "required":["thread_count","notable","has_action_items","summary"]}
+    """
+
+    private static func weeklyPrompt(query: String, label: String) -> String {
+        """
+        You are the Gmail intelligence pass for Sentient OS, a privacy-first personal-AI app. \
+        Summarize ONE window of the user's email (\(label)) into a single dense summary that feeds \
+        two things: the user's personal knowledge base, and a PROACTIVE engine that surfaces things \
+        needing the user's attention. Finding what genuinely matters is the whole job.
+
+        ## Fetch — be efficient, the inbox is heavy
+        - Use `gmail.search_emails` with EXACTLY this query: `\(query)`
+        - Consider at most the newest \(threadCap) threads in that window; if there are more, take the \
+        newest \(threadCap).
+        - Work from subjects, senders, and snippets. Open a thread with `gmail.read_email` ONLY when it \
+        looks genuinely important — a real request directed at the user, a deadline, a booking/renewal \
+        window, or a personal/financial/work matter. DO NOT open newsletters, marketing, receipts, or \
+        automated notifications, and DO NOT read every email. Over-reading wastes the budget.
+
+        ## Produce ONE summary (third person — "the user")
+        - Lead with a short overview of what actually mattered this window.
+        - Then a clear section **Action items / awaiting the user / deadlines / commitments**: each as \
+        `who · what · by when`. Only real, still-actionable ones; skip anything stale or trivial.
+        - Then: key people and threads, and anything else genuinely important about the user's life, \
+        work, money, plans, or relationships.
+
+        ## Rules
+        - Curate RUTHLESSLY. Skip spam, newsletters, marketing, promotions, and automated noise unless \
+        truly important. A quiet window with nothing worth keeping → `notable: false`, `summary: ""`.
+        - PII-light: NEVER include full card/account numbers, passwords, verification/2FA codes, or \
+        verbatim sensitive medical or financial figures. Summarize, never transcribe such details.
+        - Truth & attribution: an email FROM someone else is THEIR words, not the user's. Never assert \
+        something about the user the email doesn't support.
+
+        ## Output
+        Return ONLY the JSON object matching the schema: `thread_count` (threads you considered, after \
+        the cap), `notable` (anything worth a knowledge-base note?), `has_action_items` (anything the \
+        proactive engine should weigh?), and `summary` (the dense text; empty string when not notable).
+        """
+    }
+}

--- a/Sentient OS macOS/Ingestion/VaultCloud.swift
+++ b/Sentient OS macOS/Ingestion/VaultCloud.swift
@@ -116,7 +116,7 @@ actor VaultCloud {
         } else {
             invocation = CodexCLI.Invocation(prompt: Self.updatePrompt(skeleton: Self.skeleton(of: vault), notes: notes))
         }
-        invocation.effort = .medium                                   // daily updates are cheap
+        invocation.effort = .xhigh                                    // KB work gets the deepest pass
         invocation.sandbox = .workspaceWrite                         // edits confined to the vault
         invocation.cwd = vault.path
         invocation.timeout = 1_800

--- a/Sentient OS macOS/Self Tests - Temp/SelfTest_Triage_Pipeline_and_Vault.swift
+++ b/Sentient OS macOS/Self Tests - Temp/SelfTest_Triage_Pipeline_and_Vault.swift
@@ -111,6 +111,7 @@ enum SelfTest {
             guard case .available = availability else { return }
             do {
                 var inv = CodexCLI.Invocation(prompt: "Reply with exactly: SPINE_OK")
+                inv.effort = .low            // a ping doesn't need the xhigh default
                 inv.timeout = 120
                 let envelope = try await CodexCLI.shared.run(inv)
                 emit("result: \(envelope.result)")

--- a/Sentient OS macOS/Sources/DataSource.swift
+++ b/Sentient OS macOS/Sources/DataSource.swift
@@ -23,12 +23,15 @@
 
 import Foundation
 
-/// The four local sources. `rawValue` is what we persist on summaries and in cursor keys.
+/// The sources. `rawValue` is what we persist on summaries and in cursor keys.
+/// `file`/`whatsapp`/`imessage`/`notes` are read on-device; `gmail` is the lone CLOUD source —
+/// fetched + summarized through the user's Codex Gmail connector (no on-device read), see GmailConnect.
 enum SourceKind: String, Codable, Sendable, CaseIterable {
     case file
     case whatsapp
     case imessage
     case notes
+    case gmail
 }
 
 

--- a/Sentient OS macOS/VaultGenerator.swift
+++ b/Sentient OS macOS/VaultGenerator.swift
@@ -109,7 +109,7 @@ actor VaultGenerator {
         }
 
         var invocation = CodexCLI.Invocation(prompt: prompt)
-        invocation.effort = .high                            // the initial build gets the deep pass
+        invocation.effort = .xhigh                           // KB build gets the deepest pass (gpt-5.5)
         invocation.sandbox = .workspaceWrite                 // writes confined to the staging dir
         invocation.cwd = staging.path
         invocation.resumeSessionID = resume?.sessionID
@@ -202,6 +202,7 @@ actor VaultGenerator {
     /// can call it without coupling to a particular summary type.
     static func locSrc(kind: SourceKind, folder: String, sourceID: String) -> (loc: String, source: String) {
         if kind == .whatsapp { return (folder, "WhatsApp · \(folder)") }
+        if kind == .gmail { return (folder, "Gmail — the user's email correspondence") }
         let p = relPath(sourceID)
         let low = p.lowercased()
         if low.contains("icloud~md~obsidian") {                       // the user's own Obsidian vault

--- a/Sentient OS macOS/Views/DatabaseView.swift
+++ b/Sentient OS macOS/Views/DatabaseView.swift
@@ -150,6 +150,7 @@ struct DatabaseView: View {
         case .whatsapp: return "WhatsApp"
         case .imessage: return "iMessage"
         case .notes:    return "Notes"
+        case .gmail:    return "Gmail"
         }
     }
 

--- a/Sentient OS macOS/Views/DevToolsView.swift
+++ b/Sentient OS macOS/Views/DevToolsView.swift
@@ -103,6 +103,9 @@ struct DevToolsView: View {
     @State private var showMore = false
     @State private var fdaGranted = false
     @State private var resetResult: String?
+    @State private var showGmailConnect = false
+    @AppStorage("dbg.gmail.connected") private var gmailConnected = false
+    @AppStorage("dbg.run.gmail")       private var runGmail = false
 
     private var selectedSources: [RunSource] {
         SourceSelection.current(customRoots: customRoots, fdaGranted: fdaGranted)
@@ -149,6 +152,7 @@ struct DevToolsView: View {
         .frame(width: 720, height: 780)
         .background(Theme.bg)
         .sheet(isPresented: $showSummaries) { SummariesView() }
+        .sheet(isPresented: $showGmailConnect) { GmailConnectSheet() }
         .sheet(item: $deviceJob) { job in
             DevProcessingView(modelPath: Self.modelPath ?? "", connectors: job.connectors, mode: job.mode) {
                 deviceJob = nil
@@ -211,6 +215,7 @@ struct DevToolsView: View {
     // MARK: One action button (spinner while running + a live/final status line)
 
     private func actionButton(_ id: String, _ title: String, _ systemImage: String, tint: Color,
+                              requiresModel: Bool = true, disabled: Bool = false,
                               work: @escaping (@escaping @Sendable (String) -> Void) async -> String) -> some View {
         VStack(spacing: 5) {
             Button {
@@ -231,7 +236,7 @@ struct DevToolsView: View {
                 .frame(maxWidth: .infinity, minHeight: 44)
             }
             .buttonStyle(.bordered).tint(tint)
-            .disabled(run.busy != nil || Self.modelPath == nil)
+            .disabled(run.busy != nil || (requiresModel && Self.modelPath == nil) || disabled)
 
             if let s = run.status[id] {
                 Text(s)
@@ -254,29 +259,34 @@ struct DevToolsView: View {
 
     // MARK: The actions (all on the NEW files-iterative stack)
 
-    /// One of the two "start on device" buttons — presents the rich ProcessingView takeover.
+    /// One of the two "start" buttons. Device sources present the rich ProcessingView takeover;
+    /// Gmail (cloud) runs inline with progress in this button's status line.
     private func deviceButton(_ id: String, _ title: String, _ mode: IterativeRun.Mode) -> some View {
         VStack(spacing: 5) {
             Button { startOnDevice(id: id, mode: mode) } label: {
                 HStack(spacing: 7) {
-                    Image(systemName: mode == .initial ? "arrow.down.to.line" : "arrow.up.to.line")
+                    if run.busy == id { ProgressView().controlSize(.small) }
+                    else { Image(systemName: mode == .initial ? "arrow.down.to.line" : "arrow.up.to.line") }
                     Text(title).font(.caption.weight(.medium)).multilineTextAlignment(.center)
                         .fixedSize(horizontal: false, vertical: true)
                 }
                 .frame(maxWidth: .infinity, minHeight: 44)
             }
             .buttonStyle(.bordered).tint(.green)
-            .disabled(deviceJob != nil || Self.modelPath == nil)
-            if let s = run.status[id] {   // only set for "✗ …" guidance (no source selected, etc.)
-                Text(s).font(.system(.caption2, design: .monospaced)).foregroundStyle(.red)
+            .disabled(deviceJob != nil || run.busy != nil || (Self.modelPath == nil && !(gmailConnected && runGmail)))
+            if let s = run.status[id] {
+                Text(s)
+                    .font(.system(.caption2, design: .monospaced))
+                    .foregroundStyle(s.hasPrefix("✓") ? .green : s.hasPrefix("✗") ? .red : Theme.secondary)
                     .multilineTextAlignment(.center).fixedSize(horizontal: false, vertical: true)
             }
         }
     }
 
-    /// Build the connectors from the lit SOURCES + (initial) wipe the vault, then present ProcessingView.
+    /// Build the connectors from the lit SOURCES + (initial) wipe the vault. Device sources go through
+    /// the ProcessingView takeover; Gmail (cloud) runs alongside via GmailConnect.
     private func startOnDevice(id: String, mode: IterativeRun.Mode) {
-        guard Self.modelPath != nil else { run.status[id] = "✗ model not found"; return }
+        let gmailRun = gmailConnected && runGmail
         let roots = selectedFileRoots
         var connectors: [any Connector] = roots.isEmpty ? [] : [FilesConnector(roots: roots)]
         for src in selectedSources {
@@ -287,8 +297,12 @@ struct DevToolsView: View {
             case .files:               break   // folded into FilesConnector(roots:)
             }
         }
-        guard !connectors.isEmpty else {
-            run.status[id] = "✗ select a source above (folder / chat / Apple Notes)"; return
+        guard gmailRun || !connectors.isEmpty else {
+            run.status[id] = "✗ select a source above (folder / chat / Apple Notes / Gmail)"; return
+        }
+        // Device sources need the on-device model; Gmail (cloud) does not.
+        if !connectors.isEmpty && Self.modelPath == nil {
+            run.status[id] = "✗ model not found"; return
         }
         if mode == .initial {
             // Fresh start: immediately wipe the existing on-device knowledge base (the vault).
@@ -296,7 +310,20 @@ struct DevToolsView: View {
             Log("DevTools: INITIAL — wiped the on-device vault at \(VaultGenerator.vaultRoot.path)")
         }
         run.status[id] = nil
-        deviceJob = DeviceJob(connectors: connectors, mode: mode)
+        if gmailRun { startGmail(id: id, mode: mode) }   // cloud read, progress in this button's line
+        if !connectors.isEmpty { deviceJob = DeviceJob(connectors: connectors, mode: mode) }
+    }
+
+    /// Run Gmail's cloud read (initial = last month / iterative = since last) with progress in `id`'s line.
+    private func startGmail(id: String, mode: IterativeRun.Mode) {
+        run.busy = id
+        run.status[id] = "…"
+        let progress: @Sendable (String) -> Void = { s in Task { @MainActor in run.status[id] = s } }
+        Task {
+            let result = mode == .initial ? await runGmailInitial(progress: progress)
+                                          : await runGmailIterative(progress: progress)
+            await MainActor.run { run.status[id] = result; run.busy = nil }
+        }
     }
 
     private func cloudCreate(progress: @escaping @Sendable (String) -> Void) async -> String {
@@ -323,6 +350,26 @@ struct DevToolsView: View {
         do {
             let n = try await VaultCloud.shared.update(notes: notes)
             return "✓ folded \(n) notes into the vault"
+        } catch {
+            return "✗ \((error as? LocalizedError)?.errorDescription ?? "\(error)")"
+        }
+    }
+
+    // MARK: Gmail actions (the cloud source — GmailConnect drives Codex)
+
+    private func runGmailInitial(progress: @escaping @Sendable (String) -> Void) async -> String {
+        do {
+            let n = try await GmailConnect.runInitial { s in progress(s) }
+            return n > 0 ? "✓ \(n) weekly summaries — fold with “tell cloud”" : "✓ nothing notable in the last month"
+        } catch {
+            return "✗ \((error as? LocalizedError)?.errorDescription ?? "\(error)")"
+        }
+    }
+
+    private func runGmailIterative(progress: @escaping @Sendable (String) -> Void) async -> String {
+        do {
+            let n = try await GmailConnect.runIterative { s in progress(s) }
+            return n > 0 ? "✓ \(n) new summary — fold with “tell cloud”" : "✓ no new email since last read"
         } catch {
             return "✗ \((error as? LocalizedError)?.errorDescription ?? "\(error)")"
         }
@@ -364,10 +411,11 @@ struct DevToolsView: View {
                                turnOff: { runIMessage = false },
                                openPicker: { showIMessagePicker = true })
                 notesChip
+                gmailChip
             }
             .frame(maxWidth: 460)
 
-            Text("The INITIAL / ITERATIVE buttons run every selected source (folders + opted chats + Apple Notes) through the iterative core. Select only one to test it alone.")
+            Text("The INITIAL / ITERATIVE buttons run every selected source (folders + opted chats + Apple Notes + Gmail) through the iterative core. Select only one to test it alone.")
                 .font(.caption2).foregroundStyle(Theme.faint)
                 .multilineTextAlignment(.center).fixedSize(horizontal: false, vertical: true)
         }
@@ -386,6 +434,22 @@ struct DevToolsView: View {
         .overlay(Capsule().strokeBorder(on ? .clear : Theme.stroke, lineWidth: 1))
         .contentShape(Capsule())
         .onTapGesture { guard fdaGranted else { return }; runNotes.toggle() }
+    }
+
+    /// Gmail (cloud). Not connected → tap opens the connect popup; connected → tap toggles selection.
+    private var gmailChip: some View {
+        let on = gmailConnected && runGmail
+        return HStack(spacing: 6) {
+            Image(systemName: on ? "checkmark.circle.fill" : "envelope").font(.system(size: 11))
+            Text("Gmail").font(.caption.weight(.medium)).lineLimit(1)
+        }
+        .foregroundStyle(on ? .black : (gmailConnected ? Theme.secondary : Theme.accent))
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 11).padding(.vertical, 6)
+        .background(on ? Theme.accent : Color.white.opacity(0.06), in: Capsule())
+        .overlay(Capsule().strokeBorder(on ? .clear : (gmailConnected ? Theme.stroke : Theme.accent.opacity(0.4)), lineWidth: 1))
+        .contentShape(Capsule())
+        .onTapGesture { showGmailConnect = true }   // always open the popup (connect / select / remove)
     }
 
     private func chatSourceChip(_ name: String, systemImage: String, isOn: Bool, count: Int,

--- a/Sentient OS macOS/Views/GmailConnectSheet.swift
+++ b/Sentient OS macOS/Views/GmailConnectSheet.swift
@@ -1,0 +1,102 @@
+//
+//  GmailConnectSheet.swift
+//  Sentient OS macOS
+//
+//  The Gmail connection popup (dev). Flow:
+//    Connect Gmail  → opens OpenAI's hosted Gmail connector page (the user links Google there).
+//    I'm done       → spins, waits 3s for the connection to settle, then a `codex exec` YES/NO probe
+//                     (GmailConnect.probeConnected). YES → "Finish" lights up; NO → reconnect prompt.
+//    Finish         → persists the connected flag, runs onFinish (the cockpit kicks off the initial
+//                     4-week read), and dismisses.
+//
+//  Mirrors the exact UX in the For-You/connectors spec. See GmailConnect for the codex side.
+//
+
+import SwiftUI
+import AppKit
+
+struct GmailConnectSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @AppStorage("dbg.gmail.connected") private var connected = false
+    @AppStorage("dbg.run.gmail")       private var selected = false
+
+    private enum Phase { case idle, checking, connected, failed }
+    @State private var phase: Phase = .idle
+
+    var body: some View {
+        VStack(spacing: 22) {
+            VStack(spacing: 8) {
+                Image(systemName: "envelope.badge.fill").font(.system(size: 30)).foregroundStyle(Theme.accent)
+                Text("Connect Gmail").font(.title3.weight(.semibold)).foregroundStyle(.white)
+                Text("Link your Google account on OpenAI's connector page. Your Codex reads your email through it — Sentient never sees your password.")
+                    .font(.caption).foregroundStyle(Theme.secondary)
+                    .multilineTextAlignment(.center).fixedSize(horizontal: false, vertical: true)
+            }
+
+            VStack(spacing: 12) {
+                Button { NSWorkspace.shared.open(GmailConnect.connectorURL) } label: {
+                    Label("Connect Gmail", systemImage: "arrow.up.forward.app")
+                        .font(.callout.weight(.medium)).frame(maxWidth: .infinity, minHeight: 40)
+                }
+                .buttonStyle(.borderedProminent).tint(Theme.accent)
+
+                Button { checkDone() } label: {
+                    HStack(spacing: 7) {
+                        if phase == .checking { ProgressView().controlSize(.small) }
+                        Text(phase == .checking ? "Checking…" : "I'm done")
+                    }
+                    .font(.callout.weight(.medium)).frame(maxWidth: .infinity, minHeight: 36)
+                }
+                .buttonStyle(.bordered)
+                .disabled(phase == .checking)
+
+                Group {
+                    switch phase {
+                    case .failed:
+                        Text("Couldn't see Gmail yet. Finish connecting on the page, then tap “I'm done” again.")
+                            .foregroundStyle(.orange)
+                    case .connected:
+                        Label("Gmail connected", systemImage: "checkmark.seal.fill").foregroundStyle(.green)
+                    default:
+                        Text("After connecting on the page, come back and tap “I'm done”.")
+                            .foregroundStyle(Theme.faint)
+                    }
+                }
+                .font(.caption2.weight(.medium))
+                .multilineTextAlignment(.center).fixedSize(horizontal: false, vertical: true)
+            }
+
+            VStack(spacing: 10) {
+                HStack(spacing: 12) {
+                    Button("Cancel") { dismiss() }.buttonStyle(.bordered)
+                    Button(selected ? "Done" : "Finish") {
+                        connected = true
+                        selected = true            // include Gmail in INITIAL / ITERATIVE runs
+                        dismiss()
+                    }
+                    .buttonStyle(.borderedProminent).tint(.green)
+                    .disabled(phase != .connected)
+                }
+                if connected && selected {
+                    Button("Remove Gmail from runs") { selected = false; dismiss() }
+                        .buttonStyle(.plain).font(.caption2).foregroundStyle(.red)
+                }
+            }
+        }
+        .padding(28).frame(width: 420).background(Theme.bg)
+        .onAppear { if connected { phase = .connected } }   // already linked → Finish ready immediately
+    }
+
+    /// "I'm done": settle 3s, then the codex YES/NO probe.
+    private func checkDone() {
+        phase = .checking
+        Task {
+            try? await Task.sleep(for: .seconds(3))
+            let ok = await GmailConnect.probeConnected()
+            await MainActor.run {
+                phase = ok ? .connected : .failed
+                if ok { connected = true }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Gmail is the lone **cloud source** — fetched + summarized through the user's own Codex Gmail connector (account-level `codex_apps/gmail.*`, reached by `codex exec`). No on-device model touches Gmail.

## What's in it
- **GmailConnect**: `probeConnected()` (YES/NO), `runInitial()` (last month = 4 weekly codex calls, newest-first), `runIterative()` (since the high-water mark). Disciplined weekly prompt — metadata search, **cap newest 300 threads**, read only the important ones (a naive pass cost 220k tokens for a count in testing). One dense summary per week with an explicit action-items section for the proactive engine.
- **Connect popup** (`GmailConnectSheet`): Connect Gmail → I'm done (3s + probe) → Finish. Tapping the chip always opens it; connect / select / remove all live in the popup.
- Gmail is a **SOURCES chip** and rides the existing **INITIAL / ITERATIVE** buttons; summaries land as `CycleNote`s (bucket `gmail`) and fold via *tell cloud*.
- `SourceKind.gmail` + `locSrc` source-trust tag.
- **Model/effort tiers** in `CodexCLI`: a `model` field (`gpt-5.5` / `gpt-5.4-mini`) + `low`/`xhigh` efforts. Gmail = **gpt-5.4-mini** (low check / high reads); KB + everything else = **gpt-5.5 xhigh** (now the `Invocation` default). `gpt-5.4-spark` is API-key-only on a ChatGPT account.
- Doc: `Documentation/Gmail Connector (Codex).md`.

## Verification
- Connector access, date-range reads, the YES/NO probe, the output schema, and all three model IDs measured live against the ChatGPT-account codex (June 15–16).
- Xcode build green. Dev-only surface (the `dbg.*` prefs + DevToolsView); real onboarding/connectors UI is Phase 5.

⚠️ Supersedes two §5 facts (every job = gpt-5.5; high/medium tiers) — arch-doc update to follow.