### PR TITLE
Unify the processing pipeline + wire real MCP/identity into the home

### DIFF
--- a/Sentient OS macOS/MirrorClient.swift
+++ b/Sentient OS macOS/MirrorClient.swift
@@ -31,6 +31,29 @@ actor MirrorClient {
         ProcessInfo.processInfo.environment["SENTIENT_MIRROR_BASE"] ?? "https://mcp.sentient-os.ai"
     }
 
+    /// The coached system prompt the user pastes into ChatGPT/Claude/Gemini (custom instructions).
+    /// Naming the connector + "always call get_structure" is what reliably makes the client load and
+    /// use the tools — clients lazy-load connector tools behind a search gate (Arch §7 field learnings).
+    /// Lives here (the MCP owner) so every surface that offers "Copy System Prompt" shares one copy.
+    static let systemPrompt = """
+        Use the Sentient OS MCP whenever relevant. It gives you access to the user's personal knowledge \
+        base, created just for you! It's basically an Obsidian vault of notes about their actual life: \
+        their work, projects, plans, relationships, places, preferences, and history, built from their \
+        entire digital life (notes, messages, emails, etc.) using on-device LLMs that analyzed their \
+        whole digital life.
+
+        In fact, using it would help you improve almost anything you need to help the user with!
+
+        ALWAYS call get_structure at the start of ANY chat with the user.
+
+        It returns the folder and file-name index structure of the vault (so you can know if there's \
+        anything you want to read in full), and it also returns the README file of the vault with some \
+        incredible general context. So ALWAYS call this at the start of EVERY chat.
+
+        And yeah, any time you think another file is really relevant to a conversation/prompt, go read \
+        it in full using get_files!
+        """
+
     struct Stats: Sendable {
         let notesRead24h: Int
         let toolCalls24h: Int

--- a/Sentient OS macOS/Scheduling/OvernightScheduler.swift
+++ b/Sentient OS macOS/Scheduling/OvernightScheduler.swift
@@ -10,11 +10,13 @@
 //  engine will back the production auto-3am trigger. When enabled it: arms a wake for the chosen
 //  time → waits (the Task freezes with the Mac, thaws on the scheduled wake) → on wake keeps the Mac
 //  awake (root) + heartbeats → runs IterativeRun `.auto` (initial-if-fresh, iterative-if-caught-up,
-//  PER source) over the connectors selected in the app → then files the cycle's survivor summaries
-//  into the knowledge base via codex (VaultCloud: create if none exists yet, else a surgical update)
-//  and pushes the MCP mirror if it's on → releases → the Mac sleeps → re-arms for the next day.
-//  Connector detection goes through the SAME `SourceSelection.current(...)` the dev UI and Analyze
-//  Now use. Everything lands in ~/Library/Logs/SentientOS/scheduler.log.
+//  PER source) over the connectors selected in the app, plus the Gmail/Calendar legs → then runs the
+//  SAME shared tail the home's Analyze Now runs (`ProactiveCycle`: knowledge base create/update →
+//  MCP mirror push → proactive decide → research → prepare → wipe summaries) → releases → the Mac
+//  sleeps → re-arms for the next day. There is NO scheduler-specific processing path: source
+//  detection goes through the SAME `SourceSelection.current(...)`, the read leg is the SAME
+//  `IterativeRun`, and the tail is the SAME `ProactiveCycle` — so a 3am run and a hand-pressed
+//  Analyze Now do byte-for-byte the same work. Everything lands in ~/Library/Logs/SentientOS/scheduler.log.
 //
 
 import Foundation
@@ -100,7 +102,8 @@ final class OvernightScheduler {
         }
     }
 
