### PR TITLE
For You: glowing command bar + EWOR/Fareed demo-card updates

### DIFF
--- a/Sentient OS macOS/Documentation/Briefings Window (For You).md
+++ b/Sentient OS macOS/Documentation/Briefings Window (For You).md
@@ -21,8 +21,11 @@ the loop in `ForYouModel.run` with `CodexCLI.run` on `codexPrompt`, streaming JS
 into the same lines. One swap point, clearly marked.
 
 **All six cards are hard-coded showcase content** (Anthos/Gmail · Luis/Headline ·
-AIM/press · ZFellows · Fareed/a16z-call · the welcome letter), mined from the real vault for
-authenticity. The proactive module generates real ones post-launch.
+AIM/press · ZFellows · Fareed/a16z-call · Daniel/EWOR-call), mined from the real vault for
+authenticity. The proactive module generates real ones post-launch. The original **welcome
+"gift" letter** (the wax-sealed envelope) is parked as `Briefing.welcomeGift` — preserved
+verbatim but kept OUT of the `demo` deck; drop it back in to restore it (its envelope visuals
+in BriefingCard are still intact, and re-adding makes a 7-card deck → extend `slots(count:)`).
 
 ## `Views/BriefingCard.swift` — the card's four lives
 
@@ -43,10 +46,23 @@ under a blinking cursor) → `done` (mint check; the model flies the card away a
   styling, accent-barred draft block with Copy, the offer button lives there too). Esc /
   click-outside / ✕ closes; the scatter blurs behind.
 - Header greeting is hour-aware ("Good morning, Jesai." — name is `Demo.name` until the
-  vault portrait supplies it). Reminders whisper-strip + trust footer on the floor. Empty
-  state: *"All quiet." / YOUR AI LOOKS OUT FOR YOU*.
+  vault portrait supplies it). **Bottom dock** (`bottomDock`): the `PromptBar` command bar,
+  then the trust footer. The scatter is laid into the top 84% of the height so cards clear
+  the bar. Empty state: *"All quiet." / YOUR AI LOOKS OUT FOR YOU*.
 - Scene: its own `Window` (`BriefingsView.windowID`), hidden title bar, 1180×800. Opened by
   the Constellation's briefing satellite (which now shows the latest offer + a `+5` pill).
