### PR TITLE
VIEW SUMMARIES: export / import the summary set (dev tool)

### DIFF
--- a/Sentient OS macOS/Ingestion/CycleStore.swift
+++ b/Sentient OS macOS/Ingestion/CycleStore.swift
@@ -64,8 +64,9 @@ final class CycleNote {
     }
 }
 
-/// A Sendable snapshot of one CycleNote — what VIEW SUMMARIES + the cloud calls consume.
-struct CycleNoteItem: Sendable, Identifiable {
+/// A Sendable snapshot of one CycleNote — what VIEW SUMMARIES + the cloud calls consume. Codable so
+/// a whole summary set can be exported/imported between devs (computed props below aren't stored).
+struct CycleNoteItem: Codable, Sendable, Identifiable {
     let id: String             // sourceID (unique within a cycle)
     let bucketKey: String
     let kind: SourceKind
@@ -89,6 +90,15 @@ struct CycleNoteItem: Sendable, Identifiable {
         let home = FileManager.default.homeDirectoryForCurrentUser.path
         return p.hasPrefix(home) ? "~" + String(p.dropFirst(home.count)) : p
     }
+}
+
+/// The JSON shape for exporting/importing a summary set between devs (a debug tool — e.g. share a
+/// rich CycleStore so a co-founder can build proactive against real context). Notes ONLY: pointers
+/// are never exported (a dev's high-water marks are meaningless — and harmful — on another machine).
+struct SummaryExport: Codable, Sendable {
+    var version = 1
+    var exportedAt = Date()
+    var notes: [CycleNoteItem]
 }
 
 // MARK: - The actor
@@ -151,6 +161,21 @@ actor CycleStore {
     /// End-of-cycle wipe (fired by the proactive button) — pointers persist, notes do not.
     func wipeAllNotes() {
         try? modelContext.delete(model: CycleNote.self)
+        try? modelContext.save()
+    }
+
+    /// Bulk-insert notes from an export file (dev cross-pollination — share a rich summary set with a
+    /// co-founder). Preserves each note's original createdAt + itemDate so proactive's recency windows
+    /// stay faithful to the source timeline. `replace` wipes existing notes first. Pointers are NEVER
+    /// touched — an import carries summaries only, so the importer's own processing state is unaffected.
+    func importNotes(_ items: [CycleNoteItem], replace: Bool) {
+        if replace { try? modelContext.delete(model: CycleNote.self) }
+        for it in items {
+            modelContext.insert(CycleNote(
+                bucketKey: it.bucketKey, kind: it.kind, sourceID: it.sourceID,
+                folder: it.folder, itemDate: it.itemDate, text: it.text,
+                title: it.title, reminderFlagged: it.reminderFlagged, createdAt: it.createdAt))
+        }
         try? modelContext.save()
     }
 

--- a/Sentient OS macOS/Ingestion/SummariesView.swift
+++ b/Sentient OS macOS/Ingestion/SummariesView.swift
@@ -6,27 +6,48 @@
 //  survivor summaries, CycleStore). Any connector, initial or iterative; just shows whatever exists
 //  right now (wiped when the proactive button ends the cycle).
 //
+//  Export/Import (top-left, dev tool): dump the whole summary set to a JSON file, or load one to
+//  REPLACE this machine's set — so a dev can hand a co-founder their rich context (e.g. to build
+//  proactive against real data). Export is read-only. Import backs up the existing notes to
+//  Application Support BEFORE replacing, and never touches pointers. See CycleStore.importNotes.
+//
 
 import SwiftUI
+import AppKit
+import UniformTypeIdentifiers
 
 struct SummariesView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var notes: [CycleNoteItem] = []
     @State private var loaded = false
     @State private var showClearConfirm = false
+    @State private var showImportConfirm = false
+    @State private var pendingImport: SummaryExport?
+    @State private var status: String?
 
     var body: some View {
         VStack(spacing: 0) {
             HStack {
                 Text("SUMMARIES · \(notes.count)")
                     .font(.caption2.weight(.bold)).tracking(2).foregroundStyle(Theme.faint)
+                Button("Export") { export() }.controlSize(.small).disabled(notes.isEmpty)
+                Button("Import") { beginImport() }.controlSize(.small)
                 Spacer()
                 Button("Clear All", role: .destructive) { showClearConfirm = true }
                     .controlSize(.small).tint(.red).disabled(notes.isEmpty)
                 Button("Refresh") { Task { await load() } }.controlSize(.small)
                 Button("Done") { dismiss() }.controlSize(.small)
             }
-            .padding(.horizontal, 18).padding(.vertical, 12)
+            .padding(.horizontal, 18).padding(.top, 12).padding(.bottom, status == nil ? 12 : 6)
+
+            if let status {
+                Text(status)
+                    .font(.system(.caption2, design: .monospaced))
+                    .foregroundStyle(status.hasPrefix("✓") ? .green : status.hasPrefix("✗") ? .red : Theme.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 18).padding(.bottom, 8)
+                    .textSelection(.enabled)
+            }
 
             if loaded && notes.isEmpty {
                 Spacer()
@@ -55,12 +76,19 @@ struct SummariesView: View {
         } message: {
             Text("Deletes every summary in the current cycle. Per-source pointers are kept, so an ITERATIVE run won't re-summarize past items — run INITIAL to fully re-summarize.")
         }
+        .confirmationDialog("Replace all summaries with the imported set?",
+                            isPresented: $showImportConfirm, titleVisibility: .visible,
+                            presenting: pendingImport) { exp in
+            Button("Replace \(notes.count) with \(exp.notes.count)", role: .destructive) {
+                Task { await performImport(exp) }
+            }
+            Button("Cancel", role: .cancel) { pendingImport = nil }
+        } message: { exp in
+            Text("Your current \(notes.count) summaries are backed up to Application Support first, then replaced with the \(exp.notes.count) imported ones. Per-source pointers are left untouched.")
+        }
     }
 
-    private func clearAll() async {
-        await CycleStore.shared.wipeAllNotes()
-        await load()
-    }
+    // MARK: Rows
 
     private func row(_ n: CycleNoteItem) -> some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -82,8 +110,88 @@ struct SummariesView: View {
         .padding(.vertical, 10)
     }
 
+    // MARK: Load / clear
+
     private func load() async {
         notes = await CycleStore.shared.notes()
         loaded = true
+    }
+
+    private func clearAll() async {
+        await CycleStore.shared.wipeAllNotes()
+        await load()
+    }
+
+    // MARK: Export (read-only — never mutates this machine's store)
+
+    private func export() {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.json]
+        panel.nameFieldStringValue = "sentient-summaries-\(Self.stamp()).json"
+        panel.canCreateDirectories = true
+        panel.title = "Export Summaries"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        Task {
+            let items = await CycleStore.shared.notes()
+            do {
+                let data = try Self.encoder.encode(SummaryExport(notes: items))
+                try data.write(to: url)
+                status = "✓ exported \(items.count) summaries → \(url.lastPathComponent)"
+            } catch {
+                status = "✗ export failed: \(error.localizedDescription)"
+            }
+        }
+    }
+
+    // MARK: Import (REPLACE — backs up existing first, leaves pointers alone)
+
+    /// Pick + parse the file, then raise the confirm dialog. The actual replace happens in
+    /// `performImport` only after the user confirms.
+    private func beginImport() {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.json]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.title = "Import Summaries"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        do {
+            let data = try Data(contentsOf: url)
+            pendingImport = try Self.decoder.decode(SummaryExport.self, from: data)
+            showImportConfirm = true
+        } catch {
+            status = "✗ couldn't read that file: \(error.localizedDescription)"
+        }
+    }
+
+    private func performImport(_ exp: SummaryExport) async {
+        let existing = await CycleStore.shared.notes()
+        backup(existing)                                              // safety net before any wipe
+        await CycleStore.shared.importNotes(exp.notes, replace: true)
+        pendingImport = nil
+        await load()
+        status = "✓ imported \(exp.notes.count)" + (existing.isEmpty ? "" : " · backed up \(existing.count)")
+    }
+
+    /// Dump the soon-to-be-replaced notes to Application Support/SummaryBackups so an accidental
+    /// import is always recoverable (re-import the backup to undo).
+    private func backup(_ items: [CycleNoteItem]) {
+        guard !items.isEmpty else { return }
+        let dir = URL.applicationSupportDirectory.appending(path: "SummaryBackups", directoryHint: .isDirectory)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appending(path: "backup-\(Self.stamp()).json")
+        if let data = try? Self.encoder.encode(SummaryExport(notes: items)) {
+            try? data.write(to: url)
+            Log("SummariesView: backed up \(items.count) summaries → \(url.path)")
+        }
+    }
+
+    // MARK: Codec helpers
+
+    private static let encoder: JSONEncoder = {
+        let e = JSONEncoder(); e.outputFormatting = [.prettyPrinted, .sortedKeys]; return e
+    }()
+    private static let decoder = JSONDecoder()
+    private static func stamp() -> String {
+        let f = DateFormatter(); f.dateFormat = "yyyy-MM-dd-HHmmss"; return f.string(from: Date())
     }
 }


### PR DESCRIPTION
Now based on `main` (the unify + kill-old-store work is already merged). Just the import/export feature — 2 files, +140 lines.

## What
Top-left **Export** + **Import** buttons in the VIEW SUMMARIES sheet, so a dev can hand a co-founder their rich `CycleStore` (e.g. to build proactive against real context without their own Gmail).

- **Export** (read-only): `CycleStore.notes()` → a versioned JSON file (`SummaryExport{version, exportedAt, notes}`) via `NSSavePanel`. Only *reads* — your summaries can't be touched.
- **Import** (REPLACE): `NSOpenPanel` → decode → **confirm dialog** → **auto-backup** the current notes to `Application Support/SummaryBackups/backup-<ts>.json` → `CycleStore.importNotes(replace: true)`. Preserves each note's `createdAt` + `itemDate` (so proactive's "last week" windowing stays faithful). **Pointers are never touched** — notes only — so the importer's own processing state is unaffected.
- `CycleNoteItem` is now `Codable`; added `CycleStore.importNotes(_:replace:)` + the `SummaryExport` wrapper.

## Why JSON (not a raw `.store` copy)
Copying the live SQLite file would risk corrupting the open `CycleStore.shared` container (the "don't nuke" hazard), drag *pointers* along (polluting the importer's processing state), and is schema-coupled. JSON-of-notes avoids all three and is exactly the data proactive needs.

## Safety
Export is read-only. The only writer is Import, guarded by a confirmation **and** an automatic backup before any wipe — re-import the backup to undo.

## Test
VIEW SUMMARIES → **Export** → save. On the other Mac → **Import** → pick the file → confirm → list repopulates; a backup lands in `Application Support/SummaryBackups`. Not compiled in this env — build before merge.