### PR TITLE
Rename local knowledge base folder → 'Sentient OS - Knowledge Base'

### DIFF
--- a/Sentient OS macOS/MirrorClient.swift
+++ b/Sentient OS macOS/MirrorClient.swift
@@ -148,7 +148,7 @@ actor MirrorClient {
     /// Zip the vault's CONTENTS into a temp .zip with ROOT-RELATIVE entries (`README.md`,
     /// `Career/Job.md`). We shell to `/usr/bin/zip` from inside the vault dir on purpose:
     /// NSFileCoordinator's `.forUploading` instead wraps everything under the vault folder name
-    /// (`Sentient OS -- The Vault/…`), which breaks the server's root-relative contract — the README
+    /// (`Sentient OS - Knowledge Base/…`), which breaks the server's root-relative contract — the README
     /// portrait stops bundling in `get_structure` and every note nests a level too deep. The macOS
     /// `zip` writes UTF-8 names without the 0x800 flag; the server recovers those. (`zip` ships with
     /// macOS; the app is non-sandboxed, so spawning it is fine — same as `CodexCLI`.)

--- a/Sentient OS macOS/VaultGenerator.swift
+++ b/Sentient OS macOS/VaultGenerator.swift
@@ -4,7 +4,7 @@
 //
 //  Stage 2 — the cloud vault (Arch §6). Takes the on-device survivor summaries and has the
 //  user's own Codex CLI (via CodexCLI, Arch §5) organize them into an Obsidian-style
-//  markdown vault at "~/Sentient OS -- The Vault/": the model WRITES the .md files itself
+//  markdown vault at "~/Sentient OS - Knowledge Base/": the model WRITES the .md files itself
 //  (file tools, sandbox-scoped to a staging dir), which sidesteps per-message output caps
 //  and makes usage-limit resume natural. The old vault is only replaced on success
 //  (staging → atomic swap). No codex = no cloud organize until the free tier ships.
@@ -15,7 +15,7 @@
 //
 //  Key methods:
 //   - generate(summaries:resume:onProgress:)  → the agentic build, returns stats
-//   - vaultRoot                               → ~/Sentient OS -- The Vault
+//   - vaultRoot                               → ~/Sentient OS - Knowledge Base
 //
 //  Doc: Documentation/Vault Generation (Stage 2).md
 //
@@ -67,7 +67,7 @@ actor VaultGenerator {
             return URL(fileURLWithPath: override, isDirectory: true)
         }
         return FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent("Sentient OS -- The Vault", isDirectory: true)
+            .appendingPathComponent("Sentient OS - Knowledge Base", isDirectory: true)
     }
 
     // MARK: - The agentic build (codex exec)


### PR DESCRIPTION
Renames the on-disk knowledge base folder from `~/Sentient OS -- The Vault` → `~/Sentient OS - Knowledge Base`.

One real code change — `VaultGenerator.vaultRoot` (the single source of truth; `VaultCloud`, `MirrorClient`, `Proactive`, DevTools INITIAL-wipe, the home graph thumbnail all route through it) — plus three doc comments. The `SENTIENT_VAULT_ROOT` self-test override is unchanged.

Jesai has already moved his local KB to the new folder name, so the app will find it immediately. +4 lines, −4. (Not compiled here — trivial, but build before merge.)