+
+## `Views/PromptBar.swift` — the "Tell me what you want me to DO" command bar
+
+The one glowing object on the For You floor (jewelry rule): a glassy rounded field on a
+slowly-rotating glow in the **Analyze Now / GlowButton palette** (`GlowHalo.stops`) — via
+`PromptGlow`, the rounded-rect twin of `GlowHalo` (7s ambient spin, soft/tight rim-glow,
+brighter on focus). Left: a `[Computer use | Browser use]`
+segmented `ModeToggle` (defaults to **Computer use**). Middle: the input, whose placeholder
+bolds the verb (*"Tell me what you want me to **DO**"*). Right: a glowing circular `SendButton`
+(arrow-up; white/active when there's text). **Demo seam:** `onSend(text, mode)` just `Log()`s
+today — real execution routes the text + mode to `CodexCLI` (computer use → workspace-write
+agent · browser use → browser-driving agent).
 
 ## Still demo / future
 

--- a/Sentient OS macOS/Views/Briefing.swift
+++ b/Sentient OS macOS/Views/Briefing.swift
@@ -195,42 +195,70 @@ struct Briefing: Identifiable {
 
         Briefing(
             id: "fareed", kind: .meeting,
-            kicker: "Prep · Tomorrow · Researched",
-            title: "Prepare for your call with Fareed from Speedrun tomorrow.",
-            body: "Remember: Josh Lu wanted Fareed to be your a16z Speedrun partner. I've researched and found that GTM strategy matters a lot to him. Here's a doc that'll help you prepare for your call.",
+            kicker: "Prep · 1 PM today · Researched",
+            title: "Prepare for your call with Fareed.",
+            body: "I've researched and found that GTM strategy matters a lot to him. Here's a doc that'll help you prepare for your call.",
             letter: """
-            Remember: Josh Lu wanted Fareed to be your a16z Speedrun partner — and your call is tomorrow. I went through everything and pulled together what'll get you ready.
+            Your call with Fareed is today at 1 PM. Josh Lu wanted him as your a16z Speedrun partner — and once I read Fareed's background, it's obvious why. I pulled the highlights that'll get you ready.
 
-            ✦ **GTM is his lens.** Across his bets and writing, Fareed weighs go-to-market harder than almost anything. He'll want a crisp distribution story, not just the tech.
+            ✦ **Why Josh connected you: he OWNED GTM at Slack.** Fareed was Director of Product for Lifecycle and the revenue owner for Slack's self-serve business — acquisition, activation, retention, monetization: the whole PLG engine at the company that *defined* bottoms-up growth. Sentient's free-forever consumer wedge is exactly his world. Speak his language — growth loops, activation, the path from a loved free product to revenue.
 
-            ✦ **Open with the Reddit moment.** 2,500+ waitlist signups in 24 hours from a single post, $0 spent — that's the GTM proof that lands with him. Lead with it.
+            ✦ **He literally wrote about a thesis behind your product.** His recent post — *"Agent-native products are coming"*: *"Every product on the internet was built for a human with eyes, a cursor, and a credit card. Agents have none of those. The real opportunity is products designed for agents from scratch."* That is core to Sentient — an agent-native knowledge base your whole life feeds, offered to your AIs for Proactive Intelligence. Open here; he'll feel seen, and you'll prove you did the work.
 
-            ✦ **Have the wedge ready.** Consumer free-forever as the loved wedge; the enterprise per-employee intelligence layer as the business. Expect him to push on how one becomes the other.
+            ✦ **He thinks in product strategy — so be crisp.** At Reforge he built, with Casey Winters, the Product Strategy program that's now their **#1**. Expect him to probe your strategic spine: consumer free-forever as the loved wedge, the enterprise per-employee intelligence layer as the business, the on-device moat that makes both possible. Have the one-becomes-the-other story tight.
 
-            Walk in leading with distribution. — your Sentient
+            ✦ **Lead with distribution proof.** He loves network effects and growth loops, so the Reddit moment lands hard: **2,500+ waitlist signups in 24 hours, $0 spent.** That's the organic growth-loop evidence he's wired to respond to.
+
+            Walk in as the agent-native, PLG-native founder he's been writing about. — your Sentient
             """,
             detailLabel: "read the prep doc",
             offer: nil,
             doneTitle: "", doneBody: ""),
 
         Briefing(
-            id: "welcome", kind: .welcome,
-            kicker: "Welcome · Read across your whole life",
-            title: "A gift — connections across your life.",
-            body: "Three patterns you might not have seen yourself — visible only with everything in one place.",
+            id: "ewor", kind: .plan,
+            kicker: "Prep · 11 AM today · Researched",
+            title: "Prepare for your call with Daniel, CEO of EWOR.",
+            body: "Somya Gupta nominated you for the EWOR Fellowship — and Daniel Dippold, its founder & CEO, wants 15 minutes today at 11 AM. I researched him and EWOR and pulled together what'll get you ready.",
             letter: """
-            I read **1,704 things** across your life last night. Three patterns you might not have seen yourself:
+            Your EWOR selection interview is today — 11:00–11:15 AM PDT, on Zoom (it moved up from 10:45). Somya Gupta nominated you, and you're meeting Daniel Dippold, EWOR's founder & CEO. He called it casual, but it's 15 minutes and it's selective — so walk in sharp.
 
-            ✦ **You never accept defaults.** Your iPhone ran **iPadOS** — WIRED noticed. Macs got **Apple Intelligence** before Apple shipped it, because you ported it. Your playlists skip the charts — and now you're routing around **college** itself.
+            ✦ **Know your room.** Daniel is a mathematician-turned-founder: raised **$100M** in his twenties, angel in **7 unicorns**, and built three organizations still thriving — EWOR, New Now Group, Sigma Squared. He rewards technical depth and outlier conviction — lead with the on-device moat and your all-in, drop-out resolve.
 
-            ✦ **You spec hardware in numbers and music in feelings.** RAM chosen by the gigabyte for local LLMs; playlists curated for **“mood, tears, goosebumps.”**
+            ✦ **Speak EWOR's language.** They back the **top 0.1%** of founders building transformative tech — up to **€500K** immediate, plus weekly 1:1 coaching from unicorn founders (Adjust, ProGlove, SumUp). No standard playbooks; they tailor to each founder. Frame Sentient as exactly that non-linear, outlier bet.
 
-            ✦ **Your optimization points outward.** The systems you engineer for yourself show up rebuilt as **study systems for Jacob**, 8,000 miles away.
+            ✦ **Your 15-minute arc.** Open with the Reddit moment — **2,500+ waitlist signups in 24 hours, $0 spent**. Then the wedge: consumer free-forever as the loved foothold, the enterprise per-employee intelligence layer as the business. Close on why now, and why you.
 
-            I'll keep watch from here. — **your Sentient**
+            Somya put their name on you — make it land. — **your Sentient**
             """,
-            detailLabel: "read it again",
+            detailLabel: "read the prep doc",
             offer: nil,
             doneTitle: "", doneBody: ""),
     ]
+
+    /// PARKED — the original "gift from your Sentient" welcome letter (the wax-sealed envelope card).
+    /// Deliberately kept OUT of the `demo` deck above so it doesn't show in the UI right now, but
+    /// preserved verbatim so it's one line away from returning: drop `Briefing.welcomeGift` back into
+    /// `demo`. Its envelope visuals (`EnvelopeFace`, `welcomeGradient`, the `.sealed` phase) are still
+    /// intact in BriefingCard.swift. NOTE: re-adding makes a 7-card deck — extend `slots(count:)` in
+    /// BriefingsView (it only defines layouts up to 6), or swap it back in for another card to stay at 6.
+    static let welcomeGift = Briefing(
+        id: "welcome", kind: .welcome,
+        kicker: "Welcome · Read across your whole life",
+        title: "A gift — connections across your life.",
+        body: "Three patterns you might not have seen yourself — visible only with everything in one place.",
+        letter: """
+        I read **1,704 things** across your life last night. Three patterns you might not have seen yourself:
+
+        ✦ **You never accept defaults.** Your iPhone ran **iPadOS** — WIRED noticed. Macs got **Apple Intelligence** before Apple shipped it, because you ported it. Your playlists skip the charts — and now you're routing around **college** itself.
+
+        ✦ **You spec hardware in numbers and music in feelings.** RAM chosen by the gigabyte for local LLMs; playlists curated for **“mood, tears, goosebumps.”**
+
+        ✦ **Your optimization points outward.** The systems you engineer for yourself show up rebuilt as **study systems for Jacob**, 8,000 miles away.
+
+        I'll keep watch from here. — **your Sentient**
+        """,
+        detailLabel: "read it again",
+        offer: nil,
+        doneTitle: "", doneBody: "")
 }

