### PR TITLE
Demo deck refresh + live Charles send + command-bar computer use

### DIFF
--- a/Sentient OS macOS/CodexCLI.swift
+++ b/Sentient OS macOS/CodexCLI.swift
@@ -227,6 +227,26 @@ actor CodexCLI {
         return try Self.parseEnvelope(out, durationMS: Int(Date().timeIntervalSince(started) * 1000))
     }
 
+    /// DEMO (command-bar computer use): run a raw `codex exec` with the prompt passed as ARGV and
+    /// the minimal flag set that currently makes Codex's computer use work via the CLI —
+    /// `--dangerously-bypass-approvals-and-sandbox -m gpt-5.5 --skip-git-repo-check`, NO `--json`
+    /// (human-readable output, not JSONL). Each output LINE is pumped to `onLine` AS it arrives, so
+    /// the Xcode console shows codex's play-by-play live. Reuses the sanitized-env / PATH / watchdog
+    /// plumbing; the binary comes from the same discovery (`~/.local/bin/codex` first). Returns the
+    /// full output. Fire-and-forget — computer use is the WIP CLI path.
+    func runComputerUse(_ prompt: String, timeout: TimeInterval = 1_800,
+                        onLine: @escaping @Sendable (String) -> Void) async throws -> String {
+        guard let bin = Self.locateBinary() else { throw CLIError.notAvailable(.notInstalled) }
+        let args = ["exec", "--dangerously-bypass-approvals-and-sandbox",
+                    "-m", Model.gpt54mini.rawValue, "--skip-git-repo-check", prompt]
+        let out = try await Self.executeStreaming(binary: bin, args: args, timeout: timeout, onLine: onLine)
+        guard out.status == 0 else {
+            let detail = out.stderr.isEmpty ? out.stdout : out.stderr
+            throw CLIError.exitFailure(code: out.status, message: String(detail.prefix(600)))
+        }
+        return out.stdout.isEmpty ? out.stderr : out.stdout
+    }
+
     /// `exec resume` accepts only a subset of `exec`'s flags — no `-s`/`--cd`/`--add-dir`.
     /// [MEASURED] A resumed session's workspace root is the PROCESS cwd (not the remembered
     /// one), so `execute`'s cwd is load-bearing there, and the sandbox rides the
@@ -433,5 +453,83 @@ actor CodexCLI {
 
         if timedOut.withLock({ $0 }) { throw CLIError.timedOut(after: timeout) }
         return ExecResult(status: proc.terminationStatus, stdout: outDrain.text, stderr: errDrain.text)
+    }
+
+    /// Thread-safe append-only text accumulator for the streaming runner.
+    private final class LineSink: @unchecked Sendable {
+        private let lock = NSLock()
+        private var s = ""
+        func append(_ piece: String) { lock.lock(); s += piece; lock.unlock() }
+        var text: String { lock.lock(); defer { lock.unlock() }; return s }
+    }
+
+    /// Streaming sibling of `execute`: same sanitized env / PATH / watchdog, but it pumps each
+    /// output LINE (stdout and stderr) to `onLine` as it arrives — so the console shows codex's
+    /// computer-use play-by-play live — while also accumulating the full text. No stdin (the
+    /// computer-use prompt rides in argv). Byte-level line splitting so multibyte UTF-8 that
+    /// straddles a read boundary never garbles.
+    private static func executeStreaming(binary: String, args: [String], timeout: TimeInterval,
+                                         onLine: @escaping @Sendable (String) -> Void) async throws -> ExecResult {
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<ExecResult, Error>) in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let proc = Process()
+                proc.executableURL = URL(fileURLWithPath: binary)
+                proc.arguments = args
+                let binDir = (binary as NSString).deletingLastPathComponent
+                var env: [String: String] = [:]
+                let current = ProcessInfo.processInfo.environment
+                for key in ["HOME", "USER"] where current[key] != nil { env[key] = current[key] }
+                env["PATH"] = [binDir, "/usr/bin", "/bin", "/usr/sbin", "/sbin"].joined(separator: ":")
+                proc.environment = env
+
+                let outPipe = Pipe(), errPipe = Pipe()
+                proc.standardInput = FileHandle.nullDevice
+                proc.standardOutput = outPipe
+                proc.standardError = errPipe
+
+                let outSink = LineSink(), errSink = LineSink()
+                let group = DispatchGroup()
+                for (pipe, sink, prefix) in [(outPipe, outSink, ""), (errPipe, errSink, "stderr: ")] {
+                    group.enter()
+                    DispatchQueue.global(qos: .utility).async {
+                        var buf = Data()
+                        let handle = pipe.fileHandleForReading
+                        while true {
+                            let chunk = handle.availableData     // blocks until data, empty = EOF
+                            if chunk.isEmpty { break }
+                            buf.append(chunk)
+                            while let nl = buf.firstIndex(of: 0x0A) {
+                                let line = String(decoding: buf[..<nl], as: UTF8.self)
+                                buf = Data(buf[buf.index(after: nl)...])   // fresh 0-based remainder
+                                sink.append(line + "\n")
+                                onLine(prefix + line)
+                            }
+                        }
+                        if !buf.isEmpty {                          // trailing partial line (no newline)
+                            let line = String(decoding: buf, as: UTF8.self)
+                            sink.append(line)
+                            onLine(prefix + line)
+                        }
+                        group.leave()
+                    }
+                }
+
+                do { try proc.run() } catch { cont.resume(throwing: CLIError.launchFailed("\(error)")); return }
+
+                let timedOut = OSAllocatedUnfairLock(initialState: false)
+                let watchdog = DispatchWorkItem { [weak proc] in
+                    timedOut.withLock { $0 = true }; proc?.terminate()
+                }
+                DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + timeout, execute: watchdog)
+
+                proc.waitUntilExit()
+                watchdog.cancel()
+                group.wait()
+
+                if timedOut.withLock({ $0 }) { cont.resume(throwing: CLIError.timedOut(after: timeout)); return }
+                cont.resume(returning: ExecResult(status: proc.terminationStatus,
+                                                  stdout: outSink.text, stderr: errSink.text))
+            }
+        }
     }
 }

