### PR TITLE
Command-bar prompt: forbid AppleScript, force computer/browser use

### DIFF
--- a/Sentient OS macOS/Views/HomeView.swift
+++ b/Sentient OS macOS/Views/HomeView.swift
@@ -494,6 +494,8 @@ final class CommandRunModel {
         """
         Using \(mode.promptPhrase), \(task)
 
+        NEVER use AppleScript (or osascript, shell automation, etc.) to do your work — use your \(mode.promptPhrase) to do the task.
+
         My knowledge base is at '\(VaultGenerator.vaultRoot.path)'.
         """
     }


### PR DESCRIPTION
One-line addition to `commandPrompt`: tells codex to NEVER use AppleScript / osascript / shell automation and to do the task via its actual computer-/browser-use channel instead.