--- a/Sentient OS macOS/Views/BriefingsView.swift
+++ b/Sentient OS macOS/Views/BriefingsView.swift
@@ -6,7 +6,7 @@
 //  with staggered physics; they settle into a loose scatter (placed, not gridded). Each card
 //  is an OFFER the user can fire (BriefingCard plays the agentic theater, then the card
 //  flies away), flick-dismiss with drag physics (the scatter reflows), or expand into a full
-//  typeset letter. A faint reminders strip + trust footer hold the floor; the empty state
+//  typeset letter. A glowing command bar + trust footer hold the floor; the empty state
 //  whispers "Your AI looks out for you."
 //
 //  Doc: Documentation/Briefings Window (For You).md · Demo content + the CodexCLI seam:
@@ -34,7 +34,7 @@ struct BriefingsView: View {
                 Group {
                     header
                     scatter(geo)
-                    bottomStrip
+                    bottomDock
                     if model.entries.isEmpty { emptyState.transition(.opacity) }
                 }
                 .blur(radius: letterShown ? 7 : 0)
@@ -81,7 +81,10 @@ struct BriefingsView: View {
     // MARK: The scatter
 
     private func scatter(_ geo: GeometryProxy) -> some View {
-        let slots = Self.slots(count: model.entries.count, in: geo.size)
+        // Reserve the bottom band for the command bar + footer: lay the scatter into the
+        // top 84% of the height so no card overlaps the glowing PromptBar.
+        let field = CGSize(width: geo.size.width, height: geo.size.height * 0.84)
+        let slots = Self.slots(count: model.entries.count, in: field)
         return ZStack {
             ForEach(Array(model.entries.enumerated()), id: \.element.id) { item in
                 DealtCard(
@@ -113,19 +116,24 @@ struct BriefingsView: View {
         return f.map { CGPoint(x: $0.0 * size.width, y: $0.1 * size.height) }
     }
 
-    // MARK: Floor — reminders whisper + trust footer
+    // MARK: Floor — the command bar + trust footer
 
-    private var bottomStrip: some View {
-        VStack(spacing: 9) {
-            MonoCaps(Demo.reminders, size: 9, tracking: 1.6, color: Theme.Ink.deepMuted)
+    private var bottomDock: some View {
+        VStack(spacing: 16) {
+            PromptBar { text, mode in
+                // DEMO SEAM: real execution hands (text, mode) to CodexCLI — computer use runs a
+                // workspace-write agent; browser use drives the browser. For now, report the intent.
+                Log("ForYou/prompt: [\(mode.rawValue) use] \(text)")
+            }
             HStack(spacing: 8) {
                 Image(systemName: "shield").font(.system(size: 11)).foregroundStyle(Theme.Ink.label)
                 Text("Private by design. Your files never leave this Mac.")
                     .font(.system(size: 12)).foregroundStyle(Theme.Ink.label)
             }
         }
+        .padding(.horizontal, 40)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
-        .padding(.bottom, 14)
+        .padding(.bottom, 16)
     }
 
     private var emptyState: some View {
@@ -457,7 +465,6 @@ private struct LetterView: View {
 
 private enum Demo {
     static let name = "Jesai"   // later: the vault portrait's first name
-    static let reminders = "Other reminders: EWOR CEO call — Daniel Dippold, tomorrow at 11 AM · Workout — tonight 8 PM"
     static let readLine = "While you slept, I read 1,704 things"
 }
 

--- a/Sentient OS macOS/Views/GlowButton.swift
+++ b/Sentient OS macOS/Views/GlowButton.swift
@@ -52,7 +52,9 @@ struct GlowHalo: View {
     var reversed: Bool = false
     var colors: [Color]? = nil
 
-    private static let stops: [Color] = [
+    /// The canonical warm→cool AI-gradient stops (shared: the Analyze Now CTA + the For You
+    /// command bar's glow both use these).
+    static let stops: [Color] = [
         Color(red: 0.992, green: 0.886, blue: 0.639),  // #fde2a3 warm yellow
         Color(red: 1.000, green: 0.557, blue: 0.235),  // #ff8e3c orange
         Color(red: 1.000, green: 0.275, blue: 0.275),  // #ff4646 red

--- a/Sentient OS macOS/Views/PromptBar.swift
+++ b/Sentient OS macOS/Views/PromptBar.swift
@@ -1,0 +1,189 @@
+//
+//  PromptBar.swift
+//  Sentient OS macOS
+//
+//  The "Tell me what you want me to DO" command bar that docks at the foot of the For You
+//  window — the one glowing object on the screen (the jewelry rule). A slow, soft conic
+//  AI-gradient glow (the Analyze Now / GlowButton palette, GlowHalo.stops) hugs a glassy
+//  rounded field:
+//    [ Computer use | Browser use ]  ·  the prompt input (verb "DO" bolded bright)  ·  ◯↑ send
+//  The mode selector defaults to Computer use. `onSend(text, mode)` is the DEMO SEAM — real
+//  execution will hand the text + mode to CodexCLI (computer use → a workspace-write agent;
+//  browser use → a browser-driving agent). Today it just reports the intent.
+//
+//  Key pieces: PromptBar (the bar) · ModeToggle (the segmented selector) · SendButton ·
+//  PromptGlow (the rounded-rect twin of GlowButton's GlowHalo).
+//
+
+import SwiftUI
+
+/// What the agent is allowed to drive when it acts on the user's request.
+enum AgentMode: String, CaseIterable {
+    case computer, browser
+    var label: String { self == .computer ? "Computer use" : "Browser use" }
+    var icon: String { self == .computer ? "desktopcomputer" : "globe" }
+}
+
+struct PromptBar: View {
+    /// DEMO SEAM — fired when the user sends. Real execution routes (text, mode) → CodexCLI.
+    var onSend: (String, AgentMode) -> Void = { _, _ in }
+
+    @State private var text = ""
+    @State private var mode: AgentMode = .computer
+    @FocusState private var focused: Bool
+
+    private var trimmed: String { text.trimmingCharacters(in: .whitespacesAndNewlines) }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 12) {
+            ModeToggle(mode: $mode)
+
+            ZStack(alignment: .leading) {
+                if trimmed.isEmpty { placeholder }
+                TextField("", text: $text, axis: .vertical)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 14))
+                    .foregroundStyle(.white)
+                    .tint(Theme.accent)
+                    .lineLimit(1...4)
+                    .focused($focused)
+                    .onSubmit(send)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+            .onTapGesture { focused = true }
+
+            SendButton(active: !trimmed.isEmpty, action: send)
+        }
+        .padding(.leading, 14)
+        .padding(.trailing, 11)
+        .padding(.vertical, 11)
+        .background(field)
+        .background(PromptGlow(intensity: focused ? 0.55 : 0.32))
+        .animation(.easeInOut(duration: 0.4), value: focused)
+    }
+
+    private func send() {
+        guard !trimmed.isEmpty else { return }
+        onSend(trimmed, mode)
+        text = ""
+    }
+
+    /// "Tell me what you want me to DO" — the verb glows bright; the rest whispers.
+    private var placeholder: some View {
+        (Text("Tell me what you want me to ").foregroundColor(Theme.Ink.label)
+         + Text("DO").foregroundColor(.white.opacity(0.92)).fontWeight(.heavy))
+            .font(.system(size: 14))
+            .allowsHitTesting(false)
+    }
+
+    /// The glassy field with a faint AI-gradient hairline that brightens on focus.
+    private var field: some View {
+        RoundedRectangle(cornerRadius: 16, style: .continuous)
+            .fill(Theme.Ink.cardBG)
+            .overlay(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .strokeBorder(
+                        LinearGradient(colors: GlowHalo.stops.map { $0.opacity(focused ? 0.6 : 0.32) },
+                                       startPoint: .leading, endPoint: .trailing),
+                        lineWidth: 1)
+            )
+    }
+}
+
+// MARK: - The Computer / Browser use selector
+
+private struct ModeToggle: View {
+    @Binding var mode: AgentMode
+
+    var body: some View {
+        HStack(spacing: 3) {
+            ForEach(AgentMode.allCases, id: \.self) { segment($0) }
+        }
+        .padding(3)
+        .background(Capsule(style: .continuous).fill(.white.opacity(0.04)))
+        .overlay(Capsule(style: .continuous).strokeBorder(.white.opacity(0.08), lineWidth: 1))
+    }
+
+    private func segment(_ m: AgentMode) -> some View {
+        let on = mode == m
+        return Button {
+            withAnimation(.spring(response: 0.32, dampingFraction: 0.8)) { mode = m }
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: m.icon).font(.system(size: 10.5, weight: .semibold))
+                Text(m.label).font(.system(size: 11.5, weight: on ? .semibold : .medium))
+            }
+            .foregroundStyle(on ? .white : Theme.Ink.label)
+            .padding(.horizontal, 11).padding(.vertical, 6)
+            .background {
+                if on {
+                    Capsule(style: .continuous).fill(.white.opacity(0.07))
+                        .overlay(Capsule(style: .continuous).strokeBorder(
+                            LinearGradient(colors: [Theme.accent.opacity(0.85), Theme.accent.opacity(0.30)],
+                                           startPoint: .topLeading, endPoint: .bottomTrailing),
+                            lineWidth: 1))
+                }
+            }
+            .contentShape(Capsule(style: .continuous))
+        }
+        .buttonStyle(PressScaleStyle())
+    }
+}
+
+// MARK: - The send button
+
+private struct SendButton: View {
+    let active: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: "arrow.up")
+                .font(.system(size: 14, weight: .bold))
+                .foregroundStyle(active ? .black : .white.opacity(0.40))
+                .frame(width: 32, height: 32)
+                .background(Circle().fill(active ? Color.white : Color.white.opacity(0.08)))
+                .overlay(Circle().strokeBorder(.white.opacity(active ? 0 : 0.10), lineWidth: 1))
+        }
+        .buttonStyle(PressScaleStyle())
+        .shadow(color: Theme.accent.opacity(active ? 0.55 : 0), radius: 11)
+        .disabled(!active)
+        .animation(.easeInOut(duration: 0.25), value: active)
+    }
+}
+
+// MARK: - The rounded-rect AI-gradient glow (twin of GlowButton's GlowHalo)
+
+/// A slow, ambient rotation of the GlowButton (Analyze Now) palette, blurred to a soft glow
+/// hugging the bar. Slower than the 3.5s CTA halo (7s) so it reads as a calm, magical presence,
+/// not a spinner. Kept tight (small bleed + blur) so it's a quiet rim-glow, not a big halo.
+private struct PromptGlow: View {
+    var intensity: Double
+    private static let period: Double = 7.0
+
+    var body: some View {
+        TimelineView(.animation(minimumInterval: 1.0 / 60.0)) { ctx in
+            let t = ctx.date.timeIntervalSinceReferenceDate
+            let angle = (t.truncatingRemainder(dividingBy: Self.period) / Self.period) * 360.0
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(AngularGradient(colors: GlowHalo.stops, center: .center, angle: .degrees(angle)))
+                .blur(radius: 16)
+                .padding(-2)
+        }
+        .opacity(intensity)
+        .animation(.easeInOut(duration: 0.5), value: intensity)
+        .allowsHitTesting(false)
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Prompt bar") {
+    ZStack {
+        Theme.bg.ignoresSafeArea()
+        PromptBar { text, mode in print("[\(mode.rawValue)] \(text)") }
+            .padding(40)
+    }
+    .frame(width: 980, height: 220)
+}


### PR DESCRIPTION
## What
The For You window gets a **command bar** at its foot, plus demo-card content updates.

### New: the command bar (`PromptBar.swift`)
- Glassy rounded field on a soft, slow rotating glow — uses the **Analyze Now / GlowButton palette** (`GlowHalo.stops`, now promoted from `private` so both surfaces share one source of truth).
- Left: a `[Computer use | Browser use]` selector, defaults to **Computer use**.
- Placeholder bolds the verb: *"Tell me what you want me to **DO**"*.
- Right: a glowing circular send button.
- **Demo seam:** `onSend(text, mode)` just `Log()`s today → real execution routes to `CodexCLI` (computer use → workspace-write agent · browser use → browser-driving agent).

### Demo-card updates (`Briefing.swift`)
- Replaced the welcome **"gift" letter** card with a **Daniel / EWOR call-prep** card. The gift letter is parked verbatim as `Briefing.welcomeGift` (out of the deck, easy to restore — envelope visuals untouched).
- Rewrote the **Fareed** prep report from his LinkedIn (Slack GTM = why Josh connected them · the "agent-native products" thesis · Reforge #1 strategy program). Both calls now framed as **today**.

### Layout (`BriefingsView.swift`)
- Dropped the "Other reminders" strip; lifted the card scatter into the top 84% so cards clear the bar.

Docs updated (`Documentation/Briefings Window (For You).md`).

## Notes
- Pure SwiftUI demo UI; `PromptBar.swift` rides synchronized file groups (no `.pbxproj` change).
- Not visually verified in this session (no Xcode bridge) — reviewer, eyeball the `PromptBar` `#Preview` / the For You window.