### PR TITLE
Fix: MCP mirror keeps token on toggle OFF (stable share link)

### DIFF
--- a/Sentient OS macOS/Documentation/MCP Mirror Client.md
+++ b/Sentient OS macOS/Documentation/MCP Mirror Client.md
@@ -9,13 +9,13 @@ disposable copy.
 
 ```swift
 let mirror = MirrorClient.shared
-await mirror.isEnabled                 // tokens exist in the Keychain?
-let url = await mirror.enable()        // opt in → mints tokens → returns the share URL
+await mirror.isEnabled                 // is mirroring ON? (the toggle flag — NOT just "token exists")
+let url = await mirror.enable()        // opt in → mints token if absent → returns the share URL
 await mirror.shareURL                  // the "Copy MCP Link" value, or nil
 try await mirror.push()                // zip the vault + replace the mirror (call after any change)
 let s = try await mirror.stats()       // {notesRead24h, toolCalls24h, lastAccess} for "Your AIs"
-try await mirror.deleteRemote()        // one-click delete (keeps the token → stable URL on re-enable)
-await mirror.disable()                 // full opt-out: delete remote + forget the token
+try await mirror.deleteRemote()        // delete the cloud copy (keeps the token → stable URL)
+await mirror.disable()                 // opt out: flip OFF + delete remote, but KEEP the token (stable link)
 ```
 
 ## The single token
@@ -25,6 +25,13 @@ in the share URL (`/u/<token>/mcp`) and authorizes everything — MCP reads AND 
 (no `Authorization` header). Tradeoff: anyone who sees the share URL can also overwrite or
 delete the vault; mitigated by no accounts, the 30-day lease, one-click delete, and the vault
 being PII-stripped.
+
+**Identity ≠ on/off.** The token is the durable identity: minted once and kept across OFF→ON, so
+the share URL is **stable** (it's what the user pasted into ChatGPT/Claude — toggling must never
+reroll it and break their connectors). Whether mirroring is currently ON is a *separate* flag
+(`mcp.mirror.enabled`, UserDefaults) that `isEnabled` reads and the toggle flips — NOT "does a token
+exist". `disable()` flips OFF and deletes the cloud copy but keeps the token. (Builds before this
+flag equated enabled with token-exists; `isEnabled` migrates that state on first read.)
 
 A lost token is a non-event: mint a new one, re-push; the orphaned cloud copy expires on its
 30-day lease.
