### PR TITLE
Remove the redundant 'Start Analysis (legacy)' dev button

### DIFF
--- a/Sentient OS macOS/Views/DevToolsView.swift
+++ b/Sentient OS macOS/Views/DevToolsView.swift
@@ -18,8 +18,8 @@
 //  runs through the new self-contained stack (IterativeRun · VaultCloud · CycleStore) — the old
 //  Store/Pipeline/messages are untouched, reachable from "More" + the home's Analyze Now.
 //
-//  `SourceSelection` is the one shared reader of the dbg.run.* prefs so the home's Analyze Now and
-//  this sheet's legacy Start Analysis run EXACTLY the same selection.
+//  `SourceSelection` is the one shared reader of the dbg.run.* prefs, so the home's Analyze Now and
+//  this sheet's INITIAL/ITERATIVE buttons act on EXACTLY the same source selection.
 //
 
 import SwiftUI
@@ -79,8 +79,6 @@ struct DeviceJob: Identifiable {
 
 struct DevToolsView: View {
     @Binding var customRoots: [URL]
-    /// Closes the sheet and hands off to the (legacy) full-pipeline processing takeover.
-    var onStartAnalysis: () -> Void
 
     @Environment(\.dismiss) private var dismiss
 
@@ -523,9 +521,6 @@ struct DevToolsView: View {
 
             if showMore {
                 VStack(spacing: 12) {
-                    Button("Start Analysis (legacy)") { onStartAnalysis() }
-                        .buttonStyle(.bordered)
-
                     VStack(spacing: 4) {
                         Button(role: .destructive) { Task { await runReset() } } label: {
                             Label("Reset FILE store (pointers + summaries)", systemImage: "trash")

--- a/Sentient OS macOS/Views/RootView.swift
+++ b/Sentient OS macOS/Views/RootView.swift
@@ -45,10 +45,7 @@ struct RootView: View {
         }
         .frame(minWidth: 920, minHeight: 660)
         .sheet(isPresented: $showDevTools) {
-            DevToolsView(customRoots: $customRoots) {
-                showDevTools = false
-                withAnimation(.easeInOut(duration: 0.3)) { isProcessing = true }
-            }
+            DevToolsView(customRoots: $customRoots)
         }
         .onChange(of: showDevTools) { _, open in
             if !open { fdaGranted = Permissions.hasFullDiskAccess() }   // may have changed in the sheet


### PR DESCRIPTION
Tiny cleanup (+3/−11). In the old world this button ran the *real* legacy path — `RootView`'s `ProcessingView` over the old `Pipeline → Store` belt, genuinely distinct from the dev INITIAL/ITERATIVE buttons. After the convergence, `RootView`'s `ProcessingView` **is** the unified `IterativeRun`/`.auto` path, so the button did **literally the same thing as the home "Analyze Now"** (just closed the dev sheet first) — while still labeled "(legacy)". Pure cruft.

- Removed the button + its `onStartAnalysis` closure plumbing (`DevToolsView` param + the `RootView` trailing closure).
- Fixed the two stale comments that referenced it.

No behavior lost: the dev sheet still has its own INITIAL/ITERATIVE start buttons (with the prompt pane), and the home **Analyze Now** is untouched.

⚠️ Not compiled here — build before merge (trivial, but the rule's the rule).