### PR TITLE
MCP sync: separate manual MCP SYNC button + move Clear Summaries into the summaries sheet

### DIFF
--- a/Sentient OS macOS/Documentation/MCP Mirror Client.md
+++ b/Sentient OS macOS/Documentation/MCP Mirror Client.md
@@ -38,24 +38,26 @@ contract. (We deliberately do *not* use `NSFileCoordinator.forUploading`: it wra
 the vault folder name, which breaks the README-portrait bundling in `get_structure`. The server
 also defensively unwraps a lone wrapper dir, so old clients still sync correctly.)
 
-**The sync happens automatically after every knowledge-base change.** `VaultCloud.create()` and
-`VaultCloud.update()` each end with `markDirtyAndPush()`, which sets `VaultActivity.vaultDirty`
-then calls **`VaultCloud.pushIfDirty()`** — the single push orchestrator: push only if the mirror
-is enabled AND the vault is dirty, clearing the dirty flag only on a successful push. A failure
-leaves `vaultDirty` set so the next trigger retries. `SentientOSApp` also calls
-`VaultCloud.pushIfDirty()` once on launch (a `.task` on `RootView`) — the **durable catch-up** for
-a push that failed or never ran (e.g. the app quit between a KB update and its push). `vaultDirty`
-is persisted in `UserDefaults`, so a deferred sync survives a relaunch. (This restores the retry
-the retired `DaysEndJob.pushIfDirty()` used to provide; future vault-editor saves hook in the same
-way.)
+**Sync is currently a SEPARATE manual step (dev decision — trivially re-couplable).**
+`VaultCloud.create()` and `VaultCloud.update()` only **mark the vault dirty** (`VaultActivity.vaultDirty`)
+— they no longer auto-push. The push happens via:
+- the **MCP SYNC** button in DEV TOOLS — a forced `MirrorClient.push()` that clears the dirty flag, and
+- **`VaultCloud.pushIfDirty()`** on app launch (a `.task` on `RootView`) — the durable catch-up that
+  pushes iff the mirror is enabled AND the vault is dirty, clearing the flag only on success.
+
+`vaultDirty` is persisted in `UserDefaults`, so a deferred sync survives a relaunch. To restore
+auto-push-after-KB-update, call `await Self.pushIfDirty()` from `VaultCloud.markDirty()`.
 
 ## Turning the mirror on (today)
 
 The opt-in is "mint a token" — `enable()`. The real onboarding/Settings opt-in UI is Phase 5, so
-ahead of that there's a **MCP TOGGLE** button in **DEV TOOLS** (`DevToolsView`): ON mints the token
-and pushes the current vault; OFF deletes the cloud copy and forgets the token. Detailed actions
-(copy share link, force a Sync now, read access stats) sit under **More** while the mirror is ON.
-Use this to dogfood end-to-end sync on a real INITIAL/ITERATIVE cloud run.
+ahead of that the **DEV TOOLS** panel (`DevToolsView`) exposes, while the mirror is ON:
+- **MCP TOGGLE** — ON mints the token + pushes the current vault; OFF deletes the cloud copy + forgets the token.
+- **Copy MCP Link** / **Copy System Prompt** — the share URL and the coached connector prompt to paste into ChatGPT/Claude.
+- **MCP SYNC** — force-push the current vault to the mirror (sync is a separate manual step now; see Sync above).
+- **Stats** (under **More**) — the access-log summary.
+
+Use these to dogfood end-to-end sync on a real INITIAL/ITERATIVE cloud run.
 
 ## Keychain
 

--- a/Sentient OS macOS/Ingestion/SummariesView.swift
+++ b/Sentient OS macOS/Ingestion/SummariesView.swift
@@ -13,6 +13,7 @@ struct SummariesView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var notes: [CycleNoteItem] = []
     @State private var loaded = false
+    @State private var showClearConfirm = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -20,6 +21,8 @@ struct SummariesView: View {
                 Text("SUMMARIES · \(notes.count)")
                     .font(.caption2.weight(.bold)).tracking(2).foregroundStyle(Theme.faint)
                 Spacer()
+                Button("Clear All", role: .destructive) { showClearConfirm = true }
+                    .controlSize(.small).tint(.red).disabled(notes.isEmpty)
                 Button("Refresh") { Task { await load() } }.controlSize(.small)
                 Button("Done") { dismiss() }.controlSize(.small)
             }
