### PR TITLE
Bundle trim: thin LiteRT-LM dylib to arm64 + strip docs (~140MB → ~73MB)

### DIFF
--- a/Sentient OS macOS.xcodeproj/project.pbxproj
+++ b/Sentient OS macOS.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 				5A3F390D2FD0F43300DD835E /* Sources */,
 				5A3F390E2FD0F43300DD835E /* Frameworks */,
 				5A3F390F2FD0F43300DD835E /* Resources */,
+				5AAAA0012FD0F43300DD835E /* Trim app bundle (thin LiteRT-LM, drop docs) */,
 			);
 			buildRules = (
 			);
@@ -123,6 +124,28 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
+/* Begin PBXShellScriptBuildPhase section */
+		5AAAA0012FD0F43300DD835E /* Trim app bundle (thin LiteRT-LM, drop docs) */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Trim app bundle (thin LiteRT-LM, drop docs)";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Sentient OS bundle-trim phase (runs before the final app code-sign, so the seal stays\n# valid). Two jobs, both shrinking the shipped .app:\n#\n# 1) Thin the prebuilt LiteRT-LM dylib to the app's ARCHS. Google ships CLiteRTLM_mac as a\n#    fat arm64+x86_64 binary (~127MB); arm64-only roughly halves the .app. ARCHS=arm64\n#    only governs code Xcode COMPILES -- a checksum-pinned remote SwiftPM binary is copied\n#    in whole, so we strip it here. Idempotent (skips an already-thin slice) + re-signs.\n# 2) Drop the internal engineering docs the synchronized file group sweeps in from\n#    Documentation/. They're public in the repo and never read at runtime; ~150KB of dead\n#    weight. Globbed so future docs are dropped automatically.\nset -e\n\nDYLIB=\"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/libCLiteRTLM_mac.dylib\"\nif [ -f \"$DYLIB\" ]; then\n  THINNED=0\n  for arch in $(lipo -archs \"$DYLIB\"); do\n    case \" $ARCHS \" in\n      *\" $arch \"*) ;;\n      *) echo \"Thinning libCLiteRTLM_mac.dylib: removing $arch\"; lipo -remove \"$arch\" \"$DYLIB\" -output \"$DYLIB\"; THINNED=1 ;;\n    esac\n  done\n  if [ \"$THINNED\" = \"1\" ]; then\n    # Re-sign with the SAME options Xcode used, so a notarized Release stays valid: hardened\n    # runtime when enabled, plus a secure timestamp for Developer ID (distribution) signing\n    # only -- Apple Development / adhoc dev builds need neither (and skip the network round-trip).\n    SIGN_OPTS=\"\"\n    [ \"$ENABLE_HARDENED_RUNTIME\" = \"YES\" ] && SIGN_OPTS=\"--options runtime\"\n    case \"${EXPANDED_CODE_SIGN_IDENTITY:--}\" in \"Developer ID\"*) SIGN_OPTS=\"$SIGN_OPTS --timestamp\" ;; esac\n    echo \"Re-signing thinned libCLiteRTLM_mac.dylib ($SIGN_OPTS)\"\n    codesign --force $SIGN_OPTS --sign \"${EXPANDED_CODE_SIGN_IDENTITY:--}\" \"$DYLIB\"\n  fi\nelse\n  echo \"warning: libCLiteRTLM_mac.dylib not found at $DYLIB -- skipping arch thinning\"\nfi\n\nRES=\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}\"\nif [ -d \"$RES\" ]; then\n  find \"$RES\" -name \"*.md\" -print -delete\nfi\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
 		5A3F390D2FD0F43300DD835E /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -173,7 +196,7 @@
 				DEVELOPMENT_TEAM = YJ8AZR3G5Q;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -238,7 +261,7 @@
 				DEVELOPMENT_TEAM = YJ8AZR3G5Q;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/Sentient OS macOS/Documentation/Bundle Size (Arch Thinning & Doc Stripping).md
