### PR TITLE
Crash-safe pointers: resumable first run (floor) + atomic per-item commits

### DIFF
--- a/Sentient OS macOS/Documentation/Iterative Core (Connectors).md
+++ b/Sentient OS macOS/Documentation/Iterative Core (Connectors).md
@@ -21,14 +21,25 @@ A connector is dumb: it lists keyed work-items per bucket and loads one. *All* p
   mark`), `load(Candidate) -> Artifact`. A `Bucket` = `(key, [(ItemKey, Candidate)])`. Work payload +
   content reuse the existing `Candidate`/`Artifact` value types.
 - **`CycleStore`** (`Ingestion/CycleStore.swift`) — `@ModelActor`, own on-disk store
-  (`IterativeCycle.store`). `BucketPointer` (DURABLE high-water mark per bucket) + `CycleNote`
-  (EPHEMERAL survivor, wiped each cycle; carries `kind`+`sourceID` for the cloud's trust tag). API:
-  `pointer/setPointer/clearBucket · recordNote/notes/wipeAllNotes · counts · allPointers`.
-- **`IterativeRun`** (`Ingestion/IterativeRun.swift`) — drives any connector. **initial**: per bucket,
-  clear it, walk items newest→oldest, set the mark = newest *on completion* (interrupted ⇒ mark unset
-  ⇒ iterative says "run initial first"). **iterative**: per bucket, take items `> mark`, walk
-  oldest→newest, climb the mark *per item* (so a stopped run resumes). Reuses `Engine` + `Triage` +
-  the GPU-wedge resilience. Survivors → `CycleNote`; junk/sensitive store nothing.
+  (`IterativeCycle.store`). `BucketPointer` (DURABLE per bucket: the high-water mark, plus an optional
+  **FLOOR** while a first run is mid-descent — see IterativeRun) + `CycleNote` (EPHEMERAL survivor,
+  wiped each cycle; carries `kind`+`sourceID` for the cloud's trust tag). API: `pointer / pointerState
+  / connectorMarks / setPointer / clearBucket · recordNote / notes / wipeAllNotes · counts`.
+  **Crash-safety:** the per-item commits `advance` (iterative: note + mark) and `sinkFloor` (initial:
+  note + floor) each write the survivor note AND the progress marker in ONE save (no gap for a crash to
+  split), plus `collapseFloor` (first run done → floor cleared, mark left at top).
+- **`IterativeRun`** (`Ingestion/IterativeRun.swift`) — drives any connector; **every item commits its
+  (optional) note + its progress marker in ONE atomic store write**, so a crash mid-run resumes without
+  duplicating or skipping. **initial** (top→bottom): per bucket, fill newest→oldest, sinking a **floor**
+  (the oldest item done so far) per item; a crash RESUMES strictly below the floor instead of restarting
+  the folder; on reaching the bottom the floor collapses into the normal high-water mark. (Explicit
+  INITIAL still `clearBucket`s first for a true re-summarize; an `.auto`-chosen initial keeps partial
+  progress.) **iterative** (bottom→top): per bucket, take items `> mark`, walk oldest→newest, advance
+  the mark *per item*. **auto** per bucket: initial if no mark yet OR a first run is mid-descent (floor
+  set → resume it), else iterative. Mid-first-run buckets are hidden from `connectorMarks` so their
+  connector re-lists the full set — the descent needs items *below* the top, which a `> mark` hint would
+  hide. Reuses `Engine` + `Triage` + the GPU-wedge resilience. Survivors → `CycleNote`; junk/sensitive
+  store nothing.
 
 ## The cycle (summaries are disposable)
 *on-device summarize → cloud (make/update KB) → cloud (proactive judge) → next cycle.*
@@ -78,7 +89,9 @@ all of `CycleStore.notes()` regardless of connector.
 
 ## Verify
 `SENTIENT_SELFTEST=fileiter` — deterministic, no model/codex: ItemKey tiebreak · the newer-than-mark
-partition (twin at the boundary) · CycleStore round-trip · `FilesConnector.buckets` skip/keep.
+partition (twin at the boundary) · CycleStore round-trip · atomic `advance` (note+mark in one call) ·
+the first-run **floor** (sink per item, crash mid-descent, resume below the floor, collapse — proving
+no dupes / no lost items / new arrivals excluded) · `FilesConnector.buckets` skip/keep.
 `SENTIENT_SELFTEST=notesiter` — runs the real `NotesConnector` against the live Notes DB (structural
 invariants); needs Full Disk Access (skips gracefully without it).
 `SENTIENT_SELFTEST=chatiter` — runs the real WhatsApp + iMessage connectors over all chats (per-chat

--- a/Sentient OS macOS/Ingestion/CycleStore.swift
+++ b/Sentient OS macOS/Ingestion/CycleStore.swift
@@ -5,10 +5,12 @@
 //  The iterative system's database — connector-agnostic, with its OWN on-disk container (isolated
 //  from the old `Store`, so its models never schema-wipe the old dev DB). Two models:
 //
-//   - BucketPointer  DURABLE. One row per BUCKET (folder root / chat / "notes"). The HIGH-WATER
-//                    MARK — the newest item processed, as an `ItemKey` (order, tiebreak). Invariant:
-//                    everything ≤ mark is done, everything newer is new. The ONLY state that
-//                    survives a cycle. Initial sets it on completion; iterative climbs it per item.
+//   - BucketPointer  DURABLE. One row per BUCKET (folder root / chat / "notes"). Normally the
+//                    HIGH-WATER MARK — everything ≤ (order, tiebreak) is done, everything newer is
+//                    new. During a bucket's FIRST run it also carries a FLOOR (the oldest item done
+//                    so far, sinking one item at a time) so a crash mid-descent RESUMES below the
+//                    floor instead of restarting; the floor collapses into the mark once the descent
+//                    reaches the bottom. The ONLY state that survives a cycle.
 //   - CycleNote      EPHEMERAL. One survivor summary, wiped at cycle end (the proactive button).
 //                    Junk/sensitive store nothing. `kind` + `sourceID` carry the cloud's trust tag.
 //
@@ -20,21 +22,37 @@ import SwiftData
 
 // MARK: - Models
 
-/// DURABLE — one per bucket. The high-water mark as (order, tiebreak).
+/// DURABLE — one per bucket.
+///
+/// • Everyday state: `(order, tiebreak)` is the HIGH-WATER MARK (everything ≤ it is done); `floor` is nil.
+/// • First-run state, while filling newest→oldest: `(order, tiebreak)` holds the TOP (the newest item
+///   this first run covers — fixed for the whole descent), and `floor` is the oldest item done so far,
+///   sinking one item at a time. Everything between floor and top is done; the descent continues below
+///   the floor. A non-nil floor is the single tell that a first run is mid-flight — so a crash resumes
+///   (below the floor) instead of restarting. On reaching the bottom the floor collapses to nil,
+///   leaving `(order, tiebreak)` as a normal high-water mark.
 @Model
 final class BucketPointer {
     @Attribute(.unique) var bucketKey: String     // "file:<root.id>" / "notes" / "whatsapp:<jid>"
     var order: Double
     var tiebreak: String
+    var floorOrder: Double?                        // non-nil ⇒ first run in progress (this is the FLOOR)
+    var floorTiebreak: String?
     var updatedAt: Date
 
-    init(bucketKey: String, mark: ItemKey, updatedAt: Date = Date()) {
+    init(bucketKey: String, mark: ItemKey, floor: ItemKey? = nil, updatedAt: Date = Date()) {
         self.bucketKey = bucketKey
         self.order = mark.order
         self.tiebreak = mark.tiebreak
+        self.floorOrder = floor?.order
+        self.floorTiebreak = floor?.tiebreak
         self.updatedAt = updatedAt
     }
     var mark: ItemKey { ItemKey(order: order, tiebreak: tiebreak) }
+    var floor: ItemKey? {
+        guard let floorOrder else { return nil }
+        return ItemKey(order: floorOrder, tiebreak: floorTiebreak ?? "")
+    }
 }
 
 /// EPHEMERAL — one survivor summary for one item, this cycle only.
@@ -101,6 +119,19 @@ struct SummaryExport: Codable, Sendable {
     var notes: [CycleNoteItem]
 }
 
+/// The survivor fields for one processed item, handed to an atomic per-item commit (note + marker in
+/// ONE save). nil at a call site = a non-survivor (junk / sensitive / failed) — the marker still
+/// advances past it, but no note is kept (zero trace).
+struct NoteDraft: Sendable {
+    let kind: SourceKind
+    let sourceID: String
+    let folder: String
+    let itemDate: Date
+    let text: String
+    let title: String?
+    let reminderFlagged: Bool
+}
+
 // MARK: - The actor
 
 @ModelActor
@@ -108,17 +139,28 @@ actor CycleStore {
 
     // MARK: Pointers (durable)
 
-    /// The high-water mark for a bucket, or nil if it's never completed an initial run.
+    /// The high-water mark for a bucket, or nil if it's never run.
     func pointer(_ bucketKey: String) -> ItemKey? { row(bucketKey)?.mark }
 
-    /// Every bucket's mark (passed to a connector as the efficiency hint for iterative runs).
-    func allPointers() -> [String: ItemKey] {
-        let rows = (try? modelContext.fetch(FetchDescriptor<BucketPointer>())) ?? []
-        return Dictionary(rows.map { ($0.bucketKey, $0.mark) }, uniquingKeysWith: { a, _ in a })
+    /// A bucket's full durable state, or nil if it's never run: the high-water mark (or, mid-first-run,
+    /// the TOP), plus the FLOOR when a first run is mid-descent. A non-nil floor ⇒ resume that descent
+    /// (strictly below the floor) rather than restart. IterativeRun reads this to pick per-bucket mode.
+    func pointerState(_ bucketKey: String) -> (mark: ItemKey, floor: ItemKey?)? {
+        guard let r = row(bucketKey) else { return nil }
+        return (r.mark, r.floor)
     }
 
-    /// Set/advance a bucket's mark — initial sets it = newest on completion; iterative climbs it per
-    /// item (so a stopped run resumes rather than skips).
+    /// Per-bucket hints handed to connectors for efficient `> mark` listing. A bucket mid-first-run
+    /// (floor set) is OMITTED so its connector returns its FULL set — the descent needs items BELOW
+    /// its top, which a `> mark` hint would hide. IterativeRun still filters/advances authoritatively.
+    func connectorMarks() -> [String: ItemKey] {
+        let rows = (try? modelContext.fetch(FetchDescriptor<BucketPointer>())) ?? []
+        return Dictionary(rows.filter { $0.floor == nil }.map { ($0.bucketKey, $0.mark) },
+                          uniquingKeysWith: { a, _ in a })
+    }
+
+    /// Set a bucket's mark directly (used by the Gmail cloud leg, which stamps a run-time pointer and
+    /// has no on-device descent). On-device runs use the atomic `advance` / `sinkFloor` instead.
     func setPointer(_ bucketKey: String, _ mark: ItemKey) {
         if let r = row(bucketKey) {
             r.order = mark.order; r.tiebreak = mark.tiebreak; r.updatedAt = Date()
@@ -145,9 +187,52 @@ actor CycleStore {
 
     func recordNote(bucketKey: String, kind: SourceKind, sourceID: String, folder: String,
                     itemDate: Date, text: String, title: String?, reminderFlagged: Bool) {
-        modelContext.insert(CycleNote(bucketKey: bucketKey, kind: kind, sourceID: sourceID,
-                                      folder: folder, itemDate: itemDate, text: text, title: title,
-                                      reminderFlagged: reminderFlagged))
+        insertNote(bucketKey: bucketKey,
+                   note: NoteDraft(kind: kind, sourceID: sourceID, folder: folder, itemDate: itemDate,
+                                   text: text, title: title, reminderFlagged: reminderFlagged))
+        try? modelContext.save()
+    }
+
+    private func insertNote(bucketKey: String, note: NoteDraft) {
+        modelContext.insert(CycleNote(bucketKey: bucketKey, kind: note.kind, sourceID: note.sourceID,
+                                      folder: note.folder, itemDate: note.itemDate, text: note.text,
+                                      title: note.title, reminderFlagged: note.reminderFlagged))
+    }
+
+    // MARK: Atomic per-item commits (the crash-safety core — note + marker in ONE save)
+
+    /// EVERYDAY (iterative) — record an optional survivor note AND advance the high-water bookmark to
+    /// `mark`, in one save. No gap between the two writes ⇒ a crash can never leave a note without its
+    /// bookmark (which would re-summarize the item into a duplicate). Clears any floor.
+    func advance(bucketKey: String, note: NoteDraft?, to mark: ItemKey) {
+        if let note { insertNote(bucketKey: bucketKey, note: note) }
+        if let r = row(bucketKey) {
+            r.order = mark.order; r.tiebreak = mark.tiebreak
+            r.floorOrder = nil; r.floorTiebreak = nil; r.updatedAt = Date()
+        } else {
+            modelContext.insert(BucketPointer(bucketKey: bucketKey, mark: mark))
+        }
+        try? modelContext.save()
+    }
+
+    /// FIRST RUN (initial descent) — record an optional survivor note AND sink the floor to `floor`
+    /// (top stays fixed), in one save. Creates the row with `top` on the first step. A crash leaves an
+    /// honest floor → the next run resumes strictly below it.
+    func sinkFloor(bucketKey: String, note: NoteDraft?, top: ItemKey, floor: ItemKey) {
+        if let note { insertNote(bucketKey: bucketKey, note: note) }
+        if let r = row(bucketKey) {
+            r.order = top.order; r.tiebreak = top.tiebreak
+            r.floorOrder = floor.order; r.floorTiebreak = floor.tiebreak; r.updatedAt = Date()
+        } else {
+            modelContext.insert(BucketPointer(bucketKey: bucketKey, mark: top, floor: floor))
+        }
+        try? modelContext.save()
+    }
+
+    /// FIRST RUN done — collapse: clear the floor, leaving `(order, tiebreak)` (the top) as a normal
+    /// high-water mark. From here the bucket is in everyday mode.
+    func collapseFloor(_ bucketKey: String) {
+        if let r = row(bucketKey) { r.floorOrder = nil; r.floorTiebreak = nil; r.updatedAt = Date() }
         try? modelContext.save()
     }
 
@@ -161,6 +246,14 @@ actor CycleStore {
     /// End-of-cycle wipe (fired by the proactive button) — pointers persist, notes do not.
     func wipeAllNotes() {
         try? modelContext.delete(model: CycleNote.self)
+        try? modelContext.save()
+    }
+
+    /// Factory reset — delete EVERY pointer and EVERY note (the dev "Reset everything" button pairs
+    /// this with wiping the vault). After this, the next run is a fresh first run for every bucket.
+    func wipeEverything() {
+        try? modelContext.delete(model: CycleNote.self)
+        try? modelContext.delete(model: BucketPointer.self)
         try? modelContext.save()
     }
 

--- a/Sentient OS macOS/Ingestion/IterativeRun.swift
+++ b/Sentient OS macOS/Ingestion/IterativeRun.swift
@@ -4,15 +4,18 @@
 //
 //  The connector-agnostic on-device orchestrator — the ONE engine path behind BOTH the home
 //  "Analyze Now" takeover and the dev "start on device" buttons (both via ProcessingView). Drives
-//  any Connector through ONE Engine (sized to the biggest connector), per BUCKET:
-//   • .initial   (top→bottom): clear the bucket, walk items newest→oldest, then on completion set
-//                  the bucket's mark = newest. (Interrupted ⇒ mark unset ⇒ iterative says "run
-//                  initial first".)
-//   • .iterative (bottom→top): take items past the mark, walk oldest→newest, climbing the mark per
-//                  item (so a stopped run resumes). No mark yet ⇒ skipped.
-//   • .auto:      per bucket — initial if it has no mark yet, else iterative. This is the home
-//                  button's mode: the first run backfills, every run after just catches up, and a
-//                  freshly-added folder backfills while the rest catch up — all in one pass.
+//  any Connector through ONE Engine (sized to the biggest connector), per BUCKET. Every processed
+//  item commits its (optional) survivor note AND its progress marker in ONE atomic store write — so a
+//  crash mid-run resumes, never duplicates, never skips:
+//   • .initial   (top→bottom): fill the bucket newest→oldest, sinking a FLOOR per item (the oldest
+//                  done so far). A crash RESUMES strictly below the floor instead of restarting; on
+//                  reaching the bottom the floor collapses into the normal high-water mark.
+//   • .iterative (bottom→top): take items past the mark, walk oldest→newest, advancing the mark per
+//                  item. No mark yet (or a first run unfinished) ⇒ skipped — run initial first.
+//   • .auto:      per bucket — initial if it has no mark yet OR a first run is mid-descent (floor
+//                  set, i.e. resume it), else iterative. This is the home button's mode: the first
+//                  run backfills, every run after catches up, a freshly-added folder backfills while
+//                  the rest catch up, and an interrupted first run picks up where it left off.
 //  Reuses Engine + Triage + the GPU-wedge resilience (preemptive + reactive reloads). Survivors →
 //  CycleNote; junk/sensitive store nothing (zero trace). Synchronous generate() only — no streaming.
 //
@@ -75,20 +78,22 @@ struct IterativeRun {
             sinceReload = 0
         }
 
-        // One full attempt at one item: load → generate → decide → (survivor ⇒ recordNote). The
-        // exact prompt is stashed on the progress so ProcessingView's dev pane can show it.
-        func attempt(_ cand: Candidate, connector: any Connector, bucketKey: String) async -> Bool {
+        // One full attempt at one item: load → generate → decide. Returns whether it succeeded and,
+        // for a survivor, the NoteDraft to commit — the loop writes it atomically WITH the marker, so
+        // a crash never leaves a note without its marker. The exact prompt is stashed on the progress
+        // so ProcessingView's dev pane can show it.
+        func attempt(_ cand: Candidate, connector: any Connector) async -> (ok: Bool, draft: NoteDraft?) {
             do {
                 let artifact = try autoreleasepool { try connector.load(cand) }
                 let prompt = Triage.prompt(for: artifact, currentDate: Date())
                 p.lastPrompt = prompt
                 let result = try await engine.generate(prompt: prompt, imageData: artifact.imageData)
                 let outcome = Triage.decide(result.text)
+                var draft: NoteDraft?
                 if outcome.verdict == .survivor {
-                    await store.recordNote(
-                        bucketKey: bucketKey, kind: connector.kind, sourceID: cand.id,
-                        folder: cand.metadata["folder"] ?? "", itemDate: cand.itemDate,
-                        text: outcome.summary, title: outcome.title, reminderFlagged: false)
+                    draft = NoteDraft(kind: connector.kind, sourceID: cand.id,
+                                      folder: cand.metadata["folder"] ?? "", itemDate: cand.itemDate,
+                                      text: outcome.summary, title: outcome.title, reminderFlagged: false)
                 }
                 LifetimeStats.bump(outcome.verdict)
                 switch outcome.verdict {
@@ -104,16 +109,17 @@ struct IterativeRun {
                 #if DEBUG
                 Log("• \(cand.metadata["displayPath"] ?? cand.id) → \(outcome.verdict)")
                 #endif
-                return true
+                return (true, draft)
             } catch {
                 p.lastSummary = "(skipped: \(error))"
-                return false
+                return (false, nil)
             }
         }
 
-        // Initial wants everything (we clear + reprocess) → pass [:]. Iterative/auto pass the real
-        // marks so connectors can query efficiently; the run still filters/advances authoritatively.
-        let marks = mode == .initial ? [:] : await store.allPointers()
+        // Explicit INITIAL reprocesses from scratch → pass [:]. Otherwise pass the per-bucket marks as
+        // a connector query hint (connectorMarks omits mid-first-run buckets so their connector returns
+        // the FULL set — the descent needs items below the top); the run still filters authoritatively.
+        let marks = mode == .initial ? [:] : await store.connectorMarks()
 
         runLoop: for connector in connectors {
             if Task.isCancelled { break }
@@ -124,23 +130,45 @@ struct IterativeRun {
             for bucket in buckets {
                 if Task.isCancelled { break runLoop }
 
-                // Per-bucket effective mode: .auto = initial when the bucket has never completed an
-                // initial run (no mark), else iterative — so one "Analyze Now" backfills new buckets
-                // and catches up the rest in a single pass.
-                let mark = await store.pointer(bucket.key)
-                let effective: Mode = (mode == .auto) ? (mark == nil ? .initial : .iterative) : mode
+                var state = await store.pointerState(bucket.key)
 
+                // Per-bucket effective mode. .auto: no state → fresh first run; floor still set → a
+                // first run was interrupted, RESUME it; collapsed (floor nil) → everyday catch-up.
+                let effective: Mode
+                switch mode {
+                case .auto:      effective = (state == nil || state?.floor != nil) ? .initial : .iterative
+                case .initial:   effective = .initial
+                case .iterative: effective = .iterative
+                }
+
+                // Build this bucket's ordered work; for a first run, also capture the fixed TOP.
                 let work: [(key: ItemKey, item: Candidate)]
+                let top: ItemKey?
                 switch effective {
                 case .initial:
-                    await store.clearBucket(bucket.key)
-                    work = bucket.items                                            // newest → oldest
+                    // Explicit INITIAL = full reset (re-summarize everything). An .auto-chosen initial
+                    // (fresh first run OR resuming an interrupted one) keeps its partial progress.
+                    if mode == .initial { await store.clearBucket(bucket.key); state = nil }
+                    let resumeFloor = state?.floor
+                    let descentTop: ItemKey
+                    if let m = state?.mark, resumeFloor != nil {
+                        descentTop = m                                   // resume: top was saved
+                    } else if let newest = bucket.items.first?.key {
+                        descentTop = newest                              // fresh: top = newest
+                    } else {
+                        continue                                         // empty bucket — nothing to do
+                    }
+                    top = descentTop
+                    work = bucket.items
+                        .filter { $0.key <= descentTop && (resumeFloor == nil || $0.key < resumeFloor!) }
+                        .sorted { $0.key > $1.key }                      // newest → oldest (top-down)
                 case .iterative:
-                    guard let mark else {
-                        Log("IterativeRun: \(bucket.key) has no pointer — run initial first; skipping.")
+                    guard let s = state, s.floor == nil else {
+                        Log("IterativeRun: \(bucket.key) — \(state == nil ? "no pointer" : "first run unfinished"); run initial first; skipping.")
                         continue
                     }
-                    work = bucket.items.filter { $0.key > mark }.sorted { $0.key < $1.key }   // oldest → newest
+                    top = nil
+                    work = bucket.items.filter { $0.key > s.mark }.sorted { $0.key < $1.key }   // oldest → newest
                 case .auto:
                     continue   // resolved into .initial / .iterative above; never reached
                 }
@@ -156,7 +184,7 @@ struct IterativeRun {
                     p.lastPath = w.item.metadata["displayPath"] ?? w.item.metadata["name"]
                     p.lastFilePath = w.item.metadata["path"]
 
-                    var ok = await attempt(w.item, connector: connector, bucketKey: bucket.key)
+                    var (ok, draft) = await attempt(w.item, connector: connector)
                     if !ok {
                         consecutiveFailures += 1
                         if consecutiveFailures >= Self.failuresBeforeReload {
@@ -165,19 +193,25 @@ struct IterativeRun {
                                 finished = false; break runLoop
                             }
                             await reloadEngine(); reloadsWithoutProgress += 1; consecutiveFailures = 0
-                            ok = await attempt(w.item, connector: connector, bucketKey: bucket.key)
+                            (ok, draft) = await attempt(w.item, connector: connector)
                         }
                     }
-                    if ok { consecutiveFailures = 0; reloadsWithoutProgress = 0 } else { p.failed += 1 }
+                    if ok { consecutiveFailures = 0; reloadsWithoutProgress = 0 } else { p.failed += 1; draft = nil }
 
-                    if effective == .iterative { await store.setPointer(bucket.key, w.key) }   // climb per item
+                    // ONE atomic store write per item: optional survivor note + marker advance — no gap
+                    // for a crash to land in. Iterative climbs the mark; initial sinks the floor.
+                    switch effective {
+                    case .iterative: await store.advance(bucketKey: bucket.key, note: draft, to: w.key)
+                    case .initial:   await store.sinkFloor(bucketKey: bucket.key, note: draft, top: top!, floor: w.key)
+                    case .auto:      break
+                    }
                     sinceReload += 1; p.done += 1
                     onProgress(p)
                 }
 
-                // INITIAL completed this bucket's full descent → everything ≤ newest done → set mark.
-                if effective == .initial, finished, let newest = bucket.items.first?.key {
-                    await store.setPointer(bucket.key, newest)
+                // First run reached the bottom → collapse the floor into the normal high-water mark.
+                if effective == .initial, finished, top != nil {
+                    await store.collapseFloor(bucket.key)
                 }
             }
         }

--- a/Sentient OS macOS/Self Tests - Temp/SelfTest_FileIter.swift
+++ b/Sentient OS macOS/Self Tests - Temp/SelfTest_FileIter.swift
@@ -7,6 +7,9 @@
 //    • ItemKey ordering — the (order, tiebreak) tiebreak.
 //    • The iterative "newer than mark" partition, with a same-order TWIN at the boundary.
 //    • CycleStore round-trip — pointer set/get, clearBucket, recordNote/notes/wipeAllNotes.
+//    • Atomic advance — iterative writes note + mark in one call (no duplicate-on-crash gap).
+//    • First-run FLOOR — sink per item, crash mid-descent, resume strictly below the floor, then
+//      collapse to the normal mark; proves no dupes / no lost items / new arrivals excluded.
 //    • FilesConnector.buckets — keeps allowed files, skips a disallowed extension, prunes a .git repo.
 //
 
@@ -63,6 +66,49 @@ enum SelfTestFileIter {
         check("a note under another bucket exists", await store.counts().notes == 1)
         await store.wipeAllNotes()
         check("wipeAllNotes empties every note (cycle end)", await store.counts().notes == 0)
+
+        emit("\n=== fileiter: atomic advance (iterative — note + mark in one write) ===")
+        func k(_ o: Double) -> ItemKey { ItemKey(date: Date(timeIntervalSince1970: o), tiebreak: "p\(o)") }
+        func draftAt(_ o: Double) -> NoteDraft {
+            NoteDraft(kind: .file, sourceID: "file:/f/\(Int(o)).txt", folder: "Floor",
+                      itemDate: Date(timeIntervalSince1970: o), text: "n\(Int(o))", title: "N\(Int(o))", reminderFlagged: false)
+        }
+        let adv = "file:__adv__"
+        await store.advance(bucketKey: adv, note: NoteDraft(kind: .file, sourceID: "file:/a/2.txt", folder: "Adv",
+                            itemDate: Date(timeIntervalSince1970: 2), text: "two", title: "Two", reminderFlagged: false), to: k(2))
+        check("advance writes the mark", await store.pointer(adv) == k(2))
+        check("advance writes the note in the SAME call (atomic)", await store.counts().notes == 1)
+        await store.advance(bucketKey: adv, note: nil, to: k(3))      // a junk item — mark moves, no note
+        check("advance(note: nil) moves the mark", await store.pointer(adv) == k(3))
+        check("advance(note: nil) keeps NO note (junk → zero trace)", await store.counts().notes == 1)
+        check("a collapsed bucket appears in connectorMarks", await store.connectorMarks()[adv] == k(3))
+        await store.wipeAllNotes(); await store.clearBucket(adv)
+
+        emit("\n=== fileiter: first-run FLOOR — crash mid-descent, then resume ===")
+        let fb = "file:__floor__"
+        // A fresh first run over k5..k1 (top→bottom), top = k5. Sink the floor per item, atomically.
+        await store.sinkFloor(bucketKey: fb, note: draftAt(5), top: k(5), floor: k(5))
+        await store.sinkFloor(bucketKey: fb, note: draftAt(4), top: k(5), floor: k(4))
+        // 💥 crash here — the durable state must be honest: top k5, floor k4.
+        let s1 = await store.pointerState(fb)
+        check("mid-descent state keeps top (k5) and floor (k4)", s1?.mark == k(5) && s1?.floor == k(4))
+        check("mid-first-run bucket is HIDDEN from connectorMarks (forces full re-list)", await store.connectorMarks()[fb] == nil)
+        check("two notes survived the crash (k5, k4)", await store.counts().notes == 2)
+
+        // RESUME: work = key ≤ top AND key < floor, newest→oldest. A new arrival k6 (> top) must NOT
+        // be pulled into this descent (it waits for everyday mode after collapse).
+        let top = s1!.mark, floor = s1!.floor!
+        let resumeWork = [k(6), k(5), k(4), k(3), k(2), k(1)].filter { $0 <= top && $0 < floor }.sorted { $0 > $1 }
+        check("resume picks exactly k3,k2,k1 (below the floor, top→bottom)", resumeWork == [k(3), k(2), k(1)])
+        check("resume excludes the new arrival k6 (> top)", !resumeWork.contains(k(6)))
+        for key in resumeWork { await store.sinkFloor(bucketKey: fb, note: draftAt(key.order), top: top, floor: key) }
+        await store.collapseFloor(fb)
+
+        let s2 = await store.pointerState(fb)
+        check("after collapse: floor cleared, mark = top (k5)", s2?.floor == nil && s2?.mark == k(5))
+        check("collapsed first-run bucket re-appears in connectorMarks", await store.connectorMarks()[fb] == k(5))
+        check("exactly 5 notes — NO duplicates across crash/resume", await store.counts().notes == 5)
+        await store.wipeAllNotes(); await store.clearBucket(fb)
 
         emit("\n=== fileiter: FilesConnector.buckets (skip + keep) ===")
         let fm = FileManager.default

--- a/Sentient OS macOS/Views/DevToolsView.swift
+++ b/Sentient OS macOS/Views/DevToolsView.swift
@@ -6,17 +6,19 @@
 //  the FILES-iterative system (the hand-drawn INITIAL | ITERATIVE mockup):
 //
 //    INITIAL                          ITERATIVE
-//    • start on device (top→bottom)   • start on device (bottom→top)
+//    • start / resume (top→bottom)    • start on device (bottom→top)
 //    • tell cloud: make KB exist      • tell cloud: update KB
 //    • proactive system               • proactive system
 //                       VIEW SUMMARIES
 //
-//  Initial resets each selected file root and walks newest→oldest; iterative walks only files
-//  newer than the saved pointer, oldest→newest. "tell cloud" hands the cycle's summaries to
-//  Codex (create / surgical update). "proactive system" sends the reminder-flagged summaries to
-//  the placeholder proactive pass, then WIPES the cycle's summaries (the cycle ends). All of it
-//  runs through the new self-contained stack (IterativeRun · VaultCloud · CycleStore) — the old
-//  Store/Pipeline/messages are untouched, reachable from "More" + the home's Analyze Now.
+//  "start / resume (top→bottom)" runs the resume-aware .auto pass: a fresh bucket descends
+//  newest→oldest (sinking a crash-resume floor), an interrupted one picks up where it stopped, a
+//  finished one catches up. "start on device (bottom→top)" forces .iterative (files past the mark,
+//  oldest→newest). Neither wipes anything — a from-scratch run is the deliberate "Reset everything"
+//  button under "More" (clears pointers + summaries + the knowledge base). "tell cloud" hands the
+//  cycle's summaries to Codex (create / surgical update). "proactive system" sends the
+//  reminder-flagged summaries to the placeholder proactive pass. All of it runs through the
+//  self-contained stack (IterativeRun · VaultCloud · CycleStore).
 //
 //  `SourceSelection` is the one shared reader of the dbg.run.* prefs, so the home's Analyze Now and
 //  this sheet's INITIAL/ITERATIVE buttons act on EXACTLY the same source selection.
@@ -118,11 +120,6 @@ struct DevToolsView: View {
     private var selectedSources: [RunSource] {
         SourceSelection.current(customRoots: customRoots, fdaGranted: fdaGranted)
     }
-    /// Just the FILE roots — what the new INITIAL/ITERATIVE buttons act on (messages/Notes are the
-    /// old system's, run from the home's Analyze Now or "More" below).
-    private var selectedFileRoots: [FileRoot] {
-        selectedSources.compactMap { if case .files(let r) = $0 { return r } else { return nil } }
-    }
     private var selectedChatJIDs: Set<String> {
         Set(selectedChatsCSV.split(separator: ",").map(String.init))
     }
@@ -205,7 +202,7 @@ struct DevToolsView: View {
     private var columns: some View {
         HStack(alignment: .top, spacing: 16) {
             columnView("INITIAL") {
-                deviceButton("init.device", "start on device\n(top → bottom)", .initial)
+                deviceButton("init.device", "start / resume\n(top → bottom)", .auto)
                 actionButton("init.cloud", "tell cloud:\n“go make knowledge base exist”", "cloud.fill", tint: .purple) { progress in
                     await cloudCreate(progress: progress)
                 }
@@ -313,7 +310,7 @@ struct DevToolsView: View {
             Button { startOnDevice(id: id, mode: mode) } label: {
                 HStack(spacing: 7) {
                     if run.busy == id { ProgressView().controlSize(.small) }
-                    else { Image(systemName: mode == .initial ? "arrow.down.to.line" : "arrow.up.to.line") }
+                    else { Image(systemName: mode == .iterative ? "arrow.up.to.line" : "arrow.down.to.line") }
                     Text(title).font(.caption.weight(.medium)).multilineTextAlignment(.center)
                         .fixedSize(horizontal: false, vertical: true)
                 }
@@ -330,9 +327,9 @@ struct DevToolsView: View {
         }
     }
 
-    /// Build the connectors from the lit SOURCES + (initial) wipe the vault, then present the rich
-    /// ProcessingView takeover for ALL of it — device sources AND Gmail (the cloud leg shows in the
-    /// same takeover).
+    /// Build the connectors from the lit SOURCES, then present the rich ProcessingView takeover for ALL
+    /// of it — device sources AND Gmail (the cloud leg shows in the same takeover). Non-destructive: a
+    /// from-scratch run is the deliberate "Reset everything" button under More.
     private func startOnDevice(id: String, mode: IterativeRun.Mode) {
         let gmailRun = gmailConnected && runGmail
         let connectors = RunSource.connectors(from: selectedSources)
@@ -342,11 +339,6 @@ struct DevToolsView: View {
         // Device sources need the on-device model; Gmail (cloud) does not.
         if !connectors.isEmpty && Self.modelPath == nil {
             run.status[id] = "✗ model not found"; return
-        }
-        if mode == .initial {
-            // Fresh start: immediately wipe the existing on-device knowledge base (the vault).
-            try? FileManager.default.removeItem(at: VaultGenerator.vaultRoot)
-            Log("DevTools: INITIAL — wiped the on-device vault at \(VaultGenerator.vaultRoot.path)")
         }
         run.status[id] = nil
         deviceJob = DeviceJob(connectors: connectors, mode: mode, runGmail: gmailRun)
@@ -564,7 +556,7 @@ struct DevToolsView: View {
                 VStack(spacing: 12) {
                     VStack(spacing: 4) {
                         Button(role: .destructive) { Task { await runReset() } } label: {
-                            Label("Reset FILE store (pointers + summaries)", systemImage: "trash")
+                            Label("Reset everything (pointers · summaries · knowledge base)", systemImage: "trash")
                         }
                         .buttonStyle(.bordered)
                         if let resetResult {
@@ -783,14 +775,15 @@ struct DevToolsView: View {
         .padding(14).frame(maxWidth: 460).glassCard()
     }
 
-    /// Reset the FILE store only (the new files-iterative pointers + summaries). The old Store
-    /// (messages/Notes) is untouched.
+    /// Factory reset — wipe EVERY pointer + summary (the iterative cycle store) AND the knowledge base
+    /// (the vault), so the next "start / resume" run is a fresh first run that rebuilds everything from
+    /// scratch. The deliberate, separate alternative to the (now non-destructive) start button.
     @MainActor
     private func runReset() async {
-        await CycleStore.shared.wipeAllNotes()
-        // Clear every selected root's pointer too, so the next initial truly starts fresh.
-        for root in selectedFileRoots { await CycleStore.shared.clearBucket("file:\(root.id)") }
+        await CycleStore.shared.wipeEverything()
+        try? FileManager.default.removeItem(at: VaultGenerator.vaultRoot)
+        Log("DevTools: RESET — wiped the cycle store + the knowledge base at \(VaultGenerator.vaultRoot.path)")
         let c = await CycleStore.shared.counts()
-        resetResult = "✓ cycle store cleared — notes \(c.notes)"
+        resetResult = "✓ reset — cycle store + knowledge base wiped (notes \(c.notes))"
     }
 }


### PR DESCRIPTION
## What

Makes the on-device ingestion run **resume cleanly after an app crash / force-quit** — for both the everyday (iterative) run and the long first (initial) run — without changing the newest-first ordering of the first run.

## Why

Today an interrupted run can't auto-resume:
- **Iterative** climbs the mark per item but writes the **note** and the **mark** in two separate saves — a crash in that gap leaves a note without its mark → a **duplicate summary** on the next run.
- **Initial** walks newest→oldest and only writes the mark **on completion**, so a crash **restarts the whole folder**. A single "everything below me is done" mark *structurally cannot* describe a top-down descent's progress (any value it could save would claim the un-done bottom is done → lost data), so it never saved partway.

## How

**One atomic write per item** (`CycleStore`):
- `advance` (iterative): survivor note + high-water mark in **one save**.
- `sinkFloor` (initial): survivor note + **floor** in one save.
- `collapseFloor`: first run done → floor cleared, mark left at top.

**The floor** — a second, temporary marker meaning *"everything ABOVE me is done"* (the honest mirror of the normal mark for a top-down fill). The first run sinks it one item at a time; a crash resumes strictly **below** the floor; it collapses into the normal high-water mark at the bottom. A non-nil floor is the one tell that a first run is mid-flight.

`.auto` resolves per bucket: no mark → fresh initial · floor set → **resume** the interrupted first run · collapsed → iterative catch-up. Mid-first-run buckets are hidden from `connectorMarks` so their connector re-lists the full set (the descent needs items *below* the top).

## Dev cockpit
- **"start / resume (top → bottom)"** is now `.auto` — resume-aware and **non-destructive** (no more vault wipe on start). This is what now lets you force-quit mid-run and watch it resume.
- **"Reset everything (pointers · summaries · knowledge base)"** is the deliberate factory reset: `wipeEverything()` (all pointers + notes) + wipe the vault.

## Scope
On-device only (as scoped). The cloud KB-update's own crash-safety (double-fold / half-edited vault) and the sleep/lid-close case (scheduler) are **out of scope** and noted as still-open in the docs.

## Verification
- `SENTIENT_SELFTEST=fileiter` → **30 passed / 0 failed** (9 new checks: atomic note+mark, junk → zero trace, crash-mid-descent keeps top+floor, resume picks exactly the below-floor items, new arrivals excluded, collapse, **exactly 5 notes — no duplicates across crash/resume**).
- Debug build green.

## Docs
Updated `Documentation/Iterative Core (Connectors).md`, the self-test header, and the architecture map (flipped the "Known WIP: can't auto-resume" item to ✅).