### PR TITLE
Command bar: live codex stream + STOP button (low effort)

### DIFF
--- a/Sentient OS macOS/CodexCLI.swift
+++ b/Sentient OS macOS/CodexCLI.swift
@@ -231,7 +231,7 @@ actor CodexCLI {
     /// is just a word in the prompt the caller builds, NOT a flag here). Runs a raw `codex exec`
     /// with the prompt passed as ARGV and the exact flag set verified to make Codex's computer/
     /// browser use work via the CLI: `--dangerously-bypass-approvals-and-sandbox -m gpt-5.5
-    /// -c model_reasoning_effort="medium" --skip-git-repo-check`, NO `--json` (human-readable
+    /// -c model_reasoning_effort="low" --skip-git-repo-check`, NO `--json` (human-readable
     /// output, not JSONL). Each output LINE is pumped to `onLine` AS it arrives, so the Xcode
     /// console shows codex's play-by-play live. Reuses the sanitized-env / PATH / watchdog plumbing;
     /// the binary comes from the same discovery (`~/.local/bin/codex` first). The user's ~/.codex
@@ -242,7 +242,7 @@ actor CodexCLI {
         guard let bin = Self.locateBinary() else { throw CLIError.notAvailable(.notInstalled) }
         let args = ["exec", "--dangerously-bypass-approvals-and-sandbox",
                     "-m", Model.gpt55.rawValue,
-                    "-c", "model_reasoning_effort=\"medium\"",
+                    "-c", "model_reasoning_effort=\"low\"",
                     "--skip-git-repo-check", prompt]
         let out = try await Self.executeStreaming(binary: bin, args: args, timeout: timeout, onLine: onLine)
         guard out.status == 0 else {
@@ -468,14 +468,25 @@ actor CodexCLI {
         var text: String { lock.lock(); defer { lock.unlock() }; return s }
     }
 
-    /// Streaming sibling of `execute`: same sanitized env / PATH / watchdog, but it pumps each
-    /// output LINE (stdout and stderr) to `onLine` as it arrives — so the console shows codex's
-    /// computer-use play-by-play live — while also accumulating the full text. No stdin (the
-    /// computer-use prompt rides in argv). Byte-level line splitting so multibyte UTF-8 that
-    /// straddles a read boundary never garbles.
+    /// Thread-safe handle to the running child so the Task-cancellation handler (the STOP button)
+    /// can terminate it. Set once the process has launched.
+    private final class ProcHolder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var proc: Process?
+        func set(_ p: Process) { lock.lock(); proc = p; lock.unlock() }
+        func terminate() { lock.lock(); let p = proc; lock.unlock(); if let p, p.isRunning { p.terminate() } }
+    }
+
+    /// Streaming sibling of `execute`: same env / PATH / watchdog, but it pumps each output LINE
+    /// (stdout and stderr) to `onLine` as it arrives — so the console AND the command bar show
+    /// codex's play-by-play live — while accumulating the full text. No stdin (the prompt rides in
+    /// argv). Byte-level line splitting so multibyte UTF-8 across a read boundary never garbles.
+    /// Honors Task cancellation: cancelling the awaiting Task terminates codex (the STOP button).
     private static func executeStreaming(binary: String, args: [String], timeout: TimeInterval,
                                          onLine: @escaping @Sendable (String) -> Void) async throws -> ExecResult {
-        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<ExecResult, Error>) in
+        let holder = ProcHolder()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (cont: CheckedContinuation<ExecResult, Error>) in
             DispatchQueue.global(qos: .userInitiated).async {
                 let proc = Process()
                 proc.executableURL = URL(fileURLWithPath: binary)
@@ -533,6 +544,7 @@ actor CodexCLI {
                 }
 
                 do { try proc.run() } catch { cont.resume(throwing: CLIError.launchFailed("\(error)")); return }
+                holder.set(proc)        // expose to the cancellation handler (STOP)
 
                 let timedOut = OSAllocatedUnfairLock(initialState: false)
                 let watchdog = DispatchWorkItem { [weak proc] in
@@ -548,6 +560,9 @@ actor CodexCLI {
                 cont.resume(returning: ExecResult(status: proc.terminationStatus,
                                                   stdout: outSink.text, stderr: errSink.text))
             }
+        }
+        } onCancel: {
+            holder.terminate()    // STOP: kill codex → the run resumes with a non-zero exit
         }
     }
 }