-    /// The actual run: keep awake → process the selected connectors with `.auto` → release.
+    /// The actual run: keep awake → read the selected connectors with `.auto` (+ Gmail/Calendar) →
+    /// run the shared `ProactiveCycle` tail (knowledge base → mirror → proactive → wipe) → release.
     private func runProcessing(log: SchedulerLog) async {
         log.line("WOKE at \(Date()) — beginning the run.")
 
@@ -132,9 +135,24 @@ final class OvernightScheduler {
         if runGmail    { await cloudLeg("Gmail",    log: log) { try await GmailConnect.runIterative    { _ in } } }
         if runCalendar { await cloudLeg("Calendar", log: log) { try await CalendarConnect.runIterative { _ in } } }
 
-        // FILE this cycle's survivor summaries into the knowledge base (codex) + push the mirror,
-        // while still held awake + heartbeating. Summaries are intentionally NOT wiped afterward.
-        await knowledgeBaseLeg(log: log)
+        // The shared post-read tail — knowledge base (create/update) → mirror push → proactive
+        // (decide → research → prepare) → wipe summaries. This is the EXACT chain the home's Analyze
+        // Now runs (ProcessingView → ProactiveCycle), so a scheduled run produces the morning's
+        // For-You cards too — there is no scheduler-specific knowledge-base path. Still held awake +
+        // heartbeating throughout (proactive uses codex, same as the KB step already does).
+        if let failure = await ProactiveCycle.shared.run(progress: { phase in
+            Task { @MainActor in
+                switch phase {
+                case .knowledgeBase(let s): log.line("proactive: \(s)")
+                case .deciding:             log.line("proactive: deciding what's worth doing…")
+                case .researching(let n):   log.line("proactive: researching + preparing \(n) item(s)…")
+                case .done(let ready):      log.line("proactive: ✅ cycle done — \(ready) card(s) ready.")
+                case .failed(let m):        log.line("proactive: FAILED — \(m)")
+                }
+            }
+        }) {
+            log.line("proactive cycle ended with a failure (summaries kept for retry): \(failure)")
+        }
 
         heart.cancel()
         let ended = await WakeHelperClient.shared.endAwake()
@@ -145,33 +163,6 @@ final class OvernightScheduler {
         log.line("\(name) leg…")
         do { try await body(); log.line("\(name) DONE") }
         catch { log.line("\(name) FAILED: \((error as? LocalizedError)?.errorDescription ?? "\(error)")") }
-    }
-
-    /// Knowledge-base leg: hand this cycle's survivor summaries to codex to build the vault (first run)
-    /// or surgically update the live one, then push the MCP mirror if it's enabled. Build-vs-update is
-    /// decided by whether the vault already exists on disk. Summaries are NOT wiped afterward (the cloud
-    /// step is the second sieve and skips anything already filed). Failures are logged and swallowed so
-    /// the run still reaches its clean awake-release.
-    private func knowledgeBaseLeg(log: SchedulerLog) async {
-        let notes = await CycleStore.shared.notes().map(CloudNote.init)
-        guard !notes.isEmpty else { log.line("knowledge base: no summaries to file — skipping."); return }
-
-        let exists = FileManager.default.fileExists(atPath: VaultGenerator.vaultRoot.path)
-        log.line("knowledge base: \(exists ? "updating existing" : "creating new") from \(notes.count) summaries via codex…")
-        do {
-            if exists {
-                let merged = try await VaultCloud.shared.update(notes: notes)
-                log.line("knowledge base: ✅ updated — \(merged) summaries merged.")
-            } else {
-                let r = try await VaultCloud.shared.create(notes: notes)
-                log.line("knowledge base: ✅ created — \(r.notes) notes / \(r.folders) folders.")
-            }
-        } catch {
-            log.line("knowledge base FAILED: \((error as? LocalizedError)?.errorDescription ?? "\(error)")")
-            return   // half-edited vault isn't marked dirty, so nothing to push
-        }
-        await VaultCloud.pushIfDirty()   // no-op if the mirror is off; logs its own outcome
-        log.line("knowledge base: mirror push attempted (no-op if mirror disabled).")
     }
 
     // MARK: - Time helpers
@@ -200,7 +191,9 @@ private final class LogThrottle: @unchecked Sendable {
 }
 
 /// Persistent scheduler log — ~/Library/Logs/SentientOS/scheduler.log, flushed per line so a sudden
-/// sleep loses nothing. The "black box" for diagnosing an empty morning.
+/// sleep loses nothing. The "black box" for diagnosing an empty morning. MainActor-isolated (like the
+/// scheduler that owns it); off-main callers — e.g. ProactiveCycle's progress closure — hop to the
+/// main actor before logging, the same pattern ProcessingView uses.
 final class SchedulerLog {
     private let handle: FileHandle?
     private let fmt: DateFormatter

--- a/Sentient OS macOS/Views/DevToolsView.swift
+++ b/Sentient OS macOS/Views/DevToolsView.swift
@@ -696,28 +696,6 @@ struct DevToolsView: View {
 
     // MARK: MCP mirror (opt-in toggle + manual sync — dogfood ahead of the Phase-5 onboarding screen)
 
-    /// The coached system prompt the user pastes into ChatGPT/Claude/Gemini (custom instructions).
-    /// Naming the connector + "always call get_structure" is what reliably makes the client load and
-    /// use the tools — clients lazy-load connector tools behind a search gate (Arch §7 field learnings).
-    static let mcpSystemPrompt = """
-        Use the Sentient OS MCP whenever relevant. It gives you access to the user's personal knowledge \
-        base, created just for you! It's basically an Obsidian vault of notes about their actual life: \
-        their work, projects, plans, relationships, places, preferences, and history, built from their \
-        entire digital life (notes, messages, emails, etc.) using on-device LLMs that analyzed their \
-        whole digital life.
-
-        In fact, using it would help you improve almost anything you need to help the user with!
-
-        ALWAYS call get_structure at the start of ANY chat with the user.
-
-        It returns the folder and file-name index structure of the vault (so you can know if there's \
-        anything you want to read in full), and it also returns the README file of the vault with some \
-        incredible general context. So ALWAYS call this at the start of EVERY chat.
-
-        And yeah, any time you think another file is really relevant to a conversation/prompt, go read \
-        it in full using get_files!
-        """
-
     /// Put a string on the system clipboard.
     private func copyToPasteboard(_ s: String) {
         NSPasteboard.general.clearContents()
@@ -779,7 +757,7 @@ struct DevToolsView: View {
                     }
                     .buttonStyle(.bordered).controlSize(.small).tint(Theme.accent)
                     Button {
-                        copyToPasteboard(Self.mcpSystemPrompt)
+                        copyToPasteboard(MirrorClient.systemPrompt)
                         mirrorStatus = "✓ system prompt copied — paste into the model's custom instructions"
                     } label: {
                         Label("Copy System Prompt", systemImage: "text.quote")

--- a/Sentient OS macOS/Views/HomePopovers.swift
+++ b/Sentient OS macOS/Views/HomePopovers.swift
@@ -14,6 +14,7 @@
 //
 
 import SwiftUI
+import AppKit
 
 /// Which sources are armed to run — drives the Analysis popover's chips.
 struct HomeSources {
@@ -35,20 +36,29 @@ struct AnalysisPopover: View {
     var onAnalyze: () -> Void
     var onPickWhatsApp: () -> Void = {}    // tapping WhatsApp / iMessage opens the chat picker (in HomeView)
     var onPickIMessage: () -> Void = {}
+    var onPickGmail: () -> Void = {}       // tapping Gmail / Calendar opens the connect sheet (in HomeView)
+    var onPickCalendar: () -> Void = {}
+    var customRoots: [URL] = []            // session folders added in Dev Tools — shown so this mirrors the picker exactly
 
     // Live source selection — the SAME keys SourceSelection / DevTools use. @AppStorage so a tap toggles
     // the real selection AND the chip updates instantly. FDA is still enforced at run time (Analyze Now).
-    @AppStorage("dbg.run.downloads")  private var runDownloads = true
-    @AppStorage("dbg.run.desktop")    private var runDesktop = true
-    @AppStorage("dbg.run.documents")  private var runDocuments = true
-    @AppStorage("dbg.run.notes")      private var runNotes = false
-    @AppStorage("dbg.whatsapp.chats") private var whatsappCSV = ""
-    @AppStorage("dbg.imessage.chats") private var imessageCSV = ""
+    @AppStorage("dbg.run.downloads")      private var runDownloads = true
+    @AppStorage("dbg.run.desktop")        private var runDesktop = true
+    @AppStorage("dbg.run.documents")      private var runDocuments = true
+    @AppStorage("dbg.run.notes")          private var runNotes = false
+    @AppStorage("dbg.whatsapp.chats")     private var whatsappCSV = ""
+    @AppStorage("dbg.imessage.chats")     private var imessageCSV = ""
+    @AppStorage("dbg.gmail.connected")    private var gmailConnected = false
+    @AppStorage("dbg.run.gmail")          private var runGmail = false
+    @AppStorage("dbg.calendar.connected") private var calendarConnected = false
+    @AppStorage("dbg.run.calendar")       private var runCalendar = false
 
     @State private var vault: (notes: Int, domains: Int)?
 
     private var anyArmed: Bool {
-        runDownloads || runDesktop || runDocuments || runNotes || !whatsappCSV.isEmpty || !imessageCSV.isEmpty
+        runDownloads || runDesktop || runDocuments || runNotes || !customRoots.isEmpty
+            || !whatsappCSV.isEmpty || !imessageCSV.isEmpty
+            || (gmailConnected && runGmail) || (calendarConnected && runCalendar)
     }
     private var armed: Bool { anyArmed && !modelMissing }
 
@@ -81,13 +91,23 @@ struct AnalysisPopover: View {
                     SourceChip("Desktop",   on: runDesktop)   { runDesktop.toggle() }
                     SourceChip("Documents", on: runDocuments) { runDocuments.toggle() }
                 }
+                // Session folders added in Dev Tools — shown (✓) so the popover mirrors the picker
+                // exactly; add/remove still lives in Dev Tools (the owner of the session roots).
+                ForEach(Array(stride(from: 0, to: customRoots.count, by: 2)), id: \.self) { i in
+                    HStack(spacing: 8) {
+                        ForEach(customRoots[i..<min(i + 2, customRoots.count)], id: \.self) { url in
+                            SourceChip(url.lastPathComponent, on: true)
+                        }
+                    }
+                }
                 HStack(spacing: 8) {
                     if sources.whatsappAvailable { SourceChip("WhatsApp", on: !whatsappCSV.isEmpty, action: onPickWhatsApp) }
                     SourceChip("iMessage", on: !imessageCSV.isEmpty, action: onPickIMessage)
                 }
                 HStack(spacing: 8) {
-                    SourceChip("Notes", on: runNotes) { runNotes.toggle() }
-                    SourceChip("Gmail", on: false, soon: true)
+                    SourceChip("Notes",    on: runNotes) { runNotes.toggle() }
+                    SourceChip("Gmail",    on: gmailConnected && runGmail,       action: onPickGmail)
+                    SourceChip("Calendar", on: calendarConnected && runCalendar, action: onPickCalendar)
                 }
             }
             .padding(.top, 11)
@@ -135,62 +155,196 @@ struct AnalysisPopover: View {
 
 // MARK: - Your AIs
 
+/// The MCP glance + control. Wires straight to MirrorClient: an on/off toggle (mint pill) that
+/// mints the token + pushes the vault (or deletes the cloud copy), live access stats when on, and
+/// Copy Link / Copy System Prompt — the two things the user pastes into ChatGPT/Claude. Same
+/// MirrorClient the Dev Tools MCP panel drives, so the home and Dev Tools are one system.
 struct YourAIsPopover: View {
-    let notesRead: Int
-    let logLine: String
-    var onConnect: () -> Void
+    @State private var enabled = false
+    @State private var url: String?
+    @State private var stats: MirrorClient.Stats?
+    @State private var busy = false
+    @State private var note: String?       // transient feedback (copied / turned on) — overrides the footer
+    @State private var flashID = 0
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            MonoCaps("Your AIs", size: 10, tracking: 2.4, color: Theme.Ink.label)
-            (Text("Read ") + Text("\(notesRead) notes").italic() + Text(" yesterday."))
+            HStack {
+                MonoCaps("Your AIs", size: 10, tracking: 2.4, color: Theme.Ink.label)
+                Spacer()
+                togglePill
+            }
+
+            Text(headline)
                 .font(.system(size: 20, design: .serif)).foregroundStyle(.white)
                 .padding(.top, 11)
-            HStack(spacing: 0) {
-                Text("CHATGPT · ").foregroundStyle(Theme.Ink.label)
-                Text(logLine).foregroundStyle(Theme.Ink.body)
+            if let sub = subLineText {
+                MonoCaps(sub, size: 10, tracking: 1.0, color: Theme.Ink.body).padding(.top, 7)
             }
-            .font(.system(size: 10, design: .monospaced))
-            .padding(.top, 7)
 
-            GlowButton(title: "Connect your AIs", systemImage: "link", glowIntensity: 0.28, action: onConnect)
-                .padding(.top, 18)
+            actions.padding(.top, 18)
 
-            MonoCaps("Your whole life · offered to every AI", size: 8.5, tracking: 1.6,
-                     color: Theme.Ink.deepMuted)
+            MonoCaps(note ?? "Your whole life · offered to every AI", size: 8.5, tracking: 1.6,
+                     color: note == nil ? Theme.Ink.deepMuted : Theme.Ink.mint)
                 .padding(.top, 13)
         }
         .padding(20)
         .frame(width: 300)
         .background(Theme.Ink.cardBG)
+        .task { await refresh() }
+    }
+
+    // MARK: Pieces
+
+    /// The on/off toggle — a tappable mint pill mirroring the Analysis popover's synced stamp.
+    private var togglePill: some View {
+        Button(action: toggle) {
+            HStack(spacing: 5) {
+                if busy { ProgressView().controlSize(.mini) }
+                else { Circle().fill(enabled ? Theme.Ink.mint : Theme.Ink.deepMuted).frame(width: 6, height: 6) }
+                Text(enabled ? "ON" : "OFF")
+            }
+            .font(.system(size: 8.5, weight: .semibold, design: .monospaced)).tracking(1.4)
+            .foregroundStyle(enabled ? Theme.Ink.mint : Theme.Ink.label)
+            .padding(.horizontal, 9).padding(.vertical, 4)
+            .overlay(Capsule().strokeBorder((enabled ? Theme.Ink.mint : Theme.Ink.label).opacity(0.3), lineWidth: 1))
+            .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .disabled(busy)
+    }
+
+    private var headline: String {
+        if !enabled { return "Offer your life to every AI." }
+        if let n = stats?.notesRead24h, n > 0 { return "Read \(n) note\(n == 1 ? "" : "s") today." }
+        return "Connected. Ready for your AIs."
+    }
+
+    /// The mono sub-line — shown only when ON (live access stats). OFF shows nothing; the footer
+    /// already carries the "offered to every AI" pitch, so no "private · no account · lease" line.
+    private var subLineText: String? {
+        guard enabled else { return nil }
+        if let s = stats, s.toolCalls24h > 0 || s.lastAccess != nil {
+            let last = s.lastAccess.map { RelativeDateTimeFormatter().localizedString(for: $0, relativeTo: Date()) }
+            return "\(s.toolCalls24h) calls" + (last.map { " · \($0)" } ?? "")
+        }
+        return "No reads yet · paste your link into ChatGPT"
+    }
+
+    /// On → Copy Link + Copy System Prompt (the two things to paste). Off → the glow CTA that turns it on.
+    @ViewBuilder private var actions: some View {
+        if enabled {
+            HStack(spacing: 8) {
+                CopyPill(title: "Copy Link", systemImage: "link", action: copyLink)
+                CopyPill(title: "Copy Prompt", systemImage: "text.quote", action: copyPrompt)
+            }
+        } else {
+            GlowButton(title: "Connect your AIs", systemImage: "link", glowIntensity: 0.28, action: toggle)
+        }
+    }
+
+    // MARK: Actions (all through MirrorClient — the SAME path Dev Tools uses)
+
+    @MainActor private func refresh() async {
+        enabled = await MirrorClient.shared.isEnabled
+        url = await MirrorClient.shared.shareURL
+        stats = enabled ? (try? await MirrorClient.shared.stats()) : nil
+    }
+
+    private func toggle() {
+        guard !busy else { return }
+        Task { @MainActor in
+            busy = true
+            if enabled {
+                await MirrorClient.shared.disable()
+                flash("Mirror off · cloud copy deleted")
+            } else {
+                _ = await MirrorClient.shared.enable()
+                do {
+                    try await MirrorClient.shared.push()
+                    VaultActivity.shared.vaultDirty = false
+                    flash("On · your knowledge is live")
+                } catch MirrorClient.MirrorError.noVault {
+                    flash("On · syncs on your first analysis")
+                } catch {
+                    flash("On · sync will retry")
+                }
+            }
+            await refresh()
+            busy = false
+        }
+    }
+
+    private func copyLink() {
+        guard let url else { return }
+        setPasteboard(url); flash("Link copied · add it as a connector")
+    }
+    private func copyPrompt() {
+        setPasteboard(MirrorClient.systemPrompt); flash("Prompt copied · paste into custom instructions")
+    }
+    private func setPasteboard(_ s: String) {
+        NSPasteboard.general.clearContents(); NSPasteboard.general.setString(s, forType: .string)
+    }
+
+    /// Show a transient feedback line in place of the footer, then revert (unless superseded).
+    private func flash(_ s: String) {
+        note = s; flashID += 1; let id = flashID
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(2.6))
+            if flashID == id { note = nil }
+        }
+    }
+}
+
+/// A quiet outlined copy button (the popover's secondary action — glow is reserved for the ON CTA).
+private struct CopyPill: View {
+    let title: String
+    let systemImage: String
+    let action: () -> Void
+    @State private var hover = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 5) {
+                Image(systemName: systemImage).font(.system(size: 9))
+                Text(title)
+            }
+            .font(.system(size: 9.5, weight: .medium, design: .monospaced)).tracking(0.5)
+            .foregroundStyle(.white.opacity(0.82))
+            .frame(maxWidth: .infinity).padding(.vertical, 9)
+            .background(Capsule().fill(.white.opacity(hover ? 0.08 : 0.04)))
+            .overlay(Capsule().strokeBorder(.white.opacity(0.12), lineWidth: 1))
+            .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .onHover { hover = $0 }
     }
 }
 
 // MARK: - Shared bits
 
-/// A source pill (✓ when armed, dashed + dim when "soon"). Harvested from the Constellation.
+/// A source pill (✓ when armed). Tappable when an `action` is set (toggles a source / opens a
+/// chat or connect sheet). Harvested from the Constellation.
 struct SourceChip: View {
     let name: String
     let on: Bool
-    var soon = false
     var action: (() -> Void)? = nil    // tappable when set (toggles a source / opens the chat picker)
 
     @State private var hover = false
 
-    init(_ name: String, on: Bool, soon: Bool = false, action: (() -> Void)? = nil) {
-        self.name = name; self.on = on; self.soon = soon; self.action = action
+    init(_ name: String, on: Bool, action: (() -> Void)? = nil) {
+        self.name = name; self.on = on; self.action = action
     }
 
     var body: some View {
         let chip = HStack(spacing: 5) {
             if on { Text("✓").foregroundStyle(Theme.Ink.mint) }
-            Text(name).foregroundStyle(soon ? Theme.Ink.deepMuted : on ? Theme.Ink.chipInk : .white.opacity(0.28))
+            Text(name).foregroundStyle(on ? Theme.Ink.chipInk : .white.opacity(0.28))
         }
         .font(.system(size: 9, weight: .medium, design: .monospaced)).tracking(0.8)
         .padding(.horizontal, 9).padding(.vertical, 4)
         .background(Capsule().fill(.white.opacity(hover && action != nil ? 0.06 : 0)))
-        .overlay(Capsule().strokeBorder(Theme.Ink.chipBorder,
-                                        style: StrokeStyle(lineWidth: 1, dash: soon ? [3, 3] : [])))
+        .overlay(Capsule().strokeBorder(Theme.Ink.chipBorder, lineWidth: 1))
         .contentShape(Capsule())
 
         if let action {
@@ -230,6 +384,6 @@ enum HomeStats {
 
 #Preview("Your AIs") {
     ZStack { Theme.bg
-        YourAIsPopover(notesRead: 5, logLine: "Tokyo Trip, Visa…", onConnect: {})
+        YourAIsPopover()
     }.frame(width: 360, height: 300).preferredColorScheme(.dark)
 }

--- a/Sentient OS macOS/Views/HomeView.swift
+++ b/Sentient OS macOS/Views/HomeView.swift
@@ -28,6 +28,7 @@ struct HomeView: View {
     // Live context from RootView (the analyze/source switchboard).
     var thingsUnderstood: Int = 0
     var sources: HomeSources = .init()
+    var customRoots: [URL] = []        // session folders from RootView — shown in the Analysis popover, like Dev Tools
     var modelMissing: Bool = false
     var realCards: Bool = false        // true → show real proactive cards from latest(); false → the demo deck
     var onAnalyze: () -> Void = {}
@@ -46,6 +47,8 @@ struct HomeView: View {
     @State private var showYourAIs = false
     @State private var showWhatsAppPicker = false
     @State private var showIMessagePicker = false
+    @State private var showGmailConnect = false
+    @State private var showCalendarConnect = false
 
     // Chat selections the Analysis popover's WhatsApp/iMessage chips pick into (same keys as SourceSelection).
     @AppStorage("dbg.whatsapp.chats") private var whatsappCSV = ""
@@ -94,6 +97,9 @@ struct HomeView: View {
                 imessageCSV = sel.sorted().joined(separator: ","); runIMessage = !sel.isEmpty
             }
         }
+        // Gmail / Calendar connect sheets — the SAME sheets Dev Tools opens (connect / select / remove).
+        .sheet(isPresented: $showGmailConnect) { GmailConnectSheet() }
+        .sheet(isPresented: $showCalendarConnect) { CalendarConnectSheet() }
     }
 
     // MARK: Chrome — the top-bar nav + the editorial greeting
@@ -127,7 +133,7 @@ struct HomeView: View {
             Text(greeting)
                 .font(.system(size: 30, design: .serif).italic())
                 .foregroundStyle(Theme.Ink.statusInk)
-            MonoCaps(Demo.readLine, size: 9.5, tracking: 2.2, color: Theme.Ink.deepMuted)
+            MonoCaps(readLine, size: 9.5, tracking: 2.2, color: Theme.Ink.deepMuted)
         }
         .padding(.leading, 30)
     }
@@ -136,8 +142,27 @@ struct HomeView: View {
         let hour = Calendar.current.component(.hour, from: Date())
         let part = hour < 5 ? "Up late" : hour < 12 ? "Good morning"
                  : hour < 18 ? "Good afternoon" : "Good evening"
-        return "\(part), \(Demo.name)."
+        let name = Self.macFirstName
+        return name.isEmpty ? "\(part)." : "\(part), \(name)."
     }
+
+    /// The mono whisper under the greeting — the REAL lifetime count of things analyzed
+    /// (`thingsUnderstood`, from LifetimeStats), not a hardcoded number.
+    private var readLine: String {
+        let n = thingsUnderstood
+        guard n > 0 else { return "Ready to read your life" }
+        return "I've read \(n.formatted()) thing\(n == 1 ? "" : "s") so far"
+    }
+
+    /// The user's first name from their macOS account — full name's first word (e.g. "Jesai
+    /// Avadhani" → "Jesai"), falling back to the (capitalized) short login name, then to nothing
+    /// (the greeting just drops the name). Resolved once per launch; no account, no network.
+    static let macFirstName: String = {
+        let full = NSFullUserName().trimmingCharacters(in: .whitespacesAndNewlines)
+        if let first = full.split(separator: " ").first, !first.isEmpty { return String(first) }
+        let login = NSUserName().trimmingCharacters(in: .whitespacesAndNewlines)
+        return login.isEmpty ? "" : login.capitalized
+    }()
 
     private var analysisPopover: some View {
         AnalysisPopover(thingsUnderstood: thingsUnderstood, sources: sources,
@@ -145,7 +170,10 @@ struct HomeView: View {
                         syncedLabel: syncedLabel, pending: realCards ? 0 : Demo.pending,
                         onAnalyze: { showAnalysis = false; onAnalyze() },
                         onPickWhatsApp: { showAnalysis = false; showWhatsAppPicker = true },
-                        onPickIMessage: { showAnalysis = false; showIMessagePicker = true })
+                        onPickIMessage: { showAnalysis = false; showIMessagePicker = true },
+                        onPickGmail: { showAnalysis = false; showGmailConnect = true },
+                        onPickCalendar: { showAnalysis = false; showCalendarConnect = true },
+                        customRoots: customRoots)
             .preferredColorScheme(.dark)
     }
 
@@ -160,8 +188,7 @@ struct HomeView: View {
     }
 
     private var yourAIsPopover: some View {
-        YourAIsPopover(notesRead: Demo.aiNotesRead, logLine: Demo.aiLog,
-                       onConnect: { showYourAIs = false; openWindow(id: ConnectAIsView.windowID) })
+        YourAIsPopover()   // self-contained: toggles the real MCP mirror + copies the link / system prompt
             .preferredColorScheme(.dark)
     }
 
@@ -780,12 +807,8 @@ private struct LetterView: View {
 // MARK: - Demo data (the home's own showcase strings — cards live in Briefing.demo)
 
 private enum Demo {
-    static let name = "Jesai"   // later: the vault portrait's first name
-    static let readLine = "While you slept, I read 1,704 things"
     static let synced = "Synced · 3:41 AM"
     static let pending = 214
-    static let aiNotesRead = 5
-    static let aiLog = "Tokyo Trip, Visa…"
 }
 
 #Preview("Home — the suggestions") {

--- a/Sentient OS macOS/Views/ProcessingView.swift
+++ b/Sentient OS macOS/Views/ProcessingView.swift
@@ -443,8 +443,11 @@ struct ProcessingView: View {
             }
         }
         do {
-            _ = mode == .iterative ? try await GmailConnect.runIterative(onProgress: onProgress)
-                                   : try await GmailConnect.runInitial(onProgress: onProgress)
+            // Only the explicit force-initial mode does a full re-read; `.auto` and `.iterative` both
+            // use runIterative — which itself falls back to a full initial read when Gmail has no mark
+            // yet. (Same auto behavior the scheduler relies on; keeps every entry point in agreement.)
+            _ = mode == .initial ? try await GmailConnect.runInitial(onProgress: onProgress)
+                                 : try await GmailConnect.runIterative(onProgress: onProgress)
         } catch {
             var p = box.value
             p.lastTitle = "Gmail failed"
@@ -491,8 +494,10 @@ struct ProcessingView: View {
             }
         }
         do {
-            _ = mode == .iterative ? try await CalendarConnect.runIterative(onProgress: onProgress)
-                                   : try await CalendarConnect.runInitial(onProgress: onProgress)
+            // Force-initial only on `.initial`; `.auto`/`.iterative` → runIterative (which falls back
+            // to a full initial read when Calendar has no mark yet). Matches the Gmail leg + scheduler.
+            _ = mode == .initial ? try await CalendarConnect.runInitial(onProgress: onProgress)
+                                 : try await CalendarConnect.runIterative(onProgress: onProgress)
         } catch {
             var p = box.value
             p.lastTitle = "Calendar failed"
@@ -509,7 +514,7 @@ struct ProcessingView: View {
 
 /// Thread-safe holder so the Gmail leg's `@Sendable` progress callback can accumulate onto the
 /// device leg's final counts and hand the final value back (mirrors CodexCLI's PipeDrain pattern).
-private final class ProgressBox: @unchecked Sendable {
+private nonisolated final class ProgressBox: @unchecked Sendable {
     private let lock = NSLock()
     private var p: RunProgress
     init(_ p: RunProgress) { self.p = p }

--- a/Sentient OS macOS/Views/RootView.swift
+++ b/Sentient OS macOS/Views/RootView.swift
@@ -17,6 +17,12 @@ struct RootView: View {
     @State private var customRoots: [URL] = []   // session-only custom folders (dev picker)
     @State private var fdaGranted = Permissions.hasFullDiskAccess()
     @AppStorage("dev.proactive.realCards") private var realCards = false   // real cards + full-cycle Analyze Now
+    // Cloud sources — same flags the scheduler reads, so Analyze Now processes exactly what an
+    // overnight run would (a no-op until Gmail/Calendar are actually connected + selected).
+    @AppStorage("dbg.gmail.connected")    private var gmailConnected = false
+    @AppStorage("dbg.run.gmail")          private var runGmail = false
+    @AppStorage("dbg.calendar.connected") private var calendarConnected = false
+    @AppStorage("dbg.run.calendar")       private var runCalendar = false
 
     // Resolved at launch (env → bundle → App Support → repo root); nil = model not on this Mac.
     private static let modelPath = ModelLocator.resolve()
@@ -35,6 +41,8 @@ struct RootView: View {
                 ProcessingView(modelPath: modelPath,
                                connectors: RunSource.connectors(from: selectedSources),
                                mode: .auto,
+                               runGmail: gmailConnected && runGmail,
+                               runCalendar: calendarConnected && runCalendar,
                                fullCycle: realCards) {   // real mode → read + knowledge base + proactive + wipe
                     withAnimation(.easeInOut(duration: 0.3)) { isProcessing = false }
                 }
@@ -62,6 +70,7 @@ struct RootView: View {
                 imessage: sources.contains { if case .imessage = $0 { return true } else { return false } },
                 notes: sources.contains(.notes),
                 whatsappAvailable: WhatsAppSource.isInstalled),
+            customRoots: customRoots,
             modelMissing: Self.modelPath == nil,
             realCards: realCards,
             onAnalyze: { withAnimation(.easeInOut(duration: 0.3)) { isProcessing = true } },


### PR DESCRIPTION
## One unified system

The throughline: every entry point now runs the **same shared functions** — no dev-vs-prod forks, no reimplementations. Plus the home's identity/stats are now real instead of hardcoded.

### Scheduler (the 3am path = the home path)
- `OvernightScheduler` now runs the shared **`ProactiveCycle`** tail (KB create/update → mirror push → decide → research → prepare → wipe) instead of its private KB-only `knowledgeBaseLeg`. So a scheduled run produces For-You cards too — byte-for-byte the same work as a hand-pressed **Analyze Now**. Deleted the fork.
- `ProcessingView` cloud legs: `.auto`/`.iterative` → `runIterative` (which auto-falls-back to a full initial read only when there's no pointer yet); only the explicit `.initial` forces a re-read. Now agrees with the scheduler.
- Home **Analyze Now** honors connected Gmail/Calendar (same `dbg.*` flags the scheduler reads).

### Analysis popover mirrors the Dev Tools source picker exactly
- **Gmail** is a real, tappable chip (was greyed-out "soon"), **Calendar** added, session **custom folders** shown. Same `dbg.*` keys + the same connect sheets.

### Your AIs popover — real MCP
- Wired to the live `MirrorClient`: **on/off toggle**, **Copy Link**, **Copy System Prompt**, and **live access stats**.
- System prompt moved to `MirrorClient.systemPrompt` (one source of truth, shared with Dev Tools).

### Home identity is real, not hardcoded
- Greeting uses the **macOS account name** (`NSFullUserName()`), not `"Jesai"` — every user sees their own name.
- The "things read" whisper uses the real `LifetimeStats` total.

### Cleanup
- Removed dead `SourceChip.soon` and `Demo.name/readLine/aiNotesRead/aiLog`.

## Notes
- Builds clean via the Xcode GUI build system (0 errors; my files 0 new warnings).
- **Not committed:** the local `project.pbxproj` `DEVELOPMENT_TEAM` change (machine-specific signing ID — left out so it doesn't flip the team for everyone).
- **Not yet hardware-tested** — needs a real overnight scheduler run + a visual pass on the two popovers (the preview renderer is hitting a toolchain JIT error this session). Docs (Arch §9, MCP Mirror, Home) to update once confirmed working.
- `ConnectAIsView` (the old stub "connect" window) is now unreachable from the popover — left registered for future onboarding; can delete in a follow-up if we don't want it.