--- a/Sentient OS macOS/Views/Briefing.swift
+++ b/Sentient OS macOS/Views/Briefing.swift
@@ -93,14 +93,110 @@ struct Briefing: Identifiable {
         Jesai
         """
 
+    /// The EXACT reply we send Charles — shared by the Charles card's draft PREVIEW and its
+    /// `codexPrompt` (the live reply-all into the real "EWOR | Introducing Jesai & Charles"
+    /// thread), so the preview and the sent email can never drift.
+    private static let charlesReply = """
+        Hey Charles,
+
+        Really excited to meet you! :)
+        Thanks so much for making the time.
+
+        I'm in SF (PDT), and I'm happy to work around your schedule. For reference:
+        - I can make any time Monday work, until 4:30 PM
+        - I can make any time Tuesday work
+
+        I'll also send some materials before the call.
+
+        Looking forward to it,
+        Jesai
+        """
+
     static let demo: [Briefing] = [
         Briefing(
-            id: "anthos", kind: .overdue,
-            kicker: "Overdue · 6 days · Gmail",
-            title: "You still haven't replied to Anthos Capital.",
-            body: "Serena emailed six days ago — $3B+ AUM, names like Honey and Kalshi. She wanted time this week. I wrote your reply.",
+            id: "charles", kind: .deadline,
+            kicker: "Reply · 2 days · Gmail",
+            title: "Charles is waiting on your timeslots.",
+            body: "Daniel introduced you to Charles Ferguson — he sold companies to Microsoft and Oracle, pre-seeded Higgsfield, and won an Oscar. I checked your calendar and drafted your reply.",
             letter: """
