### PR TITLE
Proactive PART 2: research now gets the full last-week summary corpus

### DIFF
--- a/Sentient OS macOS/Ingestion/Proactive.swift
+++ b/Sentient OS macOS/Ingestion/Proactive.swift
@@ -59,6 +59,28 @@ actor Proactive {
         }
     }
 
+    // MARK: Summary windowing (shared with PART 2 so both reason over the SAME corpus)
+
+    /// The last-`lookbackDays` summaries, newest first — the exact window the judge reasons over, and
+    /// the same background PART 2 now gets. Defined once here so the windowing can never drift.
+    static func recent(from notes: [CloudNote], now: Date = Date()) -> [CloudNote] {
+        let cutoff = now.addingTimeInterval(-Double(lookbackDays) * 86_400)
+        func itemDate(_ n: CloudNote) -> Date { n.itemDate ?? .distantPast }
+        return notes.filter { itemDate($0) >= cutoff }.sorted { itemDate($0) > itemDate($1) }
+    }
+
+    /// Render summaries as the numbered prompt block both parts show:
+    /// `#n · [source] location · date` then `title — summary`.
+    static func summaryLines(_ notes: [CloudNote]) -> String {
+        let df = DateFormatter(); df.dateStyle = .medium; df.timeStyle = .none
+        return notes.enumerated().map { i, n in
+            let (loc, src) = VaultGenerator.locSrc(kind: n.kind, folder: n.folder, sourceID: n.sourceID)
+            let when = n.itemDate.map { df.string(from: $0) } ?? "undated"
+            let title = (n.title?.isEmpty == false) ? n.title! : "(untitled)"
+            return "#\(i + 1) · [\(src)] \(loc) · \(when)\n\(title) — \(n.text)"
+        }.joined(separator: "\n\n")
+    }
+
     // MARK: The judge
 
     /// Find the top action items across the last week of summaries. PART 1 is summaries-only and