@@ -45,6 +48,18 @@ struct SummariesView: View {
         .frame(width: 640, height: 720)
         .background(Theme.bg)
         .task { await load() }
+        .confirmationDialog("Clear all current summaries?", isPresented: $showClearConfirm,
+                            titleVisibility: .visible) {
+            Button("Clear All", role: .destructive) { Task { await clearAll() } }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Deletes every summary in the current cycle. Per-source pointers are kept, so an ITERATIVE run won't re-summarize past items — run INITIAL to fully re-summarize.")
+        }
+    }
+
+    private func clearAll() async {
+        await CycleStore.shared.wipeAllNotes()
+        await load()
     }
 
     private func row(_ n: CycleNoteItem) -> some View {

--- a/Sentient OS macOS/Ingestion/VaultCloud.swift
+++ b/Sentient OS macOS/Ingestion/VaultCloud.swift
@@ -11,7 +11,8 @@
 //
 //  Proactive intelligence is its OWN module — see Proactive.swift (Arch §6: own module + trigger).
 //  Connector-agnostic: operates on `CycleStore.notes()` regardless of source (files / notes / chats).
-//  After create/update the mirror is pushed (same rule as the retired DaysEndJob.pushIfDirty).
+//  Create/update only MARK the vault dirty; MCP sync is a SEPARATE step (the dev "MCP SYNC" button →
+//  MirrorClient.push, plus pushIfDirty() as the on-launch catch-up). Re-couple in markDirty() later.
 //
 
 import Foundation
@@ -78,7 +79,7 @@ actor VaultCloud {
         do {
             let result = try await VaultGenerator().generate(notes: notes, resume: createResume, onProgress: onProgress)
             createResume = nil
-            await markDirtyAndPush()
+            await markDirty()
             return result
         } catch let VaultGenerator.VaultError.usageLimit(message, resume) {
             createResume = resume
@@ -124,7 +125,7 @@ actor VaultCloud {
         do {
             let envelope = try await CodexCLI.shared.run(invocation)
             updateResumeSessionID = nil
-            await markDirtyAndPush()
+            await markDirty()
             Log("VaultCloud.update: ✅ \(notes.count) notes (turns \(envelope.numTurns ?? -1)) — \(envelope.result.prefix(120))")
             return notes.count
         } catch let CodexCLI.CLIError.usageLimit(message, sessionID) {
@@ -138,12 +139,14 @@ actor VaultCloud {
         }
     }
 
-    // MARK: Mirror push (restores the retired DaysEndJob.pushIfDirty durable retry)
+    // MARK: Mirror push
 
-    /// Mark the vault changed, then immediately try to sync it to the mirror.
-    private func markDirtyAndPush() async {
+    /// Flag the vault as changed (so a later sync knows there's something to push) WITHOUT pushing.
+    /// MCP sync is currently a SEPARATE manual step — the dev "MCP SYNC" button calls
+    /// `MirrorClient.push()`, and `pushIfDirty()` runs on app launch as the catch-up. To restore
+    /// auto-push-after-KB-update, just call `await Self.pushIfDirty()` here.
+    private func markDirty() async {
         await MainActor.run { VaultActivity.shared.vaultDirty = true }
-        await Self.pushIfDirty()
     }
 
     /// Push the vault to the mirror IFF the mirror is enabled AND there's an unsynced change

--- a/Sentient OS macOS/Views/DevToolsView.swift
+++ b/Sentient OS macOS/Views/DevToolsView.swift
@@ -103,8 +103,6 @@ struct DevToolsView: View {
     @State private var showIMessagePicker = false
     @State private var showSummaries = false
     @State private var showActionItems = false
-    @State private var showClearSummariesConfirm = false
-    @State private var clearSummariesResult: String?
     @State private var showMore = false
     @State private var fdaGranted = false
     @State private var resetResult: String?
@@ -159,7 +157,6 @@ struct DevToolsView: View {
                         viewActionItemsButton
                     }
                     mcpToggleButton
-                    clearSummariesButton
                     moreSection
                 }
                 .padding(24)
@@ -286,37 +283,6 @@ struct DevToolsView: View {
                 .frame(maxWidth: .infinity, minHeight: 40)
         }
         .buttonStyle(.bordered).tint(.orange)
-    }
-
-    /// Clears ALL current-cycle summaries at once (notes only; per-source pointers are kept — use the
-    /// Reset button below to also drop pointers). The proactive button no longer wipes, so this is the
-    /// one-click "empty the summaries" control.
-    private var clearSummariesButton: some View {
-        VStack(spacing: 5) {
-            Button(role: .destructive) { showClearSummariesConfirm = true } label: {
-                Label("CLEAR SUMMARIES", systemImage: "trash")
-                    .font(.caption2.weight(.bold)).tracking(1.5)
-                    .frame(maxWidth: .infinity, minHeight: 32)
-            }
-            .buttonStyle(.bordered).tint(.red)
-            if let s = clearSummariesResult {
-                Text(s).font(.system(.caption2, design: .monospaced)).foregroundStyle(.green)
-            }
-        }
-        .confirmationDialog("Clear all current summaries?", isPresented: $showClearSummariesConfirm,
-                            titleVisibility: .visible) {
-            Button("Clear All", role: .destructive) { Task { await clearSummaries() } }
-            Button("Cancel", role: .cancel) {}
-        } message: {
-            Text("Deletes every summary in the current cycle. Per-source pointers are kept, so an ITERATIVE run won't re-summarize past items — run INITIAL to fully re-summarize.")
-        }
-    }
-
-    @MainActor
-    private func clearSummaries() async {
-        let before = await CycleStore.shared.counts().notes
-        await CycleStore.shared.wipeAllNotes()
-        clearSummariesResult = "✓ cleared \(before) summar\(before == 1 ? "y" : "ies")"
     }
 
     // MARK: The actions (all on the NEW files-iterative stack)
@@ -682,6 +648,26 @@ struct DevToolsView: View {
                 }
                 .frame(maxWidth: 460)
                 .disabled(mirrorBusy)
+
+                // Dedicated manual sync — create/update no longer auto-push (they only mark the
+                // vault dirty), so this is the explicit "push the vault to the mirror now" step.
+                Button {
+                    Task { await runMirror {
+                        try await MirrorClient.shared.push()
+                        VaultActivity.shared.vaultDirty = false
+                        mirrorStatus = "✓ synced to mirror"
+                    } }
+                } label: {
+                    HStack(spacing: 7) {
+                        if mirrorBusy { ProgressView().controlSize(.small) }
+                        else { Image(systemName: "arrow.triangle.2.circlepath") }
+                        Text("MCP SYNC").font(.caption.weight(.bold)).tracking(2)
+                    }
+                    .frame(maxWidth: .infinity, minHeight: 40)
+                }
+                .buttonStyle(.borderedProminent).tint(.purple)
+                .frame(maxWidth: 460)
+                .disabled(mirrorBusy)
             }
 
             if let mirrorStatus {
@@ -711,12 +697,6 @@ struct DevToolsView: View {
                     .font(.system(.caption2, design: .monospaced)).foregroundStyle(Theme.faint)
                     .lineLimit(1).truncationMode(.middle).textSelection(.enabled)
                 HStack(spacing: 8) {
-                    Button("Sync now") { Task { await runMirror {
-                        try await MirrorClient.shared.push()
-                        VaultActivity.shared.vaultDirty = false
-                        mirrorStatus = "✓ synced to mirror"
-                    } } }
-                    .buttonStyle(.bordered).controlSize(.small).tint(.purple).disabled(mirrorBusy)
                     Button("Stats") { Task { await runMirror {
                         let s = try await MirrorClient.shared.stats()
                         let last = s.lastAccess.map {


### PR DESCRIPTION
Follow-up to #35 (dev-UX tweaks; #35 already merged).

## 1. MCP sync is now a separate manual step
Per request, decouple mirror sync from KB create/update **for now** (trivially re-couplable):
- `VaultCloud.create()`/`update()` only **mark the vault dirty** (`markDirty()`) — no auto-push. One line in `markDirty()` (`await Self.pushIfDirty()`) restores auto-push if we want it back.
- `pushIfDirty()` stays as the **on-launch catch-up**.
- **DevToolsView:** new prominent **MCP SYNC** button (force-push) under the MCP TOGGLE; dropped the now-redundant 'Sync now' from More (kept Stats).

## 2. Clear Summaries moved into View Summaries
- Removed `CLEAR SUMMARIES` (+ its state/handler) from the main dev panel.
- Added **Clear All** (same confirmation + warning, disabled when empty) to the **SUMMARIES** sheet header; clearing reloads the list in place.

Build green. Touches only these 4 files; `VaultGenerator.swift`/`project.pbxproj` left out (local Xcode auto-changes).