--- a/Sentient OS macOS/Views/Briefing.swift
+++ b/Sentient OS macOS/Views/Briefing.swift
@@ -114,37 +114,24 @@ struct Briefing: Identifiable {
 
     static let demo: [Briefing] = [
         Briefing(
-            id: "charles", kind: .deadline,
-            kicker: "Reply · 2 days · Gmail",
-            title: "Charles is waiting on your timeslots.",
-            body: "Daniel introduced you to Charles Ferguson — he sold companies to Microsoft and Oracle, pre-seeded Higgsfield, and won an Oscar. I checked your calendar and drafted your reply.",
+            id: "ewor", kind: .plan,
+            kicker: "Prep · 11 AM today · Researched",
+            title: "Prepare for your call with Daniel, CEO of EWOR.",
+            body: "Somya Gupta nominated you for the EWOR Fellowship — and Daniel Dippold, its founder & CEO, wants 15 minutes today at 11 AM. I researched him and EWOR and pulled together what'll get you ready.",
             letter: """
-            Daniel introduced you to Charles Ferguson for your next EWOR interview — he sold companies to **Microsoft** and **Oracle**, pre-seeded **Higgsfield** (€500M ARR in a year), and won an **Oscar**.
+            Your EWOR selection interview is today — 11:00–11:15 AM PDT, on Zoom (it moved up from 10:45). Somya Gupta nominated you, and you're meeting Daniel Dippold, EWOR's founder & CEO. He called it casual, but it's 15 minutes and it's selective — so walk in sharp.
 
-            He cc'd his assistant Emily to schedule and asked for any materials — a deck or a memo. So I checked your calendar for **Monday and Tuesday**, found your open windows, and wrote your reply: a few timeslots and a memo offer.
+            ✦ **Know your room.** Daniel is a mathematician-turned-founder: raised **$100M** in his twenties, angel in **7 unicorns**, and built three organizations still thriving — EWOR, New Now Group, Sigma Squared. He rewards technical depth and outlier conviction — lead with the on-device moat and your all-in, drop-out resolve.
+
+            ✦ **Speak EWOR's language.** They back the **top 0.1%** of founders building transformative tech — up to **€500K** immediate, plus weekly 1:1 coaching from unicorn founders (Adjust, ProGlove, SumUp). No standard playbooks; they tailor to each founder. Frame Sentient as exactly that non-linear, outlier bet.
+
+            ✦ **Your 15-minute arc.** Open with the Reddit moment — **2,500+ waitlist signups in 24 hours, $0 spent**. Then the wedge: consumer free-forever as the loved foothold, the enterprise per-employee intelligence layer as the business. Close on why now, and why you.
+
+            Somya put their name on you — make it land. — **your Sentient**
             """,
-            draft: Briefing.charlesReply,
-            draftLabel: "Draft reply · Gmail",
-            detailLabel: "read the draft",
-            offer: "Should I send it for you?",
-            workLog: ["→ reading Charles's note",
-                      "→ checking Monday & Tuesday for open slots",
-                      "→ opening Gmail",
-                      "→ composing your reply…",
-                      "✓ sent"],
-            doneTitle: "Sent to Charles.",
-            doneBody: "Emily has your availability — and materials are on the way.",
-            codexPrompt: """
-            You are running fully headless and autonomous, with the user's explicit prior approval to act on their behalf for THIS task — they clicked "send it for me." Do NOT ask for confirmation or approval, do NOT pause to verify, and do NOT merely draft. Actually SEND. If any tool surfaces a confirmation or approval step, treat it as already granted by the user and proceed.
-
-            Use the Gmail MCP to open the thread titled "EWOR | Introducing Jesai & Charles". In that thread, find the message from Charles Ferguson (chf@cferguson.com) whose body STARTS WITH "Thank you, Daniel, and moving you to bcc." REPLY-ALL to THAT message — include every recipient on it (all To and all Cc: Charles, his assistant Emily, and the EWOR "selection" address) so everyone Charles addressed receives the reply. Reply to CHARLES'S message specifically (NOT Daniel's earlier intro) so the reply respects that Charles moved Daniel to bcc — do not add Daniel. Send EXACTLY the message below, verbatim — do not change, rephrase, summarize, or add anything:
-
-            \(Briefing.charlesReply)
-
-            Send this reply-all now via the Gmail MCP — the user has already approved it. Do not ask, do not draft-and-wait; complete the send, then report exactly who it went to (the full To and Cc list).
-
-            FORMATTING: send it as an HTML email (set the send tool's content_type to "text/html"). Put each paragraph in its own <p>…</p> tag; render the two "I can make any time…" lines as a <ul><li>…</li></ul> list; write the sign-off as "Looking forward to it,<br>Jesai". Keep every word — including ":)" and "4:30 PM" — exactly as written. Do NOT send as text/plain and do NOT insert any manual line breaks inside a paragraph.
-            """),
+            detailLabel: "read the prep doc",
+            offer: nil,
+            doneTitle: "", doneBody: ""),
 
         Briefing(
             id: "fareed", kind: .meeting,
@@ -274,26 +261,41 @@ struct Briefing: Identifiable {
     // `slots(count:)` only define up to 6). Each is self-contained (no shared-constant refs).
     // Parked = NOT compiled, so these can quietly go stale — re-read before relying on one.
 
-    /* ── EWOR · "Prepare for your call with Daniel, CEO of EWOR." (researched prep card, orchid) ──
+    /* ── Charles · "Charles is waiting on your timeslots." — LIVE Gmail reply-all into the real
+       "EWOR | Introducing Jesai & Charles" thread. Uses the `charlesReply` constant above, and the
+       `charles` id is still armed in HomeView's run() seam, so swapping it back in just works. ──
         Briefing(
-            id: "ewor", kind: .plan,
-            kicker: "Prep · 11 AM today · Researched",
-            title: "Prepare for your call with Daniel, CEO of EWOR.",
-            body: "Somya Gupta nominated you for the EWOR Fellowship — and Daniel Dippold, its founder & CEO, wants 15 minutes today at 11 AM. I researched him and EWOR and pulled together what'll get you ready.",
+            id: "charles", kind: .deadline,
+            kicker: "Reply · 2 days · Gmail",
+            title: "Charles is waiting on your timeslots.",
+            body: "Daniel introduced you to Charles Ferguson — he sold companies to Microsoft and Oracle, pre-seeded Higgsfield, and won an Oscar. I checked your calendar and drafted your reply.",
             letter: """
-            Your EWOR selection interview is today — 11:00–11:15 AM PDT, on Zoom (it moved up from 10:45). Somya Gupta nominated you, and you're meeting Daniel Dippold, EWOR's founder & CEO. He called it casual, but it's 15 minutes and it's selective — so walk in sharp.
+            Daniel introduced you to Charles Ferguson for your next EWOR interview — he sold companies to **Microsoft** and **Oracle**, pre-seeded **Higgsfield** (€500M ARR in a year), and won an **Oscar**.
 
-            ✦ **Know your room.** Daniel is a mathematician-turned-founder: raised **$100M** in his twenties, angel in **7 unicorns**, and built three organizations still thriving — EWOR, New Now Group, Sigma Squared. He rewards technical depth and outlier conviction — lead with the on-device moat and your all-in, drop-out resolve.
-
-            ✦ **Speak EWOR's language.** They back the **top 0.1%** of founders building transformative tech — up to **€500K** immediate, plus weekly 1:1 coaching from unicorn founders (Adjust, ProGlove, SumUp). No standard playbooks; they tailor to each founder. Frame Sentient as exactly that non-linear, outlier bet.
-
-            ✦ **Your 15-minute arc.** Open with the Reddit moment — **2,500+ waitlist signups in 24 hours, $0 spent**. Then the wedge: consumer free-forever as the loved foothold, the enterprise per-employee intelligence layer as the business. Close on why now, and why you.
-
-            Somya put their name on you — make it land. — **your Sentient**
+            He cc'd his assistant Emily to schedule and asked for any materials — a deck or a memo. So I checked your calendar for **Monday and Tuesday**, found your open windows, and wrote your reply: a few timeslots and a memo offer.
             """,
-            detailLabel: "read the prep doc",
-            offer: nil,
-            doneTitle: "", doneBody: ""),
+            draft: Briefing.charlesReply,
+            draftLabel: "Draft reply · Gmail",
+            detailLabel: "read the draft",
+            offer: "Should I send it for you?",
+            workLog: ["→ reading Charles's note",
+                      "→ checking Monday & Tuesday for open slots",
+                      "→ opening Gmail",
+                      "→ composing your reply…",
+                      "✓ sent"],
+            doneTitle: "Sent to Charles.",
+            doneBody: "Emily has your availability — and materials are on the way.",
+            codexPrompt: """
+            You are running fully headless and autonomous, with the user's explicit prior approval to act on their behalf for THIS task — they clicked "send it for me." Do NOT ask for confirmation or approval, do NOT pause to verify, and do NOT merely draft. Actually SEND. If any tool surfaces a confirmation or approval step, treat it as already granted by the user and proceed.
+
+            Use the Gmail MCP to open the thread titled "EWOR | Introducing Jesai & Charles". In that thread, find the message from Charles Ferguson (chf@cferguson.com) whose body STARTS WITH "Thank you, Daniel, and moving you to bcc." REPLY-ALL to THAT message — include every recipient on it (all To and all Cc: Charles, his assistant Emily, and the EWOR "selection" address) so everyone Charles addressed receives the reply. Reply to CHARLES'S message specifically (NOT Daniel's earlier intro) so the reply respects that Charles moved Daniel to bcc — do not add Daniel. Send EXACTLY the message below, verbatim — do not change, rephrase, summarize, or add anything:
+
+            \(Briefing.charlesReply)
+
+            Send this reply-all now via the Gmail MCP — the user has already approved it. Do not ask, do not draft-and-wait; complete the send, then report exactly who it went to (the full To and Cc list).
+
+            FORMATTING: send it as an HTML email (set the send tool's content_type to "text/html"). Put each paragraph in its own <p>…</p> tag; render the two "I can make any time…" lines as a <ul><li>…</li></ul> list; write the sign-off as "Looking forward to it,<br>Jesai". Keep every word — including ":)" and "4:30 PM" — exactly as written. Do NOT send as text/plain and do NOT insert any manual line breaks inside a paragraph.
+            """),
     */
 
     /* ── ZFellows · "ZFellows closes in 8 days." (browser-agent registration card, ember) ──

--- a/Sentient OS macOS/Views/HomeView.swift
+++ b/Sentient OS macOS/Views/HomeView.swift
@@ -36,6 +36,7 @@ struct HomeView: View {
     @Environment(\.openWindow) private var openWindow
 
     @State private var model = ForYouModel()
+    @State private var commandRun = CommandRunModel()   // the command bar's live run (stream + STOP)
     // The letter layer is ALWAYS mounted and driven purely by opacity/scale from plain
     // @State — view INSERTION (`if let` overlays) can miss a redraw on macOS hidden-titlebar
     // windows (the "appears only after a resize" bug); opacity changes cannot.
@@ -213,12 +214,10 @@ struct HomeView: View {
 
     private var bottomDock: some View {
         VStack(spacing: 16) {
-            PromptBar { text, mode in
-                // The command bar fires the user's OWN typed task through codex — computer use OR
-                // browser use, where the mode is just a word swapped into the prompt. See
-                // ForYouModel.fireCommand / commandPrompt.
-                Task.detached(priority: .utility) { await ForYouModel.fireCommand(text, mode: mode) }
-            }
+            PromptBar(onSend: { text, mode in commandRun.start(text, mode: mode) },
+                      onStop: { commandRun.stop() },
+                      isRunning: commandRun.isRunning,
+                      statusLine: commandRun.statusLine)
             HStack(spacing: 8) {
                 Image(systemName: "shield").font(.system(size: 11)).foregroundStyle(Theme.Ink.label)
                 Text("Private by design. Your files never leave this Mac.")
@@ -392,49 +391,6 @@ final class ForYouModel {
         }
     }
 
-    /// The command bar's send button — fire the user's OWN typed task through codex, picking the
-    /// agent channel by the toggle. Computer use vs browser use is ONLY a word in the prompt
-    /// ("Using <mode.promptPhrase>, …"); both run the same `codex exec` (gpt-5.5, bypass sandbox)
-    /// via `CodexCLI.runAgentCommand`, which streams its play-by-play to the console. → `Log()`.
-    /// (Computer use is the WIP CLI path.)
-    nonisolated static func fireCommand(_ text: String, mode: AgentMode) async {
-        // Computer use spawns codex, which drives Codex's helper over an Apple Event macOS attributes
-        // to US — so the FIRST computer-use run surfaces a one-time "Sentient OS wants to control
-        // Codex Computer Use" consent prompt (Terminal/Warp already hold this grant). Just run it;
-        // codex raises the prompt itself. Approve it once via the command bar or DEV TOOLS →
-        // PERMISSIONS and every later run sails through.
-        let prompt = commandPrompt(task: text, mode: mode)
-        Log("──────── 🤖 \(mode.label.uppercased()) · command bar ────────")
-        Log("CMD: launching codex exec (gpt-5.5 · \(mode.promptPhrase) · bypass sandbox)…")
-        Log("CMD: prompt ↓\n\(prompt)")
-        Log("──────────────── live codex output ↓ ────────────────")
-        let started = Date()
-        do {
-            let output = try await CodexCLI.shared.runAgentCommand(prompt) { line in
-                Log("CMD │ \(line)")     // streams each codex line to the Xcode console live
-            }
-            let secs = Int(Date().timeIntervalSince(started))
-            Log("──────── 🤖 \(mode.label.uppercased()) ✓ DONE in \(secs)s ────────")
-            Log("CMD: final → \(output.suffix(1200))")
-        } catch {
-            let secs = Int(Date().timeIntervalSince(started))
-            Log("──────── 🤖 \(mode.label.uppercased()) ✗ FAILED after \(secs)s ────────")
-            Log("CMD: \(error)")
-        }
-    }
-
-    /// Build the command-bar prompt, mirroring the verified-working CLI command: the toggle swaps
-    /// `mode.promptPhrase` ("computer use" / "browser use"); the typed task fills the rest; and the
-    /// knowledge-base path (resolved from `~`, never hardcoded) rides along so the agent can ground
-    /// the task in the user's life.
-    nonisolated static func commandPrompt(task: String, mode: AgentMode) -> String {
-        """
-        Using \(mode.promptPhrase), \(task)
-
-        My knowledge base is at '\(VaultGenerator.vaultRoot.path)'.
-        """
-    }
-
     /// Send a card flying along `v` (a flick's predicted translation), then reflow the scatter.
     func dismiss(_ id: String, toward v: CGSize) {
         guard entry(id) != nil else { return }
@@ -449,6 +405,97 @@ final class ForYouModel {
                 entries.removeAll { $0.id == id }
             }
         }
+    }
+}
+
+// MARK: - The command bar's run model (live codex stream + STOP)
+
+/// Drives the home command bar: runs the user's typed task through codex (computer / browser use —
+/// the mode is just a word in the prompt), streams the latest output line(s) into `statusLine` for
+/// the bar to show, and `stop()` cancels the run (terminating codex via CodexCLI's cancellation).
+/// One run at a time. Everything also goes to `Log()` (tail /tmp/sentient-dev.log).
+@MainActor @Observable
+final class CommandRunModel {
+    var isRunning = false
+    var statusLine = ""               // the latest 1–2 codex lines, shown in the bar while running
+    private var recent: [String] = []
+    private var task: Task<Void, Never>?
+
+    func start(_ text: String, mode: AgentMode) {
+        guard !isRunning else { return }
+        let task0 = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !task0.isEmpty else { return }
+        isRunning = true
+        recent = []
+        statusLine = "Starting \(mode.promptPhrase)…"
+        let prompt = Self.commandPrompt(task: task0, mode: mode)
+        Log("──────── 🤖 \(mode.label.uppercased()) · command bar ────────")
+        Log("CMD: launching codex exec (gpt-5.5 · \(mode.promptPhrase) · bypass sandbox)…")
+        Log("CMD: prompt ↓\n\(prompt)")
+        Log("──────────────── live codex output ↓ ────────────────")
+        let started = Date()
+        task = Task { [weak self] in
+            do {
+                let out = try await CodexCLI.shared.runAgentCommand(prompt) { line in
+                    Log("CMD │ \(line)")
+                    Task { @MainActor in self?.push(line) }
+                }
+                let secs = Int(Date().timeIntervalSince(started))
+                Log("──────── 🤖 ✓ DONE in \(secs)s ────────")
+                Log("CMD: final → \(out.suffix(1200))")
+                self?.finish(success: true, line: "✓ done")
+            } catch {
+                let secs = Int(Date().timeIntervalSince(started))
+                if Task.isCancelled {
+                    Log("──────── 🤖 ■ STOPPED after \(secs)s ────────")
+                    self?.finish(success: false, line: "■ stopped")
+                } else {
+                    Log("──────── 🤖 ✗ FAILED after \(secs)s ────────")
+                    Log("CMD: \(error)")
+                    self?.finish(success: false, line: "✗ \(Self.short(error))")
+                }
+            }
+        }
+    }
+
+    func stop() {
+        guard isRunning else { return }
+        statusLine = "Stopping…"
+        task?.cancel()
+    }
+
+    private func push(_ line: String) {
+        guard isRunning else { return }
+        let t = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !t.isEmpty else { return }
+        recent.append(t)
+        if recent.count > 2 { recent.removeFirst() }
+        statusLine = recent.joined(separator: "\n")
+    }
+
+    private func finish(success: Bool, line: String) {
+        statusLine = line
+        isRunning = false
+        task = nil
+        Task { [weak self] in            // let the final status linger a moment, then clear the bar
+            try? await Task.sleep(for: .seconds(success ? 2.5 : 4.5))
+            if let self, !self.isRunning { self.statusLine = "" }
+        }
+    }
+
+    private static func short(_ error: Error) -> String {
+        String(((error as? LocalizedError)?.errorDescription ?? "\(error)").prefix(160))
+    }
+
+    /// Build the command-bar prompt, mirroring the verified-working CLI command: the toggle swaps
+    /// `mode.promptPhrase` ("computer use" / "browser use"); the typed task fills the rest; and the
+    /// knowledge-base path (resolved from `~`, never hardcoded) rides along as grounding context.
+    nonisolated static func commandPrompt(task: String, mode: AgentMode) -> String {
+        """
+        Using \(mode.promptPhrase), \(task)
+
+        My knowledge base is at '\(VaultGenerator.vaultRoot.path)'.
+        """
     }
 }
 

--- a/Sentient OS macOS/Views/PromptBar.swift
+++ b/Sentient OS macOS/Views/PromptBar.swift
@@ -29,8 +29,13 @@ nonisolated enum AgentMode: String, CaseIterable {
 }
 
 struct PromptBar: View {
-    /// DEMO SEAM — fired when the user sends. Real execution routes (text, mode) → CodexCLI.
+    /// Fired when the user sends — routes (text, mode) → the command run (CommandRunModel.start).
     var onSend: (String, AgentMode) -> Void = { _, _ in }
+    /// Fired when the user taps STOP during a live run.
+    var onStop: () -> Void = {}
+    /// While running, the bar shows codex's live `statusLine` and the send button becomes STOP.
+    var isRunning: Bool = false
+    var statusLine: String = ""
 
     @State private var text = ""
     @State private var mode: AgentMode = .computer
@@ -40,31 +45,53 @@ struct PromptBar: View {
 
     var body: some View {
         HStack(alignment: .center, spacing: 12) {
-            ModeToggle(mode: $mode)
-
-            ZStack(alignment: .leading) {
-                if trimmed.isEmpty { placeholder }
-                TextField("", text: $text, axis: .vertical)
-                    .textFieldStyle(.plain)
-                    .font(.system(size: 14))
-                    .foregroundStyle(.white)
-                    .tint(Theme.accent)
-                    .lineLimit(1...4)
-                    .focused($focused)
-                    .onSubmit(send)
+            if isRunning {
+                runningArea
+                StopButton(action: onStop)
+            } else {
+                ModeToggle(mode: $mode)
+                inputArea
+                SendButton(active: !trimmed.isEmpty, action: send)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .contentShape(Rectangle())
-            .onTapGesture { focused = true }
-
-            SendButton(active: !trimmed.isEmpty, action: send)
         }
         .padding(.leading, 14)
         .padding(.trailing, 11)
         .padding(.vertical, 11)
         .background(field)
-        .background(PromptGlow(intensity: focused ? 0.55 : 0.32))
+        .background(PromptGlow(intensity: isRunning ? 0.7 : (focused ? 0.55 : 0.32)))
         .animation(.easeInOut(duration: 0.4), value: focused)
+        .animation(.easeInOut(duration: 0.35), value: isRunning)
+    }
+
+    /// Idle: the editable input (bright "DO" placeholder + the text field).
+    private var inputArea: some View {
+        ZStack(alignment: .leading) {
+            if trimmed.isEmpty { placeholder }
+            TextField("", text: $text, axis: .vertical)
+                .textFieldStyle(.plain)
+                .font(.system(size: 14))
+                .foregroundStyle(.white)
+                .tint(Theme.accent)
+                .lineLimit(1...4)
+                .focused($focused)
+                .onSubmit(send)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(Rectangle())
+        .onTapGesture { focused = true }
+    }
+
+    /// Running: the living orb + codex's latest line(s) — monospace, dimmed, ≤2 lines.
+    private var runningArea: some View {
+        HStack(spacing: 10) {
+            OrbMark(size: 16)
+            Text(statusLine.isEmpty ? "Working…" : statusLine)
+                .font(.system(size: 12.5, design: .monospaced))
+                .foregroundStyle(.white.opacity(0.72))
+                .lineLimit(2).truncationMode(.tail)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .animation(.easeInOut(duration: 0.2), value: statusLine)
+        }
     }
 
     private func send() {
@@ -154,6 +181,26 @@ private struct SendButton: View {
         .shadow(color: Theme.accent.opacity(active ? 0.55 : 0), radius: 11)
         .disabled(!active)
         .animation(.easeInOut(duration: 0.25), value: active)
+    }
+}
+
+// MARK: - The stop button (replaces send while a run is live)
+
+private struct StopButton: View {
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: "stop.fill")
+                .font(.system(size: 12, weight: .bold))
+                .foregroundStyle(.white)
+                .frame(width: 32, height: 32)
+                .background(Circle().fill(Color.white.opacity(0.16)))
+                .overlay(Circle().strokeBorder(.white.opacity(0.22), lineWidth: 1))
+        }
+        .buttonStyle(PressScaleStyle())
+        .shadow(color: Theme.accent.opacity(0.40), radius: 9)
+        .help("Stop")
     }
 }
 


### PR DESCRIPTION
Streams codex's live output into the command bar (orb + latest 1–2 lines) and swaps the send button for a **STOP** that cancels the run (real `Task` cancellation → `proc.terminate()`). Computer/browser use now run gpt-5.5 at `model_reasoning_effort=low`. Critically, this is the **only way to see codex's output on a Release build** (the dev log is DEBUG-only) — so we can finally diagnose the release-build computer-use failure. Also bundles an unrelated demo-deck update (`Briefing.swift`, included intentionally).