### PR TITLE
Delete the dead scan()/DataSource/BackfillCursor machinery

### DIFF
--- a/Sentient OS macOS/Self Tests - Temp/SelfTest_FileSkipping.swift
+++ b/Sentient OS macOS/Self Tests - Temp/SelfTest_FileSkipping.swift
@@ -59,7 +59,7 @@ enum SelfTestFileSkipping {
         func counts(_ source: FilesSource) -> [String: Int] {
             let rootPath = source.root.path + "/"
             var by: [String: Int] = [:]
-            for c in (try? source.scan(since: [:]).candidates) ?? [] {
+            for c in source.eligibleFiles() {
                 guard let p = c.metadata["path"], p.hasPrefix(rootPath) else { continue }
                 by[String(p.dropFirst(rootPath.count).split(separator: "/").first ?? "?"), default: 0] += 1
             }
@@ -164,7 +164,7 @@ enum SelfTestFileSkipping {
             }
 
             // What survives, and which directories contribute the most.
-            let candidates = (try? source.scan(since: [:]).candidates) ?? []
+            let candidates = source.eligibleFiles()
             var byDir: [String: Int] = [:]
             for c in candidates {
                 byDir[((c.metadata["path"] ?? "?") as NSString).deletingLastPathComponent, default: 0] += 1

--- a/Sentient OS macOS/Self Tests - Temp/SelfTest_Triage_Pipeline_and_Vault.swift
+++ b/Sentient OS macOS/Self Tests - Temp/SelfTest_Triage_Pipeline_and_Vault.swift
@@ -253,8 +253,8 @@ enum SelfTest {
         if mode == "tokens" {
             let source = WhatsAppSource(chatJIDs: chatFilter((try? WhatsAppSource().listChats()) ?? []))
             let candidates: [Candidate]
-            do { candidates = try source.scan(since: [:]).candidates }
-            catch { emit("scan FAILED: \(error)"); return }
+            do { candidates = try source.eligibleWindows().flatMap { $0.items.map(\.item) } }
+            catch { emit("eligibleWindows FAILED: \(error)"); return }
             emit("windows in backlog: \(candidates.count) · current byte budget: \(ChatWindowing.maxWindowBytes)\n")
             guard !candidates.isEmpty else { return }
 
@@ -293,7 +293,7 @@ enum SelfTest {
             emit(pad("chat", 26) + " msgs   bytes  prefill  win-tok  B/tok  decode")
             for (i, cand) in sample.enumerated() {
                 do {
-                    let artifact = try source.load(cand)
+                    let artifact = Artifact(candidate: cand, text: cand.metadata["windowText"] ?? "")
                     let prompt = Triage.prompt(for: artifact, currentDate: Date())
                     let r = try await engine.generate(prompt: prompt)
                     guard let prefill = r.prefillTokens, prefill > 0 else {
@@ -344,31 +344,36 @@ enum SelfTest {
             return
         }
 
-        // 1) Build the source + scan candidates.
-        let source: any DataSource
-        let maxTokens: Int
-        switch mode {
-        case "whatsapp":
-            source = WhatsAppSource(chatJIDs: chatFilter((try? WhatsAppSource().listChats()) ?? []))
-            maxTokens = ChatWindowing.kvCacheTokens
-        case "imessage":
-            source = iMessageSource(chatGUIDs: chatFilter((try? iMessageSource().listChats()) ?? []))
-            maxTokens = ChatWindowing.kvCacheTokens
-        case "notes":
-            source = NotesSource(); maxTokens = 4096
-        case "files":
-            guard let files = FileRoot.downloads.source else {
-                emit("could not locate ~/Downloads"); return
-            }
-            source = files; maxTokens = 4096
-        default:
-            emit("unknown mode '\(mode)' (use whatsapp | imessage | notes | files)"); return
-        }
-
+        // 1) List candidates via the iterative path (each source's eligible…()) + a per-source loader.
         let candidates: [Candidate]
-        do { candidates = try source.scan(since: [:]).candidates }
-        catch { emit("scan FAILED: \(error)"); return }
-        emit("scanned \(candidates.count) candidates; dumping first \(min(count, candidates.count))\n")
+        let load: (Candidate) throws -> Artifact
+        let maxTokens: Int
+        do {
+            switch mode {
+            case "whatsapp":
+                candidates = try WhatsAppSource(chatJIDs: chatFilter((try? WhatsAppSource().listChats()) ?? []))
+                    .eligibleWindows().flatMap { $0.items.map(\.item) }
+                load = { Artifact(candidate: $0, text: $0.metadata["windowText"] ?? "") }
+                maxTokens = ChatWindowing.kvCacheTokens
+            case "imessage":
+                candidates = try iMessageSource(chatGUIDs: chatFilter((try? iMessageSource().listChats()) ?? []))
+                    .eligibleWindows().flatMap { $0.items.map(\.item) }
+                load = { Artifact(candidate: $0, text: $0.metadata["windowText"] ?? "") }
+                maxTokens = ChatWindowing.kvCacheTokens
+            case "notes":
+                candidates = try NotesSource().eligibleNotes()
+                load = { Artifact(candidate: $0, text: $0.metadata["noteText"] ?? "") }
+                maxTokens = 4096
+            case "files":
+                guard let files = FileRoot.downloads.source else { emit("could not locate ~/Downloads"); return }
+                candidates = files.eligibleFiles()
+                load = { try FilesSource.loadArtifact($0) }
+                maxTokens = 4096
+            default:
+                emit("unknown mode '\(mode)' (use whatsapp | imessage | notes | files)"); return
+            }
+        } catch { emit("listing FAILED: \(error)"); return }
+        emit("listed \(candidates.count) candidates; dumping first \(min(count, candidates.count))\n")
         guard !candidates.isEmpty else { emit("nothing to dump."); return }
 
         // 2) Load the model once.
@@ -381,7 +386,7 @@ enum SelfTest {
         for (i, cand) in candidates.prefix(count).enumerated() {
             let label = cand.metadata["folder"] ?? cand.metadata["displayPath"] ?? cand.id
             do {
-                let artifact = try source.load(cand)
+                let artifact = try load(cand)
                 let prompt = Triage.prompt(for: artifact, currentDate: Date())
                 let result = try await engine.generate(prompt: prompt, imageData: artifact.imageData)
                 let outcome = Triage.decide(result.text)

--- a/Sentient OS macOS/Sources/ChatWindowing.swift
+++ b/Sentient OS macOS/Sources/ChatWindowing.swift
@@ -8,10 +8,7 @@
 //  the pipeline as one Artifact. Key pieces:
 //    ChatMessage          — one decoded message, normalized across sources
 //    ChatInfo             — a row for the opt-in chat picker
-//    ChatCursorState      — a chat's decoded pointer (incremental / backfill / first run)
 //    ChatWindowing.windows(of:)  — greedy byte-budget batching
-//    ChatWindowing.chatCandidates(...) — one chat's windows under its pointer state (the
-//                                  backfill/incremental ordering logic, shared verbatim)
 //    ChatWindowing.format(...)   — frames a window for the model (chat name, group/DM,
 //                                  "you sent N of M" participation anchor, per-message senders)
 //  Limits (TODO plan): chat connectors read the last `lookbackDays` 90 days OR the newest
@@ -39,32 +36,6 @@ struct ChatInfo: Sendable, Identifiable {
     let isGroup: Bool
     let messageCount: Int
     let lastActive: Date
-}
-
-/// One chat's pointer state, decoded from its SourceCursor value (WhatsApp Z_PK / iMessage
-/// ROWID — both monotonic Int64 row ids). `.backfill` carries the consumed interval [lo, hi];
-/// chats are unbudgeted (remaining nil) — the rolling 90-day floor terminates the dig.
-enum ChatCursorState: Sendable {
-    case backfillStart                                  // no pointer yet — first run for this chat
-    case backfill(BackfillCursor, hi: Int64, lo: Int64)
-    case incremental(Int64)
-
-    static func decode(_ raw: String?) -> ChatCursorState {
-        if let bf = BackfillCursor.decode(raw), let hi = Int64(bf.hi), let lo = Int64(bf.lo) {
-            return .backfill(bf, hi: hi, lo: lo)
-        }
-        if let v = raw.flatMap(Int64.init) { return .incremental(v) }
-        return .backfillStart
-    }
-
-    /// Should a message row with this id be fetched under this state?
-    func wants(_ id: Int64) -> Bool {
-        switch self {
-        case .backfillStart:                return true
-        case .backfill(_, let hi, let lo):  return id > hi || id < lo
-        case .incremental(let v):           return id > v
-        }
-    }
 }
 
 enum ChatWindowing {
@@ -123,61 +94,6 @@ enum ChatWindowing {
 
     /// UTF-8 byte size of a formatted line — the upper bound on its token count.
     private static func msgBytes(_ m: ChatMessage) -> Int { m.text.utf8.count + 28 }   // + date/sender label overhead
-
-    // MARK: One chat's candidates under its pointer state (shared by WhatsApp + iMessage)
-
-    /// Window `msgs` (ascending by row id, already state-filtered by the source's fetch) and
-    /// assign each window's pointer write per the backfill contract (DataSource.swift):
-    ///   now — new windows (above hi / past the plain pointer), ascending
-    ///   dig — backfill descent windows, NEWEST first; each write records [window min, hi]
-    ///   completion — the plain pointer value when this chat's backfill just finished
-    /// `make` builds the source-specific Candidate from (window, cursorValue).
-    /// `mayBeClipped`: when the connector-wide newest-`maxMessages` cap was hit, an empty dig
-    /// might be the clip rather than a finished backfill — never complete on a clipped scan
-    /// (the state lingers and completes on a quieter run; collapsing early would skip the
-    /// chat's remaining history forever).
-    static func chatCandidates(
-        msgs: [ChatMessage], state: ChatCursorState, mayBeClipped: Bool,
-        make: ([ChatMessage], String) -> Candidate
-    ) -> (now: [Candidate], dig: [Candidate], completion: String?) {
-        switch state {
-        case .backfillStart:
-            let wins = windows(of: msgs).filter { !$0.isEmpty }
-            guard let hi = wins.last?.last?.id else { return ([], [], nil) }
-            let dig = wins.reversed().map { win in
-                make(win, BackfillCursor(hi: "\(hi)", lo: "\(win.first!.id)", remaining: nil).encoded)
-            }
-            return ([], dig, nil)
-
-        case .backfill(let bf, let hi, let lo):
-            let aboveWins = windows(of: msgs.filter { $0.id > hi }).filter { !$0.isEmpty }
-            let belowWins = windows(of: msgs.filter { $0.id < lo }).filter { !$0.isEmpty }
-            if belowWins.isEmpty {
-                if mayBeClipped {   // dig starved by the cap, not finished — keep the state
-                    let now = aboveWins.map { win in
-                        make(win, BackfillCursor(hi: "\(win.last!.id)", lo: bf.lo, remaining: nil).encoded)
-                    }
-                    return (now, [], nil)
-                }
-                // Backfill over — collapse to a plain pointer; new windows proceed as
-                // ordinary incrementals.
-                return (aboveWins.map { make($0, "\($0.last!.id)") }, [], bf.hi)
-            }
-            // The dig's writes must carry the hi the now-group will have swept up to.
-            let hiFinal = aboveWins.last.map { "\($0.last!.id)" } ?? bf.hi
-            let now = aboveWins.map { win in
-                make(win, BackfillCursor(hi: "\(win.last!.id)", lo: bf.lo, remaining: nil).encoded)
-            }
-            let dig = belowWins.reversed().map { win in
-                make(win, BackfillCursor(hi: hiFinal, lo: "\(win.first!.id)", remaining: nil).encoded)
-            }
-            return (now, dig, nil)
-
-        case .incremental:
-            let wins = windows(of: msgs).filter { !$0.isEmpty }
-            return (wins.map { make($0, "\($0.last!.id)") }, [], nil)
-        }
-    }
 
     // MARK: Formatting — frame the window for the model
 

--- a/Sentient OS macOS/Sources/DataSource.swift
+++ b/Sentient OS macOS/Sources/DataSource.swift
@@ -2,29 +2,21 @@
 //  DataSource.swift
 //  Sentient OS macOS
 //
-//  The ONE abstraction (Arch §2.2). Two-phase, so expensive content extraction is gated by
-//  the per-source pointers:
-//    scan(since:) -> [Candidate]   // cheap: enumerate items PAST the pointers, NO content
-//    load(_:)     -> Artifact      // expensive: extract text/image for a chosen candidate
-//  Candidate & Artifact are Sendable value types; live @Model objects never cross actors.
+//  The Sendable value types the iterative ingestion pipeline passes around — `Candidate` (a cheap,
+//  content-free work item) and `Artifact` (a Candidate plus its extracted text/image). Each source
+//  lists its current work as `Candidate`s via its `eligible…()` method (wrapped by a Connector —
+//  Ingestion/Connector.swift); IterativeRun loads the chosen ones into `Artifact`s for Triage. Live
+//  @Model objects never cross actors — only these value types do.
 //
-//  THE POINTER CONTRACT (June 11 pointer rewrite + June 12 backfill — Documentation/Pointer
-//  Architecture…): every candidate names the cursor it advances (`cursorKey` → `cursorValue`).
-//  The pipeline processes candidates in scan order and advances each candidate's cursor only
-//  after its durable save — a crash resumes exactly where it stopped. Ordering per cursorKey:
-//   - Key has a PLAIN pointer → incremental: candidates ascend (oldest first), pointer sweeps up.
-//   - Key has NO pointer → BACKFILL (first run for that key): candidates DESCEND (newest first —
-//     the user watches it understand NOW, not 2019), and each cursorValue is a `BackfillCursor`
-//     encoding the consumed interval [lo, hi]. New items arriving mid-backfill sit above `hi`
-//     and are emitted FIRST (ascending) on later runs, before the descent resumes below `lo`.
-//   - scan() reports finished backfills via `ScanResult.completions`; the pipeline collapses
-//     those keys to plain pointers before processing.
+//  (The old two-phase `DataSource.scan/load` protocol + its `ScanResult`/`BackfillCursor` machinery
+//  were removed when the connector/IterativeRun system became the only pipeline — the per-bucket
+//  high-water mark in CycleStore is the entire pointer story now.)
 //
 
 import Foundation
 
-/// The sources. `rawValue` is what we persist on summaries and in cursor keys.
-/// `file`/`whatsapp`/`imessage`/`notes` are read on-device; `gmail` is the lone CLOUD source —
+/// The sources. `rawValue` is what we persist on summaries (the cloud's source-trust tiers key on
+/// it). `file`/`whatsapp`/`imessage`/`notes` are read on-device; `gmail` is the lone CLOUD source —
 /// fetched + summarized through the user's Codex Gmail connector (no on-device read), see GmailConnect.
 enum SourceKind: String, Codable, Sendable, CaseIterable {
     case file
@@ -34,18 +26,20 @@ enum SourceKind: String, Codable, Sendable, CaseIterable {
     case gmail
 }
 
-
-/// Cheap unit produced by `scan` — enough to order and process without reading content.
-/// `metadata` carries light context (displayPath, name, created…).
+/// A cheap, content-free unit of work, produced by a source's `eligible…()` listing — enough to
+/// order and identify an item without reading its content. `metadata` carries light context
+/// (displayPath, name, created, windowText/noteText, isGroup…). The iterative core keys on `id` plus
+/// the connector's `ItemKey`; `cursorKey`/`cursorValue` are vestigial (sources still set them, but
+/// nothing reads them — they can be dropped in a later sweep).
 struct Candidate: Sendable, Identifiable {
     let id: String                    // stable source id, e.g. "file:/Users/…/a.pdf"
     let kind: SourceKind
-    let cursorKey: String             // which pointer this item advances when durably saved
-    let cursorValue: String           // the pointer value after this item is consumed
-    let itemDate: Date                // the artifact's OWN date (drives ordering + Summary.itemDate)
+    let cursorKey: String             // vestigial
+    let cursorValue: String           // vestigial
+    let itemDate: Date                // the artifact's OWN date (drives ordering + the summary's date)
     let metadata: [String: String]
 
-    init(id: String, kind: SourceKind, cursorKey: String, cursorValue: String,
+    init(id: String, kind: SourceKind, cursorKey: String = "", cursorValue: String = "",
          itemDate: Date, metadata: [String: String] = [:]) {
         self.id = id
         self.kind = kind
@@ -53,59 +47,6 @@ struct Candidate: Sendable, Identifiable {
         self.cursorValue = cursorValue
         self.itemDate = itemDate
         self.metadata = metadata
-    }
-
-    /// Same candidate with a different pointer write — backfill encodings depend on each item's
-    /// position in the consumption order, so sources assign them after selection/sorting.
-    func replacingCursorValue(_ value: String) -> Candidate {
-        Candidate(id: id, kind: kind, cursorKey: cursorKey, cursorValue: value,
-                  itemDate: itemDate, metadata: metadata)
-    }
-}
-
-/// What one scan hands the pipeline: the candidates to process (in consumption order) plus any
-/// backfills the scan discovered to be FINISHED (budget spent or nothing left below `lo`) —
-/// `completions` maps cursorKey → the final plain pointer value, applied before processing.
-struct ScanResult: Sendable {
-    var candidates: [Candidate]
-    var completions: [String: String] = [:]
-}
-
-/// A key's pointer value while its first run (the backfill) is still in flight: the consumed
-/// region is the closed interval **[lo, hi]** instead of "everything ≤ pointer".
-///   hi — the newest consumed value; new items land above it and move it up. Becomes the plain
-///        pointer when the backfill completes.
-///   lo — the descent watermark ("dug down to here"); resuming digs strictly below it.
-///   remaining — descent budget left (files/notes honor their connector cap as a TOTAL across
-///        interrupted runs); nil for chats, where the rolling 90-day floor terminates the dig.
-/// Stored JSON-encoded in the same SourceCursor.value string — a `{` prefix is unambiguous
-/// (plain values always start with a digit), so the Store/Pipeline stay encoding-blind.
-struct BackfillCursor: Codable, Sendable {
-    var hi: String
-    var lo: String
-    var remaining: Int?
-
-    /// nil input (no pointer yet) or a plain value both decode to nil — only an in-flight
-    /// backfill returns a value.
-    static func decode(_ raw: String?) -> BackfillCursor? {
-        guard let raw, raw.hasPrefix("{") else { return nil }
-        return try? JSONDecoder().decode(BackfillCursor.self, from: Data(raw.utf8))
-    }
-
-    var encoded: String {
-        String(data: (try? JSONEncoder().encode(self)) ?? Data(), encoding: .utf8) ?? ""
-    }
-
-    /// Assign backfill encodings to a newest-first descent batch (files + notes — the budgeted
-    /// sources): each item's write records the consumed interval [its value, hi] plus the budget
-    /// left after it. The item that spends the last of the budget writes the plain `hi` pointer —
-    /// completing the backfill in its own durable transaction.
-    static func descent(_ kept: [Candidate], hi: String, budget: Int) -> [Candidate] {
-        kept.enumerated().map { i, c in
-            let left = budget - (i + 1)
-            return c.replacingCursorValue(
-                left <= 0 ? hi : BackfillCursor(hi: hi, lo: c.cursorValue, remaining: left).encoded)
-        }
     }
 }
 
@@ -131,15 +72,4 @@ struct Artifact: Sendable, Identifiable {
         self.imageData = imageData
         self.metadata = candidate.metadata
     }
-}
-
-protocol DataSource {
-    var kind: SourceKind { get }
-    /// Enumerate items past the pointers — NO content extraction. `cursors` is the full pointer
-    /// map (a source reads only its own keys; missing key = backfill = everything, connector
-    /// caps still apply). Candidate ordering per cursorKey follows the contract above:
-    /// incremental keys ascend, backfilling keys descend (new-above-hi items first, ascending).
-    func scan(since cursors: [String: String]) throws -> ScanResult
-    /// Expensive content extraction for a candidate the pipeline chose to process.
-    func load(_ candidate: Candidate) throws -> Artifact
 }

--- a/Sentient OS macOS/Sources/FilesSource.swift
+++ b/Sentient OS macOS/Sources/FilesSource.swift
@@ -2,7 +2,7 @@
 //  FilesSource.swift
 //  Sentient OS macOS
 //
-//  DataSource over a user folder. Recurses subfolders, keeps only whitelisted extensions,
+//  Reads a user folder. Recurses subfolders, keeps only whitelisted extensions,
 //  and extracts a BOUNDED amount of content per type:
 //   • pdf              → first 3 pages of text (PDFKit)
 //   • doc / docx       → text (NSAttributedString, best-effort; legacy .doc may be empty)
@@ -33,7 +33,7 @@ import AppKit
 import ImageIO
 import UniformTypeIdentifiers
 
-struct FilesSource: DataSource, Sendable {
+struct FilesSource: Sendable {
     let kind: SourceKind = .file
     let root: URL
     let label: String   // human folder name ("Downloads", "Desktop", a custom folder…) → stored as each artifact's `folder` tag
@@ -165,137 +165,6 @@ struct FilesSource: DataSource, Sendable {
         "\(date.timeIntervalSince1970)|\(path)"
     }
 
-    static func parsePointer(_ raw: String?) -> (date: Double, path: String)? {
-        guard let raw, let bar = raw.firstIndex(of: "|"), let t = Double(raw[..<bar]) else { return nil }
-        return (t, String(raw[raw.index(after: bar)...]))
-    }
-
-    /// Is (date, path) strictly past the pointer? (nil pointer = everything qualifies.)
-    private static func isPast(_ pointer: (date: Double, path: String)?, date: Double, path: String) -> Bool {
-        guard let pointer else { return true }
-        return date > pointer.date || (date == pointer.date && path > pointer.path)
-    }
-
-    /// Strictly below the backfill descent watermark — the dig's mirror of `isPast`.
-    /// (nil = fail-closed: an unparseable `lo` digs nothing rather than re-digging everything.)
-    private static func isBelow(_ pointer: (date: Double, path: String)?, date: Double, path: String) -> Bool {
-        guard let pointer else { return false }
-        return date < pointer.date || (date == pointer.date && path < pointer.path)
-    }
-
-    // MARK: Scan (cheap — stat only, recurses subfolders)
-
-    func scan(since cursors: [String: String]) throws -> ScanResult {
-        let raw = cursors[cursorKey]
-        let backfill = BackfillCursor.decode(raw)
-        let pointer = backfill == nil ? Self.parsePointer(raw) : nil   // plain pointer (incremental)
-        let hiPointer = backfill.flatMap { Self.parsePointer($0.hi) }
-        let loPointer = backfill.flatMap { Self.parsePointer($0.lo) }
-        let now = Date()
-
-        let keys: Set<URLResourceKey> = [.isRegularFileKey, .isDirectoryKey,
-                                         .contentModificationDateKey, .creationDateKey,
-                                         .addedToDirectoryDateKey]
-        guard let enumerator = FileManager.default.enumerator(
-            at: root, includingPropertiesForKeys: Array(keys),
-            options: [.skipsHiddenFiles, .skipsPackageDescendants]
-        ) else { return ScanResult(candidates: []) }
-
-        // Effective "moved-in" date per directory: a folder dragged into the root carries files
-        // with OLD dates — the folder's own dateAdded (propagated down the tree) rescues them.
-        // The enumerator is preorder (parents before children), so parent lookups always hit.
-        var movedIn: [String: Date] = [root.path: .distantPast]
-
-        var rows: [(candidate: Candidate, sortKey: Double)] = []
-        for case let url as URL in enumerator {
-            let vals = try? url.resourceValues(forKeys: keys)
-            let parentEff = movedIn[url.deletingLastPathComponent().path] ?? .distantPast
-
-            // Prune at the WALK level: skipDescendants() means nothing inside is ever yielded,
-            // so it never becomes a Candidate / sees inference.
-            if vals?.isDirectory == true {
-                if Self.pruneReason(url) != nil { enumerator.skipDescendants(); continue }
-                let added = Self.testIgnoreDateAdded ? .distantPast
-                                                     : (vals?.addedToDirectoryDate ?? .distantPast)
-                movedIn[url.path] = max(parentEff, min(added, now))   // future-clamped
-                continue   // directories are never candidates themselves
-            }
-
-            guard vals?.isRegularFile == true,
-                  Self.allowedExtensions.contains(url.pathExtension.lowercased()) else { continue }
-
-            let mtime = vals?.contentModificationDate ?? .distantPast
-            let added = Self.testIgnoreDateAdded ? .distantPast
-                                                 : (vals?.addedToDirectoryDate ?? .distantPast)
-            // The file's date: whichever signal is closest to today, clamped so a future-dated
-            // file (clock weirdness) is treated as "now" instead of poisoning the pointer.
-            let date = min(max(mtime, added, parentEff), now)
-
-            // Keep only rows the current pointer state could consume: incremental = past the
-            // plain pointer; backfill resume = above hi OR below lo; backfill start = everything.
-            let (d, p) = (date.timeIntervalSince1970, url.path)
-            if backfill != nil {
-                guard Self.isPast(hiPointer, date: d, path: p) || Self.isBelow(loPointer, date: d, path: p) else { continue }
-            } else {
-                guard Self.isPast(pointer, date: d, path: p) else { continue }
-            }
-
-            var meta: [String: String] = [
-                "path": url.path,
-                "displayPath": Self.homeRelativePath(url),
-                "name": url.lastPathComponent,
-                "folder": label,
-            ]
-            if let created = vals?.creationDate { meta["created"] = Self.dateString(created) }
-
-            let candidate = Candidate(id: "file:\(url.path)", kind: .file,
-                                      cursorKey: cursorKey,
-                                      cursorValue: Self.pointerValue(date: date, path: url.path),
-                                      itemDate: date, metadata: meta)
-            rows.append((candidate, date.timeIntervalSince1970))
-        }
-        // ── Backfill resume: new-above-hi first (ascending), then dig below lo (descending) ──
-        if let backfill {
-            let aboveRows = rows.filter {
-                Self.isPast(hiPointer, date: $0.sortKey, path: $0.candidate.metadata["path"] ?? "")
-            }
-            let aboveAsc = cappedNewestFirst(aboveRows, budget: Self.perRootCap, now: now)
-                .sorted { ($0.itemDate, $0.id) < ($1.itemDate, $1.id) }
-            let belowRows = rows.filter {
-                Self.isBelow(loPointer, date: $0.sortKey, path: $0.candidate.metadata["path"] ?? "")
-            }
-            let budget = backfill.remaining ?? 0
-            let dig = budget > 0
-                ? cappedNewestFirst(belowRows, budget: min(budget, Self.perRootCap), now: now) : []
-            if dig.isEmpty {
-                // Backfill over (budget spent, everything below aged out, or nothing left) —
-                // collapse to a plain pointer; the new items proceed as ordinary incrementals.
-                return ScanResult(candidates: aboveAsc, completions: [cursorKey: backfill.hi])
-            }
-            // The dig's writes must carry the hi the above-group will have swept up to.
-            let hiFinal = aboveAsc.last?.cursorValue ?? backfill.hi
-            let aboveCands = aboveAsc.map {
-                $0.replacingCursorValue(BackfillCursor(hi: $0.cursorValue, lo: backfill.lo,
-                                                       remaining: budget).encoded)
-            }
-            return ScanResult(candidates: aboveCands + BackfillCursor.descent(dig, hi: hiFinal, budget: budget))
-        }
-
-        // ── Backfill start (no pointer at all): newest-first descent over the capped selection ──
-        if raw == nil {
-            let kept = cappedNewestFirst(rows, budget: Self.perRootCap, now: now)
-            guard let hi = kept.first?.cursorValue else { return ScanResult(candidates: []) }
-            return ScanResult(candidates: BackfillCursor.descent(kept, hi: hi, budget: kept.count))
-        }
-
-        // ── Incremental (plain pointer): newest-N selection, OLDEST-FIRST consumption — the
-        // pointer sweeps forward and a stopped run resumes exactly here. Unchanged behavior. ──
-        let kept = cappedNewestFirst(rows, budget: Self.perRootCap, now: now)
-        return ScanResult(candidates: kept.sorted {
-            ($0.itemDate, $0.id) < ($1.itemDate, $1.id)   // id = "file:<path>" → path tiebreak
-        })
-    }
-
     // MARK: Eligible files (the files-iterative system's flat, pointer-free view)
 
     /// The current eligible set for this root, for the iterative system (IterativeRun via
@@ -371,9 +240,8 @@ struct FilesSource: DataSource, Sendable {
 
     // MARK: Load (expensive — extract content)
 
-    func load(_ candidate: Candidate) throws -> Artifact { try Self.loadArtifact(candidate) }
 
-    /// Static content extraction — shared by the old DataSource path (above) and the files-iterative
+    /// Content extraction for the files-iterative
     /// `FilesConnector`. Stateless: reads only `candidate.metadata["path"]`.
     static func loadArtifact(_ candidate: Candidate) throws -> Artifact {
         guard let path = candidate.metadata["path"] else { throw FilesError.noPath }

--- a/Sentient OS macOS/Sources/NotesSource.swift
+++ b/Sentient OS macOS/Sources/NotesSource.swift
@@ -2,7 +2,7 @@
 //  NotesSource.swift
 //  Sentient OS macOS
 //
-//  DataSource over Apple Notes' local store, NoteStore.sqlite (Arch §4, [MEASURED]: the
+//  Reads Apple Notes' local store, NoteStore.sqlite (Arch §4, [MEASURED]: the
 //  gunzip → protobuf 2→3→2 recipe decoded 100% of real notes — 249 in research, 87/87 on a
 //  live Mac during this build). One note = one Artifact through the file-flavored triage
 //  prompt — no windows, no picker; the newest-1000 cap + triage do the filtering.
@@ -15,13 +15,13 @@
 //  Incrementality (June 11 pointer rewrite): one "notes" pointer, "(modEpochSeconds|UUID)" —
 //  an edited note's mod-date moves past it and the note re-summarizes as a new version.
 //  Locked (ZISPASSWORDPROTECTED) and deleted (ZMARKEDFORDELETION) notes are skipped in SQL.
-//  Requires Full Disk Access. Key methods: scan(since:) · load(_:) · decodeBody(_:).
+//  Requires Full Disk Access. Key methods: eligibleNotes() · decodeBody(_:).
 //
 
 import Foundation
 import Compression
 
-struct NotesSource: DataSource, Sendable {
+struct NotesSource: Sendable {
     let kind: SourceKind = .notes
 
     // MARK: Tunables
@@ -32,135 +32,6 @@ struct NotesSource: DataSource, Sendable {
         FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Library/Group Containers/group.com.apple.notes/NoteStore.sqlite")
             .path
-    }
-
-    // MARK: Scan — copy → query → decode → delete
-
-    /// Pointer (June 11 rewrite + June 12 backfill): one cursor, key "notes", value
-    /// "(modEpochSeconds|noteUUID)" (UUID = same-second tiebreak). An edited note's mod-date
-    /// moves past the pointer → it's re-summarized as a new version. Ordering: incremental runs ascend; the
-    /// FIRST run is a newest-first backfill descent (BackfillCursor, resumable, the newest-1000
-    /// cap as a total budget) — notes edited mid-backfill jump above `hi` and process first.
-    func scan(since cursors: [String: String]) throws -> ScanResult {
-        let raw = cursors["notes"]
-        let backfill = BackfillCursor.decode(raw)
-        let pointer = backfill == nil ? Self.parsePointer(raw) : nil   // plain pointer (incremental)
-        let hiPointer = backfill.flatMap { Self.parsePointer($0.hi) }
-        let loPointer = backfill.flatMap { Self.parsePointer($0.lo) }
-
-        let (dbURL, tempDir) = try SQLiteDB.walSafeCopy(of: dbPath)
-        defer { try? FileManager.default.removeItem(at: tempDir) }   // delete the plaintext copy immediately
-        let reader = try SQLiteReader(path: dbURL.path)
-
-        // Folder names: folder entities are rows in the same table; ZTITLE2 is the folder title.
-        var folders: [Int64: String] = [:]
-        try reader.forEachRow("SELECT Z_PK, ZTITLE2 FROM ZICCLOUDSYNCINGOBJECT WHERE ZTITLE2 IS NOT NULL") { r in
-            if let t = r.text(1) { folders[r.int(0)] = t }
-        }
-
-        // Newest notes first (the cap selects the newest `maxNotes`); locked/deleted skipped in
-        // SQL. Creation-date column name varies across macOS versions → COALESCE the variants.
-        var rows: [(cand: Candidate, modified: Int64, uuid: String)] = []
-        try reader.forEachRow("""
-            SELECT o.ZIDENTIFIER, o.ZTITLE1, o.ZMODIFICATIONDATE1,
-                   COALESCE(o.ZCREATIONDATE3, o.ZCREATIONDATE2, o.ZCREATIONDATE1, o.ZCREATIONDATE),
-                   o.ZFOLDER, d.ZDATA
-            FROM ZICCLOUDSYNCINGOBJECT o JOIN ZICNOTEDATA d ON o.ZNOTEDATA = d.Z_PK
-            WHERE o.ZISPASSWORDPROTECTED IS NOT 1 AND o.ZMARKEDFORDELETION IS NOT 1
-            ORDER BY o.ZMODIFICATIONDATE1 DESC LIMIT \(Self.maxNotes)
-            """) { r in
-            guard let id = r.text(0) else { return }
-            let modified = r.double(2)
-            // Keep only rows the current pointer state could consume: incremental = past the
-            // plain pointer; backfill resume = above hi OR below lo; backfill start = everything.
-            if backfill != nil {
-                guard Self.isPast(hiPointer, modified: Int64(modified), uuid: id)
-                   || Self.isBelow(loPointer, modified: Int64(modified), uuid: id) else { return }
-            } else {
-                guard Self.isPast(pointer, modified: Int64(modified), uuid: id) else { return }
-            }
-            guard let blob = r.blob(5),
-                  let decoded = Self.decodeBody(blob) else { return }   // no/undecodable body → skip (fail-closed)
-            let body = decoded.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !body.isEmpty else { return }                         // attachment-only / blank notes
-
-            let title = r.text(1) ?? String(body.prefix(40))
-            let folder = folders[r.int(4)] ?? "Notes"
-            let createdTS = r.double(3)
-            let created = Date(timeIntervalSinceReferenceDate: createdTS > 0 ? createdTS : modified)
-
-            rows.append((Candidate(
-                id: "notes:\(id)",
-                kind: .notes,
-                cursorKey: "notes",
-                cursorValue: "\(Int64(modified))|\(id)",
-                itemDate: Date(timeIntervalSinceReferenceDate: modified),
-                metadata: [
-                    "folder": folder,              // per-folder tag → folder pills in the viewer
-                    "name": title,
-                    "displayPath": "Apple Notes · \(folder) · \(title)",
-                    "created": Self.dateString(created),
-                    "noteText": String(body.prefix(Self.maxContentChars)),
-                ]), Int64(modified), id))
-        }
-        // `rows` is newest-first (the SQL ORDER). Assemble per pointer state:
-
-        // ── Backfill resume: edited/new notes first (ascending), then dig below lo (descending) ──
-        if let backfill {
-            let aboveAsc = rows
-                .filter { Self.isPast(hiPointer, modified: $0.modified, uuid: $0.uuid) }
-                .map(\.cand)
-                .sorted { ($0.itemDate, $0.id) < ($1.itemDate, $1.id) }
-            let budget = backfill.remaining ?? 0
-            let dig = Array(rows
-                .filter { Self.isBelow(loPointer, modified: $0.modified, uuid: $0.uuid) }
-                .map(\.cand)
-                .prefix(budget))
-            if dig.isEmpty {
-                // Backfill over (budget spent or nothing left below lo) — collapse to a plain
-                // pointer; the new/edited notes proceed as ordinary incrementals.
-                return ScanResult(candidates: aboveAsc, completions: ["notes": backfill.hi])
-            }
-            let hiFinal = aboveAsc.last?.cursorValue ?? backfill.hi
-            let aboveCands = aboveAsc.map {
-                $0.replacingCursorValue(BackfillCursor(hi: $0.cursorValue, lo: backfill.lo,
-                                                       remaining: budget).encoded)
-            }
-            return ScanResult(candidates: aboveCands + BackfillCursor.descent(dig, hi: hiFinal, budget: budget))
-        }
-
-        // ── Backfill start (no pointer at all): newest-first descent over the capped selection ──
-        if raw == nil {
-            let kept = rows.map(\.cand)
-            guard let hi = kept.first?.cursorValue else { return ScanResult(candidates: []) }
-            return ScanResult(candidates: BackfillCursor.descent(kept, hi: hi, budget: kept.count))
-        }
-
-        // ── Incremental: selection was newest-first (the cap); consumption is oldest-first. ──
-        return ScanResult(candidates: rows.map(\.cand).sorted { ($0.itemDate, $0.id) < ($1.itemDate, $1.id) })
-    }
-
-    // MARK: Pointer encoding — "(modEpochSeconds|noteUUID)"
-
-    private static func parsePointer(_ raw: String?) -> (modified: Int64, uuid: String)? {
-        guard let raw, let bar = raw.firstIndex(of: "|"), let t = Int64(raw[..<bar]) else { return nil }
-        return (t, String(raw[raw.index(after: bar)...]))
-    }
-
-    private static func isPast(_ pointer: (modified: Int64, uuid: String)?, modified: Int64, uuid: String) -> Bool {
-        guard let pointer else { return true }
-        return modified > pointer.modified || (modified == pointer.modified && uuid > pointer.uuid)
-    }
-
-    /// Strictly below the backfill descent watermark — the dig's mirror of `isPast`.
-    /// (nil = fail-closed: an unparseable `lo` digs nothing rather than re-digging everything.)
-    private static func isBelow(_ pointer: (modified: Int64, uuid: String)?, modified: Int64, uuid: String) -> Bool {
-        guard let pointer else { return false }
-        return modified < pointer.modified || (modified == pointer.modified && uuid < pointer.uuid)
-    }
-
-    func load(_ candidate: Candidate) throws -> Artifact {
-        Artifact(candidate: candidate, text: candidate.metadata["noteText"] ?? "")
     }
 
     // MARK: Eligible notes (the iterative system's flat, pointer-free view)

--- a/Sentient OS macOS/Sources/WhatsAppSource.swift
+++ b/Sentient OS macOS/Sources/WhatsAppSource.swift
@@ -2,7 +2,7 @@
 //  WhatsAppSource.swift
 //  Sentient OS macOS
 //
-//  DataSource over WhatsApp's local ChatStorage.sqlite (Arch §3.1, [MEASURED]). It's unencrypted
+//  Reads WhatsApp's local ChatStorage.sqlite (Arch §3.1, [MEASURED]). It's unencrypted
 //  plaintext in WAL mode → we WAL-safe COPY → EXTRACT → DELETE immediately (privacy: a plaintext
 //  copy of the whole chat history never lingers).
 //
@@ -18,7 +18,7 @@
 
 import Foundation
 
-struct WhatsAppSource: DataSource, Sendable {
+struct WhatsAppSource: Sendable {
     let kind: SourceKind = .whatsapp
 
     /// Opt-in filter: only these chat JIDs are analyzed. nil = every chat (used by the self-test dump).
@@ -112,127 +112,6 @@ struct WhatsAppSource: DataSource, Sendable {
         let jid: String           // ZCONTACTJID — the stable opt-in key
         let name: String          // ZPARTNERNAME (contact name for DMs, group name for groups)
         let isGroup: Bool         // ZCONTACTJID ends "@g.us"
-    }
-
-    // MARK: Scan — copy → query → window → delete
-
-    /// Pointer (June 11 rewrite + June 12 backfill): ONE cursor per opted-in chat — key
-    /// "whatsapp:<jid>", value = the highest consumed `Z_PK` (or a BackfillCursor while the
-    /// chat's first run is in flight). Per-chat (not one global Z_PK pointer) because chats
-    /// interleave in Z_PK space: with a single pointer, saving chat B's window would move the
-    /// pointer past chat A's still-unprocessed older messages and a crash would lose them.
-    /// Per-chat keys make every chat independently crash-safe — same shape as Files' per-root
-    /// pointers. Ordering: incremental windows ascend per chat; a chat's first run digs
-    /// newest-window-first, with every chat's NEW windows emitted before any chat's dig.
-    func scan(since cursors: [String: String]) throws -> ScanResult {
-        let (dbURL, tempDir) = try SQLiteDB.walSafeCopy(of: dbPath)
-        defer { try? FileManager.default.removeItem(at: tempDir) }   // delete the plaintext copy immediately
-        let reader = try SQLiteReader(path: dbURL.path)
-
-        // Chat sessions → name + DM/group. The session filter here also drops community noise
-        // from scan itself — so a stale opted-in JID (or the self-test's all-chats mode) can
-        // never window an excluded session.
-        let members = Self.activeMemberNames(reader)
-        var chats: [Int64: Chat] = [:]
-        try reader.forEachRow("SELECT s.Z_PK, s.ZPARTNERNAME, s.ZCONTACTJID FROM ZWACHATSESSION s WHERE \(Self.sessionFilter)") { r in
-            let jid = r.text(2) ?? ""
-            chats[r.int(0)] = Chat(pk: r.int(0), jid: jid,
-                                   name: Self.displayName(r.text(1), jid: jid, members: members[r.int(0)]),
-                                   isGroup: jid.hasSuffix("@g.us"))
-        }
-
-        // Opt-in + session filtering happen INSIDE the capped query: the newest-`maxMessages`
-        // budget must be spent on chats we'll actually analyze — otherwise a community-heavy
-        // or busy non-opted chat eats the cap for nothing.
-        let analyzedPKs = chats.values
-            .filter { chatJIDs == nil || chatJIDs!.contains($0.jid) }
-            .map(\.pk)
-        guard !analyzedPKs.isEmpty else { return ScanResult(candidates: []) }
-
-        // Each analyzed chat's pointer state (no row = backfill start = everything qualifies).
-        var states: [Int64: ChatCursorState] = [:]
-        for chat in chats.values {
-            states[chat.pk] = ChatCursorState.decode(cursors["whatsapp:\(chat.jid)"])
-        }
-
-        // Text messages within the limits (90-day floor AND newest-`maxMessages` cap over the
-        // analyzed chats; the outer ORDER restores per-chat ascending iteration), oldest →
-        // newest per chat.
-        let floor = ChatWindowing.lookbackFloor.timeIntervalSinceReferenceDate
-        var byChat: [Int64: [ChatMessage]] = [:]
-        var fetched = 0   // raw rows the capped query returned (cap hit = a dig may be starved)
-        // LEFT JOIN the group-member row (indexed on Z_PK → near-free) so senders without a
-        // push-name resolve to their saved contact name instead of a raw JID/LID.
-        try reader.forEachRow("""
-            SELECT m.Z_PK, m.ZMESSAGEDATE, m.ZISFROMME, m.ZTEXT, m.ZPUSHNAME, m.ZCHATSESSION, gm.ZCONTACTNAME, gm.ZFIRSTNAME
-            FROM (SELECT * FROM ZWAMESSAGE
-                  WHERE ZTEXT IS NOT NULL AND length(ZTEXT) > 0 AND ZMESSAGEDATE >= \(floor)
-                        AND ZCHATSESSION IN (\(analyzedPKs.sorted().map(String.init).joined(separator: ",")))
-                  ORDER BY ZMESSAGEDATE DESC LIMIT \(ChatWindowing.maxMessages)) m
-            LEFT JOIN ZWAGROUPMEMBER gm ON m.ZGROUPMEMBER = gm.Z_PK
-            ORDER BY m.ZCHATSESSION, m.Z_PK
-            """) { r in
-            fetched += 1
-            guard let chat = chats[r.int(5)] else { return }
-            guard states[chat.pk]?.wants(r.int(0)) ?? true else { return }   // already consumed
-            let isFromMe = r.int(2) == 1
-            byChat[r.int(5), default: []].append(ChatMessage(
-                id: r.int(0),
-                date: Date(timeIntervalSinceReferenceDate: r.double(1)),
-                sender: isFromMe ? "Me" : Self.sender(pushName: r.text(4),
-                                                      memberName: r.text(6) ?? r.text(7),   // ZCONTACTNAME ?? ZFIRSTNAME
-                                                      chat: chat),
-                isFromMe: isFromMe,
-                text: String((r.text(3) ?? "").prefix(ChatWindowing.maxMessageChars))))
-        }
-
-        // Window each chat to the byte budget; one window = one Artifact. The shared
-        // ChatWindowing.chatCandidates applies the chat's pointer state (incremental ascend /
-        // backfill descent / completion).
-        let mayBeClipped = fetched >= ChatWindowing.maxMessages
-        var perChat: [(lastActive: Date, now: [Candidate], dig: [Candidate])] = []
-        var completions: [String: String] = [:]
-        for (chatPK, msgs) in byChat {
-            guard let chat = chats[chatPK] else { continue }
-            let (now, dig, completion) = ChatWindowing.chatCandidates(
-                msgs: msgs, state: states[chatPK] ?? .backfillStart, mayBeClipped: mayBeClipped
-            ) { win, cursorValue in
-                Candidate(id: "whatsapp:c\(chatPK):\(win.first!.id)-\(win.last!.id)",
-                          kind: .whatsapp,
-                          cursorKey: "whatsapp:\(chat.jid)",
-                          cursorValue: cursorValue,
-                          itemDate: win.last!.date,
-                          metadata: [
-                              "folder": chat.name,                 // per-chat tag → folder pills in the viewer
-                              "name": chat.name,
-                              "displayPath": "WhatsApp · \(chat.name)",
-                              "isGroup": chat.isGroup ? "1" : "0", // → group vs DM bouncer prompt
-                              "msgCount": "\(win.count)",
-                              "windowText": ChatWindowing.format(chatName: chat.name, isGroup: chat.isGroup, messages: win),
-                          ])
-            }
-            if let completion { completions["whatsapp:\(chat.jid)"] = completion }
-            if !(now.isEmpty && dig.isEmpty) { perChat.append((msgs.last!.date, now, dig)) }
-        }
-        // A backfilling chat with NO fetched messages has nothing above hi and nothing left
-        // below lo (within the floor) — its backfill is over. Never collapse on a clipped scan.
-        if !mayBeClipped {
-            for chat in chats.values where chatJIDs?.contains(chat.jid) ?? true {
-                if case .backfill(let bf, _, _) = states[chat.pk] ?? .backfillStart,
-                   byChat[chat.pk] == nil {
-                    completions["whatsapp:\(chat.jid)"] = bf.hi
-                }
-            }
-        }
-        // Every chat's NEW windows first (what's happening now), then the backfill digs —
-        // active chats first within each group.
-        let ordered = perChat.sorted { $0.lastActive > $1.lastActive }
-        return ScanResult(candidates: ordered.flatMap(\.now) + ordered.flatMap(\.dig),
-                          completions: completions)
-    }
-
-    func load(_ candidate: Candidate) throws -> Artifact {
-        Artifact(candidate: candidate, text: candidate.metadata["windowText"] ?? "")
     }
 
     // MARK: Eligible windows (the iterative system's flat, pointer-free view)

--- a/Sentient OS macOS/Sources/iMessageSource.swift
+++ b/Sentient OS macOS/Sources/iMessageSource.swift
@@ -2,7 +2,7 @@
 //  iMessageSource.swift
 //  Sentient OS macOS
 //
-//  DataSource over the Mac's iMessage store, ~/Library/Messages/chat.db (Arch §4, [MEASURED]:
+//  Reads the Mac's iMessage store, ~/Library/Messages/chat.db (Arch §4, [MEASURED]:
 //  the typedstream heuristic decoded 99.97% of 12,017 real messages). Same shape as WhatsApp:
 //  WAL-safe COPY → EXTRACT → DELETE, conversation windows via ChatWindowing, opt-in per chat
 //  (chat GUIDs), group/DM routed to the matching triage prompt.
@@ -13,7 +13,7 @@
 //  deliberately do NOT build a full typedstream parser. Sender handles (E.164 phones / emails —
 //  chat.db stores no names) resolve through AddressBookNames.
 //
-//  Key methods: listChats() (picker rows) · scan(since:) · load(_:). Limits per ChatWindowing:
+//  Key methods: listChats() (picker rows) · eligibleWindows(). Limits per ChatWindowing:
 //  90-day floor AND newest-100k cap. Tapbacks (associated_message_type != 0) and system items
 //  (item_type != 0) are filtered in SQL — they'd spam every window otherwise. Incrementality:
 //  a per-chat ROWID pointer ("imessage:<guid>" in SourceCursor).
@@ -21,7 +21,7 @@
 
 import Foundation
 
-struct iMessageSource: DataSource, Sendable {
+struct iMessageSource: Sendable {
     let kind: SourceKind = .imessage
 
     /// Opt-in filter: only these chat GUIDs are analyzed. nil = every chat (used by the self-test dump).
@@ -121,120 +121,6 @@ struct iMessageSource: DataSource, Sendable {
     /// unlike WhatsApp's LID blobs there's nothing opaque to hide).
     private static func resolved(_ handle: String, _ contacts: [String: String]) -> String {
         AddressBookNames.resolve(handle, in: contacts) ?? handle
-    }
-
-    // MARK: Scan — copy → query → decode → window → delete
-
-    /// Pointer (June 11 rewrite + June 12 backfill): ONE cursor per opted-in chat — key
-    /// "imessage:<guid>", value = the highest consumed `ROWID` (or a BackfillCursor while the
-    /// chat's first run is in flight). Per-chat (not one
-    /// global ROWID pointer) because chats interleave in ROWID space; see WhatsAppSource.scan
-    /// for the full rationale. Ordering: incremental windows ascend per chat; a chat's first
-    /// run digs newest-window-first, with every chat's NEW windows emitted before any dig.
-    func scan(since cursors: [String: String]) throws -> ScanResult {
-        let (dbURL, tempDir) = try SQLiteDB.walSafeCopy(of: dbPath)
-        defer { try? FileManager.default.removeItem(at: tempDir) }   // delete the plaintext copy immediately
-        let reader = try SQLiteReader(path: dbURL.path)
-
-        let chats = try Self.chats(reader)
-        let contacts = AddressBookNames.loadMap()
-
-        // Opt-in filtering happens INSIDE the capped query: the newest-`maxMessages` budget
-        // must be spent on the chats we'll actually analyze, not eaten by busy non-opted ones.
-        let analyzedROWIDs = chats.values
-            .filter { chatGUIDs == nil || chatGUIDs!.contains($0.guid) }
-            .map(\.rowid)
-        guard !analyzedROWIDs.isEmpty else { return ScanResult(candidates: []) }
-
-        // Each analyzed chat's pointer state (no row = backfill start = everything qualifies).
-        var states: [Int64: ChatCursorState] = [:]
-        for chat in chats.values {
-            states[chat.rowid] = ChatCursorState.decode(cursors["imessage:\(chat.guid)"])
-        }
-
-        // Messages within the limits (90-day floor AND newest-`maxMessages` cap over the
-        // analyzed chats; the outer ORDER restores per-chat ascending iteration), decoded
-        // text ?? typedstream, grouped per chat.
-        var byChat: [Int64: [ChatMessage]] = [:]
-        var fetched = 0   // raw rows the capped query returned (cap hit = a dig may be starved)
-        try reader.forEachRow("""
-            SELECT m.ROWID, m.date, m.is_from_me, m.text, m.attributedBody, m.chat_id, h.id
-            FROM (SELECT message.ROWID, date, is_from_me, text, attributedBody, handle_id, cmj.chat_id
-                  FROM message JOIN chat_message_join cmj ON cmj.message_id = message.ROWID
-                  WHERE date >= \(Self.floorNS) AND \(Self.messageFilter)
-                        AND cmj.chat_id IN (\(analyzedROWIDs.sorted().map(String.init).joined(separator: ",")))
-                  ORDER BY date DESC LIMIT \(ChatWindowing.maxMessages)) m
-            LEFT JOIN handle h ON h.ROWID = m.handle_id
-            ORDER BY m.chat_id, m.ROWID
-            """) { r in
-            fetched += 1
-            guard let chat = chats[r.int(5)] else { return }
-            guard states[chat.rowid]?.wants(r.int(0)) ?? true else { return }   // already consumed
-
-            let body = r.text(3) ?? r.blob(4).flatMap(Self.typedstreamText)
-            guard let body, !body.trimmingCharacters(in: .whitespaces).isEmpty else { return }
-
-            let isFromMe = r.int(2) == 1
-            let sender: String
-            if isFromMe { sender = "Me" }
-            else if chat.isGroup { sender = Self.resolved(r.text(6) ?? "", contacts) }
-            else { sender = chat.name }   // DM: the other party is the chat partner
-
-            byChat[r.int(5), default: []].append(ChatMessage(
-                id: r.int(0),
-                date: Self.date(fromAppleNS: r.int(1)),
-                sender: sender,
-                isFromMe: isFromMe,
-                text: String(body.prefix(ChatWindowing.maxMessageChars))))
-        }
-
-        // Window each chat to the byte budget; one window = one Artifact. The shared
-        // ChatWindowing.chatCandidates applies the chat's pointer state (incremental ascend /
-        // backfill descent / completion).
-        let mayBeClipped = fetched >= ChatWindowing.maxMessages
-        var perChat: [(lastActive: Date, now: [Candidate], dig: [Candidate])] = []
-        var completions: [String: String] = [:]
-        for (chatROWID, msgs) in byChat {
-            guard let chat = chats[chatROWID] else { continue }
-            let (now, dig, completion) = ChatWindowing.chatCandidates(
-                msgs: msgs, state: states[chatROWID] ?? .backfillStart, mayBeClipped: mayBeClipped
-            ) { win, cursorValue in
-                Candidate(id: "imessage:c\(chatROWID):\(win.first!.id)-\(win.last!.id)",
-                          kind: .imessage,
-                          cursorKey: "imessage:\(chat.guid)",
-                          cursorValue: cursorValue,
-                          itemDate: win.last!.date,
-                          metadata: [
-                              "folder": chat.name,                 // per-chat tag → folder pills in the viewer
-                              "name": chat.name,
-                              "displayPath": "iMessage · \(chat.name)",
-                              "isGroup": chat.isGroup ? "1" : "0", // → group vs DM bouncer prompt
-                              "msgCount": "\(win.count)",
-                              "windowText": ChatWindowing.format(chatName: chat.name, isGroup: chat.isGroup, messages: win),
-                          ])
-            }
-            if let completion { completions["imessage:\(chat.guid)"] = completion }
-            if !(now.isEmpty && dig.isEmpty) { perChat.append((msgs.last!.date, now, dig)) }
-        }
-        // A backfilling chat with NO fetched messages has nothing above hi and nothing left
-        // below lo (within the floor) — its backfill is over. Never collapse on a clipped scan.
-        if !mayBeClipped {
-            for chat in chats.values where chatGUIDs?.contains(chat.guid) ?? true {
-                if case .backfill(let bf, _, _) = states[chat.rowid] ?? .backfillStart,
-                   byChat[chat.rowid] == nil {
-                    completions["imessage:\(chat.guid)"] = bf.hi
-                }
-            }
-        }
-        // Every chat's NEW windows first (what's happening now), then the backfill digs —
-        // active chats first within each group.
-        let ordered = perChat.sorted { $0.lastActive > $1.lastActive }
-        return ScanResult(candidates: ordered.flatMap(\.now) + ordered.flatMap(\.dig),
-                          completions: completions)
-    }
-
-    func load(_ candidate: Candidate) throws -> Artifact {
-        Artifact(candidate: candidate, text: candidate.metadata["windowText"] ?? "")
     }
 
     // MARK: Eligible windows (the iterative system's flat, pointer-free view)


### PR DESCRIPTION
The final scrap of the old pipeline. Pure deletion — **net −645 lines, 8 files.**

## What
With `Pipeline`/`Store` gone (#38), the two-phase `DataSource.scan/load` contract had **no callers**. The connector + `IterativeRun` path (each source's `eligible…()` + the per-bucket high-water mark in `CycleStore`) is the whole pointer story now. Removed:

- **`DataSource` protocol, `ScanResult`, `BackfillCursor`, `Candidate.replacingCursorValue`** — `DataSource.swift` now holds just `SourceKind` + the `Candidate`/`Artifact` value types.
- **Each source's `scan(since:)`** + its scan-only pointer helpers (`parsePointer`/`isPast`/`isBelow`) + the `DataSource` conformance + the vestigial instance `load()`. The `eligible…()` methods and all shared helpers (windowing, name resolution, gunzip/protobuf decode, prune+caps, `loadArtifact`) stay untouched.
- **`ChatWindowing`'s `ChatCursorState` + `chatCandidates`** — the chat backfill state machine.
- Repointed the triage self-test's `dump` + `tokens` modes (and the file-skipping self-test) from `scan()` to the `eligible…()` methods.

`Candidate`/`Artifact` keep `cursorKey`/`cursorValue` as **inert defaulted fields** (sources still set them; nothing reads them) — a trivial future drop, kept now to avoid touching every construction site blind.

## Verification
Grepped the whole project: **zero code references** to any removed symbol (`DataSource`, `scan(`, `ScanResult`, `BackfillCursor`, `ChatCursorState`, `chatCandidates`, `replacingCursorValue`, `source.load(`). A few in-header doc comments still mention the old scan/pointer system — cosmetic only.

## ⚠️ Not compiled in this environment
Please build before merge. Quick smoke check: `SENTIENT_SELFTEST=fileiter` / `chatiter` / `notesiter` (iterative-core proofs) + a dev INITIAL run.

---
*This completes the convergence: one store (CycleStore), one engine path (IterativeRun), one UI (ProcessingView), and now no dead ingestion machinery.*