### PR TITLE
MCP mirror: real sync (flat zip + durable retry) + dev opt-in toggle

### DIFF
--- a/Sentient OS macOS/Documentation/MCP Mirror Client.md
+++ b/Sentient OS macOS/Documentation/MCP Mirror Client.md
@@ -31,10 +31,31 @@ A lost token is a non-event: mint a new one, re-push; the orphaned cloud copy ex
 
 ## Sync
 
-Whole-vault **zip-replace**: `push()` zips `VaultGenerator.vaultRoot` via the OS's coordinated
-`.forUploading` read (no shelling out, no deps) and `POST`s it. A vault is ~KBs of markdown.
-Call `push()` after initial generation, each daily update, and any user edit (the editor-idle
-guard + change trigger are the scheduler's job).
+Whole-vault **zip-replace**: `push()` zips `VaultGenerator.vaultRoot` and `POST`s it. A vault is
+~KBs of markdown. The zip is built by shelling to `/usr/bin/zip` from **inside** the vault dir
+(`zip -r -X -q … .`) so entries are **root-relative** (`README.md`, `Career/Job.md`) — the server's
+contract. (We deliberately do *not* use `NSFileCoordinator.forUploading`: it wraps everything under
+the vault folder name, which breaks the README-portrait bundling in `get_structure`. The server
+also defensively unwraps a lone wrapper dir, so old clients still sync correctly.)
+
+**The sync happens automatically after every knowledge-base change.** `VaultCloud.create()` and
+`VaultCloud.update()` each end with `markDirtyAndPush()`, which sets `VaultActivity.vaultDirty`
+then calls **`VaultCloud.pushIfDirty()`** — the single push orchestrator: push only if the mirror
+is enabled AND the vault is dirty, clearing the dirty flag only on a successful push. A failure
+leaves `vaultDirty` set so the next trigger retries. `SentientOSApp` also calls
+`VaultCloud.pushIfDirty()` once on launch (a `.task` on `RootView`) — the **durable catch-up** for
+a push that failed or never ran (e.g. the app quit between a KB update and its push). `vaultDirty`
+is persisted in `UserDefaults`, so a deferred sync survives a relaunch. (This restores the retry
+the retired `DaysEndJob.pushIfDirty()` used to provide; future vault-editor saves hook in the same
+way.)
+
+## Turning the mirror on (today)
+
+The opt-in is "mint a token" — `enable()`. The real onboarding/Settings opt-in UI is Phase 5, so
+ahead of that there's a **MCP TOGGLE** button in **DEV TOOLS** (`DevToolsView`): ON mints the token
+and pushes the current vault; OFF deletes the cloud copy and forgets the token. Detailed actions
+(copy share link, force a Sync now, read access stats) sit under **More** while the mirror is ON.
+Use this to dogfood end-to-end sync on a real INITIAL/ITERATIVE cloud run.
 
 ## Keychain
 
@@ -52,6 +73,8 @@ Runs enable → push → stats → delete → disable. Needs a vault on disk (`~
 
 ## Not built here (downstream)
 
-UI surfaces (Copy MCP Link in the menu bar, the "Your AIs" satellite, the MCP opt-in
-onboarding screen) and the auto-push triggers (after vault changes, editor-idle-gated) are
-Phase-5 / scheduler work that calls into this client.
+The production opt-in surfaces — the MCP opt-in onboarding screen (step ⑨) with the
+no-account/token/30-day-lease explainer, the "Your AIs" satellite (access-log line), and the
+menu-bar Copy MCP Link — are Phase-5 work that calls into this client (the DEV TOOLS MCP TOGGLE is
+the interim dogfood stand-in). Auto-push *after vault changes* is now wired (see Sync above); the
+editor-idle gate (`VaultActivity.editorBusy`) still awaits the Phase-5 vault editor.

--- a/Sentient OS macOS/Ingestion/VaultCloud.swift
+++ b/Sentient OS macOS/Ingestion/VaultCloud.swift
@@ -138,17 +138,29 @@ actor VaultCloud {
         }
     }
 
-    // MARK: Mirror push (same rule as the retired DaysEndJob.pushIfDirty)
+    // MARK: Mirror push (restores the retired DaysEndJob.pushIfDirty durable retry)
 
+    /// Mark the vault changed, then immediately try to sync it to the mirror.
     private func markDirtyAndPush() async {
         await MainActor.run { VaultActivity.shared.vaultDirty = true }
+        await Self.pushIfDirty()
+    }
+
+    /// Push the vault to the mirror IFF the mirror is enabled AND there's an unsynced change
+    /// (`VaultActivity.vaultDirty`). Clears the dirty flag only on a successful push; a failure
+    /// leaves it set so the next trigger retries. Called after every create/update AND once on app
+    /// launch (`SentientOSApp`) — that launch call is the durable catch-up for a push that failed
+    /// or never ran (e.g. the app quit between a KB update and its push). No-op when the mirror is
+    /// off or the vault is already in sync, so it's safe to call anytime.
+    static func pushIfDirty() async {
         guard await MirrorClient.shared.isEnabled else { return }
+        guard await MainActor.run(body: { VaultActivity.shared.vaultDirty }) else { return }
         do {
             try await MirrorClient.shared.push()
             await MainActor.run { VaultActivity.shared.vaultDirty = false }
             Log("VaultCloud: mirror pushed ✓")
         } catch {
-            Log("VaultCloud: mirror push failed — \((error as? LocalizedError)?.errorDescription ?? "\(error)") (retries next time)")
+            Log("VaultCloud: mirror push failed — \((error as? LocalizedError)?.errorDescription ?? "\(error)") (retries next trigger)")
         }
     }
 

--- a/Sentient OS macOS/MirrorClient.swift
+++ b/Sentient OS macOS/MirrorClient.swift
@@ -145,25 +145,33 @@ actor MirrorClient {
         }
     }
 
-    /// Zip a directory into a temp .zip using the OS's own coordinated "for uploading" read —
-    /// no shelling out, no dependency. The zip's entries are vault-relative (the server expects
-    /// paths like `README.md`, `Career/Job Search.md`).
+    /// Zip the vault's CONTENTS into a temp .zip with ROOT-RELATIVE entries (`README.md`,
+    /// `Career/Job.md`). We shell to `/usr/bin/zip` from inside the vault dir on purpose:
+    /// NSFileCoordinator's `.forUploading` instead wraps everything under the vault folder name
+    /// (`Sentient OS -- The Vault/…`), which breaks the server's root-relative contract — the README
+    /// portrait stops bundling in `get_structure` and every note nests a level too deep. The macOS
+    /// `zip` writes UTF-8 names without the 0x800 flag; the server recovers those. (`zip` ships with
+    /// macOS; the app is non-sandboxed, so spawning it is fine — same as `CodexCLI`.)
     private static func zipDirectory(_ dir: URL) throws -> URL {
-        var coordError: NSError?
-        var thrown: Error?
-        var result: URL?
-        let coordinator = NSFileCoordinator()
-        coordinator.coordinate(readingItemAt: dir, options: [.forUploading], error: &coordError) { zipped in
-            // `zipped` is a temp .zip the OS created; move it somewhere we own before the block ends.
-            let dst = FileManager.default.temporaryDirectory
-                .appendingPathComponent("vault-\(UUID().uuidString).zip")
-            do { try FileManager.default.moveItem(at: zipped, to: dst); result = dst }
-            catch { thrown = error }
+        let dst = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vault-\(UUID().uuidString).zip")
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
+        proc.currentDirectoryURL = dir
+        // -r recurse · -X drop extra macOS attributes · -q quiet · "." = the dir CONTENTS (no wrapper).
+        proc.arguments = ["-r", "-X", "-q", dst.path, ".", "-x", ".DS_Store", "*/.DS_Store"]
+        let errPipe = Pipe()
+        proc.standardError = errPipe
+        proc.standardOutput = FileHandle.nullDevice
+        do { try proc.run() }
+        catch { throw MirrorError.zipFailed("couldn't launch /usr/bin/zip: \(error.localizedDescription)") }
+        let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+        proc.waitUntilExit()
+        guard proc.terminationStatus == 0, FileManager.default.fileExists(atPath: dst.path) else {
+            let msg = String(data: errData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            throw MirrorError.zipFailed("zip exited \(proc.terminationStatus): \(msg.prefix(200))")
         }
-        if let coordError { throw MirrorError.zipFailed(coordError.localizedDescription) }
-        if let thrown { throw MirrorError.zipFailed(thrown.localizedDescription) }
-        guard let result else { throw MirrorError.zipFailed("no archive produced") }
-        return result
+        return dst
     }
 }
 

--- a/Sentient OS macOS/Sentient_OS_macOSApp.swift
+++ b/Sentient OS macOS/Sentient_OS_macOSApp.swift
@@ -44,6 +44,7 @@ struct SentientOSApp: App {
             RootView(store: store)
                 .environment(appState)
                 .preferredColorScheme(.dark)   // Sentient OS is dark-only — no light mode
+                .task { await VaultCloud.pushIfDirty() }   // catch up a mirror sync deferred by an earlier quit/failure
         }
         .windowStyle(.hiddenTitleBar)            // OLED black runs edge-to-edge; no gray trim
         .windowResizability(.contentMinSize)

--- a/Sentient OS macOS/Views/DevToolsView.swift
+++ b/Sentient OS macOS/Views/DevToolsView.swift
@@ -112,6 +112,13 @@ struct DevToolsView: View {
     @AppStorage("dbg.gmail.connected") private var gmailConnected = false
     @AppStorage("dbg.run.gmail")       private var runGmail = false
 
+    // MCP mirror (the hosted Render copy). Local mirrors of MirrorClient's actor state, refreshed
+    // when "More" opens and after each action.
+    @State private var mirrorEnabled = false
+    @State private var mirrorURL: String?
+    @State private var mirrorStatus: String?
+    @State private var mirrorBusy = false
+
     private var selectedSources: [RunSource] {
         SourceSelection.current(customRoots: customRoots, fdaGranted: fdaGranted)
     }
@@ -151,6 +158,7 @@ struct DevToolsView: View {
                         viewSummariesButton
                         viewActionItemsButton
                     }
+                    mcpToggleButton
                     clearSummariesButton
                     moreSection
                 }
@@ -186,7 +194,10 @@ struct DevToolsView: View {
                 runIMessage = !newSel.isEmpty
             }
         }
-        .onAppear { fdaGranted = Permissions.hasFullDiskAccess() }
+        .onAppear {
+            fdaGranted = Permissions.hasFullDiskAccess()
+            Task { await refreshMirror() }
+        }
     }
 
     // MARK: The two columns
@@ -543,7 +554,10 @@ struct DevToolsView: View {
         VStack(spacing: 12) {
             Button {
                 withAnimation { showMore.toggle() }
-                if showMore { fdaGranted = Permissions.hasFullDiskAccess() }
+                if showMore {
+                    fdaGranted = Permissions.hasFullDiskAccess()
+                    Task { await refreshMirror() }
+                }
             } label: {
                 Label("More", systemImage: showMore ? "chevron.down" : "chevron.right")
                     .font(.caption.weight(.medium))
@@ -567,10 +581,171 @@ struct DevToolsView: View {
                     }
 
                     fdaPane
+                    mirrorPane
                 }
                 .padding(.top, 4)
             }
         }
+    }
+
+    // MARK: MCP mirror (opt-in toggle + manual sync — dogfood ahead of the Phase-5 onboarding screen)
+
+    /// The coached system prompt the user pastes into ChatGPT/Claude/Gemini (custom instructions).
+    /// Naming the connector + "always call get_structure" is what reliably makes the client load and
+    /// use the tools — clients lazy-load connector tools behind a search gate (Arch §7 field learnings).
+    static let mcpSystemPrompt = """
+        Use the Sentient OS MCP whenever relevant. It gives you access to the user's personal knowledge \
+        base, created just for you! It's basically an Obsidian vault of notes about their actual life: \
+        their work, projects, plans, relationships, places, preferences, and history, built from their \
+        entire digital life (notes, messages, emails, etc.) using on-device LLMs that analyzed their \
+        whole digital life.
+
+        In fact, using it would help you improve almost anything you need to help the user with!
+
+        ALWAYS call get_structure at the start of ANY chat with the user.
+
+        It returns the folder and file-name index structure of the vault (so you can know if there's \
+        anything you want to read in full), and it also returns the README file of the vault with some \
+        incredible general context. So ALWAYS call this at the start of EVERY chat.
+
+        And yeah, any time you think another file is really relevant to a conversation/prompt, go read \
+        it in full using get_files!
+        """
+
+    /// Put a string on the system clipboard.
+    private func copyToPasteboard(_ s: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(s, forType: .string)
+    }
+
+    /// The headline MCP control. ON mints the token and pushes the current vault to Render; OFF
+    /// deletes the cloud copy and forgets the token. The share link + coached system prompt copy
+    /// right under it (while ON); Sync now / Stats live in `mirrorPane` under "More".
+    private var mcpToggleButton: some View {
+        VStack(spacing: 5) {
+            Button {
+                Task { await runMirror {
+                    if mirrorEnabled {
+                        await MirrorClient.shared.disable()
+                        mirrorStatus = "✓ MCP mirror OFF — cloud copy deleted"
+                    } else {
+                        _ = await MirrorClient.shared.enable()
+                        do {
+                            try await MirrorClient.shared.push()
+                            VaultActivity.shared.vaultDirty = false
+                            mirrorStatus = "✓ MCP mirror ON — vault pushed to Render"
+                        } catch MirrorClient.MirrorError.noVault {
+                            mirrorStatus = "✓ MCP mirror ON — no vault yet (syncs on first KB build)"
+                        }
+                    }
+                } }
+            } label: {
+                HStack(spacing: 7) {
+                    if mirrorBusy { ProgressView().controlSize(.small) }
+                    else {
+                        Image(systemName: mirrorEnabled
+                              ? "antenna.radiowaves.left.and.right"
+                              : "antenna.radiowaves.left.and.right.slash")
+                    }
+                    Text("MCP TOGGLE").font(.caption.weight(.bold)).tracking(2)
+                    Text(mirrorEnabled ? "ON" : "OFF")
+                        .font(.caption2.weight(.bold))
+                        .padding(.horizontal, 6).padding(.vertical, 2)
+                        .background(Capsule().fill((mirrorEnabled ? Color.green : Theme.secondary).opacity(0.22)))
+                        .foregroundStyle(mirrorEnabled ? .green : Theme.secondary)
+                }
+                .frame(maxWidth: .infinity, minHeight: 40)
+            }
+            .buttonStyle(.bordered).tint(mirrorEnabled ? .green : Theme.secondary)
+            .disabled(mirrorBusy)
+
+            if mirrorEnabled, let url = mirrorURL {
+                HStack(spacing: 8) {
+                    Button {
+                        copyToPasteboard(url)
+                        mirrorStatus = "✓ MCP link copied — add it as a connector in ChatGPT/Claude"
+                    } label: {
+                        Label("Copy MCP Link", systemImage: "link")
+                            .font(.caption2.weight(.semibold))
+                            .frame(maxWidth: .infinity, minHeight: 32)
+                    }
+                    .buttonStyle(.bordered).controlSize(.small).tint(Theme.accent)
+                    Button {
+                        copyToPasteboard(Self.mcpSystemPrompt)
+                        mirrorStatus = "✓ system prompt copied — paste into the model's custom instructions"
+                    } label: {
+                        Label("Copy System Prompt", systemImage: "text.quote")
+                            .font(.caption2.weight(.semibold))
+                            .frame(maxWidth: .infinity, minHeight: 32)
+                    }
+                    .buttonStyle(.bordered).controlSize(.small).tint(.purple)
+                }
+                .frame(maxWidth: 460)
+                .disabled(mirrorBusy)
+            }
+
+            if let mirrorStatus {
+                Text(mirrorStatus)
+                    .font(.system(.caption2, design: .monospaced))
+                    .foregroundStyle(mirrorStatus.hasPrefix("✓") ? .green : mirrorStatus.hasPrefix("✗") ? .red : Theme.secondary)
+                    .multilineTextAlignment(.center).fixedSize(horizontal: false, vertical: true)
+                    .textSelection(.enabled)
+            }
+        }
+    }
+
+    /// Detailed mirror actions under "More" — shown only while the mirror is ON (flip it with the
+    /// MCP TOGGLE button above). Copy the share URL, force a sync, or read the access-log stats.
+    @ViewBuilder private var mirrorPane: some View {
+        if mirrorEnabled, let url = mirrorURL {
+            VStack(spacing: 12) {
+                HStack(spacing: 8) {
+                    Image(systemName: "antenna.radiowaves.left.and.right")
+                        .foregroundStyle(Theme.verdictColor(.survivor))
+                    Text("MCP mirror — syncs after each KB update")
+                        .font(.caption.weight(.medium)).foregroundStyle(.white)
+                    Spacer()
+                    if mirrorBusy { ProgressView().controlSize(.small) }
+                }
+                Text(url)
+                    .font(.system(.caption2, design: .monospaced)).foregroundStyle(Theme.faint)
+                    .lineLimit(1).truncationMode(.middle).textSelection(.enabled)
+                HStack(spacing: 8) {
+                    Button("Sync now") { Task { await runMirror {
+                        try await MirrorClient.shared.push()
+                        VaultActivity.shared.vaultDirty = false
+                        mirrorStatus = "✓ synced to mirror"
+                    } } }
+                    .buttonStyle(.bordered).controlSize(.small).tint(.purple).disabled(mirrorBusy)
+                    Button("Stats") { Task { await runMirror {
+                        let s = try await MirrorClient.shared.stats()
+                        let last = s.lastAccess.map {
+                            RelativeDateTimeFormatter().localizedString(for: $0, relativeTo: Date())
+                        } ?? "never"
+                        mirrorStatus = "✓ \(s.notesRead24h) notes · \(s.toolCalls24h) calls (24h) · last \(last)"
+                    } } }
+                    .buttonStyle(.bordered).controlSize(.small).tint(.white).disabled(mirrorBusy)
+                }
+            }
+            .padding(14).frame(maxWidth: 460).glassCard()
+        }
+    }
+
+    /// Pull MirrorClient's actor state into the local @State the pane renders from.
+    @MainActor private func refreshMirror() async {
+        mirrorEnabled = await MirrorClient.shared.isEnabled
+        mirrorURL = await MirrorClient.shared.shareURL
+    }
+
+    /// Run one mirror action with a busy spinner; funnel thrown errors into the status line and
+    /// always refresh the enabled/URL state afterward.
+    @MainActor private func runMirror(_ work: @escaping @MainActor () async throws -> Void) async {
+        guard !mirrorBusy else { return }
+        mirrorBusy = true
+        do { try await work() }
+        catch { mirrorStatus = "✗ \((error as? LocalizedError)?.errorDescription ?? "\(error)")" }
+        await refreshMirror()
+        mirrorBusy = false
     }
 
     private var fdaPane: some View {


### PR DESCRIPTION
## What
Makes the MCP mirror actually sync, fixes a path-wrapping bug found while testing end-to-end, and adds an interim opt-in so it's usable/dogfoodable ahead of the Phase-5 onboarding.

## Why
The push was wired into `VaultCloud.create/update` but **inert**: nothing could turn the mirror on, and the failed-push **retry was dropped** in the files-iterative rewrite (`vaultDirty` was write-only). End-to-end testing against prod also found pushes landing **wrapped** under the vault-folder name (`Sentient OS -- The Vault/README.md`), which broke `get_structure`'s **README-portrait bundling** — i.e. "what do you know about me?" returned nothing.

## Changes
- **`MirrorClient.zipDirectory`** → zip via `/usr/bin/zip` from inside the vault dir ⇒ **root-relative entries**. (Was `NSFileCoordinator.forUploading`, which wraps everything under the vault folder.) Server also defensively unwraps a lone wrapper dir as a backstop for old clients — [`sentient-os-mcp#7`](https://github.com/Sentient-OS-Labs/sentient-os-mcp/pull/7), already deployed.
- **`VaultCloud.pushIfDirty()`** → restores the durable retry: push iff mirror enabled AND `vaultDirty`, clear the flag only on success. Called after every create/update **and once on launch** (`SentientOSApp .task`) to catch a push deferred by a quit.
- **`DevToolsView`** → **MCP TOGGLE** button (mint token + push / delete + forget) with **Copy MCP Link** + **Copy System Prompt** (the coached connector prompt), and Sync now / Stats under "More".
- **Doc** → `Documentation/MCP Mirror Client.md`.

## Verification (live, against prod)
Initial + iterative runs both verified: **21/21 files byte-identical** over the live MCP tools, README portrait bundles, all paths flat. Access log records reads.

## Notes
- Pairs with the already-merged-and-deployed server unwrap (`sentient-os-mcp#7`).
- Interim opt-in is the DEV TOOLS toggle; the real onboarding opt-in (step ⑨) is still Phase 5.