@@ -52,7 +59,7 @@ auto-push-after-KB-update, call `await Self.pushIfDirty()` from `VaultCloud.mark
 
 The opt-in is "mint a token" — `enable()`. The real onboarding/Settings opt-in UI is Phase 5, so
 ahead of that the **DEV TOOLS** panel (`DevToolsView`) exposes, while the mirror is ON:
-- **MCP TOGGLE** — ON mints the token + pushes the current vault; OFF deletes the cloud copy + forgets the token.
+- **MCP TOGGLE** — ON mints the token (if absent) + pushes the current vault; OFF deletes the cloud copy but **keeps the token**, so re-enabling reuses the same share link.
 - **Copy MCP Link** / **Copy System Prompt** — the share URL and the coached connector prompt to paste into ChatGPT/Claude.
 - **MCP SYNC** — force-push the current vault to the mirror (sync is a separate manual step now; see Sync above).
 - **Stats** (under **More**) — the access-log summary.

--- a/Sentient OS macOS/MirrorClient.swift
+++ b/Sentient OS macOS/MirrorClient.swift
@@ -55,14 +55,23 @@ actor MirrorClient {
 
     // MARK: Enable / disable
 
-    /// Whether the user has opted into the mirror (the token exists in the Keychain).
-    var isEnabled: Bool { Keychain.read(Self.tokenKey) != nil }
+    /// Whether mirroring is currently ON. Deliberately INDEPENDENT of the token's existence: the
+    /// token (the identity, Invariant 4) is minted once and kept forever so the share link stays
+    /// stable across OFF→ON — it's what the user pasted into ChatGPT/Claude, so toggling must never
+    /// reroll it. This flag is the on/off the toggle flips, and what gates auto-push.
+    var isEnabled: Bool {
+        let d = UserDefaults.standard
+        // Migrate pre-flag builds, which equated "enabled" with "a token exists".
+        if d.object(forKey: Self.enabledKey) == nil { return Keychain.read(Self.tokenKey) != nil }
+        return d.bool(forKey: Self.enabledKey)
+    }
 
-    /// Opt in: mint the token (idempotent — keeps an existing one so the share URL is stable).
-    /// Returns the share URL.
+    /// Opt in: mint the token if absent (idempotent — an existing token is kept, so the share URL
+    /// is stable) and flip mirroring ON. Returns the share URL.
     @discardableResult
     func enable() -> String {
         if Keychain.read(Self.tokenKey) == nil { Keychain.set(Self.tokenKey, Self.mintToken()) }
+        UserDefaults.standard.set(true, forKey: Self.enabledKey)
         return shareURL!
     }
 
@@ -103,11 +112,12 @@ actor MirrorClient {
         try Self.check(resp, data)
     }
 
-    /// Full opt-out: delete the cloud copy AND forget the token (a fresh opt-in later mints
-    /// a new share URL). Best-effort on the network call — local forget always happens.
+    /// Opt out: flip mirroring OFF and delete the cloud copy, but KEEP the token so re-enabling
+    /// reuses the SAME share URL (it's what the user pasted into ChatGPT/Claude — opting out must
+    /// not break those connectors). Best-effort on the network call; the local OFF always sticks.
     func disable() async {
+        UserDefaults.standard.set(false, forKey: Self.enabledKey)
         try? await deleteRemote()
-        Keychain.delete(Self.tokenKey)
     }
 
     /// The "your AIs read N notes" numbers for the home screen. nil if not enabled / no vault yet.
@@ -125,7 +135,8 @@ actor MirrorClient {
 
     // MARK: Helpers
 
-    private static let tokenKey = "mcp.mirror.token"
+    private static let tokenKey = "mcp.mirror.token"      // Keychain: the identity (persists)
+    private static let enabledKey = "mcp.mirror.enabled"  // UserDefaults: the on/off the toggle flips
 
     /// 32 random bytes → base64url (43 chars, no padding) — inside the server's [32,64] window
     /// and URL-safe, so it drops straight into the path.

--- a/Sentient OS macOS/Views/DevToolsView.swift
+++ b/Sentient OS macOS/Views/DevToolsView.swift
@@ -571,15 +571,17 @@ struct DevToolsView: View {
     }
 
     /// The headline MCP control. ON mints the token and pushes the current vault to Render; OFF
-    /// deletes the cloud copy and forgets the token. The share link + coached system prompt copy
-    /// right under it (while ON); Sync now / Stats live in `mirrorPane` under "More".
+    /// deletes the cloud copy but KEEPS the token, so re-enabling reuses the same share link (the
+    /// link is what the user pasted into ChatGPT/Claude — toggling must not break those connectors).
+    /// The share link + coached system prompt copy right under it (while ON); Sync now / Stats live
+    /// in `mirrorPane` under "More".
     private var mcpToggleButton: some View {
         VStack(spacing: 5) {
             Button {
                 Task { await runMirror {
                     if mirrorEnabled {
                         await MirrorClient.shared.disable()
-                        mirrorStatus = "✓ MCP mirror OFF — cloud copy deleted"
+                        mirrorStatus = "✓ MCP mirror OFF — cloud copy deleted (link kept)"
                     } else {
                         _ = await MirrorClient.shared.enable()
                         do {


### PR DESCRIPTION
## What

The MCP `MCP TOGGLE` rerolled the share URL on every OFF→ON. `isEnabled` was defined as *"a token exists in the Keychain"* and `disable()` **deleted the token** — so each OFF→ON minted a fresh token → a fresh link.

Since the token *is* the identity and lives in the share URL the user pastes into ChatGPT/Claude, toggling silently broke every connected AI (and `pushIfDirty()` could re-create the cloud copy we'd just deleted, since it gates on `isEnabled`).

## Fix

Split the two concepts that were conflated:

- **token = durable identity** — minted once, kept across OFF→ON ⇒ **stable share link** (Arch §7: "minted once on opt-in and kept in the Keychain").
- **enabled = a separate flag** (`mcp.mirror.enabled`, UserDefaults) that the toggle flips and that gates auto-push.

- `disable()` now flips OFF + deletes the cloud copy but **keeps the token**.
- `isEnabled` reads the flag, with a **migration**: existing opted-in vaults (token present, flag never set) still read as ON and keep their current link.

## Notes

- `project.pbxproj` `DEVELOPMENT_TEAM` change deliberately **excluded** (machine-local signing).
- No UI path forgets the token anymore (correct for a toggle); a deliberate "reset link" action can be added separately if wanted.
- Builds green (Xcode). Docs updated: `Documentation/MCP Mirror Client.md` + architecture §7 (Obsidian).