### PR TITLE
DEV: Revoke (reset) button for computer-use automation grants

### DIFF
--- a/Sentient OS macOS/Permissions.swift
+++ b/Sentient OS macOS/Permissions.swift
@@ -124,6 +124,39 @@ enum Permissions {
         return "granted \(bundleID) → Codex Computer Use (csreq \(csreq.count)B · target \(target.count)B)"
     }
 
+    /// DEV: revoke this app's Automation grants — delete Sentient's `kTCCServiceAppleEvents` rows
+    /// (incl. the computer-use grant) from the user's TCC database, so the grant flow can be
+    /// re-tested from a clean slate. Requires Full Disk Access; reloads tccd. Returns rows removed.
+    @discardableResult
+    static func revokeAutomationGrants() throws -> Int {
+        guard hasFullDiskAccess() else { throw GrantError.noFDA }
+        let bundleID = Bundle.main.bundleIdentifier ?? "jesai.Sentient-OS-macOS"
+        let dbPath = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/com.apple.TCC/TCC.db").path
+
+        var db: OpaquePointer?
+        guard sqlite3_open_v2(dbPath, &db, SQLITE_OPEN_READWRITE, nil) == SQLITE_OK else {
+            let m = db.map { String(cString: sqlite3_errmsg($0)) } ?? "open failed (Full Disk Access?)"
+            sqlite3_close(db); throw GrantError.tcc(m)
+        }
+        defer { sqlite3_close(db) }
+
+        let sql = "DELETE FROM access WHERE service='kTCCServiceAppleEvents' AND client=?;"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            throw GrantError.tcc(String(cString: sqlite3_errmsg(db)))
+        }
+        defer { sqlite3_finalize(stmt) }
+        let TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        sqlite3_bind_text(stmt, 1, bundleID, -1, TRANSIENT)
+        guard sqlite3_step(stmt) == SQLITE_DONE else {
+            throw GrantError.tcc(String(cString: sqlite3_errmsg(db)))
+        }
+        let removed = Int(sqlite3_changes(db))
+        reloadTCCD()
+        return removed
+    }
+
     /// Serialize the RUNNING app's Designated Requirement — exactly what TCC stores as `csreq`.
     private static func selfRequirementData() throws -> Data {
         var code: SecCode?

--- a/Sentient OS macOS/Views/PermissionsView.swift
+++ b/Sentient OS macOS/Views/PermissionsView.swift
@@ -66,6 +66,14 @@ struct PermissionsView: View {
 
                 Button("Open Automation Settings") { Permissions.openAutomationSettings() }
                     .buttonStyle(.bordered).tint(.white)
+
+                Spacer()
+
+                // Wipe this app's automation entries → clean slate to re-test granting.
+                Button(role: .destructive, action: revoke) {
+                    Label("Revoke (reset)", systemImage: "trash").font(.caption2)
+                }
+                .buttonStyle(.borderless).controlSize(.small)
             }
 
             if let cuStatus {
@@ -86,6 +94,16 @@ struct PermissionsView: View {
         do {
             let receipt = try Permissions.grantComputerUseAutomation()
             cuStatus = "✓ \(receipt) — now run a computer-use command."
+        } catch {
+            cuStatus = "✗ \((error as? LocalizedError)?.errorDescription ?? "\(error)")"
+        }
+    }
+
+    /// Wipe this app's Automation grants (TCC) so the grant flow can be re-tested from scratch.
+    private func revoke() {
+        do {
+            let n = try Permissions.revokeAutomationGrants()
+            cuStatus = "✓ revoked \(n) automation entr\(n == 1 ? "y" : "ies") for this app — re-grant to test again."
         } catch {
             cuStatus = "✗ \((error as? LocalizedError)?.errorDescription ?? "\(error)")"
         }


### PR DESCRIPTION
Adds a destructive **Revoke (reset)** button to DEV TOOLS → PERMISSIONS that deletes this app's `kTCCServiceAppleEvents` rows from the user's TCC database (`Permissions.revokeAutomationGrants()`, symmetric with the grant: FDA + direct delete + tccd reload). Lets us wipe to a clean slate and re-test the grant flow — needed for the notarized-release-build test. `Briefing.swift` (unrelated demo-deck WIP) deliberately excluded.