@@ -67,12 +89,8 @@ actor Proactive {
     /// can surface a clear status.
     func findActionItems(from notes: [CloudNote], now: Date = Date(),
                          calendarContext: String? = nil) async throws -> [ActionItem] {
-        // 1. Window the summaries to the last N days (each note carries its own item date).
-        let cutoff = now.addingTimeInterval(-Double(Self.lookbackDays) * 86_400)
-        func itemDate(_ n: CloudNote) -> Date { n.itemDate ?? .distantPast }
-        let recent: [CloudNote] = notes
-            .filter { itemDate($0) >= cutoff }
-            .sorted { itemDate($0) > itemDate($1) }            // newest first
+        // 1. Window the summaries to the last N days (shared with PART 2 via Self.recent).
+        let recent = Self.recent(from: notes, now: now)
         guard !recent.isEmpty else { throw ProError.noRecent }
 
         // 2. One hermetic Codex call: summaries over stdin, NO tools. A neutral empty scratch dir is
@@ -170,15 +188,6 @@ actor Proactive {
 
     private static func prompt(recent: [CloudNote], now: Date, calendarContext: String?) -> String {
         let today = todayString(now)
-        let df = DateFormatter(); df.dateStyle = .medium; df.timeStyle = .none
-        var lines: [String] = []
-        lines.reserveCapacity(recent.count)
-        for (i, n) in recent.enumerated() {
-            let (loc, src) = VaultGenerator.locSrc(kind: n.kind, folder: n.folder, sourceID: n.sourceID)
-            let when = n.itemDate.map { df.string(from: $0) } ?? "undated"
-            let title = (n.title?.isEmpty == false) ? n.title! : "(untitled)"
-            lines.append("#\(i + 1) · [\(src)] \(loc) · \(when)\n\(title) — \(n.text)")
-        }
 
         // The user's LIVE calendar (last 7 days + next 24h, ALL events), pre-fetched as text so PART 1
         // stays tool-free/hermetic. Only present when Calendar is connected (CalendarConnect.fetch…).
@@ -322,7 +331,7 @@ actor Proactive {
 
         ---
 
-        \(lines.joined(separator: "\n\n"))
+        \(Self.summaryLines(recent))
         """
     }
 

--- a/Sentient OS macOS/Ingestion/ProactiveCycle.swift
+++ b/Sentient OS macOS/Ingestion/ProactiveCycle.swift
@@ -83,7 +83,7 @@ actor ProactiveCycle {
         } else {
             progress(.researching(items.count))
             do {
-                _ = try await ProactiveResearch.shared.researchAndPrepare(items: items, calendarContext: calCtx)
+                _ = try await ProactiveResearch.shared.researchAndPrepare(items: items, notes: notes, calendarContext: calCtx)
             } catch {
                 let m = "Preparing — \(Self.msg(error))"
                 progress(.failed(m)); return m

--- a/Sentient OS macOS/Ingestion/ProactiveResearch.swift
+++ b/Sentient OS macOS/Ingestion/ProactiveResearch.swift
@@ -115,16 +115,17 @@ actor ProactiveResearch {
     /// stale ones; then stage every survivor ready to fire (draft in the user's voice + the execution
     /// recipe). Read-only — it researches and stages, it NEVER fires. Verify-only — it never adds a new
     /// item. Returns the ready + dropped split; throws on no-items / no-vault / usage-limit / failure.
-    func researchAndPrepare(items: [ActionItem], now: Date = Date(),
+    func researchAndPrepare(items: [ActionItem], notes: [CloudNote] = [], now: Date = Date(),
                             calendarContext: String? = nil) async throws -> ReadyResult {
         guard !items.isEmpty else { throw ResError.noItems }
+        let recent = Proactive.recent(from: notes, now: now)   // the SAME last-week corpus PART 1 saw
 
         // The vault is a research surface, the source of the user's voice + the facts a draft/form
         // needs, AND the agent's cwd (Read/Glob/Grep over the knowledge base).
         let vault = VaultGenerator.vaultRoot
         guard FileManager.default.fileExists(atPath: vault.path) else { throw ResError.noVault }
 
-        var inv = CodexCLI.Invocation(prompt: Self.prompt(items: items, now: now, calendarContext: calendarContext))
+        var inv = CodexCLI.Invocation(prompt: Self.prompt(items: items, recent: recent, now: now, calendarContext: calendarContext))
         inv.effort = .high                  // gpt-5.5 → high (accuracy + the prepared draft are the product)
         inv.sandbox = .readOnly             // verifies + stages — never sends, drafts into a provider, or acts
         inv.cwd = vault.path                // working dir = the knowledge base (a research surface + the voice)
@@ -243,7 +244,7 @@ actor ProactiveResearch {
 
     // MARK: The prompt — verify THEN prepare, accuracy-obsessed, never fires
 
-    private static func prompt(items: [ActionItem], now: Date, calendarContext: String?) -> String {
+    private static func prompt(items: [ActionItem], recent: [CloudNote], now: Date, calendarContext: String?) -> String {
         let today = todayString(now)
         var lines: [String] = []
         lines.reserveCapacity(items.count)
@@ -272,6 +273,24 @@ actor ProactiveResearch {
             tool to read a specific event in more detail if one is connected.
 
             \(ctx)
+            """
+        }()
+
+        // The FULL last-week summary corpus — the exact context PART 1 saw. PART 2 now gets it too, so it
+        // can understand each item in full context instead of only PART 1's one-line distillation.
+        let summariesBlock: String = {
+            guard !recent.isEmpty else { return "" }
+            return """
+
+            ## THE FULL LAST-WEEK CONTEXT — the SAME summaries PART 1 saw
+            Below is the ENTIRE corpus of the user's last \(Proactive.lookbackDays) days of summaries \
+            across every source — the exact context PART 1 read when it picked the items. Use it as deep \
+            background: understand each item in its full context, notice related signals PART 1 didn't \
+            spell out, pull in extra facts a draft needs, and ground your verification. These are \
+            distilled summaries (already PII-stripped), NOT live data — still confirm time-sensitive \
+            facts against the live sources (Gmail, web, calendar). The items to work follow after.
+
+            \(Proactive.summaryLines(recent))
             """
         }()
 
@@ -309,6 +328,8 @@ actor ProactiveResearch {
         feel the pull to "just send it to be helpful" — do not. Staging it perfectly IS the job.
 
         ## YOUR SURFACES (all READ-ONLY — you only gather, never act)
+        You ALSO have the **full last-week summary corpus** (at the end of this message — the same \
+        context PART 1 saw) as background. Beyond that, gather live from:
         1. **The knowledge base** — your working directory IS the user's whole life as an Obsidian-style \
         markdown vault. Read the root `README.md`, then grep/read the notes about the people, projects, \
         and commitments involved. It's three things at once: your **identity anchor** (is a Gmail/web \
@@ -428,6 +449,7 @@ actor ProactiveResearch {
         line, and stop there.
 
         \(calendarBlock)
+        \(summariesBlock)
         The action items to research and prepare follow.
 
         ---

--- a/Sentient OS macOS/Views/DevToolsView.swift
+++ b/Sentient OS macOS/Views/DevToolsView.swift
@@ -496,6 +496,7 @@ struct DevToolsView: View {
     private func runResearch(progress: @escaping @Sendable (String) -> Void) async -> String {
         let items = Proactive.latest()
         guard !items.isEmpty else { return "✗ no action items — run “proactive system” (part 1) first" }
+        let notes = await CycleStore.shared.notes().map(CloudNote.init)   // same corpus PART 1 saw
         var calCtx: String?
         if calendarConnected {
             progress("Gathering your live calendar, then verifying every item…")
@@ -503,7 +504,7 @@ struct DevToolsView: View {
         }
         progress("Verifying + preparing \(items.count) item\(items.count == 1 ? "" : "s") against your calendar, Gmail, web & your vault…")
         do {
-            let result = try await ProactiveResearch.shared.researchAndPrepare(items: items, calendarContext: calCtx)
+            let result = try await ProactiveResearch.shared.researchAndPrepare(items: items, notes: notes, calendarContext: calCtx)
             let readyLines = result.ready.map { "✓ [\($0.method.rawValue) · \($0.status.rawValue)] \($0.title)\($0.reviewNote.isEmpty ? "" : " ⚠︎ check first")" }
             let dropLines = result.dropped.map { "✗ \($0.title) — \($0.reason)" }
             let body = (readyLines + dropLines).joined(separator: "\n")


### PR DESCRIPTION
## What
PART 2 (research & prepare) previously received only PART 1's distilled `ActionItem`s — title + action + importance + the *names* of cited summaries, never the summary text. Now it also gets the **entire last-7-days summary corpus**, the exact context PART 1 reasoned over, so it can verify and draft each item with full background instead of a one-line distillation.

## How
- Extract the windowing + formatting into shared `Proactive.recent(from:)` + `Proactive.summaryLines(_:)` so both parts reason over the **identical** set — no drift, no duplicated code. PART 1's output is byte-for-byte unchanged (verified).
- `researchAndPrepare(items:notes:…)` windows the corpus the same way and injects it into the prompt as a **"THE FULL LAST-WEEK CONTEXT"** block (calendar → corpus → items), with a surfaces-section pointer.
- Both callers feed the corpus: `ProactiveCycle` (same `notes` snapshot it already hands PART 1) and the dev "research + prepare" button.

## Safety
- **Graceful**: empty corpus → block omitted → PART 2 behaves exactly as before.
- **Privacy**: the corpus is PII-stripped summaries by construction, and PART 1 already sends these same summaries to the cloud — no new invariant crossed.
- **Budget**: PART 2's input ≈ PART 1's input + the items; well within codex's window.

Builds green. Compile-verified; wants a live-codex dev pass alongside the rest of the proactive work.