### PR TITLE
Command bar computer use + self-granted Automation permission

### DIFF
--- a/Sentient OS macOS.xcodeproj/project.pbxproj
+++ b/Sentient OS macOS.xcodeproj/project.pbxproj
@@ -294,6 +294,7 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSAppleEventsUsageDescription = "Sentient OS uses Automation so the computer-use agent you ask it to run can control apps on your Mac on your behalf.";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -328,6 +329,7 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSAppleEventsUsageDescription = "Sentient OS uses Automation so the computer-use agent you ask it to run can control apps on your Mac on your behalf.";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Sentient OS macOS/CodexCLI.swift
+++ b/Sentient OS macOS/CodexCLI.swift
@@ -227,18 +227,23 @@ actor CodexCLI {
         return try Self.parseEnvelope(out, durationMS: Int(Date().timeIntervalSince(started) * 1000))
     }
 
-    /// DEMO (command-bar computer use): run a raw `codex exec` with the prompt passed as ARGV and
-    /// the minimal flag set that currently makes Codex's computer use work via the CLI —
-    /// `--dangerously-bypass-approvals-and-sandbox -m gpt-5.5 --skip-git-repo-check`, NO `--json`
-    /// (human-readable output, not JSONL). Each output LINE is pumped to `onLine` AS it arrives, so
-    /// the Xcode console shows codex's play-by-play live. Reuses the sanitized-env / PATH / watchdog
-    /// plumbing; the binary comes from the same discovery (`~/.local/bin/codex` first). Returns the
-    /// full output. Fire-and-forget — computer use is the WIP CLI path.
-    func runComputerUse(_ prompt: String, timeout: TimeInterval = 1_800,
-                        onLine: @escaping @Sendable (String) -> Void) async throws -> String {
+    /// The command bar's "Let me DO stuff for you" spine — computer use AND browser use (the mode
+    /// is just a word in the prompt the caller builds, NOT a flag here). Runs a raw `codex exec`
+    /// with the prompt passed as ARGV and the exact flag set verified to make Codex's computer/
+    /// browser use work via the CLI: `--dangerously-bypass-approvals-and-sandbox -m gpt-5.5
+    /// -c model_reasoning_effort="medium" --skip-git-repo-check`, NO `--json` (human-readable
+    /// output, not JSONL). Each output LINE is pumped to `onLine` AS it arrives, so the Xcode
+    /// console shows codex's play-by-play live. Reuses the sanitized-env / PATH / watchdog plumbing;
+    /// the binary comes from the same discovery (`~/.local/bin/codex` first). The user's ~/.codex
+    /// config + MCP servers load by default (no --ignore-user-config). Returns the full output.
+    /// Computer use is the WIP CLI path.
+    func runAgentCommand(_ prompt: String, timeout: TimeInterval = 1_800,
+                         onLine: @escaping @Sendable (String) -> Void) async throws -> String {
         guard let bin = Self.locateBinary() else { throw CLIError.notAvailable(.notInstalled) }
         let args = ["exec", "--dangerously-bypass-approvals-and-sandbox",
-                    "-m", Model.gpt54mini.rawValue, "--skip-git-repo-check", prompt]
+                    "-m", Model.gpt55.rawValue,
+                    "-c", "model_reasoning_effort=\"medium\"",
+                    "--skip-git-repo-check", prompt]
         let out = try await Self.executeStreaming(binary: bin, args: args, timeout: timeout, onLine: onLine)
         guard out.status == 0 else {
             let detail = out.stderr.isEmpty ? out.stdout : out.stderr
@@ -475,11 +480,24 @@ actor CodexCLI {
                 let proc = Process()
                 proc.executableURL = URL(fileURLWithPath: binary)
                 proc.arguments = args
+                // Computer/browser use drives Codex's bundled GUI helper (SkyComputerUseService),
+                // which codex reaches over an IPC socket living under the per-user $TMPDIR. The
+                // bare HOME/USER env we use for headless codex elsewhere DROPS $TMPDIR (+ the GUI
+                // session/bootstrap vars), so the helper connection hangs at the first call
+                // (`list_apps`). So here we INHERIT the app's full environment — which carries the
+                // real $TMPDIR + session vars, exactly like a Terminal launch — and only overlay a
+                // rich PATH so codex finds the tools it shells out to (node, playwright-cli, the
+                // Codex.app cua_node).
                 let binDir = (binary as NSString).deletingLastPathComponent
-                var env: [String: String] = [:]
-                let current = ProcessInfo.processInfo.environment
-                for key in ["HOME", "USER"] where current[key] != nil { env[key] = current[key] }
-                env["PATH"] = [binDir, "/usr/bin", "/bin", "/usr/sbin", "/sbin"].joined(separator: ":")
+                var env = ProcessInfo.processInfo.environment
+                let home = env["HOME"] ?? NSHomeDirectory()
+                let richPath = [binDir,
+                                "\(home)/.local/bin",
+                                "/opt/homebrew/bin", "/opt/homebrew/sbin",
+                                "/usr/local/bin",
+                                "/Applications/Codex.app/Contents/Resources/cua_node/bin",
+                                "/usr/bin", "/bin", "/usr/sbin", "/sbin"].joined(separator: ":")
+                env["PATH"] = env["PATH"].map { "\(richPath):\($0)" } ?? richPath
                 proc.environment = env
 
                 let outPipe = Pipe(), errPipe = Pipe()

--- a/Sentient OS macOS/Permissions.swift
+++ b/Sentient OS macOS/Permissions.swift
@@ -17,8 +17,151 @@
 
 import Foundation
 import AppKit
+import Security   // SecCode/SecStaticCode → an app's Designated Requirement (the TCC csreq blob)
+import SQLite3    // direct, parameterized write into the user's TCC.db (we already hold Full Disk Access)
 
 enum Permissions {
+
+    // MARK: - Computer use: Automation consent for Codex's helper
+    //
+    // To run computer use we spawn `codex`, so macOS makes *us* (Sentient OS) the TCC-responsible
+    // app for everything it does — and codex talks to its bundled helper (`com.openai.sky.CUAService`,
+    // ~/.codex/computer-use/Codex Computer Use.app) over Apple Events, which is gated by the
+    // Automation grant "Sentient OS → Codex Computer Use". Terminal and Warp already hold it (that's
+    // why a manual run works); a fresh Sentient doesn't, so the first call (`list_apps`) blocks.
+    //
+    // We CANNOT pre-create that grant ourselves: `AEDeterminePermissionToAutomateTarget` returns
+    // procNotFound for this service even while it's running (it exposes no idle Apple Event endpoint),
+    // so there's no prompt to show. The grant is instead created the same way Terminal/Warp got it —
+    // by letting codex drive a REAL computer-use run, which surfaces the one-time consent prompt (now
+    // that we declare NSAppleEventsUsageDescription). The dev Permissions panel runs a tiny benign
+    // probe to trigger exactly that; thereafter every run sails through. See PermissionsView.
+
+    /// Open System Settings → Privacy & Security → Automation (where the grant shows as a toggle
+    /// under "Sentient OS" once it exists).
+    @MainActor
+    static func openAutomationSettings() {
+        let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation")!
+        NSWorkspace.shared.open(url)
+    }
+
+    // MARK: Granting the Automation entry directly (FDA-powered, device- & signer-agnostic)
+
+    /// The Codex Computer Use helper — the Apple Events TARGET we grant ourselves the right to drive.
+    static let computerUseHelperBundleID = "com.openai.sky.CUAService"
+
+    enum GrantError: LocalizedError {
+        case noFDA, helperNotFound, requirement(String), tcc(String)
+        var errorDescription: String? {
+            switch self {
+            case .noFDA:              return "Full Disk Access is required to write the permission."
+            case .helperNotFound:     return "Couldn't find the Codex Computer Use helper app on disk."
+            case .requirement(let m): return "Couldn't read a code-signature requirement (\(m))."
+            case .tcc(let m):         return "Couldn't write the TCC database (\(m))."
+            }
+        }
+    }
+
+    /// Resolve the installed Codex Computer Use helper (any copy — they share one signed identity).
+    static func computerUseHelperURL() -> URL? {
+        if let u = NSWorkspace.shared.urlForApplication(withBundleIdentifier: computerUseHelperBundleID) { return u }
+        let fallback = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".codex/computer-use/Codex Computer Use.app")
+        return FileManager.default.fileExists(atPath: fallback.path) ? fallback : nil
+    }
+
+    /// Grant THIS running app the Automation right to control the Codex Computer Use helper, by
+    /// writing the `kTCCServiceAppleEvents` row straight into the user's TCC database. Both
+    /// code-requirement blobs (ours + the helper's) are generated at runtime from the live signed
+    /// bundles — so it's correct for ANY signer (your Developer-ID release, a dev cert, or an OSS
+    /// self-build) and writes NOTHING device-specific (boot_uuid stays the schema default 'UNUSED').
+    /// Requires Full Disk Access (the write key, which Sentient holds anyway). Idempotent
+    /// (INSERT OR REPLACE), then reloads tccd. Returns a short receipt.
+    @discardableResult
+    static func grantComputerUseAutomation() throws -> String {
+        guard hasFullDiskAccess() else { throw GrantError.noFDA }
+        guard let helper = computerUseHelperURL() else { throw GrantError.helperNotFound }
+
+        let csreq  = try selfRequirementData()              // our DR     → `csreq`
+        let target = try requirementData(forAppAt: helper)  // helper's DR → `indirect_object_code_identity`
+        let bundleID = Bundle.main.bundleIdentifier ?? "jesai.Sentient-OS-macOS"
+
+        let dbPath = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/com.apple.TCC/TCC.db").path
+
+        var db: OpaquePointer?
+        guard sqlite3_open_v2(dbPath, &db, SQLITE_OPEN_READWRITE, nil) == SQLITE_OK else {
+            let m = db.map { String(cString: sqlite3_errmsg($0)) } ?? "open failed (Full Disk Access?)"
+            sqlite3_close(db); throw GrantError.tcc(m)
+        }
+        defer { sqlite3_close(db) }
+
+        // Only the stable core columns; everything else takes its schema default (incl.
+        // boot_uuid='UNUSED' → nothing device-specific). auth_value 2 = allowed, auth_reason 2 = user consent.
+        let sql = """
+        INSERT OR REPLACE INTO access
+          (service, client, client_type, auth_value, auth_reason, auth_version,
+           csreq, indirect_object_identifier_type, indirect_object_identifier, indirect_object_code_identity, flags)
+        VALUES ('kTCCServiceAppleEvents', ?, 0, 2, 2, 1, ?, 0, ?, ?, 0);
+        """
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            throw GrantError.tcc(String(cString: sqlite3_errmsg(db)))
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        let TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)   // SQLite copies the bytes at bind time
+        sqlite3_bind_text(stmt, 1, bundleID, -1, TRANSIENT)
+        _ = csreq.withUnsafeBytes  { sqlite3_bind_blob(stmt, 2, $0.baseAddress, Int32(csreq.count),  TRANSIENT) }
+        sqlite3_bind_text(stmt, 3, computerUseHelperBundleID, -1, TRANSIENT)
+        _ = target.withUnsafeBytes { sqlite3_bind_blob(stmt, 4, $0.baseAddress, Int32(target.count), TRANSIENT) }
+
+        guard sqlite3_step(stmt) == SQLITE_DONE else {
+            throw GrantError.tcc(String(cString: sqlite3_errmsg(db)))
+        }
+
+        reloadTCCD()
+        return "granted \(bundleID) → Codex Computer Use (csreq \(csreq.count)B · target \(target.count)B)"
+    }
+
+    /// Serialize the RUNNING app's Designated Requirement — exactly what TCC stores as `csreq`.
+    private static func selfRequirementData() throws -> Data {
+        var code: SecCode?
+        guard SecCodeCopySelf([], &code) == errSecSuccess, let code else { throw GrantError.requirement("SecCodeCopySelf") }
+        var stat: SecStaticCode?
+        guard SecCodeCopyStaticCode(code, [], &stat) == errSecSuccess, let stat else { throw GrantError.requirement("SecCodeCopyStaticCode") }
+        return try requirementData(of: stat)
+    }
+
+    /// Serialize the Designated Requirement of an app bundle on disk.
+    private static func requirementData(forAppAt url: URL) throws -> Data {
+        var stat: SecStaticCode?
+        guard SecStaticCodeCreateWithPath(url as CFURL, [], &stat) == errSecSuccess, let stat else {
+            throw GrantError.requirement("SecStaticCodeCreateWithPath")
+        }
+        return try requirementData(of: stat)
+    }
+
+    private static func requirementData(of stat: SecStaticCode) throws -> Data {
+        var req: SecRequirement?
+        guard SecCodeCopyDesignatedRequirement(stat, [], &req) == errSecSuccess, let req else {
+            throw GrantError.requirement("SecCodeCopyDesignatedRequirement")
+        }
+        var data: CFData?
+        guard SecRequirementCopyData(req, [], &data) == errSecSuccess, let data else {
+            throw GrantError.requirement("SecRequirementCopyData")
+        }
+        return data as Data
+    }
+
+    /// Reload the per-user TCC daemon so the new row applies immediately (tccd caches on launch).
+    private static func reloadTCCD() {
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: "/usr/bin/killall")
+        p.arguments = ["tccd"]
+        try? p.run()
+        p.waitUntilExit()
+    }
 
     /// Canonical FDA-gated files. We can READ any of these *only* with Full Disk Access. We try
     /// several because any single one may be absent on a given Mac (no Messages history, no Safari

--- a/Sentient OS macOS/Views/DevToolsView.swift
+++ b/Sentient OS macOS/Views/DevToolsView.swift
@@ -104,6 +104,7 @@ struct DevToolsView: View {
     @State private var showIMessagePicker = false
     @State private var showSummaries = false
     @State private var showActionItems = false
+    @State private var showPermissions = false
     @State private var showMore = false
     @State private var fdaGranted = false
     @State private var resetResult: String?
@@ -160,6 +161,7 @@ struct DevToolsView: View {
                         viewActionItemsButton
                     }
                     mcpToggleButton
+                    permissionsButton
                     moreSection
                 }
                 .padding(24)
@@ -170,6 +172,7 @@ struct DevToolsView: View {
         .background(Theme.bg)
         .sheet(isPresented: $showSummaries) { SummariesView() }
         .sheet(isPresented: $showActionItems) { ProactiveItemsView() }
+        .sheet(isPresented: $showPermissions) { PermissionsView() }
         .sheet(isPresented: $showGmailConnect) { GmailConnectSheet() }
         .sheet(isPresented: $showCalendarConnect) { CalendarConnectSheet() }
         .sheet(item: $deviceJob) { job in
@@ -288,6 +291,17 @@ struct DevToolsView: View {
                 .frame(maxWidth: .infinity, minHeight: 40)
         }
         .buttonStyle(.bordered).tint(.orange)
+    }
+
+    /// Opens the PERMISSIONS panel — request the macOS grants that have no toggle until the app
+    /// asks (today: Automation control of Codex's computer-use helper; plus FDA status).
+    private var permissionsButton: some View {
+        Button { showPermissions = true } label: {
+            Label("PERMISSIONS", systemImage: "hand.raised.fill")
+                .font(.caption.weight(.bold)).tracking(2)
+                .frame(maxWidth: .infinity, minHeight: 40)
+        }
+        .buttonStyle(.bordered).tint(.white)
     }
 
     /// Proactive PART 3 — the executor. Opens the PROACTIVE · EXECUTE window listing the real

--- a/Sentient OS macOS/Views/HomeView.swift
+++ b/Sentient OS macOS/Views/HomeView.swift
@@ -213,11 +213,11 @@ struct HomeView: View {
 
     private var bottomDock: some View {
         VStack(spacing: 16) {
-            PromptBar { _, _ in
-                // DEMO: the command bar fires a FIXED Codex computer-use run (regardless of what's
-                // typed or which mode is picked) — open WhatsApp and message Aditya Hemanth a
-                // 2-paragraph summary of Sentient OS. See ForYouModel.fireComputerUseDemo.
-                Task.detached(priority: .utility) { await ForYouModel.fireComputerUseDemo() }
+            PromptBar { text, mode in
+                // The command bar fires the user's OWN typed task through codex — computer use OR
+                // browser use, where the mode is just a word swapped into the prompt. See
+                // ForYouModel.fireCommand / commandPrompt.
+                Task.detached(priority: .utility) { await ForYouModel.fireCommand(text, mode: mode) }
             }
             HStack(spacing: 8) {
                 Image(systemName: "shield").font(.system(size: 11)).foregroundStyle(Theme.Ink.label)
@@ -392,34 +392,47 @@ final class ForYouModel {
         }
     }
 
-    /// DEMO — the command bar's send button: regardless of what's typed (or the mode), fire a
-    /// Codex COMPUTER-USE run that first READS the user's Sentient OS knowledge base for context,
-    /// then opens WhatsApp and sends Aditya Hemanth a summary of Sentient OS it composes from that
-    /// knowledge base. (Computer use is the WIP CLI path — see `CodexCLI.runComputerUse`.) → `Log()`.
-    nonisolated static func fireComputerUseDemo() async {
-        let kbPath = "/Users/jesaitarun/Sentient OS - Knowledge Base"
-        let prompt = """
-        First, read the user's Sentient OS knowledge base to learn what Sentient OS is. Read the markdown files in "\(kbPath)" — especially "README.md" and "Sentient OS/Product & Vision/Sentient OS - What It Is.md" (the canonical, current product description).
-
-        Then, using computer use, open WhatsApp, go to Aditya Hemanth's chat, and send him a great, warm summary of what Sentient OS is — about two short paragraphs, in Jesai's first-person voice (enthusiastic, with a casual ":)"). Lead with Proactive Intelligence (Sentient *does things for you* — drafts the reply you forgot, registers you for things, runs tasks via browser use and computer use), and mention the private knowledge base offered to all your AIs as the foundation it stands on. Compose the message yourself from the knowledge base — do not ask for confirmation, just send it.
-        """
-        Log("──────── 🖥️ COMPUTER USE · WhatsApp → Aditya Hemanth ────────")
-        Log("CU: launching codex exec (gpt-5.5 · computer use · bypass sandbox)…")
-        Log("CU: prompt ↓\n\(prompt)")
+    /// The command bar's send button — fire the user's OWN typed task through codex, picking the
+    /// agent channel by the toggle. Computer use vs browser use is ONLY a word in the prompt
+    /// ("Using <mode.promptPhrase>, …"); both run the same `codex exec` (gpt-5.5, bypass sandbox)
+    /// via `CodexCLI.runAgentCommand`, which streams its play-by-play to the console. → `Log()`.
+    /// (Computer use is the WIP CLI path.)
+    nonisolated static func fireCommand(_ text: String, mode: AgentMode) async {
+        // Computer use spawns codex, which drives Codex's helper over an Apple Event macOS attributes
+        // to US — so the FIRST computer-use run surfaces a one-time "Sentient OS wants to control
+        // Codex Computer Use" consent prompt (Terminal/Warp already hold this grant). Just run it;
+        // codex raises the prompt itself. Approve it once via the command bar or DEV TOOLS →
+        // PERMISSIONS and every later run sails through.
+        let prompt = commandPrompt(task: text, mode: mode)
+        Log("──────── 🤖 \(mode.label.uppercased()) · command bar ────────")
+        Log("CMD: launching codex exec (gpt-5.5 · \(mode.promptPhrase) · bypass sandbox)…")
+        Log("CMD: prompt ↓\n\(prompt)")
         Log("──────────────── live codex output ↓ ────────────────")
         let started = Date()
         do {
-            let output = try await CodexCLI.shared.runComputerUse(prompt) { line in
-                Log("CU │ \(line)")     // streams each codex line to the Xcode console live
+            let output = try await CodexCLI.shared.runAgentCommand(prompt) { line in
+                Log("CMD │ \(line)")     // streams each codex line to the Xcode console live
             }
             let secs = Int(Date().timeIntervalSince(started))
-            Log("──────── 🖥️ COMPUTER USE ✓ DONE in \(secs)s ────────")
-            Log("CU: final → \(output.suffix(1200))")
+            Log("──────── 🤖 \(mode.label.uppercased()) ✓ DONE in \(secs)s ────────")
+            Log("CMD: final → \(output.suffix(1200))")
         } catch {
             let secs = Int(Date().timeIntervalSince(started))
-            Log("──────── 🖥️ COMPUTER USE ✗ FAILED after \(secs)s ────────")
-            Log("CU: \(error)")
+            Log("──────── 🤖 \(mode.label.uppercased()) ✗ FAILED after \(secs)s ────────")
+            Log("CMD: \(error)")
         }
+    }
+
+    /// Build the command-bar prompt, mirroring the verified-working CLI command: the toggle swaps
+    /// `mode.promptPhrase` ("computer use" / "browser use"); the typed task fills the rest; and the
+    /// knowledge-base path (resolved from `~`, never hardcoded) rides along so the agent can ground
+    /// the task in the user's life.
+    nonisolated static func commandPrompt(task: String, mode: AgentMode) -> String {
+        """
+        Using \(mode.promptPhrase), \(task)
+
+        My knowledge base is at '\(VaultGenerator.vaultRoot.path)'.
+        """
     }
 
     /// Send a card flying along `v` (a flick's predicted translation), then reflow the scatter.

--- a/Sentient OS macOS/Views/PermissionsView.swift
+++ b/Sentient OS macOS/Views/PermissionsView.swift
@@ -1,0 +1,126 @@
+//
+//  PermissionsView.swift
+//  Sentient OS macOS
+//
+//  Dev-tools PERMISSIONS panel (a sheet behind DEV TOOLS → PERMISSIONS). A home for the macOS
+//  privacy grants that have NO in-place toggle until the app makes the system ask.
+//
+//  Hero: the Automation grant to drive Codex's computer-use helper (Sentient → com.openai.sky
+//  .CUAService). macOS won't reliably surface a consent prompt for that target, so the button calls
+//  Permissions.grantComputerUseAutomation(), which writes the grant straight into the user's TCC
+//  database using the Full Disk Access Sentient already holds (both code-requirement blobs are
+//  generated at runtime, so it's correct for any signer and device). Full Disk Access status rides along.
+//
+
+import SwiftUI
+
+struct PermissionsView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var cuStatus: String?
+    @State private var fdaGranted = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("PERMISSIONS").font(.caption2.weight(.bold)).tracking(2).foregroundStyle(Theme.faint)
+                Spacer()
+                Button("Done") { dismiss() }.controlSize(.small)
+            }
+            .padding(.horizontal, 18).padding(.vertical, 12)
+
+            ScrollView {
+                VStack(spacing: 16) {
+                    computerUsePane
+                    fdaPane
+                }
+                .padding(24)
+            }
+        }
+        .frame(width: 580, height: 500)
+        .background(Theme.bg)
+        .onAppear { fdaGranted = Permissions.hasFullDiskAccess() }
+    }
+
+    // MARK: Computer Use — the Automation grant for Codex's helper
+
+    private var computerUsePane: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 8) {
+                Image(systemName: "desktopcomputer").foregroundStyle(Theme.accent)
+                Text("Computer Use — control “Codex Computer Use”")
+                    .font(.caption.weight(.semibold)).foregroundStyle(.white)
+                Spacer()
+            }
+
+            Text("Computer use spawns codex, which drives Codex's bundled helper over Apple Events — so Sentient needs the Automation right to control “Codex Computer Use”. macOS won't reliably surface a prompt for it, so (using the Full Disk Access Sentient already holds) this writes the grant straight into the TCC database. Both code-signature blobs are generated from the live apps, so it's correct for any build/signer and writes nothing device-specific. One click → granted.")
+                .font(.caption2).foregroundStyle(Theme.faint)
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack(spacing: 10) {
+                Button(action: grant) {
+                    Label("Grant computer-use control", systemImage: "hand.raised.fill")
+                        .font(.caption.weight(.semibold))
+                }
+                .buttonStyle(.bordered).tint(Theme.accent)
+
+                Button("Open Automation Settings") { Permissions.openAutomationSettings() }
+                    .buttonStyle(.bordered).tint(.white)
+            }
+
+            if let cuStatus {
+                Text(cuStatus)
+                    .font(.system(.caption2, design: .monospaced))
+                    .foregroundStyle(cuStatus.hasPrefix("✓") ? .green : cuStatus.hasPrefix("✗") ? .red : Theme.secondary)
+                    .multilineTextAlignment(.leading).fixedSize(horizontal: false, vertical: true)
+                    .textSelection(.enabled)
+            }
+        }
+        .padding(14).frame(maxWidth: .infinity, alignment: .leading).glassCard()
+    }
+
+    /// Write the Automation grant (Sentient → Codex Computer Use) straight into the user's TCC
+    /// database via Full Disk Access — the device- & signer-agnostic path. Synchronous + fast;
+    /// no codex run, no prompt. After it, a computer-use command works (no relaunch needed).
+    private func grant() {
+        do {
+            let receipt = try Permissions.grantComputerUseAutomation()
+            cuStatus = "✓ \(receipt) — now run a computer-use command."
+        } catch {
+            cuStatus = "✗ \((error as? LocalizedError)?.errorDescription ?? "\(error)")"
+        }
+    }
+
+    // MARK: Full Disk Access (status + deep-link; same flow as the More pane)
+
+    private var fdaPane: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 8) {
+                Image(systemName: fdaGranted ? "checkmark.shield.fill" : "exclamationmark.shield.fill")
+                    .foregroundStyle(fdaGranted ? Theme.verdictColor(.survivor) : .orange)
+                Text("Full Disk Access")
+                    .font(.caption.weight(.semibold)).foregroundStyle(.white)
+                Spacer()
+                Text(fdaGranted ? "GRANTED" : "NEEDED").font(.caption2.weight(.bold))
+                    .foregroundStyle(fdaGranted ? Theme.verdictColor(.survivor) : .orange)
+            }
+            Text("Lets the WhatsApp · iMessage · Apple Notes sources read their protected databases. Changing it needs an app restart.")
+                .font(.caption2).foregroundStyle(Theme.faint)
+                .fixedSize(horizontal: false, vertical: true)
+            HStack(spacing: 10) {
+                Button("Grant Full Disk Access…") { Permissions.openFullDiskAccessSettings() }
+                    .buttonStyle(.bordered).tint(Theme.accent)
+                Button("Restart app") { Permissions.relaunch() }
+                    .buttonStyle(.bordered).tint(.white)
+                Spacer()
+                Button("Re-check") { fdaGranted = Permissions.hasFullDiskAccess() }
+                    .buttonStyle(.borderless).controlSize(.small).tint(Theme.accent)
+            }
+        }
+        .padding(14).frame(maxWidth: .infinity, alignment: .leading).glassCard()
+    }
+}
+
+#Preview("Permissions") {
+    PermissionsView().preferredColorScheme(.dark)
+}

