### PR TITLE
Overnight scheduler: wake → process → sleep, lid shut

### DIFF
--- a/Sentient OS macOS/AppState.swift
+++ b/Sentient OS macOS/AppState.swift
@@ -24,6 +24,9 @@ final class AppState {
 
     var status: Status = .idle
 
+    /// The in-app scheduler — only ever runs while the app is alive (DEV TOOLS "Scheduled run").
+    let scheduler = OvernightScheduler()
+
     private static let onboardingKey = "hasCompletedOnboarding"
     var hasCompletedOnboarding: Bool {
         didSet { UserDefaults.standard.set(hasCompletedOnboarding, forKey: Self.onboardingKey) }
@@ -31,5 +34,6 @@ final class AppState {
 
     init() {
         self.hasCompletedOnboarding = UserDefaults.standard.bool(forKey: Self.onboardingKey)
+        scheduler.reevaluate()   // arm if the dev setting was left on; otherwise a no-op
     }
 }

--- a/Sentient OS macOS/Scheduling/OvernightScheduler.swift
+++ b/Sentient OS macOS/Scheduling/OvernightScheduler.swift
@@ -1,0 +1,168 @@
+//
+//  OvernightScheduler.swift
+//  Sentient OS macOS  ·  Scheduling/
+//
+//  The in-app scheduler. Lives inside the running app (owned by AppState), so scheduled processing
+//  only ever happens while Sentient is open — force-quit it and nothing runs (and the root helper
+//  cancels the pending wake when the app's connection drops, so the Mac won't even wake).
+//
+//  Driven today by the DEV TOOLS "Scheduled run" control (a time + on/off — for testing); the same
+//  engine will back the production auto-3am trigger. When enabled it: arms a wake for the chosen
+//  time → waits (the Task freezes with the Mac, thaws on the scheduled wake) → on wake keeps the Mac
+//  awake (root) + heartbeats → runs IterativeRun `.auto` (initial-if-fresh, iterative-if-caught-up,
+//  PER source) over the connectors selected in the app → releases → the Mac sleeps → re-arms for the
+//  next day. Connector detection goes through the SAME `SourceSelection.current(...)` the dev UI and
+//  Analyze Now use. Everything lands in ~/Library/Logs/SentientOS/scheduler.log.
+//
+
+import Foundation
+
+@MainActor
+@Observable
+final class OvernightScheduler {
+
+    /// One-line status for the dev UI ("off" / "armed for 4:00 PM" / "running…").
+    var statusLine = "off"
+
+    static let enabledKey = "dbg.scheduler.enabled"
+    static let minutesKey = "dbg.scheduler.minutes"   // minutes since midnight
+    static let defaultMinutes = 16 * 60               // 4:00 PM — shared by the UI default and the reader
+
+    /// The configured time-of-day in minutes since midnight (shared default so the UI and the loop agree).
+    static var configuredMinutes: Int { (UserDefaults.standard.object(forKey: minutesKey) as? Int) ?? defaultMinutes }
+
+    private var loopTask: Task<Void, Never>?
+    private var everArmed = false
+
+    /// Re-read the dev settings and (re)start or stop. Call on launch and on any settings change.
+    func reevaluate() {
+        if UserDefaults.standard.bool(forKey: Self.enabledKey) { start() } else { stop() }
+    }
+
+    private func start() {
+        loopTask?.cancel()
+        loopTask = Task { await loop() }
+    }
+
+    private func stop() {
+        loopTask?.cancel(); loopTask = nil
+        statusLine = "off"
+        if everArmed {   // only reach out to the helper if we actually scheduled something
+            everArmed = false
+            Task { _ = await WakeHelperClient.shared.cancelWake() }
+        }
+    }
+
+    private func loop() async {
+        let log = SchedulerLog()
+        while !Task.isCancelled {
+            let minutes = Self.configuredMinutes
+            let target = Self.nextOccurrence(minutesSinceMidnight: minutes)
+            statusLine = "armed for \(Self.clock(target))"
+            log.line("arming wake for \(target)")
+            everArmed = true
+            _ = await WakeHelperClient.shared.armWake(at: target)
+
+            // Wait for the target. Re-arm every ~5 min while awake (idempotent — keeps the helper's
+            // record fresh so its force-quit auto-cancel always knows what to cancel).
+            while Date() < target && !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(300))
+                if !Task.isCancelled && Date() < target { _ = await WakeHelperClient.shared.armWake(at: target) }
+            }
+            if Task.isCancelled { break }
+
+            statusLine = "running…"
+            await runProcessing(log: log)
+            statusLine = "armed (next \(Self.clock(Self.nextOccurrence(minutesSinceMidnight: minutes))))"
+        }
+    }
+
+    /// The actual run: keep awake → process the selected connectors with `.auto` → release.
+    private func runProcessing(log: SchedulerLog) async {
+        log.line("WOKE at \(Date()) — beginning the run.")
+
+        // DETECT — identical to the dev UI / Analyze Now (the shared SourceSelection reader).
+        let fda = Permissions.hasFullDiskAccess()
+        let sources = SourceSelection.current(customRoots: [], fdaGranted: fda)
+        let connectors = RunSource.connectors(from: sources)
+        let runGmail = ud("dbg.gmail.connected") && ud("dbg.run.gmail")
+        let runCalendar = ud("dbg.calendar.connected") && ud("dbg.run.calendar")
+        log.line("FDA=\(fda) · detected: \(sources.isEmpty ? "none" : sources.map(\.label).joined(separator: ", ")) · gmail=\(runGmail) calendar=\(runCalendar)")
+        guard !connectors.isEmpty || runGmail || runCalendar else { log.line("nothing enabled — skipping run."); return }
+        let modelPath = ModelLocator.resolve()
+        if !connectors.isEmpty && modelPath == nil { log.line("model not found — skipping run."); return }
+
+        let began = await WakeHelperClient.shared.beginAwake(timeout: 1800)
+        log.line("beginAwake (disablesleep 1): \(began ? "OK" : "FAILED")")
+        let heart = Task {
+            while !Task.isCancelled { _ = await WakeHelperClient.shared.heartbeat(); try? await Task.sleep(for: .seconds(60)) }
+        }
+
+        if !connectors.isEmpty, let modelPath {
+            log.line("IterativeRun .auto over \(connectors.count) connector(s)…")
+            let throttle = LogThrottle()
+            let p = await IterativeRun(modelPath: modelPath).run(connectors, mode: .auto) { pr in
+                throttle.maybe { log.line("  … \(pr.done)/\(pr.total)  kept=\(pr.survivors) junk=\(pr.junk) failed=\(pr.failed)") }
+            }
+            log.line("device DONE: \(p.survivors) kept · \(p.junk) junk · \(p.failed) failed of \(p.total)")
+        }
+        if runGmail    { await cloudLeg("Gmail",    log: log) { try await GmailConnect.runIterative    { _ in } } }
+        if runCalendar { await cloudLeg("Calendar", log: log) { try await CalendarConnect.runIterative { _ in } } }
+
+        heart.cancel()
+        let ended = await WakeHelperClient.shared.endAwake()
+        log.line("endAwake (disablesleep 0): \(ended ? "OK" : "FAILED") — run complete, Mac will sleep.")
+    }
+
+    private func cloudLeg(_ name: String, log: SchedulerLog, _ body: () async throws -> Void) async {
+        log.line("\(name) leg…")
+        do { try await body(); log.line("\(name) DONE") }
+        catch { log.line("\(name) FAILED: \((error as? LocalizedError)?.errorDescription ?? "\(error)")") }
+    }
+
+    // MARK: - Time helpers
+
+    static func nextOccurrence(minutesSinceMidnight m: Int) -> Date {
+        var c = Calendar.current.dateComponents([.year, .month, .day], from: Date())
+        c.hour = m / 60; c.minute = m % 60; c.second = 0
+        var t = Calendar.current.date(from: c) ?? Date().addingTimeInterval(60)
+        if t <= Date() { t = Calendar.current.date(byAdding: .day, value: 1, to: t) ?? t }
+        return t
+    }
+
+    static func clock(_ d: Date) -> String { let f = DateFormatter(); f.dateFormat = "h:mm a"; return f.string(from: d) }
+
+    private func ud(_ key: String) -> Bool { UserDefaults.standard.bool(forKey: key) }
+}
+
+/// Throttles progress logging to ~once every 20s so a long run leaves a readable trail without spam.
+private final class LogThrottle: @unchecked Sendable {
+    private let lock = NSLock()
+    private var last = Date.distantPast
+    func maybe(_ body: () -> Void) {
+        lock.lock(); let go = Date().timeIntervalSince(last) > 20; if go { last = Date() }; lock.unlock()
+        if go { body() }
+    }
+}
+
+/// Persistent scheduler log — ~/Library/Logs/SentientOS/scheduler.log, flushed per line so a sudden
+/// sleep loses nothing. The "black box" for diagnosing an empty morning.
+final class SchedulerLog {
+    private let handle: FileHandle?
+    private let fmt: DateFormatter
+    init() {
+        let dir = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("Logs/SentientOS", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent("scheduler.log")
+        if !FileManager.default.fileExists(atPath: url.path) { FileManager.default.createFile(atPath: url.path, contents: nil) }
+        handle = try? FileHandle(forWritingTo: url)
+        handle?.seekToEndOfFile()
+        fmt = DateFormatter(); fmt.dateFormat = "yyyy-MM-dd HH:mm:ss"
+    }
+    func line(_ s: String) {
+        let stamped = "[\(fmt.string(from: Date()))] \(s)"
+        Log(stamped)
+        handle?.write(Data((stamped + "\n").utf8)); try? handle?.synchronize()
+    }
+}

--- a/Sentient OS macOS/Scheduling/WakeHelper.swift
+++ b/Sentient OS macOS/Scheduling/WakeHelper.swift
@@ -1,0 +1,185 @@
+//
+//  WakeHelper.swift
+//  Sentient OS macOS  ·  Scheduling/
+//
+//  Root-side wake helper. Runs as a LaunchDaemon — the app binary relaunched by launchd with
+//  --wake-helper (entry in main.swift). It is the ONLY code path that runs as root, and all it
+//  does is toggle `pmset disablesleep` and schedule wakes, behind a DEADMAN timer: if the app
+//  crashes mid-run and stops sending heartbeats, the helper itself restores normal sleep — so a
+//  bug can never leave the Mac awake all day. Connections are gated by a code-signing check.
+//
+
+import Foundation
+import Security
+
+final class WakeHelper: NSObject, WakeHelperProtocol, NSXPCListenerDelegate {
+
+    /// Entry point from main.swift when launched with --wake-helper. Never returns.
+    static func run() -> Never {
+        let helper = WakeHelper()
+        helper.log("starting (uid \(getuid()))")
+        helper.pmset(["-a", "disablesleep", "0"])   // defensive: clear any keep-awake leaked by a prior crash
+        helper.armedSpec = helper.loadArmed()        // re-learn a wake we armed before a daemon restart (don't cancel it)
+
+        let listener = NSXPCListener(machServiceName: WakeHelperConfig.machServiceName)
+        listener.delegate = helper
+        listener.resume()
+        helper.log("listening on \(WakeHelperConfig.machServiceName)")
+        RunLoop.current.run()
+        fatalError("wake helper run loop exited")
+    }
+
+    private let queue = DispatchQueue(label: "wakehelper")
+    private var deadman: DispatchSourceTimer?
+    private var lastTimeout = 7200
+    private var armedSpec: String?   // the pmset wake we last scheduled (for idempotent re-arm + cancel)
+    private static let armedFile = "/Library/Application Support/SentientOS/armed-wake"
+
+    // MARK: - NSXPCListenerDelegate
+
+    func listener(_ listener: NSXPCListener, shouldAcceptNewConnection conn: NSXPCConnection) -> Bool {
+        let trusted = isClientTrusted(conn)
+        log("connection from pid \(conn.processIdentifier): codesign check \(trusted ? "PASSED" : "FAILED")")
+        if !trusted {
+            #if DEBUG
+            log("DEBUG build: allowing despite failed check (verify the codesign gate before Release).")
+            #else
+            return false
+            #endif
+        }
+        conn.exportedInterface = NSXPCInterface(with: WakeHelperProtocol.self)
+        conn.exportedObject = self
+        conn.invalidationHandler = { [weak self] in
+            // The app's connection dropped (quit / crash / force-quit) → cancel the armed wake so a
+            // Mac with Sentient closed never wakes on a stale schedule.
+            self?.queue.async { self?.cancelArmed(reason: "client gone") }
+        }
+        conn.resume()
+        return true
+    }
+
+    // MARK: - WakeHelperProtocol
+
+    func beginAwake(timeoutSeconds: Int, withReply reply: @escaping (Bool) -> Void) {
+        queue.async {
+            let ok = self.pmset(["-a", "disablesleep", "1"])
+            self.startDeadman(seconds: max(60, timeoutSeconds))
+            self.log("beginAwake timeout=\(timeoutSeconds)s ok=\(ok)")
+            reply(ok)
+        }
+    }
+
+    func heartbeat(withReply reply: @escaping (Bool) -> Void) {
+        queue.async { self.startDeadman(seconds: self.lastTimeout); reply(true) }
+    }
+
+    func endAwake(withReply reply: @escaping (Bool) -> Void) {
+        queue.async {
+            self.cancelDeadman()
+            let ok = self.pmset(["-a", "disablesleep", "0"])
+            self.log("endAwake ok=\(ok)")
+            reply(ok)
+        }
+    }
+
+    func armWake(atEpoch epoch: Double, withReply reply: @escaping (Bool) -> Void) {
+        queue.async {
+            let spec = Self.spec(epoch)
+            // Idempotent: drop any existing event at this exact time, then add exactly one — so the
+            // app can re-arm the same time repeatedly without piling up duplicate wakes.
+            _ = self.pmset(["schedule", "cancel", "wake", spec])
+            let ok = self.pmset(["schedule", "wake", spec])
+            self.armedSpec = spec
+            self.persistArmed(spec)
+            self.log("armWake \(spec) ok=\(ok)")
+            reply(ok)
+        }
+    }
+
+    func cancelWake(withReply reply: @escaping (Bool) -> Void) {
+        queue.async { self.cancelArmed(reason: "explicit"); reply(true) }
+    }
+
+    // MARK: - Deadman
+
+    private func startDeadman(seconds: Int) {
+        lastTimeout = seconds
+        cancelDeadman()
+        let t = DispatchSource.makeTimerSource(queue: queue)
+        t.schedule(deadline: .now() + .seconds(seconds))
+        t.setEventHandler { [weak self] in
+            self?.log("DEADMAN fired — no heartbeat in \(seconds)s; forcing disablesleep 0")
+            self?.pmset(["-a", "disablesleep", "0"])
+            self?.cancelDeadman()
+        }
+        t.resume()
+        deadman = t
+    }
+
+    private func cancelDeadman() { deadman?.cancel(); deadman = nil }
+
+    // MARK: - pmset / codesign gate / log
+
+    @discardableResult
+    private func pmset(_ args: [String]) -> Bool {
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: "/usr/bin/pmset")
+        p.arguments = args
+        do { try p.run(); p.waitUntilExit(); return p.terminationStatus == 0 }
+        catch { log("pmset \(args) failed: \(error)"); return false }
+    }
+
+    /// Cancels whatever wake we last armed (from memory, falling back to the persisted record so a
+    /// restarted helper can still clean up). Idempotent. MUST run on `queue`.
+    private func cancelArmed(reason: String) {
+        if let spec = armedSpec ?? loadArmed() {
+            _ = pmset(["schedule", "cancel", "wake", spec])
+            log("cancelWake \(spec) (\(reason))")
+        }
+        armedSpec = nil
+        persistArmed(nil)
+    }
+
+    private static func spec(_ epoch: Double) -> String {
+        let f = DateFormatter(); f.dateFormat = "MM/dd/yy HH:mm:ss"   // local time, matches pmset
+        return f.string(from: Date(timeIntervalSince1970: epoch))
+    }
+
+    private func persistArmed(_ spec: String?) {
+        let url = URL(fileURLWithPath: Self.armedFile)
+        try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        if let spec { try? spec.write(to: url, atomically: true, encoding: .utf8) }
+        else { try? FileManager.default.removeItem(at: url) }
+    }
+
+    private func loadArmed() -> String? {
+        (try? String(contentsOf: URL(fileURLWithPath: Self.armedFile), encoding: .utf8))?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Verifies the connecting process is our signed app via its audit token (PID is racy).
+    private func isClientTrusted(_ conn: NSXPCConnection) -> Bool {
+        guard let tokenData = conn.value(forKey: "auditToken") as? Data,
+              tokenData.count == MemoryLayout<audit_token_t>.size else { return false }
+        let attrs = [kSecGuestAttributeAudit: tokenData] as CFDictionary
+        var code: SecCode?
+        guard SecCodeCopyGuestWithAttributes(nil, attrs, [], &code) == errSecSuccess, let code else { return false }
+        var req: SecRequirement?
+        guard SecRequirementCreateWithString(WakeHelperConfig.clientRequirement as CFString, [], &req) == errSecSuccess,
+              let req else { return false }
+        return SecCodeCheckValidity(code, [], req) == errSecSuccess
+    }
+
+    /// Root-side diagnostics. Goes to a root-writable log + stderr (visible in Console.app).
+    private func log(_ s: String) {
+        let line = "[\(ISO8601DateFormatter().string(from: Date()))] [helper] \(s)\n"
+        let url = URL(fileURLWithPath: "/Library/Logs/SentientOS-wakehelper.log")
+        if let h = try? FileHandle(forWritingTo: url) {
+            h.seekToEndOfFile(); h.write(Data(line.utf8)); try? h.close()
+        } else {
+            try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try? Data(line.utf8).write(to: url)
+        }
+        FileHandle.standardError.write(Data(line.utf8))
+    }
+}

--- a/Sentient OS macOS/Scheduling/WakeHelperClient.swift
+++ b/Sentient OS macOS/Scheduling/WakeHelperClient.swift
@@ -1,0 +1,77 @@
+//
+//  WakeHelperClient.swift
+//  Sentient OS macOS  ·  Scheduling/
+//
+//  App-side client for the root wake helper. Registers the LaunchDaemon via SMAppService (a
+//  one-time user approval in System Settings > Login Items), then drives the four XPC ops. Every
+//  call is async and fail-safe — if the helper isn't reachable, calls return false rather than throw.
+//
+
+import Foundation
+import ServiceManagement
+
+/// Runs a `(Bool) -> Void` exactly once, from whichever of reply/error/timeout wins. Thread-safe.
+private final class Once: @unchecked Sendable {
+    private let lock = NSLock()
+    private var done = false
+    private let body: (Bool) -> Void
+    init(_ body: @escaping (Bool) -> Void) { self.body = body }
+    func fire(_ value: Bool) {
+        lock.lock(); let go = !done; done = true; lock.unlock()
+        if go { body(value) }
+    }
+}
+
+@MainActor
+final class WakeHelperClient {
+    static let shared = WakeHelperClient()
+    private var connection: NSXPCConnection?
+
+    /// Register the daemon. The first call surfaces a System Settings approval prompt.
+    @discardableResult
+    func register() -> SMAppService.Status {
+        let service = SMAppService.daemon(plistName: WakeHelperConfig.daemonPlistName)
+        do { try service.register() } catch { Log("WakeHelper register error: \(error)") }
+        Log("WakeHelper status after register: \(service.status.rawValue)")
+        return service.status
+    }
+
+    func unregister() async {
+        let service = SMAppService.daemon(plistName: WakeHelperConfig.daemonPlistName)
+        try? await service.unregister()
+    }
+
+    // MARK: - The four ops
+
+    func beginAwake(timeout: Int = 7200) async -> Bool { await call { $0.beginAwake(timeoutSeconds: timeout, withReply: $1) } }
+    func heartbeat() async -> Bool { await call { $0.heartbeat(withReply: $1) } }
+    func endAwake() async -> Bool { await call { $0.endAwake(withReply: $1) } }
+    func armWake(at date: Date) async -> Bool { await call { $0.armWake(atEpoch: date.timeIntervalSince1970, withReply: $1) } }
+    func cancelWake() async -> Bool { await call { $0.cancelWake(withReply: $1) } }
+
+    // MARK: - XPC plumbing
+
+    private func conn() -> NSXPCConnection {
+        if let c = connection { return c }
+        let c = NSXPCConnection(machServiceName: WakeHelperConfig.machServiceName, options: .privileged)
+        c.remoteObjectInterface = NSXPCInterface(with: WakeHelperProtocol.self)
+        c.invalidationHandler = { [weak self] in Task { @MainActor in self?.connection = nil } }
+        c.resume()
+        connection = c
+        return c
+    }
+
+    /// Every call is guarded three ways so it can NEVER hang at 3am: the reply block, the XPC
+    /// error handler (fires if the helper is unreachable), and a 30s timeout — all resume-once.
+    private func call(_ body: @escaping (WakeHelperProtocol, @escaping (Bool) -> Void) -> Void) async -> Bool {
+        let connection = conn()
+        return await withCheckedContinuation { cont in
+            let once = Once { cont.resume(returning: $0) }
+            DispatchQueue.global().asyncAfter(deadline: .now() + 30) { once.fire(false) }
+            guard let proxy = connection.remoteObjectProxyWithErrorHandler({ err in
+                Log("WakeHelper XPC error: \(err)"); once.fire(false)
+            }) as? WakeHelperProtocol else { once.fire(false); return }
+            body(proxy) { ok in once.fire(ok) }
+        }
+    }
+}

--- a/Sentient OS macOS/Scheduling/WakeHelperProtocol.swift
+++ b/Sentient OS macOS/Scheduling/WakeHelperProtocol.swift
@@ -1,0 +1,40 @@
+//
+//  WakeHelperProtocol.swift
+//  Sentient OS macOS  ·  Scheduling/
+//
+//  The XPC contract between the app (client) and the root "wake helper" — the SAME app binary
+//  that launchd relaunches with --wake-helper (see main.swift). Deliberately tiny: the only code
+//  that ever runs as root is these four operations (toggle keep-awake + schedule a wake), each
+//  guarded by a deadman so a crashed app can never leave the Mac unable to sleep.
+//
+
+import Foundation
+
+@objc protocol WakeHelperProtocol {
+    /// Keep the Mac awake (root `pmset disablesleep 1`) and start a deadman timer. If the app
+    /// stops calling `heartbeat()` within `timeoutSeconds`, the helper resets disablesleep itself.
+    func beginAwake(timeoutSeconds: Int, withReply reply: @escaping (Bool) -> Void)
+    /// Feed the deadman — the app calls this every ~60s while a run is in progress.
+    func heartbeat(withReply reply: @escaping (Bool) -> Void)
+    /// Stop keeping awake (root `pmset disablesleep 0`) and cancel the deadman. Idempotent.
+    func endAwake(withReply reply: @escaping (Bool) -> Void)
+    /// Schedule a one-time system wake at a wall-clock time (epoch seconds). Idempotent — re-arming
+    /// the same time never piles up duplicate wakes.
+    func armWake(atEpoch epoch: Double, withReply reply: @escaping (Bool) -> Void)
+    /// Cancel any scheduled wake. Also invoked automatically when the app's connection drops (quit /
+    /// crash / force-quit), so a Mac with Sentient closed never wakes on a stale schedule.
+    func cancelWake(withReply reply: @escaping (Bool) -> Void)
+}
+
+/// Shared constants — the names here MUST match the LaunchDaemon plist we install in the bundle.
+enum WakeHelperConfig {
+    /// Mach service name (must equal the plist's `MachServices` key).
+    static let machServiceName = "jesai.Sentient-OS-macOS.WakeHelper"
+    /// LaunchDaemon plist filename in Contents/Library/LaunchDaemons/.
+    static let daemonPlistName = "jesai.Sentient-OS-macOS.WakeHelper.plist"
+    /// CLI flag that puts the shared binary into root helper mode.
+    static let helperFlag = "--wake-helper"
+    /// Code-signing requirement a client must satisfy to talk to the root helper. Bundle id +
+    /// Apple anchor blocks arbitrary/other code; pin the Developer ID team for Release hardening.
+    static let clientRequirement = "anchor apple generic and identifier \"jesai.Sentient-OS-macOS\""
+}

--- a/Sentient OS macOS/Sentient_OS_macOSApp.swift
+++ b/Sentient OS macOS/Sentient_OS_macOSApp.swift
@@ -10,7 +10,7 @@
 
 import SwiftUI
 
-@main
+// Entry point is main.swift (the binary doubles as the root wake helper) — so no @main here.
 struct SentientOSApp: App {
     @State private var appState = AppState()
 

--- a/Sentient OS macOS/Views/DevToolsView.swift
+++ b/Sentient OS macOS/Views/DevToolsView.swift
@@ -85,6 +85,7 @@ struct DevToolsView: View {
 
     @Environment(\.dismiss) private var dismiss
     @Environment(\.openWindow) private var openWindow
+    @Environment(AppState.self) private var appState
 
     private static let modelPath = ModelLocator.resolve()
 
@@ -114,6 +115,9 @@ struct DevToolsView: View {
     @State private var showCalendarConnect = false
     @AppStorage("dbg.calendar.connected") private var calendarConnected = false
     @AppStorage("dbg.run.calendar")       private var runCalendar = false
+    // Scheduled run (dev testing — drives OvernightScheduler).
+    @AppStorage(OvernightScheduler.enabledKey) private var schedEnabled = false
+    @AppStorage(OvernightScheduler.minutesKey) private var schedMinutes = OvernightScheduler.defaultMinutes
 
     // MCP mirror (the hosted Render copy). Local mirrors of MirrorClient's actor state, refreshed
     // when "More" opens and after each action.
@@ -132,6 +136,48 @@ struct DevToolsView: View {
         Set(selectedIMessageChatsCSV.split(separator: ",").map(String.init))
     }
 
+    // MARK: Scheduled run (dev testing)
+
+    /// Bridges the stored minutes-since-midnight to/from the DatePicker's Date.
+    private var schedTimeBinding: Binding<Date> {
+        Binding(
+            get: {
+                var c = Calendar.current.dateComponents([.year, .month, .day], from: Date())
+                c.hour = schedMinutes / 60; c.minute = schedMinutes % 60
+                return Calendar.current.date(from: c) ?? Date()
+            },
+            set: { newDate in
+                let c = Calendar.current.dateComponents([.hour, .minute], from: newDate)
+                schedMinutes = (c.hour ?? 0) * 60 + (c.minute ?? 0)
+            })
+    }
+
+    private var schedulerSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text("SCHEDULED RUN").font(.caption2.weight(.bold)).tracking(2).foregroundStyle(Theme.faint)
+                Spacer()
+                Toggle("", isOn: $schedEnabled).labelsHidden().toggleStyle(.switch).controlSize(.small)
+            }
+            HStack(spacing: 10) {
+                Text("Wake & process at").font(.caption)
+                    .foregroundStyle(.white.opacity(schedEnabled ? 0.8 : 0.3))
+                DatePicker("", selection: schedTimeBinding, displayedComponents: .hourAndMinute)
+                    .labelsHidden().disabled(!schedEnabled)
+                Spacer()
+                Text(schedEnabled ? appState.scheduler.statusLine : "off")
+                    .font(.caption2.monospaced()).foregroundStyle(Theme.faint)
+            }
+            Text("Wakes the Mac at this time with the lid shut, runs .auto over the selected sources, then sleeps. Runs ONLY while Sentient is open — quit it and the wake is cancelled.")
+                .font(.caption2).foregroundStyle(Theme.faint.opacity(0.7))
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(12)
+        .background(.white.opacity(0.03), in: RoundedRectangle(cornerRadius: 12))
+        .onChange(of: schedEnabled) { _, _ in appState.scheduler.reevaluate() }
+        .onChange(of: schedMinutes) { _, _ in if schedEnabled { appState.scheduler.reevaluate() } }
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             HStack {
@@ -144,6 +190,7 @@ struct DevToolsView: View {
             ScrollView {
                 VStack(spacing: 22) {
                     sourcePicker
+                    schedulerSection
 
                     if Self.modelPath == nil {
                         Text("On-device model not found — place \(ModelLocator.fileName) next to the .xcodeproj, or set SENTIENT_MODEL_PATH.")

--- a/Sentient OS macOS/main.swift
+++ b/Sentient OS macOS/main.swift
@@ -1,0 +1,18 @@
+//
+//  main.swift
+//  Sentient OS macOS
+//
+//  The process entry point. The SAME binary is reused as the root wake helper: launchd relaunches
+//  it with --wake-helper, and we branch into helper mode HERE — before SwiftUI exists — so the
+//  privileged path never touches the UI. Without the flag, this is the normal app.
+//  (This is why SentientOSApp no longer carries @main: an explicit main.swift replaces it.)
+//
+
+import Foundation
+import SwiftUI
+
+if CommandLine.arguments.contains(WakeHelperConfig.helperFlag) {
+    WakeHelper.run()        // root LaunchDaemon mode — never returns
+} else {
+    SentientOSApp.main()    // normal GUI app
+}


### PR DESCRIPTION
## What

Sentient wakes the Mac at a chosen time, keeps it awake, runs processing over the selected connectors, and lets it sleep again — **all with the lid closed.** Driven today by a DEV TOOLS "Scheduled run" control (time + on/off) for testing; the same engine will back the production auto-3am trigger.

**Proven end-to-end on real hardware** (Apple Silicon, Tahoe 26): woke at the exact set time lid-shut, ran `.initial` over the enabled connector (46 items, ~2¼ min), released, and slept again. macOS's own power log confirmed it was genuinely asleep before the wake.

## How it works

```
detect enabled connectors (shared SourceSelection reader)
  → arm a pmset wake (root helper)
  → wait (the Task freezes with the Mac, thaws on the scheduled wake)
  → on wake: disablesleep 1 (root) + 60s heartbeat
  → IterativeRun(.auto) over the connectors  [initial-if-fresh / iterative-if-caught-up, per source]
  → disablesleep 0 → Mac sleeps → re-arm for the next day
```

Key findings that shaped this (corrects a wrong assumption in our own §9 docs): a userspace `IOPMAssertion` does **not** hold a closed lid — only root `pmset disablesleep` does — and Gemma/Metal **runs fine with the lid shut**.

## Files
- **`Scheduling/WakeHelper.swift`** — the only code that runs as root: the SAME app binary relaunched by launchd with `--wake-helper` (no separate target). Exposes `armWake`/`beginAwake`/`heartbeat`/`endAwake`/`cancelWake` over XPC, gated by a client code-sign check, with a **deadman** that restores sleep if the app stops heartbeating (so a crash can never leave the Mac awake).
- **`WakeHelperClient.swift` / `WakeHelperProtocol.swift`** — fail-safe XPC client (reply/error/timeout guarded — can't hang).
- **`OvernightScheduler.swift`** — the in-app scheduler. Runs **only while the app is alive**; the helper **auto-cancels the wake when the app's connection drops** (force-quit safe — a Mac with Sentient closed won't wake).
- **`main.swift`** — entry point that branches into `--wake-helper` mode before SwiftUI (so `@main` moved off `SentientOSApp`).
- **`DevToolsView`** — the "Scheduled run" control.

## Still to build (follow-ups, not in this PR)
- `SMAppService.daemon` onboarding (one System Settings approval) instead of the current **manual `launchctl` install** of the helper.
- **Enforce the client code-sign gate in Release** (DEBUG currently allows-and-logs on failure so testing isn't blocked).
- AC / Low-Power / thermal gating; production auto-3am trigger + nightly re-arm without the dev UI.
- Caveats surfaced in the log: `customRoots` are session-only; Full Disk Access can read false when launched from Terminal.

## Test notes
Reload the helper after building (`~/install-wakehelper.sh`), run the app, set a near-future time in DEV TOOLS → Scheduled run, close the lid. Force-quit test: arm a time, force-quit the app, confirm `pmset -g sched` no longer lists the `pmset` wake.

Excluded from this PR: a local `DEVELOPMENT_TEAM` change in project.pbxproj (kept out so it doesn't break the other dev's signing).