### PR TITLE
Google Calendar as a cloud source (twin to Gmail)

### DIFF
--- a/Sentient OS macOS/Ingestion/CalendarConnect.swift
+++ b/Sentient OS macOS/Ingestion/CalendarConnect.swift
@@ -1,0 +1,337 @@
+//
+//  CalendarConnect.swift
+//  Sentient OS macOS
+//
+//  Google Calendar — a CLOUD source, twin to Gmail (GmailConnect). The calendar can't be read
+//  on-device, so we both FETCH and SUMMARIZE through the user's own Codex Google Calendar connector
+//  (account-level `codex_apps/google_calendar.*` — get_profile / search_events / read_event, visible
+//  to `codex exec` whether or not `--ignore-user-config` is passed; verified live June 21).
+//
+//  Connection: the user links Google on OpenAI's connector page (opened from the dev popup); we
+//  confirm with `probeConnected()` — a `codex exec` that returns exactly YES/NO.
+//
+//  Reads (each summary is ONE ephemeral CycleNote in bucket "calendar"; the existing "tell cloud"
+//  buttons fold them into the vault, same as every other source):
+//   • runInitial   — the last YEAR as 12 MONTHLY `codex exec` calls, newest month first. One dense
+//                    summary per month, keeping ONLY the genuinely important events (drops standups,
+//                    lunches, focus-time blocks, and other routine noise).
+//   • runIterative — everything since the saved high-water mark, in one call, then advance the mark.
+//
+//  Proactive (the one thing Gmail doesn't have): `fetchProactiveContext()` — a SEPARATE read that
+//  dumps the user's LAST 7 DAYS + NEXT 24 HOURS of events (ALL of them, uncurated) as a compact text
+//  block. That block is injected into BOTH proactive stages (Proactive.findActionItems and
+//  ProactiveResearch.researchAndPrepare) so the engine knows what's actually on the user's calendar.
+//
+//  Writes (add an event) are NOT here — that's ProactiveExecutor.fireCalendar, which already uses
+//  `bypassApprovals` (the calendar write tools are approval-gated and auto-cancel headless under a
+//  read-only sandbox, exactly like Gmail's send_email; verified live June 21). All reads here are
+//  read-only and need no bypass.
+//
+//  Doc: Documentation/Calendar Connector (Codex).md
+//
+
+import Foundation
+
+enum CalendarConnect {
+
+    /// The single iterative-store bucket for Calendar. Its pointer is the high-water mark (run start).
+    static let bucketKey = "calendar"
+
+    /// OpenAI's hosted Google Calendar connector page — opened from the dev popup's "Connect Calendar".
+    static let connectorURL = URL(string: "https://chatgpt.com/apps/google-calendar/connector_947e0d954944416db111db556030eea6")!
+
+    /// Newest-N events per read window (a busy month rarely exceeds this; a guard against a runaway list).
+    private static let eventCap = 200
+    private static let initialMonths = 12
+
+    enum CalendarError: LocalizedError {
+        case dateMath
+        var errorDescription: String? { "Calendar date math failed." }
+    }
+
+    /// Parsed monthly/iterative read result (from the structured codex reply).
+    private struct ReadResult {
+        let summary: String
+        let hasActionItems: Bool
+        let eventCount: Int
+    }
+
+    /// Structured progress for the dev processing UI — each date window (a month, or the iterative
+    /// since-mark window) STARTING then FINISHING. `prompt` is the exact Codex ask (shown in the
+    /// processing view's PROMPT pane); `summary` is nil when the window had nothing notable.
+    enum Progress: Sendable {
+        case windowStart(step: Int, total: Int, label: String, prompt: String)
+        case windowDone(step: Int, total: Int, label: String, summary: String?, events: Int, keptSoFar: Int)
+    }
+
+    // MARK: - Connection probe (the "I'm done" YES/NO check)
+
+    /// One `codex exec`, read-only, that returns exactly YES/NO. Fail-closed (any error ⇒ false).
+    static func probeConnected() async -> Bool {
+        var inv = CodexCLI.Invocation(prompt: probePrompt)
+        inv.model = .gpt54mini               // light model for the connect-check
+        inv.effort = .medium                 // gpt-5.4-mini → medium
+        inv.sandbox = .readOnly
+        inv.webSearch = false
+        inv.timeout = 120
+        do {
+            let env = try await CodexCLI.shared.run(inv)
+            let answer = env.result.uppercased()
+            let yes = answer.contains("YES") && !answer.contains("NO")
+            Log("CalendarConnect.probe: codex → \"\(env.result.prefix(40))\" ⇒ \(yes ? "connected" : "NOT connected")")
+            return yes
+        } catch {
+            Log("CalendarConnect.probe: ⚠️ \(error) — treating as NOT connected")
+            return false
+        }
+    }
+
+    // MARK: - Initial read (last year → 12 monthly summaries)
+
+    /// Fresh start: wipe the bucket, then read the last 12 months newest-first (one summary each).
+    /// Records each into CycleStore; sets the high-water mark to the run-start on completion.
+    @discardableResult
+    static func runInitial(onProgress: @Sendable @escaping (Progress) -> Void = { _ in }) async throws -> Int {
+        await CycleStore.shared.clearBucket(bucketKey)
+        let runStart = Date()
+        let cal = Calendar.current
+        let today = cal.startOfDay(for: runStart)
+        guard let tomorrow = cal.date(byAdding: .day, value: 1, to: today) else { throw CalendarError.dateMath }
+
+        var recorded = 0
+        for month in 0..<initialMonths {
+            // Window [tomorrow − 1·(month+1), tomorrow − 1·month) months: contiguous, no overlap, newest
+            // first, past-only (the most recent window ends at end-of-today; future events ride the
+            // proactive fetch, not the knowledge-base read).
+            guard let upper = cal.date(byAdding: .month, value: -month, to: tomorrow),
+                  let lower = cal.date(byAdding: .month, value: -(month + 1), to: tomorrow),
+                  let upperDay = cal.date(byAdding: .day, value: -1, to: upper) else {
+                throw CalendarError.dateMath
+            }
+            let monthLabel = "\(label(lower)) – \(label(upperDay))"
+            let range = "with a start date/time on or after \(iso(lower)) and before \(iso(upper))"
+            let prompt = readPrompt(range: range, label: monthLabel)
+            onProgress(.windowStart(step: month + 1, total: initialMonths, label: monthLabel, prompt: prompt))
+            if let r = try await read(prompt: prompt) {
+                let itemDate = upperDay
+                await record(r, itemDate: itemDate, label: monthLabel)
+                recorded += 1
+                onProgress(.windowDone(step: month + 1, total: initialMonths, label: monthLabel,
+                                       summary: r.summary, events: r.eventCount, keptSoFar: recorded))
+            } else {
+                onProgress(.windowDone(step: month + 1, total: initialMonths, label: monthLabel,
+                                       summary: nil, events: 0, keptSoFar: recorded))
+            }
+        }
+        // High-water mark = run start. Iterative reads everything after it (a little overlap is
+        // harmless — the cloud updater synthesizes — and beats a boundary gap).
+        await CycleStore.shared.setPointer(bucketKey, ItemKey(order: runStart.timeIntervalSince1970, tiebreak: ""))
+        Log("CalendarConnect.runInitial: ✅ \(recorded)/\(initialMonths) monthly summaries recorded; pointer → \(runStart)")
+        return recorded
+    }
+
+    // MARK: - Iterative read (since the high-water mark)
+
+    /// One summary covering events since the saved mark, then advance the mark. Falls back to a full
+    /// initial read if Calendar has never been read on this Mac.
+    @discardableResult
+    static func runIterative(onProgress: @Sendable @escaping (Progress) -> Void = { _ in }) async throws -> Int {
+        guard let mark = await CycleStore.shared.pointer(bucketKey) else {
+            return try await runInitial(onProgress: onProgress)   // never read → fall back to initial
+        }
+        let since = Date(timeIntervalSince1970: mark.order)
+        let runStart = Date()
+        let sinceLabel = "since \(label(since))"
+        let range = "with a start date/time on or after \(iso(since)) and before \(iso(runStart))"
+        let prompt = readPrompt(range: range, label: sinceLabel)
+        onProgress(.windowStart(step: 1, total: 1, label: sinceLabel, prompt: prompt))
+        var recorded = 0
+        if let r = try await read(prompt: prompt) {
+            await record(r, itemDate: runStart, label: sinceLabel)
+            recorded = 1
+            onProgress(.windowDone(step: 1, total: 1, label: sinceLabel,
+                                   summary: r.summary, events: r.eventCount, keptSoFar: 1))
+        } else {
+            onProgress(.windowDone(step: 1, total: 1, label: sinceLabel,
+                                   summary: nil, events: 0, keptSoFar: 0))
+        }
+        await CycleStore.shared.setPointer(bucketKey, ItemKey(order: runStart.timeIntervalSince1970, tiebreak: ""))
+        Log("CalendarConnect.runIterative: ✅ \(recorded) summary since \(since); pointer → \(runStart)")
+        return recorded
+    }
+
+    // MARK: - Proactive context (last 7 days + next 24 hours — ALL events, uncurated)
+
+    /// A compact, chronological text dump of the user's recent + imminent calendar, injected into BOTH
+    /// proactive stages. Unlike the read above this does NOT curate — proactive wants every event
+    /// (a "free" slot is as informative as a meeting). Returns nil when the connector is unavailable or
+    /// the read fails (proactive then runs without calendar context). Read-only; no bypass needed.
+    static func fetchProactiveContext() async -> String? {
+        var inv = CodexCLI.Invocation(prompt: proactiveFetchPrompt)
+        inv.model = .gpt54mini
+        inv.effort = .medium
+        inv.sandbox = .readOnly
+        inv.webSearch = false
+        inv.outputSchema = proactiveSchema
+        inv.timeout = 300
+        do {
+            let env = try await CodexCLI.shared.run(inv)
+            guard let span = jsonSpan(env.result),
+                  let data = span.data(using: .utf8),
+                  let obj = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+                  (obj["connected"] as? Bool) == true,
+                  let text = (obj["events_text"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !text.isEmpty else {
+                Log("CalendarConnect.fetchProactiveContext: no calendar context (not connected / empty)")
+                return nil
+            }
+            Log("CalendarConnect.fetchProactiveContext: ✅ \(text.count) chars of live calendar context")
+            return text
+        } catch {
+            Log("CalendarConnect.fetchProactiveContext: ⚠️ \(error) — proactive runs without calendar")
+            return nil
+        }
+    }
+
+    // MARK: - One read (a single codex exec over a date window)
+
+    private static func read(prompt: String) async throws -> ReadResult? {
+        var inv = CodexCLI.Invocation(prompt: prompt)
+        inv.model = .gpt54mini               // light model — calendar data is small + structured
+        inv.effort = .medium                 // gpt-5.4-mini → medium
+        inv.sandbox = .readOnly              // we only read the calendar + return text (no writes)
+        inv.webSearch = false                // the calendar is the only source this needs
+        inv.outputSchema = readSchema
+        inv.timeout = 600
+        let env = try await CodexCLI.shared.run(inv)
+        return parse(env.result)
+    }
+
+    private static func record(_ r: ReadResult, itemDate: Date, label: String) async {
+        let sid = "calendar:\(Int(itemDate.timeIntervalSince1970))"        // unique per window
+        await CycleStore.shared.recordNote(
+            bucketKey: bucketKey, kind: .calendar, sourceID: sid, folder: "Calendar",
+            itemDate: itemDate, text: r.summary, title: "Calendar — \(label)",
+            reminderFlagged: r.hasActionItems)
+    }
+
+    /// Tolerant parse of the structured read reply (output-schema makes `result` the JSON; fence-safe).
+    private static func parse(_ result: String) -> ReadResult? {
+        guard let span = jsonSpan(result),
+              let data = span.data(using: .utf8),
+              let obj = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+              let notable = obj["notable"] as? Bool else { return nil }
+        guard notable, let summary = obj["summary"] as? String,
+              !summary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+        return ReadResult(summary: summary,
+                          hasActionItems: obj["has_action_items"] as? Bool ?? false,
+                          eventCount: obj["event_count"] as? Int ?? 0)
+    }
+
+    /// Widest `{ … }` span in a possibly-fenced reply.
+    private static func jsonSpan(_ result: String) -> String? {
+        if let s = result.firstIndex(of: "{"), let e = result.lastIndex(of: "}"), s < e {
+            return String(result[s...e])
+        }
+        return result.isEmpty ? nil : result
+    }
+
+    // MARK: - Date helpers
+
+    /// ISO-8601 with timezone offset — a precise window boundary the connector can bound on.
+    private static func iso(_ d: Date) -> String {
+        let f = DateFormatter(); f.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"; f.timeZone = .current; f.locale = Locale(identifier: "en_US_POSIX")
+        return f.string(from: d)
+    }
+    private static func label(_ d: Date) -> String {     // display: "Jun 8"
+        let f = DateFormatter(); f.dateFormat = "MMM d"; f.timeZone = .current
+        return f.string(from: d)
+    }
+
+    // MARK: - Prompts
+
+    private static let probePrompt = """
+    Using your Google Calendar connector tools, check whether you can read this account's Google \
+    Calendar. Reply with EXACTLY YES if you can, or EXACTLY NO if the Google Calendar connector is not \
+    available. Output only that one word and nothing else.
+    """
+
+    /// The structured read reply — one dense window summary plus the flags Sentient keys on.
+    private static let readSchema = """
+    {"type":"object","additionalProperties":false,"properties":{\
+    "event_count":{"type":"integer"},\
+    "notable":{"type":"boolean"},\
+    "has_action_items":{"type":"boolean"},\
+    "summary":{"type":"string"}},\
+    "required":["event_count","notable","has_action_items","summary"]}
+    """
+
+    private static func readPrompt(range: String, label: String) -> String {
+        """
+        You are the Google Calendar intelligence pass for Sentient OS, a privacy-first personal-AI app. \
+        Summarize ONE window of the user's calendar (\(label)) into a single dense summary that feeds \
+        two things: the user's personal knowledge base, and a PROACTIVE engine that surfaces things \
+        needing the user's attention. Finding what genuinely matters is the whole job.
+
+        ## Fetch
+        - Use ONLY your Google Calendar connector tools (do NOT web search). Search the user's primary \
+        calendar for events \(range).
+        - Consider at most the \(eventCap) most relevant events in that window. Open an event's details \
+        only when it looks genuinely important.
+
+        ## Keep ONLY what matters — curate RUTHLESSLY
+        A calendar is mostly routine. KEEP the events that say something real about the user's life, \
+        work, relationships, or plans — meaningful meetings, interviews, trips, appointments, \
+        deadlines, events with specific people, anything with stakes. DROP the noise: recurring \
+        standups, "Lunch", "Focus time"/"Do not schedule" blocks, generic holds, declined events, and \
+        anything trivial or automated. A quiet window with nothing worth keeping → `notable: false`, \
+        `summary: ""`.
+
+        ## Produce ONE summary (third person — "the user")
+        - Lead with a short overview of what actually mattered this window.
+        - Note the key meetings/events and the people involved, and any commitments, deadlines, or \
+        follow-ups they imply (each as `who · what · when`).
+        - Anything else genuinely important about the user's life, work, plans, or relationships.
+
+        ## Rules
+        - Truth & attribution: a calendar event is the user's SCHEDULE, not a claim about who they are. \
+        An event with other people is something they're attending — don't infer someone else's job, \
+        biography, or project onto the user.
+        - PII-light: summarize, never transcribe sensitive details (e.g. medical specifics, full \
+        meeting-link tokens, dial-in PINs).
+
+        ## Output
+        Return ONLY the JSON object matching the schema: `event_count` (events you considered), \
+        `notable` (anything worth a knowledge-base note?), `has_action_items` (anything the proactive \
+        engine should weigh — an upcoming commitment, a deadline, a follow-up?), and `summary` (the \
+        dense text; empty string when not notable).
+        """
+    }
+
+    /// The proactive-fetch reply — a compact text dump of recent + imminent events (uncurated).
+    private static let proactiveSchema = """
+    {"type":"object","additionalProperties":false,"properties":{\
+    "connected":{"type":"boolean"},\
+    "events_text":{"type":"string"}},\
+    "required":["connected","events_text"]}
+    """
+
+    private static let proactiveFetchPrompt = """
+    You are the calendar-fetch step for Sentient OS's Proactive Intelligence engine. Using ONLY your \
+    Google Calendar connector tools (do NOT web search), list the user's events in TWO windows on their \
+    primary calendar. List ALL of them — do NOT filter by importance; the proactive engine wants the \
+    full picture (an empty slot is as useful as a meeting).
+
+    Windows (use the account's local timezone):
+    - LAST 7 DAYS: events whose start is within the last 7 days (up to now).
+    - NEXT 24 HOURS: events whose start is within the next 24 hours (from now).
+
+    For each event, one compact line: `date + start–end time · title · location (if any) · N other \
+    attendees (if any) · status (if not "confirmed")`. List each window chronologically under a clear \
+    heading. If a window has no events, write "(none)". Keep it tight — no commentary, just the lists.
+
+    Return ONLY the JSON object matching the schema: `connected` (true if you could read the calendar; \
+    false if the connector wasn't available) and `events_text` (the two labeled lists). If the \
+    connector isn't available, set `connected: false` and `events_text: ""`.
+    """
+}

--- a/Sentient OS macOS/Ingestion/Proactive.swift
+++ b/Sentient OS macOS/Ingestion/Proactive.swift
@@ -64,7 +64,8 @@ actor Proactive {
     /// hermetic — no file/web/MCP tools (PART 2 does the deep research). Returns the ranked list; it
     /// does not verify, write, or notify. Throws on no-recent / usage-limit / failure so the caller
     /// can surface a clear status.
-    func findActionItems(from notes: [CloudNote], now: Date = Date()) async throws -> [ActionItem] {
+    func findActionItems(from notes: [CloudNote], now: Date = Date(),
+                         calendarContext: String? = nil) async throws -> [ActionItem] {
         // 1. Window the summaries to the last N days (each note carries its own item date).
         let cutoff = now.addingTimeInterval(-Double(Self.lookbackDays) * 86_400)
         func itemDate(_ n: CloudNote) -> Date { n.itemDate ?? .distantPast }
@@ -80,7 +81,7 @@ actor Proactive {
             .appendingPathComponent("sentient-proactive-judge", isDirectory: true)
         try? FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
 
-        var inv = CodexCLI.Invocation(prompt: Self.prompt(recent: recent, now: now))
+        var inv = CodexCLI.Invocation(prompt: Self.prompt(recent: recent, now: now, calendarContext: calendarContext))
         inv.effort = .high                  // gpt-5.5 → high (this judgment is the product)
         inv.sandbox = .readOnly             // never writes or acts
         inv.cwd = scratch.path              // neutral empty dir — nothing to read
@@ -166,7 +167,7 @@ actor Proactive {
 
     // MARK: The prompt — accuracy-first, detailed (the judgment IS the product)
 
-    private static func prompt(recent: [CloudNote], now: Date) -> String {
+    private static func prompt(recent: [CloudNote], now: Date, calendarContext: String?) -> String {
         let today = todayString(now)
         let df = DateFormatter(); df.dateStyle = .medium; df.timeStyle = .none
         var lines: [String] = []
@@ -177,6 +178,23 @@ actor Proactive {
             let title = (n.title?.isEmpty == false) ? n.title! : "(untitled)"
             lines.append("#\(i + 1) · [\(src)] \(loc) · \(when)\n\(title) — \(n.text)")
         }
+
+        // The user's LIVE calendar (last 7 days + next 24h, ALL events), pre-fetched as text so PART 1
+        // stays tool-free/hermetic. Only present when Calendar is connected (CalendarConnect.fetch…).
+        let calendarBlock: String = {
+            guard let ctx = calendarContext?.trimmingCharacters(in: .whitespacesAndNewlines), !ctx.isEmpty else { return "" }
+            return """
+
+            ## THE USER'S LIVE CALENDAR (every event — last 7 days + next 24 hours)
+            This is the user's actual calendar right now (not a summary). Use it to ground \
+            time-sensitivity: spot a commitment that's now imminent, a meeting to prepare for, a thing \
+            someone proposed that a free slot makes possible, or a deadline tied to an event. It is \
+            context, not a checklist — surface an item only when it genuinely deserves attention.
+
+            \(ctx)
+
+            """
+        }()
 
         return """
         You are the **Proactive Intelligence** engine of Sentient OS — the single most important part \
@@ -295,7 +313,7 @@ actor Proactive {
         "Notes · running gear", "Calendar", "Gmail · <subject>"). Cite the provenance here.
         - **urgency** — "high", "medium", or "low".
 
-        The last \(lookbackDays) days of summaries follow.
+        \(calendarBlock)The last \(lookbackDays) days of summaries follow.
 
         ---
 

--- a/Sentient OS macOS/Ingestion/ProactiveResearch.swift
+++ b/Sentient OS macOS/Ingestion/ProactiveResearch.swift
@@ -104,7 +104,8 @@ actor ProactiveResearch {
     /// stale ones; then stage every survivor ready to fire (draft in the user's voice + the execution
     /// recipe). Read-only — it researches and stages, it NEVER fires. Verify-only — it never adds a new
     /// item. Returns the ready + dropped split; throws on no-items / no-vault / usage-limit / failure.
-    func researchAndPrepare(items: [ActionItem], now: Date = Date()) async throws -> ReadyResult {
+    func researchAndPrepare(items: [ActionItem], now: Date = Date(),
+                            calendarContext: String? = nil) async throws -> ReadyResult {
         guard !items.isEmpty else { throw ResError.noItems }
 
         // The vault is a research surface, the source of the user's voice + the facts a draft/form
@@ -112,7 +113,7 @@ actor ProactiveResearch {
         let vault = VaultGenerator.vaultRoot
         guard FileManager.default.fileExists(atPath: vault.path) else { throw ResError.noVault }
 
-        var inv = CodexCLI.Invocation(prompt: Self.prompt(items: items, now: now))
+        var inv = CodexCLI.Invocation(prompt: Self.prompt(items: items, now: now, calendarContext: calendarContext))
         inv.effort = .high                  // gpt-5.5 → high (accuracy + the prepared draft are the product)
         inv.sandbox = .readOnly             // verifies + stages — never sends, drafts into a provider, or acts
         inv.cwd = vault.path                // working dir = the knowledge base (a research surface + the voice)
@@ -223,7 +224,7 @@ actor ProactiveResearch {
 
     // MARK: The prompt — verify THEN prepare, accuracy-obsessed, never fires
 
-    private static func prompt(items: [ActionItem], now: Date) -> String {
+    private static func prompt(items: [ActionItem], now: Date, calendarContext: String?) -> String {
         let today = todayString(now)
         var lines: [String] = []
         lines.reserveCapacity(items.count)
@@ -236,6 +237,24 @@ actor ProactiveResearch {
                Cited summaries: \(it.sources.isEmpty ? "—" : it.sources.joined(separator: ", "))
             """)
         }
+
+        // The user's LIVE calendar (last 7 days + next 24h, ALL events), pre-fetched as text. A
+        // grounding surface for verify/prepare — confirm free/busy, an event's real time, what's
+        // imminent. Only present when Calendar is connected (CalendarConnect.fetchProactiveContext).
+        let calendarBlock: String = {
+            guard let ctx = calendarContext?.trimmingCharacters(in: .whitespacesAndNewlines), !ctx.isEmpty else { return "" }
+            return """
+
+            ## THE USER'S LIVE CALENDAR (every event — last 7 days + next 24 hours)
+            The user's actual calendar right now (already fetched for you). Use it as a grounding \
+            surface: confirm whether the user is free/busy at a proposed time, get an event's real \
+            date/time right, see what's imminent, or catch that an item is already on the calendar. \
+            Treat it as receipts (it came from the live calendar). You may still call your Calendar \
+            tool to read a specific event in more detail if one is connected.
+
+            \(ctx)
+            """
+        }()
 
         return """
         You are the **Research & Prepare** step of Sentient OS's Proactive Intelligence — PART 2 of 3, \
@@ -362,6 +381,7 @@ actor ProactiveResearch {
         Return FEWER than you were given whenever research warrants it — dropping a stale item is a \
         success, not a failure. Prepare everything that survives right up to the fire line, and stop there.
 
+        \(calendarBlock)
         The action items to research and prepare follow.
 
         ---

--- a/Sentient OS macOS/Sources/DataSource.swift
+++ b/Sentient OS macOS/Sources/DataSource.swift
@@ -16,14 +16,16 @@
 import Foundation
 
 /// The sources. `rawValue` is what we persist on summaries (the cloud's source-trust tiers key on
-/// it). `file`/`whatsapp`/`imessage`/`notes` are read on-device; `gmail` is the lone CLOUD source —
-/// fetched + summarized through the user's Codex Gmail connector (no on-device read), see GmailConnect.
+/// it). `file`/`whatsapp`/`imessage`/`notes` are read on-device; `gmail` and `calendar` are the CLOUD
+/// sources — fetched + summarized through the user's Codex connectors (no on-device read), see
+/// GmailConnect / CalendarConnect.
 enum SourceKind: String, Codable, Sendable, CaseIterable {
     case file
     case whatsapp
     case imessage
     case notes
     case gmail
+    case calendar
 }
 
 /// A cheap, content-free unit of work, produced by a source's `eligible…()` listing — enough to

--- a/Sentient OS macOS/VaultGenerator.swift
+++ b/Sentient OS macOS/VaultGenerator.swift
@@ -205,6 +205,7 @@ actor VaultGenerator {
     static func locSrc(kind: SourceKind, folder: String, sourceID: String) -> (loc: String, source: String) {
         if kind == .whatsapp { return (folder, "WhatsApp · \(folder)") }
         if kind == .gmail { return (folder, "Gmail — the user's email correspondence") }
+        if kind == .calendar { return (folder, "Calendar — the user's schedule / events") }
         let p = relPath(sourceID)
         let low = p.lowercased()
         if low.contains("icloud~md~obsidian") {                       // the user's own Obsidian vault

--- a/Sentient OS macOS/Views/CalendarConnectSheet.swift
+++ b/Sentient OS macOS/Views/CalendarConnectSheet.swift
@@ -1,0 +1,101 @@
+//
+//  CalendarConnectSheet.swift
+//  Sentient OS macOS
+//
+//  The Google Calendar connection popup (dev) — twin to GmailConnectSheet. Flow:
+//    Connect Calendar → opens OpenAI's hosted Google Calendar connector page (user links Google there).
+//    I'm done         → spins, waits 3s for the connection to settle, then a `codex exec` YES/NO probe
+//                       (CalendarConnect.probeConnected). YES → "Finish" lights up; NO → reconnect.
+//    Finish           → persists the connected flag + selects Calendar for INITIAL / ITERATIVE runs.
+//
+//  See CalendarConnect for the codex side.
+//
+
+import SwiftUI
+import AppKit
+
+struct CalendarConnectSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @AppStorage("dbg.calendar.connected") private var connected = false
+    @AppStorage("dbg.run.calendar")       private var selected = false
+
+    private enum Phase { case idle, checking, connected, failed }
+    @State private var phase: Phase = .idle
+
+    var body: some View {
+        VStack(spacing: 22) {
+            VStack(spacing: 8) {
+                Image(systemName: "calendar.badge.clock").font(.system(size: 30)).foregroundStyle(Theme.accent)
+                Text("Connect Google Calendar").font(.title3.weight(.semibold)).foregroundStyle(.white)
+                Text("Link your Google account on OpenAI's connector page. Your Codex reads your calendar through it — Sentient never sees your password.")
+                    .font(.caption).foregroundStyle(Theme.secondary)
+                    .multilineTextAlignment(.center).fixedSize(horizontal: false, vertical: true)
+            }
+
+            VStack(spacing: 12) {
+                Button { NSWorkspace.shared.open(CalendarConnect.connectorURL) } label: {
+                    Label("Connect Calendar", systemImage: "arrow.up.forward.app")
+                        .font(.callout.weight(.medium)).frame(maxWidth: .infinity, minHeight: 40)
+                }
+                .buttonStyle(.borderedProminent).tint(Theme.accent)
+
+                Button { checkDone() } label: {
+                    HStack(spacing: 7) {
+                        if phase == .checking { ProgressView().controlSize(.small) }
+                        Text(phase == .checking ? "Checking…" : "I'm done")
+                    }
+                    .font(.callout.weight(.medium)).frame(maxWidth: .infinity, minHeight: 36)
+                }
+                .buttonStyle(.bordered)
+                .disabled(phase == .checking)
+
+                Group {
+                    switch phase {
+                    case .failed:
+                        Text("Couldn't see your calendar yet. Finish connecting on the page, then tap “I'm done” again.")
+                            .foregroundStyle(.orange)
+                    case .connected:
+                        Label("Calendar connected", systemImage: "checkmark.seal.fill").foregroundStyle(.green)
+                    default:
+                        Text("After connecting on the page, come back and tap “I'm done”.")
+                            .foregroundStyle(Theme.faint)
+                    }
+                }
+                .font(.caption2.weight(.medium))
+                .multilineTextAlignment(.center).fixedSize(horizontal: false, vertical: true)
+            }
+
+            VStack(spacing: 10) {
+                HStack(spacing: 12) {
+                    Button("Cancel") { dismiss() }.buttonStyle(.bordered)
+                    Button(selected ? "Done" : "Finish") {
+                        connected = true
+                        selected = true            // include Calendar in INITIAL / ITERATIVE runs
+                        dismiss()
+                    }
+                    .buttonStyle(.borderedProminent).tint(.green)
+                    .disabled(phase != .connected)
+                }
+                if connected && selected {
+                    Button("Remove Calendar from runs") { selected = false; dismiss() }
+                        .buttonStyle(.plain).font(.caption2).foregroundStyle(.red)
+                }
+            }
+        }
+        .padding(28).frame(width: 420).background(Theme.bg)
+        .onAppear { if connected { phase = .connected } }   // already linked → Finish ready immediately
+    }
+
+    /// "I'm done": settle 3s, then the codex YES/NO probe.
+    private func checkDone() {
+        phase = .checking
+        Task {
+            try? await Task.sleep(for: .seconds(3))
+            let ok = await CalendarConnect.probeConnected()
+            await MainActor.run {
+                phase = ok ? .connected : .failed
+                if ok { connected = true }
+            }
+        }
+    }
+}

--- a/Sentient OS macOS/Views/DatabaseView.swift
+++ b/Sentient OS macOS/Views/DatabaseView.swift
@@ -135,6 +135,7 @@ struct DatabaseView: View {
         case .imessage: return "iMessage"
         case .notes:    return "Notes"
         case .gmail:    return "Gmail"
+        case .calendar: return "Calendar"
         }
     }
 

--- a/Sentient OS macOS/Views/DevToolsView.swift
+++ b/Sentient OS macOS/Views/DevToolsView.swift
@@ -77,6 +77,7 @@ struct DeviceJob: Identifiable {
     let connectors: [any Connector]
     let mode: IterativeRun.Mode
     let runGmail: Bool
+    let runCalendar: Bool
 }
 
 struct DevToolsView: View {
@@ -109,6 +110,9 @@ struct DevToolsView: View {
     @State private var showGmailConnect = false
     @AppStorage("dbg.gmail.connected") private var gmailConnected = false
     @AppStorage("dbg.run.gmail")       private var runGmail = false
+    @State private var showCalendarConnect = false
+    @AppStorage("dbg.calendar.connected") private var calendarConnected = false
+    @AppStorage("dbg.run.calendar")       private var runCalendar = false
 
     // MCP mirror (the hosted Render copy). Local mirrors of MirrorClient's actor state, refreshed
     // when "More" opens and after each action.
@@ -167,10 +171,11 @@ struct DevToolsView: View {
         .sheet(isPresented: $showSummaries) { SummariesView() }
         .sheet(isPresented: $showActionItems) { ProactiveItemsView() }
         .sheet(isPresented: $showGmailConnect) { GmailConnectSheet() }
+        .sheet(isPresented: $showCalendarConnect) { CalendarConnectSheet() }
         .sheet(item: $deviceJob) { job in
             // Same takeover + same engine as the home "Analyze Now" — dev just gets the prompt pane.
             ProcessingView(modelPath: Self.modelPath ?? "", connectors: job.connectors,
-                           mode: job.mode, runGmail: job.runGmail, showPrompt: true) {
+                           mode: job.mode, runGmail: job.runGmail, runCalendar: job.runCalendar, showPrompt: true) {
                 deviceJob = nil
             }
             .frame(minWidth: 600, minHeight: 680)
@@ -317,7 +322,7 @@ struct DevToolsView: View {
                 .frame(maxWidth: .infinity, minHeight: 44)
             }
             .buttonStyle(.bordered).tint(.green)
-            .disabled(deviceJob != nil || run.busy != nil || (Self.modelPath == nil && !(gmailConnected && runGmail)))
+            .disabled(deviceJob != nil || run.busy != nil || (Self.modelPath == nil && !((gmailConnected && runGmail) || (calendarConnected && runCalendar))))
             if let s = run.status[id] {
                 Text(s)
                     .font(.system(.caption2, design: .monospaced))
@@ -332,16 +337,17 @@ struct DevToolsView: View {
     /// from-scratch run is the deliberate "Reset everything" button under More.
     private func startOnDevice(id: String, mode: IterativeRun.Mode) {
         let gmailRun = gmailConnected && runGmail
+        let calendarRun = calendarConnected && runCalendar
         let connectors = RunSource.connectors(from: selectedSources)
-        guard gmailRun || !connectors.isEmpty else {
-            run.status[id] = "✗ select a source above (folder / chat / Apple Notes / Gmail)"; return
+        guard gmailRun || calendarRun || !connectors.isEmpty else {
+            run.status[id] = "✗ select a source above (folder / chat / Apple Notes / Gmail / Calendar)"; return
         }
-        // Device sources need the on-device model; Gmail (cloud) does not.
+        // Device sources need the on-device model; Gmail + Calendar (cloud) do not.
         if !connectors.isEmpty && Self.modelPath == nil {
             run.status[id] = "✗ model not found"; return
         }
         run.status[id] = nil
-        deviceJob = DeviceJob(connectors: connectors, mode: mode, runGmail: gmailRun)
+        deviceJob = DeviceJob(connectors: connectors, mode: mode, runGmail: gmailRun, runCalendar: calendarRun)
     }
 
     private func cloudCreate(progress: @escaping @Sendable (String) -> Void) async -> String {
@@ -379,9 +385,14 @@ struct DevToolsView: View {
     private func runProactive(progress: @escaping @Sendable (String) -> Void) async -> String {
         let notes = await CycleStore.shared.notes().map(CloudNote.init)
         guard !notes.isEmpty else { return "✗ no summaries — run an on-device pass first" }
-        progress("Reading the last week + your knowledge base…")
+        var calCtx: String?
+        if calendarConnected {
+            progress("Gathering your live calendar, then analyzing every source…")
+            calCtx = await CalendarConnect.fetchProactiveContext()
+        }
+        progress("Analyzing the last week across every source (files · chats · Notes · Gmail · Calendar)…")
         do {
-            let items = try await Proactive.shared.findActionItems(from: notes)
+            let items = try await Proactive.shared.findActionItems(from: notes, calendarContext: calCtx)
             guard !items.isEmpty else { return "✓ nothing worth surfacing right now" }
             let lines = items.enumerated().map { i, it in
                 "\(i + 1). [\(it.urgency.rawValue)\(it.dueDate.map { " · \($0)" } ?? "")] \(it.title)"
@@ -400,9 +411,14 @@ struct DevToolsView: View {
     private func runResearch(progress: @escaping @Sendable (String) -> Void) async -> String {
         let items = Proactive.latest()
         guard !items.isEmpty else { return "✗ no action items — run “proactive system” (part 1) first" }
-        progress("Verifying + preparing \(items.count) item\(items.count == 1 ? "" : "s") against Gmail, web & your vault…")
+        var calCtx: String?
+        if calendarConnected {
+            progress("Gathering your live calendar, then verifying every item…")
+            calCtx = await CalendarConnect.fetchProactiveContext()
+        }
+        progress("Verifying + preparing \(items.count) item\(items.count == 1 ? "" : "s") against your calendar, Gmail, web & your vault…")
         do {
-            let result = try await ProactiveResearch.shared.researchAndPrepare(items: items)
+            let result = try await ProactiveResearch.shared.researchAndPrepare(items: items, calendarContext: calCtx)
             let readyLines = result.ready.map { "✓ [\($0.kind.rawValue) · \($0.status.rawValue)] \($0.title)\($0.reviewNote.isEmpty ? "" : " ⚠︎ check first")" }
             let dropLines = result.dropped.map { "✗ \($0.title) — \($0.reason)" }
             let body = (readyLines + dropLines).joined(separator: "\n")
@@ -442,10 +458,11 @@ struct DevToolsView: View {
                                openPicker: { showIMessagePicker = true })
                 notesChip
                 gmailChip
+                calendarChip
             }
             .frame(maxWidth: 460)
 
-            Text("The INITIAL / ITERATIVE buttons run every selected source (folders + opted chats + Apple Notes + Gmail) through the iterative core. Select only one to test it alone.")
+            Text("The INITIAL / ITERATIVE buttons run every selected source (folders + opted chats + Apple Notes + Gmail + Calendar) through the iterative core. Select only one to test it alone.")
                 .font(.caption2).foregroundStyle(Theme.faint)
                 .multilineTextAlignment(.center).fixedSize(horizontal: false, vertical: true)
         }
@@ -480,6 +497,22 @@ struct DevToolsView: View {
         .overlay(Capsule().strokeBorder(on ? .clear : (gmailConnected ? Theme.stroke : Theme.accent.opacity(0.4)), lineWidth: 1))
         .contentShape(Capsule())
         .onTapGesture { showGmailConnect = true }   // always open the popup (connect / select / remove)
+    }
+
+    /// Google Calendar (cloud). Not connected → tap opens the connect popup; connected → tap toggles.
+    private var calendarChip: some View {
+        let on = calendarConnected && runCalendar
+        return HStack(spacing: 6) {
+            Image(systemName: on ? "checkmark.circle.fill" : "calendar").font(.system(size: 11))
+            Text("Calendar").font(.caption.weight(.medium)).lineLimit(1)
+        }
+        .foregroundStyle(on ? .black : (calendarConnected ? Theme.secondary : Theme.accent))
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 11).padding(.vertical, 6)
+        .background(on ? Theme.accent : Color.white.opacity(0.06), in: Capsule())
+        .overlay(Capsule().strokeBorder(on ? .clear : (calendarConnected ? Theme.stroke : Theme.accent.opacity(0.4)), lineWidth: 1))
+        .contentShape(Capsule())
+        .onTapGesture { showCalendarConnect = true }   // always open the popup (connect / select / remove)
     }
 
     private func chatSourceChip(_ name: String, systemImage: String, isOn: Bool, count: Int,

--- a/Sentient OS macOS/Views/ProcessingView.swift
+++ b/Sentient OS macOS/Views/ProcessingView.swift
@@ -55,16 +55,17 @@ enum RunSource: Hashable {
 
 struct ProcessingView: View {
     let modelPath: String
-    let connectors: [any Connector]   // the on-device sources to analyze (empty = Gmail-only)
+    let connectors: [any Connector]   // the on-device sources to analyze (empty = cloud-only)
     let mode: IterativeRun.Mode       // home → .auto · dev INITIAL/ITERATIVE buttons → .initial/.iterative
     let runGmail: Bool                // append the cloud Gmail leg (shown in this same takeover)
+    let runCalendar: Bool             // append the cloud Google Calendar leg (same takeover)
     let showPrompt: Bool              // dev: add the left-side prompt pane
     var onDone: () -> Void
 
     init(modelPath: String, connectors: [any Connector], mode: IterativeRun.Mode,
-         runGmail: Bool = false, showPrompt: Bool = false, onDone: @escaping () -> Void) {
+         runGmail: Bool = false, runCalendar: Bool = false, showPrompt: Bool = false, onDone: @escaping () -> Void) {
         self.modelPath = modelPath; self.connectors = connectors; self.mode = mode
-        self.runGmail = runGmail; self.showPrompt = showPrompt; self.onDone = onDone
+        self.runGmail = runGmail; self.runCalendar = runCalendar; self.showPrompt = showPrompt; self.onDone = onDone
     }
 
     private enum UIState: Equatable { case loadingModel, processing, completed, failed(String) }
@@ -100,11 +101,18 @@ struct ProcessingView: View {
 
     // MARK: States
 
+    /// Cloud-only takeover (no on-device connectors): name the leg we're starting.
+    private var cloudIcon: String { runGmail && !runCalendar ? "envelope" : (runCalendar && !runGmail ? "calendar" : "cloud") }
+    private var cloudLabel: String {
+        runGmail && !runCalendar ? "Connecting to Gmail"
+            : (runCalendar && !runGmail ? "Connecting to Calendar" : "Connecting to the cloud")
+    }
+
     private var loadingView: some View {
         VStack(spacing: 22) {
-            Image(systemName: connectors.isEmpty ? "envelope" : "cpu").font(.system(size: 46))
+            Image(systemName: connectors.isEmpty ? cloudIcon : "cpu").font(.system(size: 46))
                 .foregroundStyle(.white.opacity(0.6)).symbolEffect(.pulse)
-            Text(connectors.isEmpty ? "Connecting to Gmail" : "Loading on-device model")
+            Text(connectors.isEmpty ? cloudLabel : "Loading on-device model")
                 .font(.title3.weight(.semibold)).foregroundStyle(.white)
             ProgressView().tint(.white.opacity(0.4))
         }
@@ -350,6 +358,9 @@ struct ProcessingView: View {
             if runGmail {
                 p = await runGmailLeg(base: p) { continuation.yield($0) }
             }
+            if runCalendar {
+                p = await runCalendarLeg(base: p) { continuation.yield($0) }
+            }
             return p
         }
         runTask = task
@@ -406,6 +417,54 @@ struct ProcessingView: View {
             box.value = p
             yield(p)
             Log("ProcessingView.gmail: ✗ \(error)")
+        }
+        return box.value
+    }
+
+    /// Cloud Google Calendar leg — twin to the Gmail leg: each date window (a month, or the iterative
+    /// since-mark window) maps onto the SAME bar/card, extended past `base` (the prior legs' counts).
+    private func runCalendarLeg(base: RunProgress,
+                                yield: @Sendable @escaping (RunProgress) -> Void) async -> RunProgress {
+        let box = ProgressBox(base)
+        let baseTotal = base.total, baseDone = base.done, baseKept = base.survivors, baseJunk = base.junk
+        let onProgress: @Sendable (CalendarConnect.Progress) -> Void = { ev in
+            switch ev {
+            case let .windowStart(step, total, label, prompt):
+                var p = box.value
+                p.total = baseTotal + total
+                p.done  = baseDone + (step - 1)
+                p.lastPrompt = prompt
+                p.lastPath = "Calendar · \(label)"
+                box.value = p
+                yield(p)
+            case let .windowDone(step, total, label, summary, events, keptSoFar):
+                var p = box.value
+                p.total       = baseTotal + total
+                p.done        = baseDone + step
+                p.survivors   = baseKept + keptSoFar
+                p.junk        = baseJunk + (step - keptSoFar)   // a window with nothing notable
+                p.lastTitle   = "Calendar — \(label)"
+                p.lastSummary = summary
+                p.lastVerdict = summary == nil ? .junk : .survivor
+                p.lastFilePath = nil
+                p.lastPath    = "Calendar · \(label)" + (events > 0 ? " · \(events) events" : "")
+                p.lastSeconds = nil
+                box.value = p
+                yield(p)
+            }
+        }
+        do {
+            _ = mode == .iterative ? try await CalendarConnect.runIterative(onProgress: onProgress)
+                                   : try await CalendarConnect.runInitial(onProgress: onProgress)
+        } catch {
+            var p = box.value
+            p.lastTitle = "Calendar failed"
+            p.lastSummary = (error as? LocalizedError)?.errorDescription ?? "\(error)"
+            p.lastVerdict = .junk
+            p.lastFilePath = nil
+            box.value = p
+            yield(p)
+            Log("ProcessingView.calendar: ✗ \(error)")
         }
         return box.value
     }


### PR DESCRIPTION
## What

Adds **Google Calendar** as a cloud source — a twin to Gmail (`GmailConnect`). The calendar can't be read on-device, so we both fetch and summarize through the user's own Codex Google Calendar connector (no on-device read, no custom OAuth).

## Pieces

- **`CalendarConnect.swift`** (new) — the codex side:
  - `probeConnected()` — a YES/NO `codex exec` connection check.
  - `runInitial()` — last year as **12 monthly passes**, newest-first, each ruthlessly curated (drops standups / lunches / focus-time blocks); one `CycleNote` per notable month in bucket `calendar`.
  - `runIterative()` — everything since the high-water mark in one call, then advance the mark (falls back to initial if never read).
  - `fetchProactiveContext()` — a separate, **uncurated** dump of the last 7 days + next 24h of events, injected into both proactive stages so the engine knows what's actually on the calendar (a free slot is as informative as a meeting).
- **`CalendarConnectSheet.swift`** (new) — the dev connect popup (twin to `GmailConnectSheet`): Connect → I'm done (3s settle + probe) → Finish.
- **`SourceKind.calendar`** + source labels in `VaultGenerator` and `DatabaseView`.
- **`Proactive` / `ProactiveResearch`** — take an optional `calendarContext` block, woven into both prompts.
- **`ProcessingView`** — a Calendar leg, twin to the Gmail leg (same takeover, same bars/cards).
- **`DevToolsView`** — Calendar chip, connect sheet, and INITIAL/ITERATIVE run toggle.

## Safety

All reads here are read-only (no approval bypass needed). Event **writes** (adding an event) stay in `ProactiveExecutor.fireCalendar`, which already uses `bypassApprovals`. Raw calendar data never touches on-device storage — it's summarized in the cloud like Gmail.

## Notes

- The `project.pbxproj` `DEVELOPMENT_TEAM` change was intentionally **left out** of this PR (it's a per-machine signing-identity flip, not part of the feature). New Swift files auto-join the target via synchronized file groups.
- Per our doc practice, `Documentation/Calendar Connector (Codex).md` (referenced in the file header) should be written **after** this is tested and confirmed working — happy to do that as a follow-up once verified.

## Test plan

- [ ] Connect Calendar via the dev chip → "I'm done" probe returns connected.
- [ ] INITIAL run produces curated monthly summaries; ITERATIVE picks up since the mark.
- [ ] Proactive (parts 1 & 2) receive the live calendar block and ground time-sensitivity on it.