--- a/Sentient OS macOS/Views/PromptBar.swift
+++ b/Sentient OS macOS/Views/PromptBar.swift
@@ -7,9 +7,10 @@
 //  AI-gradient glow (the Analyze Now / GlowButton palette, GlowHalo.stops) hugs a glassy
 //  rounded field:
 //    [ Computer use | Browser use ]  ·  the prompt input (verb "DO" bolded bright)  ·  ◯↑ send
-//  The mode selector defaults to Computer use. `onSend(text, mode)` is the DEMO SEAM — real
-//  execution will hand the text + mode to CodexCLI (computer use → a workspace-write agent;
-//  browser use → a browser-driving agent). Today it just reports the intent.
+//  The mode selector defaults to Computer use. `onSend(text, mode)` is wired LIVE: HomeView builds
+//  "Using <mode.promptPhrase>, <text>.  My knowledge base is at …" and runs it through
+//  CodexCLI.runAgentCommand (codex exec, gpt-5.5, bypass sandbox). Computer vs browser use is ONLY
+//  the word swapped into the prompt — same invocation either way.
 //
 //  Key pieces: PromptBar (the bar) · ModeToggle (the segmented selector) · SendButton ·
 //  PromptGlow (the rounded-rect twin of GlowButton's GlowHalo).
