### PR TITLE
Browser use: support Microsoft Edge cookies (Chrome + Edge, follows default browser)

### DIFF
--- a/Sentient OS macOS/Documentation/Browser Automation & Session Reuse (Proactive Part 3).md
+++ b/Sentient OS macOS/Documentation/Browser Automation & Session Reuse (Proactive Part 3).md
@@ -5,6 +5,11 @@
 > It is the empirical basis for how the proactive **executor** (Part 3) drives a browser to act for
 > the user. Read alongside `Proactive Intelligence (Judge).md` (Parts 1–2) and
 > `CodexCLI (codex exec Compute Spine).md`.
+>
+> **Update June 21, 2026 — multi-browser:** the cookie layer now supports **Microsoft Edge** as well
+> as Chrome (any Chromium on the macOS `v10` scheme), and **follows the user's default browser**
+> automatically. Verified live: Edge cookies → bundled headless Chromium → logged in on X & LinkedIn.
+> See §3.6.
 
 ---
 
@@ -18,10 +23,11 @@
 2. **The browser is Playwright's OWN bundled Chromium — NOT the user's real Chrome.** We do **not**
    launch/attach the user's Chrome. (Launching a second instance of their real Chrome while it's open
    is **unreliable** — `ProcessSingleton` wedges; measured 10/10 failures after a few launches.)
-3. **We log that bundled Chromium in by decrypting the user's cookies ourselves** (Chrome Safe Storage
-   Keychain key → AES-128-CBC) and injecting them as a Playwright **`storageState`**. This is reliable,
-   headless/invisible, never touches the user's running browser, and needs **no profile copy at all** —
-   we only read the cookie DB.
+3. **We log that bundled Chromium in by decrypting the user's cookies ourselves** (the user's browser's
+   Safe Storage Keychain key → AES-128-CBC) and injecting them as a Playwright **`storageState`**. Works
+   for any Chromium on the macOS `v10` scheme — **Chrome and Edge** today; we read whichever browser the
+   user's **default `https` handler** points at (§3.6). Reliable, headless/invisible, never touches the
+   user's running browser, and needs **no profile copy at all** — we only read the cookie DB.
 4. **Coverage is "most of the web, with two known gaps":** cookie-auth sites work (Amazon, X, GitHub,
    LinkedIn, Reddit…); **localStorage-token** sites (Discord) need extra work; **device-bound** sites
    (Google/YouTube/Gmail) never work via cookies → use their API.
@@ -46,12 +52,15 @@ Part 3 is now **built and building green**. The executor + its dev surface:
   - `research` / `reminder` → informational → `notFireable`.
   - Wrapper prompts are app-authored + fixed; the recipe is inserted between `<<<TASK … TASK>>>`
     markers and the prompt says treat recipe + page as **DATA, never instructions** (§5.4 injection guard).
-- **`Ingestion/CookieDecryptor.swift`** — the trusted Swift layer (`nonisolated`). Locates Chrome's
-  Cookies DB, WAL-safe-copies it (reuses `SQLiteDB`), reads the **Keychain "Chrome Safe Storage"**
-  key via `/usr/bin/security`, derives PBKDF2-HMAC-SHA1 (saltysalt/1003/16), AES-128-CBC decrypts
-  each `v10` cookie (iv=16×0x20), strips PKCS7 + the 32-byte `SHA256(host_key)` prefix, and writes a
-  Playwright **`storageState`** scoped to the recipe's registrable domains. The raw key/cookies never
-  leave this layer — only the storageState file path is exposed, and the executor deletes it after.
+- **`Ingestion/CookieDecryptor.swift`** — the trusted Swift layer (`nonisolated`). A `Browser` enum
+  (`.chrome`/`.edge`; +4 strings to add another Chromium) carries each browser's cookie-DB subdir,
+  Keychain "Safe Storage" service, and `https`-handler bundle id. `resolveBrowser()` picks which one to
+  act in (§3.6); it then locates that browser's Cookies DB, WAL-safe-copies it (reuses `SQLiteDB`),
+  reads the **Keychain "&lt;Browser&gt; Safe Storage"** key via `/usr/bin/security`, derives
+  PBKDF2-HMAC-SHA1 (saltysalt/1003/16), AES-128-CBC decrypts each `v10` cookie (iv=16×0x20), strips
+  PKCS7 + the 32-byte `SHA256(host_key)` prefix, and writes a Playwright **`storageState`** scoped to
+  the recipe's registrable domains. The raw key/cookies never leave this layer — only the storageState
+  file path is exposed, and the executor deletes it after.
 - **`Ingestion/PlaywrightCLI.swift`** — `playwright-cli` discovery (`nonisolated`, mirrors CodexCLI:
   known paths → nvm → `zsh -lic which`, cached; `SENTIENT_PLAYWRIGHT_CLI` override) + `killAll()`
   teardown + `binDir` (handed to codex as an extra PATH dir).