-            Serena Saxena from Anthos Capital emailed six days ago — she found Sentient down an on-device-vs-cloud rabbit hole. Anthos runs a $1.5B fund with $3B+ in AUM, and backs companies people are obsessed with: Honey, Kalshi, Erewhon, Olaplex.
+            Daniel introduced you to Charles Ferguson for your next EWOR interview — he sold companies to **Microsoft** and **Oracle**, pre-seeded **Higgsfield** (€500M ARR in a year), and won an **Oscar**.
+
+            He cc'd his assistant Emily to schedule and asked for any materials — a deck or a memo. So I checked your calendar for **Monday and Tuesday**, found your open windows, and wrote your reply: a few timeslots and a memo offer.
+            """,
+            draft: Briefing.charlesReply,
+            draftLabel: "Draft reply · Gmail",
+            detailLabel: "read the draft",
+            offer: "Should I send it for you?",
+            workLog: ["→ reading Charles's note",
+                      "→ checking Monday & Tuesday for open slots",
+                      "→ opening Gmail",
+                      "→ composing your reply…",
+                      "✓ sent"],
+            doneTitle: "Sent to Charles.",
+            doneBody: "Emily has your availability — and materials are on the way.",
+            codexPrompt: """
+            You are running fully headless and autonomous, with the user's explicit prior approval to act on their behalf for THIS task — they clicked "send it for me." Do NOT ask for confirmation or approval, do NOT pause to verify, and do NOT merely draft. Actually SEND. If any tool surfaces a confirmation or approval step, treat it as already granted by the user and proceed.
+
+            Use the Gmail MCP to open the thread titled "EWOR | Introducing Jesai & Charles". In that thread, find the message from Charles Ferguson (chf@cferguson.com) whose body STARTS WITH "Thank you, Daniel, and moving you to bcc." REPLY-ALL to THAT message — include every recipient on it (all To and all Cc: Charles, his assistant Emily, and the EWOR "selection" address) so everyone Charles addressed receives the reply. Reply to CHARLES'S message specifically (NOT Daniel's earlier intro) so the reply respects that Charles moved Daniel to bcc — do not add Daniel. Send EXACTLY the message below, verbatim — do not change, rephrase, summarize, or add anything:
+
+            \(Briefing.charlesReply)
+
+            Send this reply-all now via the Gmail MCP — the user has already approved it. Do not ask, do not draft-and-wait; complete the send, then report exactly who it went to (the full To and Cc list).
+
+            FORMATTING: send it as an HTML email (set the send tool's content_type to "text/html"). Put each paragraph in its own <p>…</p> tag; render the two "I can make any time…" lines as a <ul><li>…</li></ul> list; write the sign-off as "Looking forward to it,<br>Jesai". Keep every word — including ":)" and "4:30 PM" — exactly as written. Do NOT send as text/plain and do NOT insert any manual line breaks inside a paragraph.
+            """),
+
+        Briefing(
+            id: "fareed", kind: .meeting,
+            kicker: "Prep · 4:30 PM tomorrow · Researched",
+            title: "Prepare for your call with Fareed from Speedrun.",
+            body: "Remember: Josh Lu wanted Fareed to be your a16z Speedrun partner. I've researched and found that GTM strategy matters a lot to him. Here's a doc that'll help you prepare for your call.",
+            letter: """
+            Your call with Fareed is tomorrow at 4:30 PM. Josh Lu wanted him as your a16z Speedrun partner — and once I read Fareed's background, it's obvious why. I pulled the highlights that'll get you ready.
+
+            ✦ **Why Josh connected you: he OWNED GTM at Slack.** Fareed was Director of Product for Lifecycle and the revenue owner for Slack's self-serve business — acquisition, activation, retention, monetization: the whole PLG engine at the company that *defined* bottoms-up growth. Sentient's free-forever consumer wedge is exactly his world. Speak his language — growth loops, activation, the path from a loved free product to revenue.
+
+            ✦ **He literally wrote about a thesis behind your product.** His recent post — *"Agent-native products are coming"*: *"Every product on the internet was built for a human with eyes, a cursor, and a credit card. Agents have none of those. The real opportunity is products designed for agents from scratch."* That is core to Sentient — an agent-native knowledge base your whole life feeds, offered to your AIs for Proactive Intelligence. Open here; he'll feel seen, and you'll prove you did the work.
+
+            ✦ **He thinks in product strategy — so be crisp.** At Reforge he built, with Casey Winters, the Product Strategy program that's now their **#1**. Expect him to probe your strategic spine: consumer free-forever as the loved wedge, the enterprise per-employee intelligence layer as the business, the on-device moat that makes both possible. Have the one-becomes-the-other story tight.
+
+            ✦ **Lead with distribution proof.** He loves network effects and growth loops, so the Reddit moment lands hard: **2,500+ waitlist signups in 24 hours, $0 spent.** That's the organic growth-loop evidence he's wired to respond to.
+
+            Walk in as the agent-native, PLG-native founder he's been writing about. — your Sentient
+            """,
+            detailLabel: "read the prep doc",
+            offer: nil,
+            doneTitle: "", doneBody: ""),
+
+        Briefing(
+            id: "aim", kind: .promise,
+            kicker: "Press · Early next week · WhatsApp",
+            title: "AIM India wants your voice.",
+            body: "Supreeth wants to interview you on Apple's Siri AI — and offered to cover the Sentient launch. He asked if you're free early next week. Reply's drafted.",
+            letter: """
+            Supreeth from AIM (Analytics India Magazine) reached out — he wants you as an expert voice on Apple's Siri AI, and offered to cover the Sentient OS launch while he's at it. Two birds.
+
+            He asked if you're free early next week. You are — your week's wide open. Say the word and I'll send your yes.
+            """,
+            draft: "Hi Supreeth! Would love to — early next week works great on my end. And thank you for offering to cover the Sentient OS launch; happy to give you a hands-on look. Talk soon!",
+            draftLabel: "Draft reply · WhatsApp",
+            detailLabel: "read the draft",
+            offer: "Reply & lock it in?",
+            workLog: ["→ opening WhatsApp",
+                      "→ finding Supreeth (AIM India)",
+                      "→ confirming early next week…",
+                      "✓ replied"],
+            doneTitle: "You're on with AIM.",
+            doneBody: "Confirmed for early next week — Supreeth's expecting you.",
+            codexPrompt: "Reply to Supreeth (AIM India) on WhatsApp with the approved draft confirming the interview early next week."),
+
+        Briefing(
+            id: "anthos", kind: .overdue,
+            kicker: "Overdue · 2 days · Gmail",
+            title: "You need to reply to Anthos Capital.",
+            body: "Serena emailed two days ago — $3B+ AUM, names like Honey and Kalshi. She wanted time this week. I wrote your reply.",
+            letter: """
+            Serena Saxena from Anthos Capital emailed two days ago — she found Sentient down an on-device-vs-cloud rabbit hole. Anthos runs a $1.5B fund with $3B+ in AUM, and backs companies people are obsessed with: Honey, Kalshi, Erewhon, Olaplex.
 
             She's in LA and asked for time early this week. You went quiet. Let's fix that — the draft's below, warm and ready.
             """,
@@ -150,115 +246,23 @@ struct Briefing: Identifiable {
             codexPrompt: "Reply to Luis Schmitz on iMessage with the approved draft, then create the calendar event 'Lunch @ Presidio — Jesai x Luis' for next Wednesday 1 PM at 101 Montgomery St (Presidio)."),
 
         Briefing(
-            id: "aim", kind: .promise,
-            kicker: "Press · 10 AM tomorrow · WhatsApp",
-            title: "AIM India wants your voice.",
-            body: "Supreeth wants to interview you on Apple's Siri AI — and offered to cover the Sentient launch. He asked if you're free at 10 AM tomorrow. Reply's drafted.",
+            id: "welcome", kind: .welcome,
+            kicker: "Welcome · Read across your whole life",
+            title: "A gift — connections across your life.",
+            body: "Three patterns you might not have seen yourself — visible only with everything in one place.",
             letter: """
-            Supreeth from AIM (Analytics India Magazine) reached out — he wants you as an expert voice on Apple's Siri AI, and offered to cover the Sentient OS launch while he's at it. Two birds.
+            I read **1,704 things** across your life last night. Three patterns you might not have seen yourself:
 
-            He asked if you're free tomorrow at 10 AM PST. You are — your morning is clear. Say the word and I'll send your yes.
+            ✦ **You never accept defaults.** Your iPhone ran **iPadOS** — WIRED noticed. Macs got **Apple Intelligence** before Apple shipped it, because you ported it. Your playlists skip the charts — and now you're routing around **college** itself.
+
+            ✦ **You spec hardware in numbers and music in feelings.** RAM chosen by the gigabyte for local LLMs; playlists curated for **“mood, tears, goosebumps.”**
+
+            ✦ **Your optimization points outward.** The systems you engineer for yourself show up rebuilt as **study systems for Jacob**, 8,000 miles away.
+
+            I'll keep watch from here. — **your Sentient**
             """,
-            draft: "Hi Supreeth! Would love to — 10 AM PST tomorrow works perfectly. And thank you for offering to cover the Sentient OS launch; happy to give you an early, hands-on look. Talk then!",
-            draftLabel: "Draft reply · WhatsApp",
-            detailLabel: "read the draft",
-            offer: "Reply & lock it in?",
-            workLog: ["→ opening WhatsApp",
-                      "→ finding Supreeth (AIM India)",
-                      "→ confirming 10 AM tomorrow…",
-                      "✓ replied"],
-            doneTitle: "You're on with AIM.",
-            doneBody: "Confirmed for 10 AM — Supreeth's expecting you.",
-            codexPrompt: "Reply to Supreeth (AIM India) on WhatsApp with the approved draft confirming the 10 AM PST interview tomorrow."),
-
-        Briefing(
-            id: "zfellows", kind: .deadline,
-            kicker: "Deadline · 8 days · Browser agent",
-            title: "ZFellows closes in 8 days.",
-            body: "You bookmarked the Dropout Graduation but never registered. The form needs your name, school, and what you're building — I have all three.",
-            letter: """
-            You bookmarked the ZFellows Dropout Graduation three weeks ago and never registered. It closes in 8 days.
-
-            The form is short: name, school, and what you're building. I have all three — say the word and an agent fills it while you watch.
-            """,
-            detailLabel: nil,
-            offer: "Want an agent to register you?",
-            workLog: ["→ launching a browser agent",
-                      "→ zfellows.com/dropout-graduation",
-                      "→ name: Jesai Tarun · school: UMass Amherst",
-                      "→ building: Sentient OS",
-                      "→ submitting the form…",
-                      "✓ registered — confirmation in your inbox"],
-            doneTitle: "You're registered.",
-            doneBody: "The ZFellows confirmation is in your inbox.",
-            codexPrompt: "Use the browser to open the ZFellows Dropout Graduation registration and submit it for Jesai Tarun, UMass Amherst, building Sentient OS."),
-
-        Briefing(
-            id: "fareed", kind: .meeting,
-            kicker: "Prep · 1 PM today · Researched",
-            title: "Prepare for your call with Fareed.",
-            body: "I've researched and found that GTM strategy matters a lot to him. Here's a doc that'll help you prepare for your call.",
-            letter: """
-            Your call with Fareed is today at 1 PM. Josh Lu wanted him as your a16z Speedrun partner — and once I read Fareed's background, it's obvious why. I pulled the highlights that'll get you ready.
-
-            ✦ **Why Josh connected you: he OWNED GTM at Slack.** Fareed was Director of Product for Lifecycle and the revenue owner for Slack's self-serve business — acquisition, activation, retention, monetization: the whole PLG engine at the company that *defined* bottoms-up growth. Sentient's free-forever consumer wedge is exactly his world. Speak his language — growth loops, activation, the path from a loved free product to revenue.
-
-            ✦ **He literally wrote about a thesis behind your product.** His recent post — *"Agent-native products are coming"*: *"Every product on the internet was built for a human with eyes, a cursor, and a credit card. Agents have none of those. The real opportunity is products designed for agents from scratch."* That is core to Sentient — an agent-native knowledge base your whole life feeds, offered to your AIs for Proactive Intelligence. Open here; he'll feel seen, and you'll prove you did the work.
-
-            ✦ **He thinks in product strategy — so be crisp.** At Reforge he built, with Casey Winters, the Product Strategy program that's now their **#1**. Expect him to probe your strategic spine: consumer free-forever as the loved wedge, the enterprise per-employee intelligence layer as the business, the on-device moat that makes both possible. Have the one-becomes-the-other story tight.
-
-            ✦ **Lead with distribution proof.** He loves network effects and growth loops, so the Reddit moment lands hard: **2,500+ waitlist signups in 24 hours, $0 spent.** That's the organic growth-loop evidence he's wired to respond to.
-
-            Walk in as the agent-native, PLG-native founder he's been writing about. — your Sentient
-            """,
-            detailLabel: "read the prep doc",
-            offer: nil,
-            doneTitle: "", doneBody: ""),
-
-        Briefing(
-            id: "ewor", kind: .plan,
-            kicker: "Prep · 11 AM today · Researched",
-            title: "Prepare for your call with Daniel, CEO of EWOR.",
-            body: "Somya Gupta nominated you for the EWOR Fellowship — and Daniel Dippold, its founder & CEO, wants 15 minutes today at 11 AM. I researched him and EWOR and pulled together what'll get you ready.",
-            letter: """
-            Your EWOR selection interview is today — 11:00–11:15 AM PDT, on Zoom (it moved up from 10:45). Somya Gupta nominated you, and you're meeting Daniel Dippold, EWOR's founder & CEO. He called it casual, but it's 15 minutes and it's selective — so walk in sharp.
-
-            ✦ **Know your room.** Daniel is a mathematician-turned-founder: raised **$100M** in his twenties, angel in **7 unicorns**, and built three organizations still thriving — EWOR, New Now Group, Sigma Squared. He rewards technical depth and outlier conviction — lead with the on-device moat and your all-in, drop-out resolve.
-
-            ✦ **Speak EWOR's language.** They back the **top 0.1%** of founders building transformative tech — up to **€500K** immediate, plus weekly 1:1 coaching from unicorn founders (Adjust, ProGlove, SumUp). No standard playbooks; they tailor to each founder. Frame Sentient as exactly that non-linear, outlier bet.
-
-            ✦ **Your 15-minute arc.** Open with the Reddit moment — **2,500+ waitlist signups in 24 hours, $0 spent**. Then the wedge: consumer free-forever as the loved foothold, the enterprise per-employee intelligence layer as the business. Close on why now, and why you.
-
-            Somya put their name on you — make it land. — **your Sentient**
-            """,
-            detailLabel: "read the prep doc",
+            detailLabel: "read it again",
             offer: nil,
             doneTitle: "", doneBody: ""),
     ]
-
-    /// PARKED — the original "gift from your Sentient" welcome letter (the wax-sealed envelope card).
-    /// Deliberately kept OUT of the `demo` deck above so it doesn't show in the UI right now, but
-    /// preserved verbatim so it's one line away from returning: drop `Briefing.welcomeGift` back into
-    /// `demo`. Its envelope visuals (`EnvelopeFace`, `welcomeGradient`, the `.sealed` phase) are still
-    /// intact in BriefingCard.swift. NOTE: re-adding makes a 7-card deck — extend `slots(count:)` in
-    /// HomeView (it only defines layouts up to 6), or swap it back in for another card to stay at 6.
-    static let welcomeGift = Briefing(
-        id: "welcome", kind: .welcome,
-        kicker: "Welcome · Read across your whole life",
-        title: "A gift — connections across your life.",
-        body: "Three patterns you might not have seen yourself — visible only with everything in one place.",
-        letter: """
-        I read **1,704 things** across your life last night. Three patterns you might not have seen yourself:
-
-        ✦ **You never accept defaults.** Your iPhone ran **iPadOS** — WIRED noticed. Macs got **Apple Intelligence** before Apple shipped it, because you ported it. Your playlists skip the charts — and now you're routing around **college** itself.
-
-        ✦ **You spec hardware in numbers and music in feelings.** RAM chosen by the gigabyte for local LLMs; playlists curated for **“mood, tears, goosebumps.”**
-
-        ✦ **Your optimization points outward.** The systems you engineer for yourself show up rebuilt as **study systems for Jacob**, 8,000 miles away.
-
-        I'll keep watch from here. — **your Sentient**
-        """,
-        detailLabel: "read it again",
-        offer: nil,
-        doneTitle: "", doneBody: "")
 }

--- a/Sentient OS macOS/Views/GlowButton.swift
+++ b/Sentient OS macOS/Views/GlowButton.swift
@@ -16,6 +16,7 @@ struct GlowButton: View {
     var active: Bool = true
     var reversed: Bool = false       // spin the halo the other direction
     var colors: [Color]? = nil       // custom halo palette (nil = default warm stops)
+    var glowIntensity: Double = 0.85 // halo opacity when active (lower = subtler glow)
     let action: () -> Void
 
     var body: some View {
@@ -31,7 +32,7 @@ struct GlowButton: View {
             .overlay(Capsule(style: .continuous).stroke(active ? .clear : Color.white.opacity(0.1), lineWidth: 1))
         }
         .buttonStyle(GlowPressStyle())
-        .background(GlowHalo(active: active, reversed: reversed, colors: colors))
+        .background(GlowHalo(active: active, reversed: reversed, colors: colors, intensity: glowIntensity))
         .disabled(!active)
         .animation(.easeInOut(duration: 0.4), value: active)
     }
@@ -51,6 +52,7 @@ struct GlowHalo: View {
     let active: Bool
     var reversed: Bool = false
     var colors: [Color]? = nil
+    var intensity: Double = 0.85     // halo opacity when active
 
     /// The canonical warm→cool AI-gradient stops (shared: the Analyze Now CTA + the For You
     /// command bar's glow both use these).
@@ -78,7 +80,7 @@ struct GlowHalo: View {
                     .blur(radius: 24)
                     .offset(x: -16, y: -16)
             }
-            .opacity(active ? 0.85 : 0)
+            .opacity(active ? intensity : 0)
             .animation(.easeInOut(duration: 0.6), value: active)
         }
         .allowsHitTesting(false)

--- a/Sentient OS macOS/Views/HomePopovers.swift
+++ b/Sentient OS macOS/Views/HomePopovers.swift
@@ -109,7 +109,7 @@ struct AnalysisPopover: View {
                 .contentShape(Capsule())
         }
         .buttonStyle(PressScaleStyle())
-        .background(GlowHalo(active: analyzeEnabled))
+        .background(GlowHalo(active: analyzeEnabled, intensity: 0.28))
         .disabled(!analyzeEnabled)
     }
 }
@@ -134,7 +134,7 @@ struct YourAIsPopover: View {
             .font(.system(size: 10, design: .monospaced))
             .padding(.top, 7)
 
-            GlowButton(title: "Connect your AIs", systemImage: "link", action: onConnect)
+            GlowButton(title: "Connect your AIs", systemImage: "link", glowIntensity: 0.28, action: onConnect)
                 .padding(.top, 18)
 
             MonoCaps("Your whole life · offered to every AI", size: 8.5, tracking: 1.6,

--- a/Sentient OS macOS/Views/HomeView.swift
+++ b/Sentient OS macOS/Views/HomeView.swift
@@ -153,18 +153,20 @@ struct HomeView: View {
     }
 
     /// Organic slot positions per population, laid into the CARD ZONE — the band between the
-    /// top chrome (nav + greeting) and the command-bar dock — so nothing overlaps either.
-    /// Pinned, not gridded; reflows as cards leave. (y-fraction is WITHIN the zone.)
+    /// top chrome (nav + greeting) and the command-bar dock. The two rows cluster toward the
+    /// vertical centre with a tight, deliberate gap (one composed spread, not two stranded rows)
+    /// and a gentle stagger. Pinned, not gridded; reflows as cards leave. (y-fraction is WITHIN
+    /// the zone.)
     private static func slots(count: Int, in size: CGSize) -> [CGPoint] {
         let top = size.height * 0.20
         let bottom = size.height * 0.86
         let h = bottom - top
         let f: [(CGFloat, CGFloat)]
         switch count {
-        case 6...: f = [(0.21, 0.24), (0.50, 0.10), (0.79, 0.16),
-                        (0.21, 0.74), (0.50, 0.80), (0.79, 0.74)]
-        case 5:    f = [(0.22, 0.20), (0.50, 0.08), (0.78, 0.16), (0.34, 0.76), (0.66, 0.76)]
-        case 4:    f = [(0.28, 0.18), (0.72, 0.18), (0.30, 0.76), (0.70, 0.76)]
+        case 6...: f = [(0.21, 0.24), (0.50, 0.20), (0.79, 0.20),
+                        (0.21, 0.72), (0.50, 0.70), (0.79, 0.66)]
+        case 5:    f = [(0.22, 0.22), (0.50, 0.14), (0.78, 0.19), (0.34, 0.68), (0.66, 0.68)]
+        case 4:    f = [(0.28, 0.22), (0.72, 0.22), (0.30, 0.68), (0.70, 0.68)]
         case 3:    f = [(0.24, 0.46), (0.50, 0.32), (0.76, 0.46)]
         case 2:    f = [(0.35, 0.44), (0.65, 0.44)]
         default:   f = [(0.50, 0.42)]
@@ -211,10 +213,11 @@ struct HomeView: View {
 
     private var bottomDock: some View {
         VStack(spacing: 16) {
-            PromptBar { text, mode in
-                // DEMO SEAM: real execution hands (text, mode) to CodexCLI — computer use runs a
-                // workspace-write agent; browser use drives the browser. For now, report the intent.
-                Log("Home/prompt: [\(mode.rawValue) use] \(text)")
+            PromptBar { _, _ in
+                // DEMO: the command bar fires a FIXED Codex computer-use run (regardless of what's
+                // typed or which mode is picked) — open WhatsApp and message Aditya Hemanth a
+                // 2-paragraph summary of Sentient OS. See ForYouModel.fireComputerUseDemo.
+                Task.detached(priority: .utility) { await ForYouModel.fireComputerUseDemo() }
             }
             HStack(spacing: 8) {
                 Image(systemName: "shield").font(.system(size: 11)).foregroundStyle(Theme.Ink.label)
@@ -341,12 +344,13 @@ final class ForYouModel {
         guard let e = entry(id), e.phase == .offer, e.b.offer != nil else { return }
         let v = visit
 
-        // THE CODEX SEAM — LIVE for the Anthos card: actually run `codex exec` on its codexPrompt
-        // (real CodexCLI.run, with the user's Gmail MCP in scope, so the reply truly sends). The
-        // scripted theater below still plays for visual feedback; the real run happens in the
-        // background and its outcome is logged. Other cards stay pure demo — their prompts would
-        // attempt bogus sends.
-        if e.b.id == "anthos", let prompt = e.b.codexPrompt {
+        // THE CODEX SEAM — LIVE for the Anthos + Charles cards: actually run `codex exec` on the
+        // card's codexPrompt (real CodexCLI.run, with the user's Gmail MCP in scope, so the reply
+        // truly sends). The scripted theater below still plays for visual feedback; the real run
+        // happens in the background and its outcome is logged. (Charles replies-all into the real
+        // "EWOR | Introducing Jesai & Charles" thread — see its codexPrompt.) Other cards stay
+        // pure demo — their prompts would attempt bogus sends.
+        if e.b.id == "anthos" || e.b.id == "charles", let prompt = e.b.codexPrompt {
             Task.detached(priority: .utility) { await Self.fireLiveCodex(prompt) }
         }
 
@@ -367,11 +371,12 @@ final class ForYouModel {
         }
     }
 
-    /// Live CODEX SEAM test (Anthos card): run the prompt through the real `codex exec` spine.
-    /// The user's Gmail MCP rides the CodexCLI defaults; `bypassApprovals` lets the connector's
-    /// approval-gated `send_email` actually fire headless. Outcome → `Log()` (tail /tmp/sentient-dev.log).
+    /// Live CODEX SEAM (Anthos + Charles cards): run the card's codexPrompt through the real
+    /// `codex exec` spine. The user's Gmail MCP rides the CodexCLI defaults; `bypassApprovals`
+    /// lets the connector's approval-gated `send_email` actually fire headless. Outcome → `Log()`
+    /// (tail /tmp/sentient-dev.log).
     nonisolated static func fireLiveCodex(_ prompt: String) async {
-        Log("Home/codex: firing live codex exec (Anthos → Gmail MCP)…")
+        Log("Home/codex: firing live codex exec (Gmail MCP send)…")
         do {
             var inv = CodexCLI.Invocation(prompt: prompt)
             inv.effort = .high                  // gpt-5.5 → high
@@ -384,6 +389,36 @@ final class ForYouModel {
             Log("Home/codex: --- full JSONL (debug) ---\n\(env.raw)\n--- end JSONL ---")
         } catch {
             Log("Home/codex: ✗ failed — \(error)")
+        }
+    }
+
+    /// DEMO — the command bar's send button: regardless of what's typed (or the mode), fire a
+    /// Codex COMPUTER-USE run that first READS the user's Sentient OS knowledge base for context,
+    /// then opens WhatsApp and sends Aditya Hemanth a summary of Sentient OS it composes from that
+    /// knowledge base. (Computer use is the WIP CLI path — see `CodexCLI.runComputerUse`.) → `Log()`.
+    nonisolated static func fireComputerUseDemo() async {
+        let kbPath = "/Users/jesaitarun/Sentient OS - Knowledge Base"
+        let prompt = """
+        First, read the user's Sentient OS knowledge base to learn what Sentient OS is. Read the markdown files in "\(kbPath)" — especially "README.md" and "Sentient OS/Product & Vision/Sentient OS - What It Is.md" (the canonical, current product description).
+
+        Then, using computer use, open WhatsApp, go to Aditya Hemanth's chat, and send him a great, warm summary of what Sentient OS is — about two short paragraphs, in Jesai's first-person voice (enthusiastic, with a casual ":)"). Lead with Proactive Intelligence (Sentient *does things for you* — drafts the reply you forgot, registers you for things, runs tasks via browser use and computer use), and mention the private knowledge base offered to all your AIs as the foundation it stands on. Compose the message yourself from the knowledge base — do not ask for confirmation, just send it.
+        """
+        Log("──────── 🖥️ COMPUTER USE · WhatsApp → Aditya Hemanth ────────")
+        Log("CU: launching codex exec (gpt-5.5 · computer use · bypass sandbox)…")
+        Log("CU: prompt ↓\n\(prompt)")
+        Log("──────────────── live codex output ↓ ────────────────")
+        let started = Date()
+        do {
+            let output = try await CodexCLI.shared.runComputerUse(prompt) { line in
+                Log("CU │ \(line)")     // streams each codex line to the Xcode console live
+            }
+            let secs = Int(Date().timeIntervalSince(started))
+            Log("──────── 🖥️ COMPUTER USE ✓ DONE in \(secs)s ────────")
+            Log("CU: final → \(output.suffix(1200))")
+        } catch {
+            let secs = Int(Date().timeIntervalSince(started))
+            Log("──────── 🖥️ COMPUTER USE ✗ FAILED after \(secs)s ────────")
+            Log("CU: \(error)")
         }
     }
 


### PR DESCRIPTION
## What

Demo-deck content refresh, a **live** Charles Gmail send, the command bar wired to **computer use**, and UI polish. Build verified green (Xcode).

### 1. Cards (`Briefing.swift`)
- Removed EWOR & ZFellows; added a **Charles Ferguson** reply card; brought back the gift/welcome envelope.
- Order: **Charles · Fareed · AIM** / **Anthos · Luis · gift**.
- Copy: Anthos ("You need to reply…", 2 days) · AIM ("early next week") · Fareed (restored "from Speedrun" + the Josh line, 4:30 PM tomorrow) · Charles (real email draft + "checked your calendar" framing).

### 2. Live Charles send (`Briefing.swift` + `HomeView.swift`)
- Charles "Should I send it?" fires a real `codex exec` Gmail **reply-all** into the *EWOR | Introducing Jesai & Charles* thread; shared `charlesReply` constant; `charles` armed in the live seam alongside `anthos`.
- ⚠️ **Live — clicking it really emails Charles + Emily + the EWOR selection address.**

### 3. Command bar → computer use (`CodexCLI.swift` + `HomeView.swift`)
- New `CodexCLI.runComputerUse` (raw `codex exec` computer use, prompt as argv, no `--json`) + `executeStreaming`/`LineSink` for **live line-by-line console logging**.
- Send button (regardless of typed input) reads the knowledge base → opens WhatsApp → messages Aditya, on `gpt-5.4-mini`.
- ⚠️ Demo/test wiring (fixed action; hardcoded `~/.local/bin/codex` + KB path).

### 4. Polish (`HomeView.swift`, `GlowButton.swift`, `HomePopovers.swift`)
- DEV TOOLS → dimmed bottom-right overlay; card-scatter spacing tuned.
- Reduced glow on Analyze Now + Connect your AIs (new `GlowHalo.intensity` knob; default unchanged everywhere else).

## ⚠️ Note
**Themes 2 & 3 are demo/live wirings** for the launch demo — not production behavior. Gate/parametrize (binary discovery, action routing, recipient targeting) before a real release.