@@ -18,10 +19,13 @@
 import SwiftUI
 
 /// What the agent is allowed to drive when it acts on the user's request.
-enum AgentMode: String, CaseIterable {
+nonisolated enum AgentMode: String, CaseIterable {
     case computer, browser
     var label: String { self == .computer ? "Computer use" : "Browser use" }
     var icon: String { self == .computer ? "desktopcomputer" : "globe" }
+    /// The ONE thing the toggle changes in the command-bar prompt: "Using <promptPhrase>, <task>".
+    /// Both phrases run the same `codex exec` (CodexCLI.runAgentCommand) — the word picks the channel.
+    var promptPhrase: String { self == .computer ? "computer use" : "browser use" }
 }
 
 struct PromptBar: View {


### PR DESCRIPTION
## What
Makes the home **command bar** ("Tell me what you want me to **DO**") actually run the user's typed task through codex, and solves the macOS permission wall that blocked **computer use** when codex is spawned by Sentient (vs. a terminal).

### Command bar
- `PromptBar.onSend(text, mode)` is wired live → `ForYouModel.fireCommand`. Computer vs **browser** use is just the word swapped into the prompt (`mode.promptPhrase`), both run `CodexCLI.runAgentCommand` (codex exec, `gpt-5.5`, `model_reasoning_effort=medium`, `--dangerously-bypass-approvals-and-sandbox`). Replaces the hardcoded "message Aditya" demo.
- The streaming runner now inherits the app's **full environment** (real `$TMPDIR`) + a rich `PATH` — without this, Codex's computer-use helper IPC hangs at `list_apps`.

### The Automation permission (the hard part)
Computer use makes codex drive Codex's bundled helper (`com.openai.sky.CUAService`) over Apple Events. macOS attributes that to **Sentient** (the responsible app), which needs an Automation grant Terminal/Warp already hold — and macOS won't reliably surface a consent prompt for that target.

`Permissions.grantComputerUseAutomation()` writes the `kTCCServiceAppleEvents` row **directly into the user's TCC database**, using the **Full Disk Access Sentient already holds**. Both code-requirement blobs (ours + the helper's) are **generated at runtime** from the live signed bundles via the Security framework — so it's correct for **any signer** (your dev cert, the Developer-ID release, or an OSS self-build) and writes **nothing device-specific**. Idempotent; reloads `tccd`.

Exposed via a new **DEV TOOLS → PERMISSIONS** panel (`PermissionsView`). Also declares `NSAppleEventsUsageDescription`.

## Caveats / status
- Dev-stage: surfaced behind DEV TOOLS for now (onboarding wiring later).
- Direct TCC.db write is an "unsupported" path (works today with FDA; re-check on major macOS bumps). Sanctioned prompt kept as the long-term fallback.
- Verified working on the author's Mac (grant → real computer-use run). **Testing next on a second machine + a notarized release build** (the runtime-generated `csreq` should carry straight to the Developer-ID requirement).

## Not included
`Briefing.swift` has an unrelated in-progress change (demo cards) — deliberately left out of this PR.