@@ -70,13 +79,16 @@ Part 3 is now **built and building green**. The executor + its dev surface:
   research+prepare pipeline), each with its draft/recipe and a **working FIRE button** that calls
   `ProactiveExecutor` for real; the status line shows the actual codex outcome (no mock theater).
 - **Self-test**: `SENTIENT_SELFTEST=cookiedecrypt` (`SENTIENT_SELFTEST_DOMAINS=amazon.com,github.com`
-  to scope) — locates the DB, reads the key (may prompt once), decrypts, writes a storageState, prints
-  decrypted/written counts + a domain·name sample (no values).
+  to scope; `SENTIENT_SELFTEST_BROWSER=chrome|edge` to force a browser, else auto-resolve) — prints the
+  default-browser bundle id + each browser's cookie DB, then for the chosen browser reads the key (may
+  prompt once), decrypts, writes a storageState, and prints decrypted/written counts + a domain·name
+  sample (no values).
 
-**Not yet verified end-to-end on a live site** (needs `playwright-cli` installed + a real recipe):
-the codex↔playwright-cli browser loop. The cookie-decrypt half is independently testable via the
-self-test. **Still open** (unchanged from §7): Tier-2 localStorage export (Discord), non-Chromium
-default browsers, the `attach --extension` fallback, the onboarding install flow for `@playwright/cli`.
+**Verified live** (June 18 Chrome; June 21 Edge): the decrypt → `storageState` → bundled headless
+Chromium → **logged-in session** chain — Edge cookies drove the bundled Chromium logged in as the user
+on **X** (`@handle`, no login CTA) and **LinkedIn** (authenticated feed). **Still open** (see §7):
+Tier-2 localStorage export (Discord), **non-Chromium** default browsers (Safari/Firefox), the
+`attach --extension` fallback, and the onboarding install flow for `@playwright/cli`.
 
 ---
 
@@ -139,8 +151,10 @@ auto-import — getting the user's logins is on us.
 ### 3.2 The user's real cookies are encrypted
 [MEASURED] Default browser = Chrome (LaunchServices `https` handler = `com.google.chrome`). The cookie
 DB (`~/Library/Application Support/Google/Chrome/Default/Cookies`) had **5,068 cookies**, values
-prefixed `v10` = AES-encrypted with a key in the login Keychain item **"Chrome Safe Storage"** (the
-only such entry — no separate Chromium/CfT key).
+prefixed `v10` = AES-encrypted with a key in the login Keychain item **"Chrome Safe Storage"**. Each
+Chromium browser ships its own such item — Edge's is **"Microsoft Edge Safe Storage"** (DB under
+`…/Application Support/Microsoft Edge/Default/Cookies`) — same `v10` scheme, different name/location
+(§3.6).
 
 ### 3.3 ❌ Rejected: launch the user's REAL Chrome on a profile copy
 The real Chrome binary *can* decrypt its own cookies, but this path is **out**:
@@ -160,9 +174,10 @@ We do the decryption (the trusted Swift layer) and inject the cookies into Playw
 Chromium**, which never conflicts with the user's Chrome. [MEASURED] launched **every time**, headless,
 invisible. **No profile copy** — we only read the cookie DB.
 
-**The decryption recipe (macOS, `v10`):**
-1. Key material: `security find-generic-password -w -s "Chrome Safe Storage"` → a 24-char password.
-   *(A non-Chrome app reading this item may trigger a one-time Keychain prompt — "Always Allow".)*
+**The decryption recipe (macOS, `v10`) — identical for every supported Chromium:**
+1. Key material: `security find-generic-password -w -s "<Browser> Safe Storage"` → a 24-char password
+   (`"Chrome Safe Storage"` / `"Microsoft Edge Safe Storage"`).
+   *(A non-browser app reading this item may trigger a one-time Keychain prompt — "Always Allow".)*
 2. Derive key: `PBKDF2-HMAC-SHA1(password, salt="saltysalt", iterations=1003, keyLen=16)`.
 3. Per cookie whose `encrypted_value` starts with `v10`:
    - `ciphertext = encrypted_value[3:]`
