### PR TITLE
Wake helper self-installs via one password prompt (no Terminal)

### DIFF
--- a/Sentient OS macOS/Scheduling/OvernightScheduler.swift
+++ b/Sentient OS macOS/Scheduling/OvernightScheduler.swift
@@ -55,6 +55,17 @@ final class OvernightScheduler {
 
     private func loop() async {
         let log = SchedulerLog()
+
+        // Make sure the root helper is installed — one-time native password prompt, no Terminal.
+        if !WakeHelperInstaller.isInstalledAndCurrent() {
+            statusLine = "installing helper…"
+            log.line("helper not installed/current — requesting install (admin prompt)")
+            let ok = await WakeHelperInstaller.installAsync()
+            log.line("helper install: \(ok ? "OK" : "declined/failed")")
+            guard ok else { statusLine = "needs your password — toggle off then on to retry"; return }
+            try? await Task.sleep(for: .seconds(1))   // let launchd settle before the first connection
+        }
+
         while !Task.isCancelled {
             let minutes = Self.configuredMinutes
             let target = Self.nextOccurrence(minutesSinceMidnight: minutes)

--- a/Sentient OS macOS/Scheduling/WakeHelperInstaller.swift
+++ b/Sentient OS macOS/Scheduling/WakeHelperInstaller.swift
@@ -1,0 +1,85 @@
+//
+//  WakeHelperInstaller.swift
+//  Sentient OS macOS  ·  Scheduling/
+//
+//  Self-install for the root wake helper — so the user never touches Terminal. When the scheduler
+//  needs the helper and it isn't installed (or points at a stale binary), the app installs the
+//  LaunchDaemon itself behind ONE native "enter your password" dialog (osascript admin):
+//    write the plist (with THIS app's current binary path) to a temp file → privileged cp into
+//    /Library/LaunchDaemons → chown/chmod → launchctl bootstrap.
+//
+//  This is the dev/testing path; production will swap it for SMAppService.daemon (a one-click
+//  System Settings approval, no password). Same daemon, same plist — only the install UX differs.
+//
+
+import Foundation
+
+enum WakeHelperInstaller {
+
+    private static var label: String { WakeHelperConfig.machServiceName }   // plist Label == Mach service name
+    private static var plistPath: String { "/Library/LaunchDaemons/\(label).plist" }
+
+    /// This app's running executable — what the daemon must launch (with --wake-helper).
+    private static var currentBinary: String {
+        Bundle.main.executableURL?.path ?? CommandLine.arguments[0]
+    }
+
+    /// True when the daemon plist exists AND points at this exact binary (a moved/rebuilt-to-a-new
+    /// path app fails this, so we reinstall). World-readable, so no privileges needed to check.
+    static func isInstalledAndCurrent() -> Bool {
+        guard let data = FileManager.default.contents(atPath: plistPath),
+              let plist = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil) as? [String: Any],
+              let args = plist["ProgramArguments"] as? [String]
+        else { return false }
+        return args.first == currentBinary
+    }
+
+    /// Install (or refresh) the daemon via one admin prompt. Blocking — call off the main actor.
+    static func installAsync() async -> Bool {
+        await Task.detached { install() }.value
+    }
+
+    private static func install() -> Bool {
+        let tmp = (NSTemporaryDirectory() as NSString).appendingPathComponent("sentient-wakehelper.plist")
+        guard (try? plistXML(binary: currentBinary).write(toFile: tmp, atomically: true, encoding: .utf8)) != nil
+        else { return false }
+
+        // Privileged: copy into place, set ownership/perms, (re)load. Full paths for the minimal shell.
+        let dest = plistPath
+        let sh = "/bin/cp '\(tmp)' '\(dest)'"
+            + " && /usr/sbin/chown root:wheel '\(dest)'"
+            + " && /bin/chmod 644 '\(dest)'"
+            + " && (/bin/launchctl bootout system '\(dest)' 2>/dev/null; /bin/launchctl bootstrap system '\(dest)')"
+        return runAdmin(sh)
+    }
+
+    private static func plistXML(binary: String) -> String {
+        let bin = binary
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+        return """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0"><dict>
+          <key>Label</key><string>\(label)</string>
+          <key>ProgramArguments</key><array><string>\(bin)</string><string>\(WakeHelperConfig.helperFlag)</string></array>
+          <key>MachServices</key><dict><key>\(label)</key><true/></dict>
+          <key>RunAtLoad</key><true/>
+          <key>KeepAlive</key><false/>
+        </dict></plist>
+        """
+    }
+
+    /// Runs a shell command as root via the native auth dialog. Returns true on success (false if the
+    /// user cancels or it errors).
+    private static func runAdmin(_ shell: String) -> Bool {
+        let esc = shell.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\"")
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        p.arguments = ["-e", "do shell script \"\(esc)\" with administrator privileges"]
+        p.standardOutput = Pipe(); p.standardError = Pipe()
+        do { try p.run(); p.waitUntilExit() } catch { return false }
+        return p.terminationStatus == 0
+    }
+}


### PR DESCRIPTION
Follow-up to #64. Makes the wake helper install itself, so a tester (or eventually a user) just **sets a time + flips the scheduler on + enters their password once** — no Terminal, no scripts, no hardcoded paths.

## What
When the scheduler starts and the root helper isn't installed (or its plist points at a stale binary), the app installs the LaunchDaemon itself behind the **native "enter your password" dialog**:
1. Write the plist — with **this app's own runtime binary path** (`Bundle.main.executableURL`) — to a temp file.
2. One privileged shell op (`osascript … with administrator privileges`): `cp` into `/Library/LaunchDaemons`, `chown root:wheel`, `chmod 644`, `launchctl bootstrap`.

The install check (`isInstalledAndCurrent()`) reads the world-readable plist and compares its `ProgramArguments` to the current binary — so it only prompts when something's actually missing/stale, and a path change (moved/rebuilt app) triggers a clean reinstall.

## Files
- **`Scheduling/WakeHelperInstaller.swift`** — `isInstalledAndCurrent()` + `installAsync()`.
- **`Scheduling/OvernightScheduler.swift`** — ensures the helper is installed before the first arm; on decline, status reads *"needs your password — toggle off then on to retry."*

## UX
Toggle the scheduler on → native password dialog (the only consent macOS allows for a root daemon) → armed. That's it.

## Note
This is the dev/testing install path. Production swaps it for **`SMAppService.daemon`** — a one-click System Settings approval, no password — same daemon, same plist, only the install UX changes. The DEBUG codesign-allow from #64 still applies; Release enforcement is still a follow-up.

Excluded from this PR: the local `DEVELOPMENT_TEAM` change in project.pbxproj (kept out so it doesn't break the other dev's signing).