+++ b/Sentient OS macOS/Documentation/Bundle Size (Arch Thinning & Doc Stripping).md
@@ -1,0 +1,53 @@
+# Bundle Size — Arch Thinning & Doc Stripping
+
+**What:** a single build-phase script — **"Trim app bundle (thin LiteRT-LM, drop docs)"** — that
+shrinks the shipped `.app` from ~140 MB to ~73 MB (model not included). Lives in the app target's
+build phases (last phase, runs before the final code-sign).
+
+## Why the app was 130 MB+
+
+Measured on a Debug build: **`Contents/Frameworks/libCLiteRTLM_mac.dylib` was 127 MB — ~91% of the
+whole app.** Everything else is rounding error (your code ~9 MB, `Assets.car`/icon ~3 MB, no stray
+media). The dylib was a **fat universal binary**: ~70 MB x86_64 (Intel) + ~64 MB arm64.
+
+The catch: our project already builds **`ARCHS = arm64`**, but that only governs code Xcode
+*compiles*. `CLiteRTLM_mac` is a **prebuilt, checksum-pinned, remote SwiftPM binary target** (see
+`Vendor/LiteRTLM/Package.swift` — downloaded from Google's GitHub releases into
+`DerivedData/SourcePackages/artifacts/`). Xcode copies that fat binary into the bundle **wholesale**;
+nothing re-thins it. So flipping a build setting can't fix it — and we can't edit the artifact at the
+source (it's checksum-locked and wiped on clean). The fix has to run at build time on the *product*.
+
+## What the script does
+
+1. **Thin the dylib** to the app's `$ARCHS` (drops the x86_64 slice → ~61 MB). Idempotent: it only
+   `lipo -remove`s an arch that's present *and* not wanted, so an already-thin slice is a no-op on
+   incremental builds.
+2. **Re-sign the dylib** (modifying a Mach-O invalidates its signature). It mirrors Xcode's options
+   so distribution stays valid: `--options runtime` when Hardened Runtime is on, and `--timestamp`
+   for `Developer ID` (distribution) signing only — Apple Development / adhoc dev builds skip the
+   timestamp (no network round-trip). The final app code-sign (which runs *after* this phase) re-seals
+   the bundle over the thinned dylib, so the whole-app signature is valid.
+3. **Drop internal docs:** globs `*.md` out of `Contents/Resources`. The synchronized file group
+   sweeps everything under `Documentation/` into the bundle as resources (~150 KB of markdown).
+   They're public in the repo and never read at runtime, so they're dead weight. Globbed, so new docs
+   are dropped automatically — no per-file maintenance.
+
+## Gotchas / receipts
+
+- **`ENABLE_USER_SCRIPT_SANDBOXING` is set to `NO`** for the target. Xcode 16's default (`YES`)
+  sandboxes run-script phases to declared input/output files only, which made `lipo` fail with
+  `Operation not permitted` and would also block `codesign`'s keychain access on Developer ID builds.
+  This is trusted, auditable build tooling, so sandboxing is off.
+- **The phase must stay last** (after Sources/Frameworks/Resources) so it runs after the dylib is
+  embedded and after resources are copied, but before the final app code-sign.
+- **Verify quickly:** `lipo -archs <app>/Contents/Frameworks/libCLiteRTLM_mac.dylib` → `arm64`;
+  `codesign -d --verbose=2 <dylib>` → `flags=0x10000(runtime)`;
+  `codesign --verify --deep --strict <app>` → silent/exit 0; `find <app> -name '*.md'` → empty.
+- **Dropping x86_64 drops Intel Mac support** — a deliberate decision (the on-device Gemma inference
+  needs Apple-Silicon Metal anyway). If an Intel build is ever wanted, ship it separately.
+
+## Not done (future size wins)
+
+- **Strip symbols** from the arm64 slice (`strip -x -S`) → another ~14 MB (→ ~47 MB dylib). Deferred:
+  it's a prebuilt dynamic lib, so test a full inference batch (incl. an Engine reload) before trusting
+  it, and it must run before signing.


### PR DESCRIPTION
## What
A single **"Trim app bundle (thin LiteRT-LM, drop docs)"** build-script phase that shrinks the shipped `.app` from **~140 MB → ~73 MB** (model not included).

## Why
`Contents/Frameworks/libCLiteRTLM_mac.dylib` was **127 MB — ~91% of the app**: a fat universal binary (~70 MB x86_64 + ~64 MB arm64). It's a **checksum-pinned prebuilt remote SwiftPM binary** that Xcode copies in *wholesale*, so `ARCHS = arm64` doesn't touch it — the fix has to run at build time on the product.

## What the phase does (runs last, before the final code-sign)
1. **Thins the dylib** to `$ARCHS` (drops the x86_64 slice → ~61 MB). Idempotent on incremental builds.
2. **Re-signs** it, mirroring Xcode's options (`--options runtime` w/ Hardened Runtime; `--timestamp` for Developer ID only) so notarized Release stays valid.
3. **Strips `*.md`** from `Contents/Resources` — the synchronized file group sweeps `Documentation/` into the bundle (~150 KB dead weight at runtime).

## Notes
- Sets **`ENABLE_USER_SCRIPT_SANDBOXING = NO`** (Xcode 16 default sandboxes run-script phases, which makes `lipo`/`codesign` fail) — required for this trusted build tooling.
- **Drops Intel support** — deliberate; on-device Gemma inference needs Apple-Silicon Metal anyway.
- Verify: `lipo -archs …/libCLiteRTLM_mac.dylib` → `arm64`; `codesign --verify --deep --strict <app>` → exit 0; `find <app> -name '*.md'` → empty.
- Scoped strictly to bundle-size: a local `DEVELOPMENT_TEAM`/signing edit that was in the same working file was **deliberately excluded** from this PR.

Doc: `Documentation/Bundle Size (Arch Thinning & Doc Stripping).md`.