### PR TITLE
Refresh demo briefing cards for the a16z demo

### DIFF
--- a/Sentient OS macOS/Views/Briefing.swift
+++ b/Sentient OS macOS/Views/Briefing.swift
@@ -111,7 +111,7 @@ struct Briefing: Identifiable {
             id: "luis", kind: .meeting,
             kicker: "Meeting · iMessage + Calendar",
             title: "Luis invited you to lunch at Headline.",
-            body: "Lunch at Headline's Presidio office, next Wednesday at 1 PM. I checked your calendar — you're free. The reply is drafted.",
+            body: "He proposed next Wednesday at 1 PM. I checked your calendar — you're free. Should I reply and add it to your cal?",
             letter: """
             Luis Schmitz invited you to lunch at Headline next Wednesday at 1 PM, at their Presidio office. I checked your calendar: you're free, with nothing for two hours on either side.
 

--- a/Sentient OS macOS/Views/Briefing.swift
+++ b/Sentient OS macOS/Views/Briefing.swift
@@ -75,23 +75,23 @@ struct Briefing: Identifiable {
 
     static let demo: [Briefing] = [
         Briefing(
-            id: "deepika", kind: .overdue,
-            kicker: "Overdue · 3 days · Gmail",
-            title: "Deepika is waiting.",
-            body: "She's connecting you with Jordan, Outlander's senior partner, about the ~$1.5M — and asked for a TLDR she can forward. I wrote it.",
+            id: "anthos", kind: .overdue,
+            kicker: "Overdue · 4 days · Gmail",
+            title: "You ghosted Anthos Capital.",
+            body: "Serena cold-emailed four days ago — $1.5B fund, names like Honey and Kalshi. She wants time next week. I wrote your reply.",
             letter: """
-            Deepika (Outlander VC) loved Sentient and is connecting you with Jordan, their senior partner, to talk through the ~$1.5M. She asked for a TLDR she could forward.
+            Serena Saxena from Anthos Capital cold-emailed four days ago — she found Sentient down an on-device-vs-cloud rabbit hole. Anthos runs a $1.5B fund with $3B+ in AUM, and backs companies people are obsessed with: Honey, Kalshi, Erewhon, Olaplex.
 
-            That was three days ago. Time to land it — the draft is below, written to be forwarded.
+            She's in LA and asked for time early next week. You went quiet. Let's fix that — the draft's below, warm and ready.
             """,
             draft: """
-            Hi Deepika,
+            Hi Serena,
 
-            So great speaking with you — and thank you for connecting me with Jordan! Here's a TLDR you can forward along:
+            Thank you for reaching out — and for going down the on-device rabbit hole. That's exactly the bet.
 
-            Sentient OS is the private, on-device intelligence layer for your digital life. Your Mac reads everything you've saved — files, screenshots, WhatsApp, iMessage, Notes — entirely on your own hardware, and distills it into a knowledge vault every AI you use can plug into. Raw data never leaves the device. 2,500+ waitlist signups in 24 hours from a single Reddit post, a working product, and a public launch this month.
+            Quick context: Sentient OS is a private, on-device intelligence layer for your whole digital life. Your Mac reads everything you've saved — files, screenshots, WhatsApp, iMessage, Notes — entirely on your own hardware, and distills it into a knowledge vault every AI you use can plug into. Raw data never leaves the device. We hit 2,500+ waitlist signups in 24 hours from a single Reddit post, and we launch publicly this month.
 
-            Would love to walk Jordan through a live demo whenever suits.
+            I'd love to find time next week. I'm in SF — happy to do a call, or grab time if you're ever up here. Would Tuesday or Wednesday afternoon work on your end?
 
             Best,
             Jesai
@@ -99,62 +99,58 @@ struct Briefing: Identifiable {
             draftLabel: "Draft · Gmail",
             detailLabel: "read the draft",
             offer: "Should I send it for you?",
-            workLog: ["→ reading the thread with Deepika",
+            workLog: ["→ reading Serena's note",
                       "→ opening Gmail",
-                      "→ composing the forwardable TLDR…",
+                      "→ composing your reply…",
                       "✓ sent"],
-            doneTitle: "Sent to Deepika.",
-            doneBody: "The TLDR is on its way to Jordan.",
-            codexPrompt: "Open Gmail and reply to the latest thread with Deepika (Outlander VC) using the approved draft in this briefing. Send it."),
+            doneTitle: "Sent to Anthos.",
+            doneBody: "Serena has your reply — and two times next week.",
+            codexPrompt: "Open Gmail and reply to Serena Saxena (Anthos Capital) with the approved draft in this briefing. Send it."),
 
         Briefing(
             id: "luis", kind: .meeting,
             kicker: "Meeting · iMessage + Calendar",
-            title: "Luis wants Friday, 1 PM.",
-            body: "Luis Schmitz (Headline) proposed meeting next Friday. I checked your calendar — you're free at 1 PM. The reply is drafted.",
+            title: "Luis wants Wednesday, 1 PM.",
+            body: "Luis Schmitz (Headline) set lunch for next Wednesday at the Presidio. I checked your calendar — you're free at 1 PM. The reply is drafted.",
             letter: """
-            Luis Schmitz from Headline proposed meeting next week — Friday at 1 PM. I checked your calendar: you're free, with nothing for two hours on either side.
+            Luis Schmitz from Headline set lunch for next Wednesday at 1 PM, at the Presidio. I checked your calendar: you're free, with nothing for two hours on either side.
 
             Worth remembering: their HQ is 101 Montgomery Street in the Presidio — NOT the Montgomery in Downtown. I'll remind you that morning.
             """,
-            draft: "Hi Luis! Friday at 1 PM works perfectly — see you at 101 Montgomery. Looking forward to it!",
+            draft: "Hi Luis! Wednesday at 1 PM works perfectly — see you at the Presidio. Looking forward to it!",
             draftLabel: "Draft reply · iMessage",
             detailLabel: "read the draft",
             offer: "Reply & add it to your calendar?",
             workLog: ["→ opening Messages",
                       "→ replying to Luis…",
-                      "→ adding Friday 1:00 PM to Calendar",
-                      "→ location: 101 Montgomery St — the Presidio",
+                      "→ adding Wednesday 1:00 PM to Calendar",
+                      "→ location: the Presidio (101 Montgomery St)",
                       "✓ replied & scheduled"],
-            doneTitle: "Friday's locked in.",
-            doneBody: "Replied to Luis · calendar updated — the Presidio one.",
-            codexPrompt: "Reply to Luis Schmitz on iMessage with the approved draft, then create a calendar event Friday 1 PM at 101 Montgomery St (Presidio), title 'Luis — Headline'."),
+            doneTitle: "Wednesday's locked in.",
+            doneBody: "Replied to Luis · lunch on your calendar — the Presidio one.",
+            codexPrompt: "Reply to Luis Schmitz on iMessage with the approved draft, then create the calendar event 'Lunch @ Presidio — Jesai x Luis' for next Wednesday 1 PM at 101 Montgomery St (Presidio)."),
 
         Briefing(
-            id: "dad", kind: .promise,
-            kicker: "Promise · WhatsApp",
-            title: "Dad's running shoes, found.",
-            body: "You promised him shoe research. Done — a clear winner for daily runs and two backups. The message is ready to send.",
+            id: "aim", kind: .promise,
+            kicker: "Press · 10 AM tomorrow · WhatsApp",
+            title: "AIM India wants your voice.",
+            body: "Supreeth wants to interview you on Apple's Siri AI — and offered to cover the Sentient launch. He asked if you're free at 10 AM tomorrow. Reply's drafted.",
             letter: """
-            You told your dad you'd research running shoes for him. Done — he needs stability shoes for daily walks and easy 5Ks, and this year the field has a clear winner.
+            Supreeth from AIM (Analytics India Magazine) reached out — he wants you as an expert voice on Apple's Siri AI, and offered to cover the Sentient OS launch while he's at it. Two birds.
 
-            ✦ The pick: ASICS Gel-Kayano 31 — the benchmark stability shoe; plush, supportive, kindest to knees. ₹13,999 on amazon.in.
-
-            ✦ Backup: Brooks Adrenaline GTS 24 — lighter, slightly firmer ride, same support. ₹11,500.
-
-            ✦ Budget: New Balance 860v14 — the value play, often discounted. ₹9,999.
+            He asked if you're free tomorrow at 10 AM PST. You are — your morning is clear. Say the word and I'll send your yes.
             """,
-            draft: "Appa — researched the shoes properly :) Get the ASICS Gel-Kayano 31 — best stability for daily runs and easiest on the knees. If the size is sold out, the Brooks Adrenaline GTS 24 is just as good. Sending links!",
-            draftLabel: "Draft · WhatsApp",
-            detailLabel: "view the full research",
-            offer: "Shall I send it to him?",
+            draft: "Hi Supreeth! Would love to — 10 AM PST tomorrow works perfectly. And thank you for offering to cover the Sentient OS launch; happy to give you an early, hands-on look. Talk then!",
+            draftLabel: "Draft reply · WhatsApp",
+            detailLabel: "read the draft",
+            offer: "Reply & lock it in?",
             workLog: ["→ opening WhatsApp",
-                      "→ finding Dad",
-                      "→ sending the message + links…",
-                      "✓ delivered"],
-            doneTitle: "Dad has it.",
-            doneBody: "Delivered on WhatsApp, links and all.",
-            codexPrompt: "Send Dad the approved WhatsApp message from this briefing, followed by the three amazon.in product links from the research."),
+                      "→ finding Supreeth (AIM India)",
+                      "→ confirming 10 AM tomorrow…",
+                      "✓ replied"],
+            doneTitle: "You're on with AIM.",
+            doneBody: "Confirmed for 10 AM — Supreeth's expecting you.",
+            codexPrompt: "Reply to Supreeth (AIM India) on WhatsApp with the approved draft confirming the 10 AM PST interview tomorrow."),
 
         Briefing(
             id: "zfellows", kind: .deadline,

--- a/Sentient OS macOS/Views/Briefing.swift
+++ b/Sentient OS macOS/Views/Briefing.swift
@@ -175,32 +175,37 @@ struct Briefing: Identifiable {
             codexPrompt: "Use the browser to open the ZFellows Dropout Graduation registration and submit it for Jesai Tarun, UMass Amherst, building Sentient OS."),
 
         Briefing(
-            id: "sfbreak", kind: .plan,
-            kicker: "Plan · WhatsApp · Cofounders",
-            title: "Your perfect SF break.",
-            body: "You three were brainstorming attractions in the group chat. I built the day from everything I know about you — golden hour included.",
+            id: "deepika", kind: .plan,
+            kicker: "Warm intro · 3 days · Gmail",
+            title: "Deepika opened a $1.5M door.",
+            body: "She's connecting you with Jordan, Outlander's senior partner, and asked for a TLDR she can forward. I wrote it.",
             letter: """
-            The three of you were brainstorming a break day in the group chat. I built it from everything I know about you — the camera itch, the food list, the fog:
+            Deepika (Outlander VC) loved Sentient and is connecting you with Jordan, their senior partner, to talk through the ~$1.5M. She asked for a TLDR she could forward.
 
-            ✦ 9 AM — Tartine in the Mission. It's been sitting on your Food to Try list since April.
-
-            ✦ 11 AM — Marin Headlands. The Golden Gate from above, and the best photography light of the day.
-
-            ✦ 2 PM — Musée Mécanique and Pier 39 chaos, settled by an It's-It taste test.
-
-            ✦ 5 PM — Karl the Fog permitting: Twin Peaks at golden hour.
-
-            ✦ 8 PM — the Alcatraz night tour — the one booking that actually sells out. I can grab three tickets the moment you say yes.
+            That was three days ago. Time to land it — the draft is below, written to be forwarded.
             """,
-            detailLabel: "view the plan",
-            offer: "Shall I post it to the chat?",
-            workLog: ["→ opening WhatsApp",
-                      "→ “Aditya, Aryaman & Jesai”",
-                      "→ posting the plan…",
-                      "✓ posted"],
-            doneTitle: "It's on the chat.",
-            doneBody: "Aditya and Aryaman are typing…",
-            codexPrompt: "Post the SF break-day plan from this briefing to the WhatsApp group 'Aditya, Aryaman & Jesai'."),
+            draft: """
+            Hi Deepika,
+
+            So great speaking with you — and thank you for connecting me with Jordan! Here's a TLDR you can forward along:
+
+            Sentient OS is the private, on-device intelligence layer for your digital life. Your Mac reads everything you've saved — files, screenshots, WhatsApp, iMessage, Notes — entirely on your own hardware, and distills it into a knowledge vault every AI you use can plug into. Raw data never leaves the device. 2,500+ waitlist signups in 24 hours from a single Reddit post, a working product, and a public launch this month.
+
+            Would love to walk Jordan through a live demo whenever suits.
+
+            Best,
+            Jesai
+            """,
+            draftLabel: "Draft · Gmail",
+            detailLabel: "read the draft",
+            offer: "Should I send it for you?",
+            workLog: ["→ reading the thread with Deepika",
+                      "→ opening Gmail",
+                      "→ composing the forwardable TLDR…",
+                      "✓ sent"],
+            doneTitle: "Sent to Deepika.",
+            doneBody: "The TLDR is on its way to Jordan.",
+            codexPrompt: "Open Gmail and reply to the latest thread with Deepika (Outlander VC) using the approved draft in this briefing. Send it."),
 
         Briefing(
             id: "welcome", kind: .welcome,

--- a/Sentient OS macOS/Views/Briefing.swift
+++ b/Sentient OS macOS/Views/Briefing.swift
@@ -110,10 +110,10 @@ struct Briefing: Identifiable {
         Briefing(
             id: "luis", kind: .meeting,
             kicker: "Meeting · iMessage + Calendar",
-            title: "Luis wants Wednesday, 1 PM.",
-            body: "Luis Schmitz (Headline) set lunch for next Wednesday at the Presidio. I checked your calendar — you're free at 1 PM. The reply is drafted.",
+            title: "Luis invited you to lunch at Headline.",
+            body: "Lunch at Headline's Presidio office, next Wednesday at 1 PM. I checked your calendar — you're free. The reply is drafted.",
             letter: """
-            Luis Schmitz from Headline set lunch for next Wednesday at 1 PM, at the Presidio. I checked your calendar: you're free, with nothing for two hours on either side.
+            Luis Schmitz invited you to lunch at Headline next Wednesday at 1 PM, at their Presidio office. I checked your calendar: you're free, with nothing for two hours on either side.
 
             Worth remembering: their HQ is 101 Montgomery Street in the Presidio — NOT the Montgomery in Downtown. I'll remind you that morning.
             """,

--- a/Sentient OS macOS/Views/Briefing.swift
+++ b/Sentient OS macOS/Views/Briefing.swift
@@ -78,7 +78,7 @@ struct Briefing: Identifiable {
             id: "anthos", kind: .overdue,
             kicker: "Overdue · 4 days · Gmail",
             title: "You ghosted Anthos Capital.",
-            body: "Serena cold-emailed four days ago — $1.5B fund, names like Honey and Kalshi. She wants time next week. I wrote your reply.",
+            body: "Serena cold-emailed four days ago — $3B+ AUM, names like Honey and Kalshi. She wants time next week. I wrote your reply.",
             letter: """
             Serena Saxena from Anthos Capital cold-emailed four days ago — she found Sentient down an on-device-vs-cloud rabbit hole. Anthos runs a $1.5B fund with $3B+ in AUM, and backs companies people are obsessed with: Honey, Kalshi, Erewhon, Olaplex.
 

--- a/Sentient OS macOS/Views/BriefingsView.swift
+++ b/Sentient OS macOS/Views/BriefingsView.swift
@@ -426,7 +426,7 @@ private struct LetterView: View {
 
 private enum Demo {
     static let name = "Jesai"   // later: the vault portrait's first name
-    static let reminders = "Reminders · Luis @ Headline — Fri 1 PM · ZFellows — 8 days · Workout — tonight 8 PM"
+    static let reminders = "Reminders · EWOR call — Daniel Dippold, Fri 11 AM · ZFellows — 8 days · Workout — tonight 8 PM"
     static func readLine(count: Int) -> String {
         "While you slept, I read 1,704 things · \(count) offering\(count == 1 ? "" : "s")"
     }

--- a/Sentient OS macOS/Views/ConstellationHome.swift
+++ b/Sentient OS macOS/Views/ConstellationHome.swift
@@ -471,8 +471,8 @@ private enum Demo {
     static let synced = "Synced · 3:41 AM"
     static let pending = 214
     static let forYouTeasers: [(kind: Briefing.Kind, text: String)] = [
-        (.overdue,  "Send your reply to Outlander VC?"),
-        (.promise,  "Text Dad his running-shoe research?"),
+        (.overdue,  "Reply to Anthos Capital?"),
+        (.promise,  "Confirm the AIM interview?"),
         (.deadline, "Register you for ZFellows?"),
     ]
     static let forYouFoot = "6 offerings · one click each"


### PR DESCRIPTION
Tweaks the hard-coded For You ("Offerings") demo content to current, real-context cards ahead of the a16z demo. **Demo strings only — no logic, no layout changes.**

### Card swaps
| Slot | Was | Now |
|---|---|---|
| Top-left (overdue / Gmail) | Deepika / Outlander VC | **Anthos Capital** — Serena's cold email (the $3B-AUM fund Jesai ghosted), with a drafted, ready-to-send reply. Title: *"You ghosted Anthos Capital."* |
| Top-mid (meeting) | Luis — **Friday** 1 PM | Luis — **next Wednesday** 1 PM, at the Presidio (the real *Lunch @ Presidio* event) |
| Top-right (promise) | Dad's running shoes | **AIM India** — Supreeth's interview invite (expert voice on Siri AI + launch coverage), 10 AM tomorrow, reply drafted |
| Bottom reminders strip | Luis @ Headline — Fri 1 PM | **EWOR call — Daniel Dippold, Fri 11 AM** |

The home For You satellite's teaser lines now track the new cards (Anthos · AIM · ZFellows) so home → window stays consistent.

### Notes
- The Anthos reply draft is written in Jesai's voice (on-device pitch, 2,500 waitlist, proposes Tue/Wed next week) — **give it a once-over before the demo**, it's the one that would actually get sent.
- Each card's `codexPrompt` (the real-execution seam) was updated to match the new content.
- Build: ✅ green via xcodebuild, zero warnings.