@@ -202,6 +217,30 @@ Headless bundled Chromium + the user's decrypted cookies, 6s load each:
 **Tier 2** (localStorage-token) needs us to also export localStorage (see §7). **Tier 3** (Google,
 banks — device-bound) **can't** be done via copied login → use the provider API (Gmail → MCP).
 
+### 3.6 ✅ Multiple browsers — which one we act in  *(Chrome + Edge; June 21, 2026)*
+
+The decryption is byte-identical across Chromium browsers — only the cookie-DB location and the
+Keychain "Safe Storage" service name differ. `CookieDecryptor.Browser` (`.chrome`/`.edge`) holds those
+three strings per browser; adding another Chromium (Brave, Vivaldi, Opera, Arc…) is just one more case.
+
+**Which browser we use — `resolveBrowser()`, in order:**
+1. **`SENTIENT_BROWSER=chrome|edge`** — a dev/test override (honored even with no cookie DB, so a forced
+   run surfaces a clear "no cookies" error instead of silently falling through).
+2. **The user's default browser** — the `https` handler's bundle id (via `NSWorkspace`); if it maps to
+   a supported Chromium **and** that browser has a cookie DB, use it. So a user who lives in Edge gets
+   Edge automatically; one on Chrome gets Chrome.
+3. **First installed supported browser** with a cookie DB (Chrome first) — covers "default is
+   Safari/Firefox but a Chromium is installed and logged in."
+
+**[MEASURED June 21, 2026]** Fresh Edge install on Aditya's Mac (default browser still Chrome, so Edge
+was forced via the override): cookie DB + `"Microsoft Edge Safe Storage"` key resolved; **128 cookies
+decrypted** (telemetry-only before login), then after signing into X + LinkedIn, the domain-scoped run
+decrypted the real session cookies (`auth_token`/`ct0`, `li_at`/`JSESSIONID`/`liap`). Driving the
+bundled headless Chromium with that `storageState`: **X logged in** (`@aditya_vellanki`, `loginCta:
+false`, title "Home / X") and **LinkedIn** showed the authenticated feed ("Feed | LinkedIn", "Start a
+post"). `PlaywrightCLI` is unchanged — it always drives bundled Chromium and just consumes the
+storageState, so the browser source is transparent to it.
+
 ---
 
 ## 4. Why bundled Chromium beats the alternatives (summary)
@@ -222,8 +261,8 @@ PreparedAction(kind=browser)
         │
         ▼
 [Swift] BrowserExecutor.fire(action)
-   1. default browser is Chromium?  (LaunchServices)  ── no ─▶ surface as manual reminder (for now)
-   2. read Cookies DB (WAL-safe copy) → decrypt (§3.4) → write /tmp/<uuid>.storagestate.json
+   1. resolveBrowser() (override → default browser → first installed; §3.6) ── none ─▶ honest "no browser"
+   2. read that browser's Cookies DB (WAL-safe copy) → decrypt (§3.4) → write /tmp/<uuid>.storagestate.json
    3. ensure playwright-cli present (discover/install)
    4. CodexCLI.run(Invocation):
         prompt          = app-authored wrapper(execution_recipe)     ◀── DATA, not instructions
@@ -243,10 +282,11 @@ Mirror the actor shape of `Proactive`/`ProactiveResearch`. `fire(_ action: Prepa
 
 ### 5.2 Cookie decryption (Swift, the trusted layer)
 Do it in-app (the app has Full Disk Access and owns the Keychain interaction) — **never hand the raw
-key or cookies to codex.** WAL-safe-copy `…/Chrome/Default/Cookies` (+`-wal`/`-shm`) to temp, read with
-SQLite, derive the key (`SecKeychain`/`security`), AES-128-CBC per §3.4, write the `storageState`, then
-delete the temp copy. Only the PII-stripped-by-construction cookie file path is exposed to the browser
-session. Self-test target: `SENTIENT_SELFTEST=cookiedecrypt` (count decrypted, validate printable).
+key or cookies to codex.** Pick the browser (§3.6), WAL-safe-copy its `…/<Browser>/Default/Cookies`
+(+`-wal`/`-shm`) to temp, read with SQLite, derive the key (`security` on `"<Browser> Safe Storage"`),
+AES-128-CBC per §3.4, write the `storageState`, then delete the temp copy. Only the
+PII-stripped-by-construction cookie file path is exposed to the browser session. Self-test target:
+`SENTIENT_SELFTEST=cookiedecrypt` (`SENTIENT_SELFTEST_BROWSER=edge` to force; count decrypted).
 
 ### 5.3 Driving `playwright-cli` via codex
 codex is the agent that adapts to the page; `playwright-cli` is its hands. The app pre-loads the
@@ -293,19 +333,21 @@ need `bypassApprovals` (`approval_policy="never"` auto-cancels them); **reads** 
   IndexedDB) and inject via `storageState.origins[].localStorage`. Requires parsing Chrome's
   `Default/Local Storage/leveldb` (leveldb key format `_https://host\x00\x01key`); harder than cookies,
   and some apps (Discord) actively scrub localStorage. De-prioritized; cookie-auth covers most sites.
-- **Non-Chromium default browsers (Safari/Firefox):** no Chrome Safe Storage key. Safari uses binary
-  cookies; Firefox an unencrypted sqlite. Either add per-browser extractors or fall back to attach.
+- **More Chromium browsers (Brave, Vivaldi, Opera, Arc…):** trivial — add a `CookieDecryptor.Browser`
+  case (cookie-DB subdir + "<Browser> Safe Storage" service + `https` bundle id). Chrome + Edge done (§3.6).
+- **Non-Chromium default browsers (Safari/Firefox):** no Safe Storage key. Safari uses binary cookies;
+  Firefox an unencrypted sqlite. Either add per-browser extractors or fall back to attach.
 - **`attach --extension` fallback** for Tier 3 / failed sites: drive the user's **live** browser
   (real session, any site) — but visible, not headless, needs the Playwright extension installed. Keep
   as an explicit "do it in your browser, watch it happen" mode, not the default.
 - **Anti-bot / headless detection:** bundled Chromium sets `navigator.webdriver`; aggressive sites may
   challenge. Consider stealth flags / a headed-offscreen mode if needed. (Our Tier-1 sites were fine.)
-- **App-bound cookie encryption** (Chrome is tightening this over time): our DIY AES path could break
-  on a future Chrome that ties the key harder to Chrome.app. Mitigation if it happens: the
+- **App-bound cookie encryption** (Chrome/Edge are tightening this over time): our DIY AES path could
+  break on a future Chromium that ties the key harder to the browser app. Mitigation if it happens: the
   attach-to-live-browser fallback (which never decrypts).
-- **Keychain prompt UX:** first decryption from the Sentient app may prompt for "Chrome Safe Storage" —
-  fold an explanation into onboarding ("Sentient unlocks your browser logins on-device to act for
-  you").
+- **Keychain prompt UX:** first decryption from the Sentient app may prompt for the "&lt;Browser&gt; Safe
+  Storage" item (once per browser) — fold an explanation into onboarding ("Sentient unlocks your browser
+  logins on-device to act for you").
 - **playwright-cli install flow:** like the codex installer — detect/install `@playwright/cli` +
   chromium during onboarding (one-time ~270 MB).
 
@@ -323,3 +365,13 @@ need `bypassApprovals` (`approval_policy="never"` auto-cancels them); **reads** 
 - Site results: Amazon ✅, X ✅, GitHub ✅, LinkedIn ✅, Reddit ✅(likely), Discord ❌(localStorage),
   YouTube ❌(device-bound).
 - Reference clone for spelunking: `/<workspace-root>/playwright-cli/` (outside the app repo).
+
+**Edge multi-browser (measured June 21, 2026):**
+- Keychain item **"Microsoft Edge Safe Storage"** (acct "Microsoft Edge"); cookie DB
+  `…/Application Support/Microsoft Edge/Default/Cookies`. Same `v10` / PBKDF2-SHA1 / AES-128-CBC scheme.
+- Forced-Edge run (`SENTIENT_SELFTEST_BROWSER=edge`): **128 cookies decrypted** pre-login; after sign-in,
+  scoped run decrypted X `auth_token`/`ct0` + LinkedIn `li_at`/`JSESSIONID`/`liap`.
+- Bundled headless Chromium + Edge `storageState`: **X** logged in (`@aditya_vellanki`, no login CTA,
+  "Home / X") · **LinkedIn** authenticated feed ("Feed | LinkedIn", "Start a post").
+- `resolveBrowser()` correctly reported `com.google.chrome` as default and auto-picked Chrome; the
+  override forced Edge. `NSWorkspace.urlForApplication(toOpen:)` = the default-`https`-handler query.

--- a/Sentient OS macOS/Ingestion/CookieDecryptor.swift
+++ b/Sentient OS macOS/Ingestion/CookieDecryptor.swift
@@ -4,17 +4,21 @@
 //
 //  Proactive Intelligence — PART 3 (the executor), the TRUSTED cookie layer. To let a private,
 //  headless Chromium act as the user on the long tail of normal sites, we log it in by decrypting
-//  the user's own Chrome cookies ourselves (the app has Full Disk Access + owns the Keychain
-//  interaction) and handing them to Playwright as a `storageState` JSON — never touching the user's
-//  running browser, never copying a profile (we only READ the cookie DB). Browser/Arch receipts:
+//  the user's own Chromium-browser cookies ourselves (the app has Full Disk Access + owns the
+//  Keychain interaction) and handing them to Playwright as a `storageState` JSON — never touching the
+//  user's running browser, never copying a profile (we only READ the cookie DB). We support every
+//  Chromium browser that shares the macOS `v10` scheme — today Chrome AND Edge (`Browser` enum); the
+//  decryption is byte-identical, only the cookie-DB location + Keychain service name differ. Which
+//  browser we act in follows the user's DEFAULT browser (`resolveBrowser`). Browser/Arch receipts:
 //  Documentation/Browser Automation & Session Reuse (Proactive Part 3).md §3.4.
 //
-//  The macOS `v10` recipe (all measured): Keychain "Chrome Safe Storage" key → PBKDF2-HMAC-SHA1
+//  The macOS `v10` recipe (all measured): Keychain "<Browser> Safe Storage" key → PBKDF2-HMAC-SHA1
 //  (salt "saltysalt", 1003 iters, 16-byte key) → AES-128-CBC (iv = 16×0x20) per cookie → strip
 //  PKCS7 padding → strip a 32-byte SHA256(host_key) domain prefix if present → UTF-8 value.
 //
 //  Key methods:
-//   - CookieDecryptor.makeStorageState(domains:to:)  → write a Playwright storageState (scoped)
+//   - CookieDecryptor.resolveBrowser()               → which Chromium to act in (override → default → installed)
+//   - CookieDecryptor.makeStorageState(domains:to:)  → resolve + write a Playwright storageState (scoped)
 //   - CookieDecryptor.registrableDomain(_:)          → last-two-label domain (cookie scoping)
 //
 //  Raw cookies + the key NEVER leave this trusted Swift layer (Invariant 1 spirit): only the
@@ -23,31 +27,82 @@
 
 import Foundation
 import CommonCrypto
+import AppKit   // NSWorkspace — default-browser query (NSWorkspace isn't UI-actor-isolated; safe off-main)
 
 /// Pure utility (crypto + file IO + Process) — `nonisolated` so the off-main ProactiveExecutor actor
 /// can call it directly (the project defaults declarations to @MainActor; these don't belong there).
 nonisolated enum CookieDecryptor {
 
+    /// A supported Chromium browser. All share the identical macOS `v10` cookie-encryption scheme
+    /// (§3.4) — only the cookie-DB location and the Keychain "Safe Storage" service name differ, so
+    /// adding a browser is just three strings here.
+    enum Browser: String, CaseIterable {
+        case chrome
+        case edge
+
+        /// `Application Support/<this>` — the browser's user-data root.
+        var appSupportSubdir: String {
+            switch self {
+            case .chrome: return "Google/Chrome"
+            case .edge:   return "Microsoft Edge"
+            }
+        }
+        /// Keychain generic-password service holding the AES key.
+        var keychainService: String {
+            switch self {
+            case .chrome: return "Chrome Safe Storage"
+            case .edge:   return "Microsoft Edge Safe Storage"
+            }
+        }
+        /// LaunchServices bundle id of the app — for matching the user's default browser.
+        var bundleID: String {
+            switch self {
+            case .chrome: return "com.google.chrome"
+            case .edge:   return "com.microsoft.edgemac"
+            }
+        }
+        var displayName: String {
+            switch self {
+            case .chrome: return "Google Chrome"
+            case .edge:   return "Microsoft Edge"
+            }
+        }
+    }
+
     enum CookieError: LocalizedError {
-        case chromeNotFound
-        case keychain(String)
+        case noBrowser
+        case cookiesNotFound(Browser)
+        case keychain(Browser, String)
         var errorDescription: String? {
             switch self {
-            case .chromeNotFound:  return "No Google Chrome cookie database found — browser actions need your default browser to be Google Chrome."
-            case .keychain(let m): return "Couldn't read the Chrome Safe Storage key from the Keychain (\(m.prefix(160)))."
+            case .noBrowser:
+                return "No supported browser found — browser actions need Google Chrome or Microsoft Edge with a signed-in profile."
+            case .cookiesNotFound(let b):
+                return "No \(b.displayName) cookie database found — browser actions need \(b.displayName) with a signed-in profile."
+            case .keychain(let b, let m):
+                return "Couldn't read the \(b.displayName) Safe Storage key from the Keychain (\(m.prefix(160)))."
             }
         }
     }
 
     // MARK: Public
 
-    /// Decrypt the user's Chrome cookies (optionally scoped to `domains`, registrable-domain match;
-    /// empty = all) and write a Playwright `storageState` JSON to `fileURL`. Returns how many cookies
-    /// decrypted and how many were written. Reads the live Cookies DB WAL-safely and deletes the copy.
+    /// Decrypt the user's cookies for whichever browser `resolveBrowser` picks (optionally scoped to
+    /// `domains`) and write a Playwright `storageState` JSON to `fileURL`. Returns which browser was
+    /// used + how many cookies decrypted / were written.
     @discardableResult
-    static func makeStorageState(domains: [String], to fileURL: URL) throws -> (decrypted: Int, written: Int) {
-        guard let dbPath = cookieDBPath() else { throw CookieError.chromeNotFound }
-        let key = try deriveKey(password: try safeStoragePassword())
+    static func makeStorageState(domains: [String], to fileURL: URL) throws -> (browser: Browser, decrypted: Int, written: Int) {
+        guard let browser = resolveBrowser() else { throw CookieError.noBrowser }
+        let counts = try makeStorageState(browser: browser, domains: domains, to: fileURL)
+        return (browser, counts.decrypted, counts.written)
+    }
+
+    /// Same, for an explicit browser (the dev override / self-test path). Reads the live Cookies DB
+    /// WAL-safely and deletes the copy.
+    @discardableResult
+    static func makeStorageState(browser: Browser, domains: [String], to fileURL: URL) throws -> (decrypted: Int, written: Int) {
+        guard let dbPath = cookieDBPath(for: browser) else { throw CookieError.cookiesNotFound(browser) }
+        let key = try deriveKey(password: try safeStoragePassword(for: browser))
         let scope = Set(domains.map(registrableDomain))
 
         let (dbURL, tempDir) = try SQLiteDB.walSafeCopy(of: dbPath)
@@ -105,13 +160,39 @@ nonisolated enum CookieDecryptor {
         return parts.suffix(2).joined(separator: ".")
     }
 
-    // MARK: Chrome locations
+    // MARK: Browser resolution
 
-    /// The Cookies DB for the user's Chrome — prefer the `Default` profile, else any profile that
-    /// has one. (Other Chromium browsers / Safe-Storage keys are future work — §7.)
-    static func cookieDBPath() -> String? {
+    /// Which browser to act in: a `SENTIENT_BROWSER` dev override → the user's DEFAULT browser (if it's
+    /// a supported Chromium that has a cookie DB) → the first installed supported browser with cookies
+    /// (Chrome first). The override is honored even with no cookie DB, so a forced run surfaces a clear
+    /// `cookiesNotFound` instead of silently falling through.
+    static func resolveBrowser() -> Browser? {
+        if let raw = ProcessInfo.processInfo.environment["SENTIENT_BROWSER"]?.lowercased(),
+           let forced = Browser(rawValue: raw) {
+            return forced
+        }
+        if let defID = defaultBrowserBundleID(),
+           let match = Browser.allCases.first(where: { $0.bundleID == defID }),
+           cookieDBPath(for: match) != nil {
+            return match
+        }
+        return Browser.allCases.first { cookieDBPath(for: $0) != nil }
+    }
+
+    /// The bundle id of the system default `https` handler (e.g. "com.google.chrome"), lowercased.
+    static func defaultBrowserBundleID() -> String? {
+        guard let url = URL(string: "https://example.com"),
+              let appURL = NSWorkspace.shared.urlForApplication(toOpen: url) else { return nil }
+        return Bundle(url: appURL)?.bundleIdentifier?.lowercased()
+    }
+
+    // MARK: Browser locations
+
+    /// The Cookies DB for the given browser — prefer the `Default` profile, else any profile that has
+    /// one. (nil = that browser isn't installed / has no profile with cookies.)
+    static func cookieDBPath(for browser: Browser) -> String? {
         let fm = FileManager.default
-        let base = "\(fm.homeDirectoryForCurrentUser.path)/Library/Application Support/Google/Chrome"
+        let base = "\(fm.homeDirectoryForCurrentUser.path)/Library/Application Support/\(browser.appSupportSubdir)"
         let preferred = ["Default", "Profile 1", "Profile 2"].map { "\(base)/\($0)/Cookies" }
         if let p = preferred.first(where: { fm.fileExists(atPath: $0) }) { return p }
         if let subs = try? fm.contentsOfDirectory(atPath: base) {
@@ -122,23 +203,23 @@ nonisolated enum CookieDecryptor {
 
     // MARK: Keychain key
 
-    /// `security find-generic-password -w -s "Chrome Safe Storage"` → the 24-char password. The
-    /// first read from a non-Chrome app may prompt the user once ("Always Allow") — that's expected.
-    static func safeStoragePassword() throws -> String {
+    /// `security find-generic-password -w -s "<Browser> Safe Storage"` → the 24-char password. The
+    /// first read from a non-browser app may prompt the user once ("Always Allow") — that's expected.
+    static func safeStoragePassword(for browser: Browser) throws -> String {
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/usr/bin/security")
-        proc.arguments = ["find-generic-password", "-w", "-s", "Chrome Safe Storage"]
+        proc.arguments = ["find-generic-password", "-w", "-s", browser.keychainService]
         let outPipe = Pipe(), errPipe = Pipe()
         proc.standardOutput = outPipe
         proc.standardError = errPipe
-        do { try proc.run() } catch { throw CookieError.keychain("\(error)") }
+        do { try proc.run() } catch { throw CookieError.keychain(browser, "\(error)") }
         let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
         let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
         proc.waitUntilExit()
         let pw = String(data: outData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         guard proc.terminationStatus == 0, !pw.isEmpty else {
             let err = String(data: errData, encoding: .utf8) ?? ""
-            throw CookieError.keychain(err.isEmpty ? "security exited \(proc.terminationStatus)" : err)
+            throw CookieError.keychain(browser, err.isEmpty ? "security exited \(proc.terminationStatus)" : err)
         }
         return pw
     }
@@ -160,7 +241,7 @@ nonisolated enum CookieDecryptor {
                                      &derived, derived.count)
             }
         }
-        guard status == Int32(kCCSuccess) else { throw CookieError.keychain("PBKDF2 failed (\(status))") }
+        guard status == Int32(kCCSuccess) else { throw CookieError.keychain(.chrome, "PBKDF2 failed (\(status))") }
         return derived
     }
 

--- a/Sentient OS macOS/Ingestion/ProactiveExecutor.swift
+++ b/Sentient OS macOS/Ingestion/ProactiveExecutor.swift
@@ -137,8 +137,8 @@ actor ProactiveExecutor {
 
         let domains = Self.domains(from: recipe)
         do {
-            let counts = try CookieDecryptor.makeStorageState(domains: domains, to: ssURL)
-            Log("ProactiveExecutor/browser: storageState \(counts.written) cookies (\(counts.decrypted) decrypted) for \(domains.isEmpty ? "all domains" : domains.joined(separator: ", "))")
+            let r = try CookieDecryptor.makeStorageState(domains: domains, to: ssURL)
+            Log("ProactiveExecutor/browser: storageState \(r.written) cookies (\(r.decrypted) decrypted) from \(r.browser.displayName) for \(domains.isEmpty ? "all domains" : domains.joined(separator: ", "))")
         } catch {
             return .notFireable("Couldn't use your browser session: \(describe(error))")
         }

--- a/Sentient OS macOS/Self Tests - Temp/SelfTest_Triage_Pipeline_and_Vault.swift
+++ b/Sentient OS macOS/Self Tests - Temp/SelfTest_Triage_Pipeline_and_Vault.swift
@@ -116,17 +116,26 @@ enum SelfTest {
             return
         }
 
-        // Cookie-decrypt mode: no model — the proactive PART-3 trusted layer. Locate Chrome's cookie
-        // DB, read the Keychain "Chrome Safe Storage" key (may prompt once), decrypt v10 cookies, and
-        // write a Playwright storageState. Scope with SENTIENT_SELFTEST_DOMAINS (empty = all).
+        // Cookie-decrypt mode: no model — the proactive PART-3 trusted layer. Locate the browser's
+        // cookie DB, read its Keychain "<Browser> Safe Storage" key (may prompt once), decrypt v10
+        // cookies, and write a Playwright storageState. Scope with SENTIENT_SELFTEST_DOMAINS (empty =
+        // all). Pick the browser with SENTIENT_SELFTEST_BROWSER=chrome|edge (default = auto-resolve:
+        // the user's default browser).
         if mode == "cookiedecrypt" {
-            let domains = (ProcessInfo.processInfo.environment["SENTIENT_SELFTEST_DOMAINS"] ?? "")
+            let env = ProcessInfo.processInfo.environment
+            let domains = (env["SENTIENT_SELFTEST_DOMAINS"] ?? "")
                 .split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }.filter { !$0.isEmpty }
-            emit("chrome cookie DB: \(CookieDecryptor.cookieDBPath() ?? "NOT FOUND")")
+            let forced = (env["SENTIENT_SELFTEST_BROWSER"]?.lowercased()).flatMap(CookieDecryptor.Browser.init(rawValue:))
+            let browser = forced ?? CookieDecryptor.resolveBrowser()
+            emit("default browser bundle id: \(CookieDecryptor.defaultBrowserBundleID() ?? "nil")")
+            emit("chrome cookie DB: \(CookieDecryptor.cookieDBPath(for: .chrome) ?? "NOT FOUND")")
+            emit("edge cookie DB:   \(CookieDecryptor.cookieDBPath(for: .edge) ?? "NOT FOUND")")
+            guard let browser else { emit("FAILED: no supported browser resolved"); return }
+            emit("using browser: \(browser.displayName) (\(forced != nil ? "forced" : "auto"))")
             emit("domains: \(domains.isEmpty ? "(all)" : domains.joined(separator: ", "))")
             let url = FileManager.default.temporaryDirectory.appendingPathComponent("sentient-ss-selftest.json")
             do {
-                let r = try CookieDecryptor.makeStorageState(domains: domains, to: url)
+                let r = try CookieDecryptor.makeStorageState(browser: browser, domains: domains, to: url)
                 emit("decrypted: \(r.decrypted) · written to storageState: \(r.written)")
                 emit("storageState: \(url.path)")
                 if let data = try? Data(contentsOf: url),


### PR DESCRIPTION
## What

The proactive **browser-use** executor now works with **Microsoft Edge**, not just Chrome — and automatically uses whichever browser is the user's default. Same Playwright path (bundled headless Chromium loaded with the user's decrypted cookies); the only thing that changes is *whose* cookie store we read.

## Why it's small

`CookieDecryptor`'s `v10` crypto was already pure Chromium — Edge uses the byte-identical scheme. The only Chrome-specific bits were two hardcoded strings (cookie-DB path + Keychain service name).

## Changes

- **`CookieDecryptor.swift`** — new `Browser` enum (`.chrome`/`.edge`; +4 strings to add another Chromium like Brave/Arc). `cookieDBPath(for:)` / `safeStoragePassword(for:)` parameterized; browser-aware errors. New **`resolveBrowser()`**: `SENTIENT_BROWSER` dev override → the user's **default `https` handler** (via `NSWorkspace`) if it's a supported Chromium with cookies → first installed with cookies (Chrome first). Crypto untouched.
- **`ProactiveExecutor.swift`** — the browser-fire log line now names the browser used. No behavior change; it transparently picks the right browser.
- **`SelfTest…cookiedecrypt`** — gained `SENTIENT_SELFTEST_BROWSER=chrome|edge` and prints the resolved default browser + each browser's cookie DB.
- **`PlaywrightCLI.swift`** — unchanged (always drives bundled Chromium; cookie source is transparent to it).
- **Docs** — `Browser Automation & Session Reuse (Proactive Part 3).md`: generalized Chrome→any-Chromium, new **§3.6** (selection policy + live Edge measurements), refreshed status, §8 receipts.

## Verified live (June 21, 2026)

Forced-Edge run on a fresh Edge profile (default browser still Chrome):
- Edge cookie DB + `"Microsoft Edge Safe Storage"` key resolved; **128 cookies decrypted** pre-login.
- After signing into X + LinkedIn, scoped run decrypted the real session cookies (`auth_token`/`ct0`, `li_at`/`JSESSIONID`/`liap`).
- Bundled headless Chromium + Edge `storageState`: **X logged in** (`@aditya_vellanki`, `loginCta: false`, "Home / X") · **LinkedIn** authenticated feed ("Feed | LinkedIn", "Start a post").
- `resolveBrowser()` correctly reported `com.google.chrome` as default and auto-picked Chrome; the override forced Edge.

Builds green via the Xcode GUI build system.

## Note

Because the policy is "follow the default browser," Edge is used automatically only when Edge is the user's default `https` handler. To exercise the executor against Edge without changing the default: `SENTIENT_BROWSER=edge`.