### PR TITLE
For You: live codex Gmail-MCP send + demo-card polish + orb fix

### DIFF
--- a/Sentient OS macOS/CodexCLI.swift
+++ b/Sentient OS macOS/CodexCLI.swift
@@ -60,7 +60,16 @@ actor CodexCLI {
         var sandbox: Sandbox = .readOnly
         var cwd: String? = nil                 // the agent's working root (vault/staging dir)
         var addDirs: [String] = []             // extra writable roots beyond cwd
-        var webSearch = false                  // native web_search tool
+        var webSearch = true                   // native web_search tool — available to EVERY call
+        var includeUserConfig = true           // load the user's ~/.codex config + MCP servers (e.g.
+                                               // their Gmail MCP) for EVERY call. Set false for a
+                                               // hermetic run (then we pass --ignore-user-config).
+        var bypassApprovals = false            // --dangerously-bypass-approvals-and-sandbox: NO
+                                               // approval prompts AND NO sandbox. Needed for hosted
+                                               // connector WRITE tools (Gmail `send_email`), which
+                                               // are approval-gated and return "user cancelled MCP
+                                               // tool call" headless even under approval_policy=never.
+                                               // TRUSTED, app-authored prompts ONLY (no sandbox!).
         var outputSchema: String? = nil        // JSON Schema for the final message (the judge)
         var resumeSessionID: String? = nil     // continue a prior session (usage-limit recovery)
         var timeout: TimeInterval = 3_600      // agentic vault runs are long; default generous
@@ -219,15 +228,32 @@ actor CodexCLI {
         if let sid = inv.resumeSessionID { args += ["resume", sid] }
         args += ["--json",
                  "--skip-git-repo-check",      // staging dirs and the vault aren't git repos
-                 "--ignore-user-config",       // hermetic: personal config/plugins stay out of our jobs
                  "-m", inv.model.rawValue,
                  "-c", "model_reasoning_effort=\"\(inv.effort.rawValue)\""]
-        if inv.resumeSessionID == nil {
-            args += ["-s", inv.sandbox.rawValue]
-            if let cwd = inv.cwd { args += ["--cd", cwd] }
-            for dir in inv.addDirs { args += ["--add-dir", dir] }
+        if !inv.includeUserConfig {
+            args += ["--ignore-user-config"]   // explicit hermetic opt-out only — includeUserConfig
+        }                                      // defaults TRUE, so by default we DON'T pass this and
+                                               // the user's ~/.codex config + MCP servers ARE loaded.
+
+        // Approvals + sandbox. `codex exec` is headless and can't answer an approval prompt:
+        //  · default → `approval_policy=never` (don't stall) + the Seatbelt sandbox (`-s`) as the
+        //    real guardrail for shell/file ops.
+        //  · bypassApprovals → `--dangerously-bypass-approvals-and-sandbox` (NO approvals, NO
+        //    sandbox). Required for hosted-connector WRITE tools (Gmail `send_email`), which are
+        //    approval-gated and return "user cancelled MCP tool call" headless even under
+        //    approval_policy=never. Mutually exclusive — codex rejects `-s`/approval_policy with it.
+        if inv.bypassApprovals {
+            args += ["--dangerously-bypass-approvals-and-sandbox"]
+            if inv.resumeSessionID == nil, let cwd = inv.cwd { args += ["--cd", cwd] }
         } else {
-            args += ["-c", "sandbox_mode=\"\(inv.sandbox.rawValue)\""]
+            args += ["-c", "approval_policy=\"never\""]
+            if inv.resumeSessionID == nil {
+                args += ["-s", inv.sandbox.rawValue]
+                if let cwd = inv.cwd { args += ["--cd", cwd] }
+                for dir in inv.addDirs { args += ["--add-dir", dir] }
+            } else {
+                args += ["-c", "sandbox_mode=\"\(inv.sandbox.rawValue)\""]
+            }
         }
         if inv.webSearch { args += ["-c", "tools.web_search=true"] }
         if let schemaFile { args += ["--output-schema", schemaFile] }

--- a/Sentient OS macOS/Documentation/Briefings Window (For You).md
+++ b/Sentient OS macOS/Documentation/Briefings Window (For You).md
@@ -20,8 +20,8 @@ the full gradient).
 the loop in `ForYouModel.run` with `CodexCLI.run` on `codexPrompt`, streaming JSONL events
 into the same lines. One swap point, clearly marked.
 
-**All six cards are hard-coded showcase content** (Deepika/Outlander · Luis/Headline ·
-Dad's shoes · ZFellows · SF break plan · the welcome letter), mined from the real vault for
+**All six cards are hard-coded showcase content** (Anthos/Gmail · Luis/Headline ·
+AIM/press · ZFellows · Fareed/a16z-call · the welcome letter), mined from the real vault for
 authenticity. The proactive module generates real ones post-launch.
 
 ## `Views/BriefingCard.swift` — the card's four lives

--- a/Sentient OS macOS/Documentation/CodexCLI (codex exec Compute Spine).md
+++ b/Sentient OS macOS/Documentation/CodexCLI (codex exec Compute Spine).md
@@ -16,8 +16,13 @@ piggybacks on the user's own Codex CLI (their ChatGPT subscription pays). Replac
 
 `Invocation`: `prompt` (always over **stdin**, never argv) · `effort` (`.high` = initial gen,
 `.medium` = everything daily) · `sandbox` (`.readOnly` default / `.workspaceWrite`) · `cwd` ·
-`addDirs` (extra writable roots) · `webSearch` · `outputSchema` (JSON-Schema
-string → temp file → `--output-schema`) · `resumeSessionID` · `timeout` (default 1 h).
+`addDirs` (extra writable roots) · `webSearch` (**default `true`** — web search is available to
+every call) · `includeUserConfig` (**default `true`** — loads `~/.codex` + the user's MCP
+servers, e.g. their Gmail MCP, on every call; set `false` for a hermetic run) · `bypassApprovals`
+(default `false`; `true` → `--dangerously-bypass-approvals-and-sandbox`, the only way a hosted-
+connector WRITE tool like Gmail `send_email` fires headless — TRUSTED prompts only, no sandbox) ·
+`outputSchema` (JSON-Schema string → temp file → `--output-schema`) · `resumeSessionID` · `timeout`
+(default 1 h).
 
 `Envelope`: `result` (final agent message) · `sessionID` (thread id — the resume handle) ·
 `numTurns` (completed items) · `durationMS` (wall clock, measured here) · `inputTokens` /
@@ -29,8 +34,11 @@ string → temp file → `--output-schema`) · `resumeSessionID` · `timeout` (d
 |---|---|
 | `--json` | JSONL events → the envelope. `thread.started` carries the thread id in the FIRST event, so the resume handle survives mid-run failures. |
 | `--skip-git-repo-check` | staging dirs and the vault aren't git repos; codex refuses to run otherwise |
-| `--ignore-user-config` | hermetic runs — the user's personal `~/.codex/config.toml` (personality, plugins, MCP servers) must never leak into our jobs |
+| `--ignore-user-config` | **Default OFF (we DON'T pass it):** `Invocation.includeUserConfig` defaults `true`, so every call loads the user's `~/.codex` config + MCP servers (their Gmail MCP, etc.). We pass `--ignore-user-config` ONLY for an explicitly hermetic run (`includeUserConfig = false`). |
+| `-c tools.web_search=true` | added whenever `Invocation.webSearch` is true — now the **default**, so web search is an available tool on every call |
 | `-m gpt-5.5` + `-c model_reasoning_effort=…` | explicit beats the binary's drifting default |
+| `-c approval_policy="never"` (default path) | headless `exec` can't ask a human, so without it codex would stall on shell/file approvals. `never` = don't prompt; the Seatbelt sandbox (`-s`) stays the real guardrail. **Caveat:** for hosted-connector WRITE tools this resolves to auto-CANCEL, not auto-allow (`gmail.send_email` → "user cancelled MCP tool call") — that needs `bypassApprovals` instead |
+| `--dangerously-bypass-approvals-and-sandbox` (`bypassApprovals`) | the ONLY lever that makes an approval-gated connector write (Gmail `send_email`) fire headless. Removes BOTH approvals AND the sandbox, so it's mutually exclusive with `-s`/`approval_policy`. Used for the For You "send it" action. **TRUSTED, app-authored prompts only** — there's no sandbox left |
 | `-s <sandbox>` | OS-level Seatbelt confinement — stronger than a tool allowlist; even model-run shell commands can't escape cwd + addDirs |
 
 Web search = `-c tools.web_search=true` (`--search` exists only on the interactive CLI, not

--- a/Sentient OS macOS/Views/Briefing.swift
+++ b/Sentient OS macOS/Views/Briefing.swift
@@ -27,7 +27,7 @@ struct Briefing: Identifiable {
         var accent: Color {
             switch self {
             case .meeting:  Color(red: 0.36, green: 0.55, blue: 1.00)   // cobalt
-            case .overdue:  Theme.Ink.amber
+            case .overdue:  Color(red: 1.00, green: 0.50, blue: 0.18)   // overdue orange — hotter than amber
             case .promise:  Theme.Ink.mint
             case .deadline: Color(red: 1.00, green: 0.42, blue: 0.45)   // ember
             case .plan:     Color(red: 0.72, green: 0.46, blue: 0.96)   // orchid
@@ -73,29 +73,38 @@ struct Briefing: Identifiable {
 
     // MARK: The demo six
 
+    /// The EXACT reply we send Serena — ONE source of truth, shared by the Anthos card's draft
+    /// PREVIEW (what you read when you click the card) and the `codexPrompt` that actually sends
+    /// it. They interpolate this same string, so the preview and the sent email can never drift.
+    private static let anthosReply = """
+        Hey Serena,
+
+        Thanks for reaching out, and that's awesome to hear! :)
+
+        Would love to chat! I think you'll be surprised — what you see on the website right now is a really old version of Sentient from over a month ago.
+
+        I'm using our core on-device processing moat to build a knowledge base for all your LLMs from your entire life. And cooler still, what I call Proactive Intelligence:
+
+        Sentient, with its continuous free on-device compute, understands your entire life and then *acts* on it for you (backed by that rich knowledge base!). It does this through computer use and browser use.
+
+        I'd love to show you live any time you're free. Would tomorrow (Friday) work? If not, happy to chat early next week.
+
+        Best,
+        Jesai
+        """
+
     static let demo: [Briefing] = [
         Briefing(
             id: "anthos", kind: .overdue,
-            kicker: "Overdue · 4 days · Gmail",
-            title: "You ghosted Anthos Capital.",
-            body: "Serena cold-emailed four days ago — $3B+ AUM, names like Honey and Kalshi. She wants time next week. I wrote your reply.",
+            kicker: "Overdue · 6 days · Gmail",
+            title: "You still haven't replied to Anthos Capital.",
+            body: "Serena emailed six days ago — $3B+ AUM, names like Honey and Kalshi. She wanted time this week. I wrote your reply.",
             letter: """
-            Serena Saxena from Anthos Capital cold-emailed four days ago — she found Sentient down an on-device-vs-cloud rabbit hole. Anthos runs a $1.5B fund with $3B+ in AUM, and backs companies people are obsessed with: Honey, Kalshi, Erewhon, Olaplex.
+            Serena Saxena from Anthos Capital emailed six days ago — she found Sentient down an on-device-vs-cloud rabbit hole. Anthos runs a $1.5B fund with $3B+ in AUM, and backs companies people are obsessed with: Honey, Kalshi, Erewhon, Olaplex.
 
-            She's in LA and asked for time early next week. You went quiet. Let's fix that — the draft's below, warm and ready.
+            She's in LA and asked for time early this week. You went quiet. Let's fix that — the draft's below, warm and ready.
             """,
-            draft: """
-            Hi Serena,
-
-            Thank you for reaching out — and for going down the on-device rabbit hole. That's exactly the bet.
-
-            Quick context: Sentient OS is a private, on-device intelligence layer for your whole digital life. Your Mac reads everything you've saved — files, screenshots, WhatsApp, iMessage, Notes — entirely on your own hardware, and distills it into a knowledge vault every AI you use can plug into. Raw data never leaves the device. We hit 2,500+ waitlist signups in 24 hours from a single Reddit post, and we launch publicly this month.
-
-            I'd love to find time next week. I'm in SF — happy to do a call, or grab time if you're ever up here. Would Tuesday or Wednesday afternoon work on your end?
-
-            Best,
-            Jesai
-            """,
+            draft: Briefing.anthosReply,
             draftLabel: "Draft · Gmail",
             detailLabel: "read the draft",
             offer: "Should I send it for you?",
@@ -104,8 +113,18 @@ struct Briefing: Identifiable {
                       "→ composing your reply…",
                       "✓ sent"],
             doneTitle: "Sent to Anthos.",
-            doneBody: "Serena has your reply — and two times next week.",
-            codexPrompt: "Open Gmail and reply to Serena Saxena (Anthos Capital) with the approved draft in this briefing. Send it."),
+            doneBody: "Serena has your reply — Friday, or early next week.",
+            codexPrompt: """
+            You are running fully headless and autonomous, with the user's explicit prior approval to act on their behalf for THIS task — they clicked "send it for me." Do NOT ask for confirmation or approval, do NOT pause to verify, and do NOT merely draft. Actually SEND. If any tool surfaces a confirmation or approval step, treat it as already granted by the user and proceed.
+
+            Use the Gmail MCP to reply to the email from jesaitarun@gmail.com with the subject "Sentient OS test". Reply in that thread and send EXACTLY the message below, verbatim — do not change, rephrase, summarize, or add anything:
+
+            \(Briefing.anthosReply)
+
+            Send this reply now via the Gmail MCP — the user has already approved this send. Do not ask, do not draft-and-wait; complete the send and confirm it went out.
+
+            IMPORTANT — formatting: send it as an HTML email. Set the send tool's content_type to "text/html" and format the body as clean HTML so it reflows naturally in the reader's inbox: put EACH paragraph above inside its own <p>…</p> tag, and write the sign-off as "Best,<br>Jesai". Keep every word — including ":)", the "—" em-dash, "*acts*", and "(Friday)" — exactly as written. Do NOT send as text/plain and do NOT insert any manual line breaks inside a paragraph; plain text gets hard-wrapped mid-sentence, which is the ugly formatting we're fixing.
+            """),
 
         Briefing(
             id: "luis", kind: .meeting,
@@ -175,37 +194,24 @@ struct Briefing: Identifiable {
             codexPrompt: "Use the browser to open the ZFellows Dropout Graduation registration and submit it for Jesai Tarun, UMass Amherst, building Sentient OS."),
 
         Briefing(
-            id: "deepika", kind: .plan,
-            kicker: "Warm intro · 3 days · Gmail",
-            title: "Deepika opened a $1.5M door.",
-            body: "She's connecting you with Jordan, Outlander's senior partner, and asked for a TLDR she can forward. I wrote it.",
+            id: "fareed", kind: .meeting,
+            kicker: "Prep · Tomorrow · Researched",
+            title: "Prepare for your call with Fareed from Speedrun tomorrow.",
+            body: "Remember: Josh Lu wanted Fareed to be your a16z Speedrun partner. I've researched and found that GTM strategy matters a lot to him. Here's a doc that'll help you prepare for your call.",
             letter: """
-            Deepika (Outlander VC) loved Sentient and is connecting you with Jordan, their senior partner, to talk through the ~$1.5M. She asked for a TLDR she could forward.
+            Remember: Josh Lu wanted Fareed to be your a16z Speedrun partner — and your call is tomorrow. I went through everything and pulled together what'll get you ready.
 
-            That was three days ago. Time to land it — the draft is below, written to be forwarded.
+            ✦ **GTM is his lens.** Across his bets and writing, Fareed weighs go-to-market harder than almost anything. He'll want a crisp distribution story, not just the tech.
+
+            ✦ **Open with the Reddit moment.** 2,500+ waitlist signups in 24 hours from a single post, $0 spent — that's the GTM proof that lands with him. Lead with it.
+
+            ✦ **Have the wedge ready.** Consumer free-forever as the loved wedge; the enterprise per-employee intelligence layer as the business. Expect him to push on how one becomes the other.
+
+            Walk in leading with distribution. — your Sentient
             """,
-            draft: """
-            Hi Deepika,
-
-            So great speaking with you — and thank you for connecting me with Jordan! Here's a TLDR you can forward along:
-
-            Sentient OS is the private, on-device intelligence layer for your digital life. Your Mac reads everything you've saved — files, screenshots, WhatsApp, iMessage, Notes — entirely on your own hardware, and distills it into a knowledge vault every AI you use can plug into. Raw data never leaves the device. 2,500+ waitlist signups in 24 hours from a single Reddit post, a working product, and a public launch this month.
-
-            Would love to walk Jordan through a live demo whenever suits.
-
-            Best,
-            Jesai
-            """,
-            draftLabel: "Draft · Gmail",
-            detailLabel: "read the draft",
-            offer: "Should I send it for you?",
-            workLog: ["→ reading the thread with Deepika",
-                      "→ opening Gmail",
-                      "→ composing the forwardable TLDR…",
-                      "✓ sent"],
-            doneTitle: "Sent to Deepika.",
-            doneBody: "The TLDR is on its way to Jordan.",
-            codexPrompt: "Open Gmail and reply to the latest thread with Deepika (Outlander VC) using the approved draft in this briefing. Send it."),
+            detailLabel: "read the prep doc",
+            offer: nil,
+            doneTitle: "", doneBody: ""),
 
         Briefing(
             id: "welcome", kind: .welcome,

--- a/Sentient OS macOS/Views/BriefingsView.swift
+++ b/Sentient OS macOS/Views/BriefingsView.swift
@@ -64,7 +64,7 @@ struct BriefingsView: View {
             Text(greeting)
                 .font(.system(size: 30, design: .serif).italic())
                 .foregroundStyle(Theme.Ink.statusInk)
-            MonoCaps(Demo.readLine(count: model.entries.count), size: 9.5, tracking: 2.2,
+            MonoCaps(Demo.readLine, size: 9.5, tracking: 2.2,
                      color: Theme.Ink.deepMuted)
         }
         .padding(.leading, 36).padding(.top, 28)
@@ -219,12 +219,23 @@ final class ForYouModel {
         update(e.id) { $0.phase = .offer }
     }
 
-    /// Fire the offer. THE CODEX SEAM: real execution replaces the scripted loop below with
-    /// `CodexCLI.shared.run(...)` on `briefing.codexPrompt`, streaming JSONL events into the
-    /// same `working(n)` lines. The demo plays the briefing's hard-coded theater.
+    /// Fire the offer. THE CODEX SEAM: most cards play the briefing's hard-coded `workLog`
+    /// theater, but the Anthos card is wired LIVE — it actually runs `CodexCLI.shared.run(...)`
+    /// on its `codexPrompt` (via `fireLiveCodex`, a real Gmail-MCP send) while the theater plays
+    /// for show; the real outcome is logged. Streaming JSONL into `working(n)` is the next step.
     func run(_ id: String) {
         guard let e = entry(id), e.phase == .offer, e.b.offer != nil else { return }
         let v = visit
+
+        // THE CODEX SEAM — LIVE for the Anthos card: actually run `codex exec` on its codexPrompt
+        // (real CodexCLI.run, with the user's Gmail MCP in scope, so the reply truly sends). The
+        // scripted theater below still plays for visual feedback; the real run happens in the
+        // background and its outcome is logged. Other cards stay pure demo — their prompts would
+        // attempt bogus sends.
+        if e.b.id == "anthos", let prompt = e.b.codexPrompt {
+            Task.detached(priority: .utility) { await Self.fireLiveCodex(prompt) }
+        }
+
         Task {
             withAnimation(.easeInOut(duration: 0.3)) { update(id) { $0.phase = .working(0) } }
             for n in 1...e.b.workLog.count {
@@ -239,6 +250,26 @@ final class ForYouModel {
             guard self.visit == v else { return }
             dismiss(id, toward: CGSize(width: CGFloat.random(in: 250...520),
                                        height: -CGFloat.random(in: 350...560)))
+        }
+    }
+
+    /// Live CODEX SEAM test (Anthos card): run the prompt through the real `codex exec` spine.
+    /// The user's Gmail MCP rides the CodexCLI defaults; `bypassApprovals` lets the connector's
+    /// approval-gated `send_email` actually fire headless. Outcome → `Log()` (tail /tmp/sentient-dev.log).
+    nonisolated static func fireLiveCodex(_ prompt: String) async {
+        Log("ForYou/codex: firing live codex exec (Anthos → Gmail MCP)…")
+        do {
+            var inv = CodexCLI.Invocation(prompt: prompt)
+            inv.effort = .medium                // an email reply doesn't need xhigh
+            inv.bypassApprovals = true          // hosted Gmail send_email is approval-gated → it
+                                                // auto-cancels headless unless we bypass approvals
+            inv.timeout = 300
+
+            let env = try await CodexCLI.shared.run(inv)
+            Log("ForYou/codex: ✓ finished in \(env.durationMS ?? -1)ms (\(env.numTurns ?? -1) turns) — \(env.result)")
+            Log("ForYou/codex: --- full JSONL (debug) ---\n\(env.raw)\n--- end JSONL ---")
+        } catch {
+            Log("ForYou/codex: ✗ failed — \(error)")
         }
     }
 
@@ -426,10 +457,8 @@ private struct LetterView: View {
 
 private enum Demo {
     static let name = "Jesai"   // later: the vault portrait's first name
-    static let reminders = "Reminders · EWOR call — Daniel Dippold, Fri 11 AM · ZFellows — 8 days · Workout — tonight 8 PM"
-    static func readLine(count: Int) -> String {
-        "While you slept, I read 1,704 things · \(count) offering\(count == 1 ? "" : "s")"
-    }
+    static let reminders = "Other reminders: EWOR CEO call — Daniel Dippold, tomorrow at 11 AM · Workout — tonight 8 PM"
+    static let readLine = "While you slept, I read 1,704 things"
 }
 
 #Preview("For You — the offerings") {

--- a/Sentient OS macOS/Views/Orb.swift
+++ b/Sentient OS macOS/Views/Orb.swift
@@ -68,6 +68,12 @@ struct Orb: View {
                 .fill(AngularGradient(colors: Orb.haloColors(for: mode), center: .center))
                 .frame(width: size * 1.8, height: size * 1.8)
                 .blur(radius: size * 0.30)
+                // .drawingGroup() rasterizes at the view's RECTANGULAR bounds and clips the
+                // blur's soft falloff — without this padding the glow is chopped into a hard
+                // square that then visibly spins (haloLayer rotates the cached texture). Pad so
+                // the whole blur tail fits inside the raster bounds; the margin is transparent,
+                // so the halo stays a soft circle. (Disc reaches ~0.9·size, blur adds ~0.9·size.)
+                .padding(size * 1.1)
                 .drawingGroup()
         }
     }


### PR DESCRIPTION
## What

Turns the **For You** window's "send it for you" from scripted theater into a **real** codex-exec action, plus a round of demo-card polish and an orb fix.

### ✉️ Live codex send (flagship #2, working end-to-end)
- The Anthos card's button now fires `CodexCLI.run` on a real prompt via the user's **Gmail MCP** (`fireLiveCodex`, scoped to the Anthos card only — every other card keeps the scripted theater).
- One `anthosReply` constant is the **single source of truth** for both the card's draft *preview* and the *codexPrompt* body, so what you read and what gets sent can't drift.
- Recipient is a **safe test address** (the user's own), not a real contact — a stray click can't email anyone external.

### 🔧 CodexCLI tool availability
- `includeUserConfig` + `webSearch` now **default true** — every call loads the user's `~/.codex` + MCP servers and has web search available.
- Always pass `-c approval_policy="never"`.
- New `bypassApprovals` → `--dangerously-bypass-approvals-and-sandbox`: the only lever that lets an approval-gated hosted-connector write (Gmail `send_email`) fire headless — it returns `user cancelled MCP tool call` otherwise (measured). Removes the sandbox, so **trusted app-authored prompts only**.

### 🎴 Demo-card polish
- Anthos: orange overdue accent, "You still haven't replied to Anthos Capital", 6 days, "emailed" (not "cold-emailed"), this-week phrasing.
- Replaced the Deepika card with a **Fareed** "prep doc" card.
- Trimmed the reminders strip; dropped the offering count from the For You header.

### 🔮 Orb
- Padded the halo before `.drawingGroup()` so the blurred glow isn't clipped into a **spinning square**.

## Notes
- Not compile-checked in this environment (no Xcode bridge), but the bulk was build-validated via live testing of the codex send.
- `fireLiveCodex` (Anthos wiring) is pre-launch demo/test scaffolding — gate or remove for production: it hardcodes a recipient and uses `bypassApprovals` (no sandbox).
- The architecture context file (in `Our_Stuff`, not part of this repo) was updated in parallel for the CodexCLI changes.