### PR TITLE
Scheduled run: a "Done" button + no duplicate wakes

### DIFF
--- a/Sentient OS macOS/Scheduling/OvernightScheduler.swift
+++ b/Sentient OS macOS/Scheduling/OvernightScheduler.swift
@@ -34,9 +34,16 @@ final class OvernightScheduler {
     private var loopTask: Task<Void, Never>?
     private var everArmed = false
 
-    /// Re-read the dev settings and (re)start or stop. Call on launch and on any settings change.
+    /// Re-read the dev settings and (re)start or stop. Call on launch and on the on/off toggle.
     func reevaluate() {
         if UserDefaults.standard.bool(forKey: Self.enabledKey) { start() } else { stop() }
+    }
+
+    /// "Done" — finalize the chosen time: restart the loop, which wipes EVERY scheduled wake (clears
+    /// duplicates / stale times) then arms exactly this one. No-op while the feature is off.
+    func commit() {
+        guard UserDefaults.standard.bool(forKey: Self.enabledKey) else { return }
+        start()
     }
 
     private func start() {
@@ -66,12 +73,15 @@ final class OvernightScheduler {
             try? await Task.sleep(for: .seconds(1))   // let launchd settle before the first connection
         }
 
+        // Clean slate: wipe every existing scheduled wake (duplicates / stale), then arm exactly one.
+        everArmed = true
+        _ = await WakeHelperClient.shared.cancelAllWakes()
+
         while !Task.isCancelled {
             let minutes = Self.configuredMinutes
             let target = Self.nextOccurrence(minutesSinceMidnight: minutes)
             statusLine = "armed for \(Self.clock(target))"
             log.line("arming wake for \(target)")
-            everArmed = true
             _ = await WakeHelperClient.shared.armWake(at: target)
 
             // Wait for the target. Re-arm every ~5 min while awake (idempotent — keeps the helper's

--- a/Sentient OS macOS/Scheduling/WakeHelper.swift
+++ b/Sentient OS macOS/Scheduling/WakeHelper.swift
@@ -100,6 +100,16 @@ final class WakeHelper: NSObject, WakeHelperProtocol, NSXPCListenerDelegate {
         queue.async { self.cancelArmed(reason: "explicit"); reply(true) }
     }
 
+    func cancelAllWakes(withReply reply: @escaping (Bool) -> Void) {
+        queue.async {
+            _ = self.pmset(["schedule", "cancelall"])   // wipe every scheduled wake — clean slate
+            self.armedSpec = nil
+            self.persistArmed(nil)
+            self.log("cancelAllWakes (pmset schedule cancelall)")
+            reply(true)
+        }
+    }
+
     // MARK: - Deadman
 
     private func startDeadman(seconds: Int) {

--- a/Sentient OS macOS/Scheduling/WakeHelperClient.swift
+++ b/Sentient OS macOS/Scheduling/WakeHelperClient.swift
@@ -48,6 +48,7 @@ final class WakeHelperClient {
     func endAwake() async -> Bool { await call { $0.endAwake(withReply: $1) } }
     func armWake(at date: Date) async -> Bool { await call { $0.armWake(atEpoch: date.timeIntervalSince1970, withReply: $1) } }
     func cancelWake() async -> Bool { await call { $0.cancelWake(withReply: $1) } }
+    func cancelAllWakes() async -> Bool { await call { $0.cancelAllWakes(withReply: $1) } }
 
     // MARK: - XPC plumbing
 

--- a/Sentient OS macOS/Scheduling/WakeHelperProtocol.swift
+++ b/Sentient OS macOS/Scheduling/WakeHelperProtocol.swift
@@ -21,9 +21,12 @@ import Foundation
     /// Schedule a one-time system wake at a wall-clock time (epoch seconds). Idempotent — re-arming
     /// the same time never piles up duplicate wakes.
     func armWake(atEpoch epoch: Double, withReply reply: @escaping (Bool) -> Void)
-    /// Cancel any scheduled wake. Also invoked automatically when the app's connection drops (quit /
-    /// crash / force-quit), so a Mac with Sentient closed never wakes on a stale schedule.
+    /// Cancel the wake we last armed. Also invoked automatically when the app's connection drops
+    /// (quit / crash / force-quit), so a Mac with Sentient closed never wakes on a stale schedule.
     func cancelWake(withReply reply: @escaping (Bool) -> Void)
+    /// Wipe EVERY scheduled wake (clean slate) — backs the "Done" button so finalizing a time leaves
+    /// exactly one timer with no duplicates. (System maintenance wakes are auto-rescheduled by macOS.)
+    func cancelAllWakes(withReply reply: @escaping (Bool) -> Void)
 }
 
 /// Shared constants — the names here MUST match the LaunchDaemon plist we install in the bundle.

--- a/Sentient OS macOS/Views/DevToolsView.swift
+++ b/Sentient OS macOS/Views/DevToolsView.swift
@@ -164,6 +164,9 @@ struct DevToolsView: View {
                     .foregroundStyle(.white.opacity(schedEnabled ? 0.8 : 0.3))
                 DatePicker("", selection: schedTimeBinding, displayedComponents: .hourAndMinute)
                     .labelsHidden().disabled(!schedEnabled)
+                Button("Done") { appState.scheduler.commit() }
+                    .controlSize(.small).disabled(!schedEnabled)
+                    .help("Finalize this time — clears every other scheduled wake and arms just this one.")
                 Spacer()
                 Text(schedEnabled ? appState.scheduler.statusLine : "off")
                     .font(.caption2.monospaced()).foregroundStyle(Theme.faint)
@@ -175,7 +178,7 @@ struct DevToolsView: View {
         .padding(12)
         .background(.white.opacity(0.03), in: RoundedRectangle(cornerRadius: 12))
         .onChange(of: schedEnabled) { _, _ in appState.scheduler.reevaluate() }
-        .onChange(of: schedMinutes) { _, _ in if schedEnabled { appState.scheduler.reevaluate() } }
+        // Changing the time does NOT arm — the user presses "Done" to commit (no duplicate wakes).
     }
 
     var body: some View {


### PR DESCRIPTION
Follow-up to #64/#65. Fixes the duplicate scheduled-wakes problem in the DEV TOOLS "Scheduled run" control.

## Problem
Every nudge of the time picker armed a new wake, so changing the time piled up duplicate/stale scheduled wakes (the leftover 4pm wakes we saw in the logs).

## Fix
- **The time picker no longer arms anything** — spin it freely, no side effects.
- A new **"Done"** button beside the picker is the single commit action: it **wipes every scheduled wake** (`pmset schedule cancelall`) and then arms **exactly one** for the finalized time. Spin → Done → precisely one timer.

## Changes
- **DevToolsView:** "Done" button beside the picker; removed the arm-on-picker-change `.onChange`.
- **OvernightScheduler:** `commit()` (restarts the loop on Done); the loop now opens with a clean-slate `cancelAllWakes()` before arming exactly one, so toggling on / committing / launch all converge to one wake.
- **WakeHelper / Client / Protocol:** new `cancelAllWakes()` op (`pmset schedule cancelall`). macOS auto-reschedules its own maintenance wakes, so this only sweeps the clutter.

## Test
Reload the helper (it's new helper code), then: toggle on → set a time → **Done** → `pmset -g sched` shows exactly one `by 'pmset'` wake. Changing the time + Done again replaces it (never duplicates).

Note: unrelated to the **dark-wake-on-battery** processing issue (that needs AC + the separate "helper promotes the wake" fix). This PR is purely the duplicate-timers cleanup. Excludes the local `DEVELOPMENT_TEAM` pbxproj change.