### PR TITLE
Files source: cut Downloads noise (camera roll, boilerplate, walk bounds, extraction timeout)

### DIFF
--- a/Sentient OS macOS/Documentation/Files Source (Skipping & Caps).md
+++ b/Sentient OS macOS/Documentation/Files Source (Skipping & Caps).md
@@ -1,15 +1,17 @@
 # Files Source — Skipping & Caps
 
-How `FilesSource.eligibleFiles()` decides what *never* reaches the model. Two halves: **subtree
-pruning** (directories we refuse to walk into) and **caps** (bounds on what survives the walk).
-All of it lives in `Sources/FilesSource.swift`; everything here happens at the walk level via
-`enumerator.skipDescendants()`, so a skipped item never becomes a `Candidate` and never sees
-inference. `FilesConnector` (`Ingestion/Connectors/FilesConnector.swift`) wraps `eligibleFiles()`
-into one bucket per root for the iterative pipeline.
+How `FilesSource.eligibleFiles()` decides what *never* reaches the model. **Three free layers** (no
+inference, all from filesystem metadata): **subtree pruning** (whole directories we refuse to walk
+into), **per-file rejects** (obvious-noise files dropped by name/size), and **caps** (bounds on what
+survives the walk) — plus **walk bounds** that stop a pathological folder tree from stalling the run.
+All of it lives in `Sources/FilesSource.swift`; a skipped item never becomes a `Candidate` and never
+sees inference. `FilesConnector` wraps `eligibleFiles()` into one bucket per root for the iterative
+pipeline.
 
-## Pruning — `pruneReason(_:) -> String?`
+## 1. Subtree pruning — `pruneReason(_:) -> String?`
 
-One directory listing is read per directory; every rule runs against it. First match wins:
+One directory listing is read per directory; every rule runs against it. First match wins, and on a
+match the whole subtree is skipped via `enumerator.skipDescendants()`.
 
 | Rule | Trigger | Example |
 |---|---|---|
@@ -17,14 +19,17 @@ One directory listing is read per directory; every rule runs against it. First m
 | name blocklist | dep/build/cache/dataset names | `node_modules`, `venv`, `dist`, `datasets`, `checkpoints` |
 | never-index marker | `.metadata_never_index` present | Spotlight opt-outs |
 | **vault exemption** | `.obsidian` or `logseq` present → **never prune** (overrides everything below) | personal vaults — even git-synced, even with a stray `package.json` |
-| **`.git`** | `.git` present → prune, period (decision June 11 — a 38-repo survey found zero notes repos; git notes journals are ~1% and have the escape hatch below) | every cloned/own repo |
-| manifest | a known project manifest present | `package.json`, `Cargo.toml`, `Makefile`, `CMakeLists.txt`, `pyproject.toml`… |
+| **`.git`** | `.git` present → prune, period (June 11 — a 38-repo survey found zero notes repos; the ~1% git-synced journals have the escape hatch below) | every cloned/own repo |
+| manifest | a known project manifest present | `package.json`, `Cargo.toml`, `Makefile`, `pyproject.toml`… |
 | project bundle | any `*.xcodeproj` / `*.sln` entry | Xcode/VS project folders |
-| code-density | ≥10 extensioned entries, majority source-code extensions | manifest-less script folders |
-| **dataset** | ≥100 files of one extension, ≥90% homogeneous, ≥80% machine-generated names (`chunk_0001`, pure numbers, hashes, UUIDs) | scraped corpora, ML datasets. **Skipped entirely** — no sampling (decision June 10) |
+| code-density | ≥10 extensioned entries, and **code OR bulk data/markup** is the majority | manifest-less script folders; folders dominated by `.json`/`.html`/`.ipynb`/`.css`/`.xml`/`.yaml` (2026-06-25: data/markup added — these never reach the model anyway, so a folder that's mostly them is a project/dump, not a life) |
+| **dataset** | ≥100 files of one extension, ≥90% homogeneous, ≥80% machine-generated names (`chunk_0001`, pure numbers, hashes, UUIDs) | scraped corpora, ML datasets. **Skipped entirely** — no sampling (June 10) |
 
-**Screenshots & camera rolls are exempt from the dataset rule** (`Screenshot…`, `IMG_…`, `DSC…`
-prefixes): they're personal gold — the per-directory cap bounds their volume instead.
+**Screenshots stay; camera rolls don't.** `isDatasetName` still exempts `Screenshot…`/`IMG_…`/`DSC…`
+names from the *folder-level* dataset rule — so a real document sitting in a photo folder is never
+lost to an all-or-nothing folder skip. Screenshots are keepers (one can hold a ticket / address /
+confirmation). Camera-roll **photos** are removed precisely, one file at a time, by the per-file
+reject in §2 — not by pruning the folder.
 
 **The escape hatch (by construction):** `pruneReason` only runs on *subdirectories* — a root the
 user explicitly added in Sources is never itself prune-checked. Anyone whose plain git notes repo
@@ -33,15 +38,46 @@ gets skipped can add that folder as a custom root and it walks fine.
 Hidden dirs and bundle *contents* are already excluded by the enumerator options
 (`.skipsHiddenFiles`, `.skipsPackageDescendants`).
 
-## Caps (connector-limits decision, June 10)
+## 2. Per-file rejects — `fileRejectReason(name:ext:size:)` (added 2026-06-25)
+
+Content-free: judged from the **name and size only, never by reading the file**. Runs per file after
+the extension whitelist. Every reject is one model call saved.
+
+| Reject | Trigger |
+|---|---|
+| camera roll | image named `IMG_` / `IMG-` / `PXL_` / `DSC*` / `MVIMG` / `PANO` / `GOPR` / `BURST` (phone/camera photos; **screenshots excluded** — they often carry real info) |
+| lock/temp | name starts `~$` or `.~` (e.g. Word's `~$Report.docx` — garbage content) |
+| boilerplate | basename is `README` / `LICENSE` / `COPYING` / `NOTICE` / `CHANGELOG` / `AUTHORS` / `CONTRIBUTING` / `CODE_OF_CONDUCT` / `EULA`, any extension |
+| empty | 0-byte file |
+| oversize | over `maxFileBytes` (~100 MB) — the **hang guard**; never even opens a giant file |
+
+Decision (2026-06-25): camera-roll photos add nothing to a *life* knowledge base, so they're dropped
+outright (describing random pictures is wasted vision inference). The "blind" semantic categories —
+logos, avatars, album art, an NDA's text, a `.txt` log — have no reliable name/size tell and stay
+the model's job; we never read a file's contents to classify it.
+
+## 3. Walk bounds (added 2026-06-25)
+
+Stop one pathological folder from stalling the run:
+
+- **Max depth 3** — never descend past 3 subfolder levels (`maxWalkDepth`). Bounds a deeply nested
+  downloaded tree.
+- **Symlinks skipped** — never followed, so a symlink loop can't make the walk run forever.
+- **Per-item extraction timeout** — content extraction is wrapped in a 30 s wall-clock cap in
+  `IterativeRun` (`withExtractionTimeout`); a corrupt file abandons instead of hanging. The ~100 MB
+  ceiling in §2 is the first-line guard against a giant file; this is the backstop for a
+  small-but-corrupt one. (A truly-hung synchronous extractor can't be force-killed — it leaks its
+  thread — but it never blocks the pipeline.)
+
+## 4. Caps
 
 Applied newest-first (by date-added) after the walk, in `cappedNewestFirst`:
 
-- **Age cutoff** — Downloads only: files older than **1 year** are dropped (old downloads are
-  noise; old Desktop/Documents files can be keepers). `FilesSource.maxAge`.
-- **Per-directory cap** — **300, every root** (raised from 100 for Downloads, June 11 — downloads
-  are high-signal: tickets, receipts, PDFs); any one directory contributes at most that many
-  (newest win). The blunt backstop for bulk dumps the heuristics miss. `FilesSource.perDirectoryCap`.
+- **Age cutoff** — Downloads only: files older than **1 year** are dropped (old downloads are noise;
+  old Desktop/Documents files can be keepers). `FilesSource.maxAge`.
+- **Per-directory cap** — **100, every root** (any one directory contributes at most this many,
+  newest win — the blunt backstop for bulk dumps the heuristics miss). `FilesSource.perDirectoryCap`.
+  *(Was briefly 300 for Downloads, June 11; back to 100 across the board on 2026-06-25.)*
 - **Per-root cap** — newest **1,000** per root, every root. `FilesSource.perRootCap`.
 
 `FileRoot.source` builds the correctly-configured `FilesSource` for each root — use it instead of
@@ -49,20 +85,21 @@ constructing `FilesSource` by hand.
 
 ## Thresholds are [STARTING POINT]
 
-The density/dataset numbers (10 / majority · 100 / 90% / 80%) were tuned on real census runs but
-are judgment calls. Tune with evidence, not vibes — that's what the census mode is for.
+The density/dataset numbers (10 / majority · 100 / 90% / 80%) and the new walk/size/cap numbers
+(depth 3 · 100/dir · ~100 MB · 30 s) were tuned on real runs but are judgment calls. Tune with
+evidence, not vibes.
 
 ## Self-test
 
-`Self Tests - Temp/SelfTest_FileSkipping.swift`, no model needed:
+The `SENTIENT_SELFTEST=skipping` (synthetic fixtures, no model) and `skipcensus` (read-only real-Mac
+report: every pruned dir + reason, top contributors) modes are scaffolding — deleted when done
+(`Self Tests - Temp/` is kept empty). Recreate them from `Documentation/Self-Testing (Eval
+Harness).md` whenever you next tune these heuristics; `skipcensus` is the fastest way to see exactly
+which folders get pruned and why.
 
-```sh
-SENTIENT_SELFTEST=skipping   "<app>/Contents/MacOS/Sentient OS"   # synthetic fixtures, 17 assertions
-SENTIENT_SELFTEST=skipcensus "<app>/Contents/MacOS/Sentient OS"   # read-only real-Mac report:
-                                                                  # every pruned dir + reason, top contributors
-```
+## Historical census (June 11 — predates the 2026-06-25 per-file rejects + 100/dir cap)
 
-June 11 census on a dev's Mac (waterfall: 21,364 raw whitelisted files in Downloads → 5,286
-after pruning → 551 after the 1-year cutoff → 324 after caps; Desktop 19,216 → 582 → 375):
-218 Downloads subtrees pruned (an ML dataset + course repos); Desktop screenshots capped at 300;
-the Documents Obsidian vault fully kept.
+Downloads waterfall: 21,364 raw whitelisted files → 5,286 after pruning → 551 after the 1-year cutoff
+→ 324 after caps; Desktop 19,216 → 582 → 375. 218 Downloads subtrees pruned (an ML dataset + course
+repos); the Documents Obsidian vault fully kept. (Re-run `skipcensus` for current numbers — the
+per-file rejects and 100/dir cap now cut further.)

--- a/Sentient OS macOS/Ingestion/IterativeRun.swift
+++ b/Sentient OS macOS/Ingestion/IterativeRun.swift
@@ -22,6 +22,38 @@
 
 import Foundation
 
+// MARK: - Per-item extraction timeout (Arch §H — one corrupt/huge file must never hang the run)
+
+private struct ExtractionTimeout: Error { let seconds: Double }
+
+/// Holds the racing continuation behind a lock so it resumes exactly once, and so the `@Sendable`
+/// dispatch closures capture this (`@unchecked Sendable`) box instead of the continuation directly.
+private final class TimeoutBox<T>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var cont: CheckedContinuation<T, Error>?
+    init(_ c: CheckedContinuation<T, Error>) { cont = c }
+    func resume(_ result: Result<T, Error>) {
+        lock.lock(); let c = cont; cont = nil; lock.unlock()
+        c?.resume(with: result)
+    }
+}
+
+/// Runs blocking `work` with a hard wall-clock cap, resolving to whichever wins — the work
+/// finishing or the deadline. On timeout it throws `ExtractionTimeout` and the run moves on; a
+/// truly-hung synchronous extractor keeps running on its background thread (sync work can't be
+/// force-killed) but never blocks the pipeline. FilesSource's size ceiling is the first-line guard
+/// against this; the timeout is the backstop for a small-but-corrupt file.
+private func withExtractionTimeout<T: Sendable>(_ seconds: Double,
+                                                _ work: @escaping @Sendable () throws -> T) async throws -> T {
+    try await withCheckedThrowingContinuation { (cont: CheckedContinuation<T, Error>) in
+        let box = TimeoutBox(cont)
+        DispatchQueue.global(qos: .utility).async { box.resume(Result { try work() }) }
+        DispatchQueue.global().asyncAfter(deadline: .now() + seconds) {
+            box.resume(.failure(ExtractionTimeout(seconds: seconds)))
+        }
+    }
+}
+
 /// Live progress for one analysis run — the bar, the verdict counts, and the most-recently-processed
 /// item (its prompt/title/summary/verdict). Every snapshot is internally consistent: all the `last*`
 /// fields describe the SAME item, so a UI can show them together without desync. Read by ProcessingView.
@@ -51,6 +83,7 @@ struct IterativeRun {
     private static let preemptiveReloadEvery = 40
     private static let failuresBeforeReload = 3
     private static let maxReloadsWithoutProgress = 4
+    private static let extractionTimeoutSeconds: Double = 30   // Arch §H: one file's content extraction can't hang the run
 
     /// Runs each connector's buckets through ONE engine (sized to the biggest connector). The caller
     /// passes every selected source at once; per-connector load + kind ride along per bucket.
@@ -84,7 +117,9 @@ struct IterativeRun {
         // so ProcessingView's dev pane can show it.
         func attempt(_ cand: Candidate, connector: any Connector) async -> (ok: Bool, draft: NoteDraft?) {
             do {
-                let artifact = try autoreleasepool { try connector.load(cand) }
+                let artifact = try await withExtractionTimeout(Self.extractionTimeoutSeconds) {
+                    try autoreleasepool { try connector.load(cand) }
+                }
                 let prompt = Triage.prompt(for: artifact, currentDate: Date())
                 p.lastPrompt = prompt
                 let result = try await engine.generate(prompt: prompt, imageData: artifact.imageData)

--- a/Sentient OS macOS/Sources/FilesSource.swift
+++ b/Sentient OS macOS/Sources/FilesSource.swift
@@ -13,18 +13,17 @@
 //  date — the folder structure alone is strong signal for junk/intent.
 //
 //  POINTER: one per-bucket high-water mark per folder root (bucket "file:<FileRoot.id>"),
-//  held in CycleStore and advanced by IterativeRun — no separate cursor object, no backfill.
-//  A file's date is max(dateAdded, dateModified, nearest moved-in ancestor's dateAdded) —
-//  dateAdded catches downloads with old mtimes, dateModified catches edits, and the ancestor
-//  propagation catches whole folders dragged into a root (their files keep old dates).
-//  Guards: a future-date clamp (clock weirdness can't poison the pointer). Ordering: incremental runs ascend
-//  (oldest-first); a root's FIRST run (no pointer yet) is a BACKFILL — newest-first descent
-//  tracked by a BackfillCursor [lo, hi] interval, resumable, with the root cap as a TOTAL
-//  budget across interruptions. New files arriving mid-backfill process before the dig resumes.
+//  held in CycleStore and advanced by IterativeRun — no separate cursor object, no backfill engine.
+//  eligibleFiles() keys each file on its pure addedToDirectoryDate (future-clamped, so a bad clock
+//  can't poison the pointer) and returns the eligible set NEWEST-FIRST; IterativeRun's pointer (a
+//  high-water mark, plus a floor while a first run is mid-descent) decides new-vs-done — so edits
+//  never reprocess and a stopped run resumes.
 //
-//  Skipping & caps (see Documentation/Files Source (Skipping & Caps).md): code repos and
-//  machine-generated datasets are pruned at the walk level (`pruneReason`), and `scan` bounds
-//  every run — newest 1,000 per root, 300 per directory, 1-year age cutoff for Downloads.
+//  Skipping & caps (see Documentation/Files Source (Skipping & Caps).md): three free layers, no
+//  inference — subtree pruning (`pruneReason`: code repos, datasets, data/markup dumps), per-file
+//  rejects (`fileRejectReason`: camera roll, lock/temp, boilerplate, empty, oversize), and caps
+//  (newest 1,000/root · 100/dir · Downloads 1-year). The walk is bounded too — max depth 3, symlinks
+//  skipped — and content extraction is timeout-guarded in IterativeRun.
 //
 
 import Foundation
@@ -42,7 +41,7 @@ struct FilesSource: Sendable {
     let maxAge: TimeInterval?    // drop files older than this (nil = no age cutoff)
 
     init(root: URL, label: String, cursorKey: String? = nil,
-         perDirectoryCap: Int = 300, maxAge: TimeInterval? = nil) {
+         perDirectoryCap: Int = 100, maxAge: TimeInterval? = nil) {
         self.root = root
         self.label = label
         self.cursorKey = cursorKey ?? "file:custom:" + root.path
@@ -52,6 +51,8 @@ struct FilesSource: Sendable {
 
     static let allowedExtensions: Set<String> = ["pdf", "doc", "docx", "md", "txt", "png", "jpg", "jpeg", "heic"]
     static let perRootCap = 1_000   // connector limit (June 10): newest 1,000 per root, every root
+    static let maxWalkDepth = 3                     // don't explore past 3 subfolder levels (bounds a pathological tree)
+    static let maxFileBytes = 100 * 1_024 * 1_024   // skip files over ~100 MB — hang guard (never even open a giant file)
     private static let imageExtensions: Set<String> = ["png", "jpg", "jpeg", "heic"]
     private static let maxContentChars = 8_000
     private static let pdfPageLimit = 3
@@ -85,12 +86,17 @@ struct FilesSource: Sendable {
         "Makefile", "makefile", "CMakeLists.txt", "mix.exs", "deno.json", "build.sbt",
     ]
 
-    /// Source-code extensions for the density heuristic — a folder that's mostly these is a code
-    /// project even without a recognized manifest.
+    /// Extensions for the density heuristic — a folder that's mostly these is a code project or a
+    /// bulk data/markup dump (even without a manifest), so its few readable stragglers (a README, a
+    /// stray screenshot) are project noise, not a life. The data/markup ones aren't in
+    /// `allowedExtensions`, so they're never read as files anyway — listing them here only governs
+    /// the subtree-skip decision (if >half a folder is JSON/HTML/notebooks, walking in is noise).
     private static let codeExtensions: Set<String> = [
         "py", "js", "jsx", "ts", "tsx", "mjs", "c", "h", "cpp", "cc", "hpp", "m", "mm",
         "swift", "java", "kt", "rs", "go", "rb", "php", "cs", "scala", "sh", "lua",
         "dart", "vue", "svelte", "sql", "pl", "r",
+        // Data / markup — bulk presence signals a project or data dump, not personal content.
+        "json", "html", "htm", "css", "scss", "less", "ipynb", "xml", "yaml", "yml", "toml",
     ]
 
     /// Why this directory's whole subtree is skipped — nil means walk in. Reads the directory
@@ -159,6 +165,45 @@ struct FilesSource: Sendable {
         return patterns.contains { base.range(of: $0, options: .regularExpression) != nil }
     }
 
+    // MARK: File-level rejects (content-free — name & size only; decided 2026-06-25)
+
+    /// Obvious noise we refuse from the NAME and SIZE alone — never by reading the file. Every item
+    /// rejected here is one model call saved. Runs per file in eligibleFiles(), after the extension
+    /// whitelist. (Subtree-level skips live in pruneReason; this is the per-file companion.)
+    static func fileRejectReason(name: String, ext: String, size: Int?) -> String? {
+        // App lock / temp owner files (e.g. Word's "~$Report.docx") — garbage content.
+        if name.hasPrefix("~$") || name.hasPrefix(".~") { return "lock/temp file" }
+        // Empty stub — a model call for nothing.
+        if let size, size == 0 { return "empty file" }
+        // Hang guard — refuse to even open something huge (a 2 GB PDF can stall the run).
+        if let size, size > maxFileBytes { return "oversize" }
+        // Boilerplate that ships inside downloaded tools/zips — never the user's own life.
+        if boilerplateNames.contains((name as NSString).deletingPathExtension.lowercased()) {
+            return "boilerplate doc"
+        }
+        // Camera-roll photos — describing random pictures adds nothing (decided: drop outright).
+        // Screenshots are deliberately NOT here: a screenshot can hold a ticket/address/confirmation.
+        if imageExtensions.contains(ext), isCameraRollName(name) { return "camera roll" }
+        return nil
+    }
+
+    /// Boilerplate filenames bundled with software/downloads — matched on the basename, any extension.
+    /// (A real code repo is already pruned by .git/manifest; this catches a loose README/LICENSE that
+    /// got unzipped into Downloads on its own.)
+    private static let boilerplateNames: Set<String> = [
+        "readme", "license", "licence", "copying", "notice",
+        "changelog", "authors", "contributing", "code_of_conduct", "eula",
+    ]
+
+    /// Phone/camera photo filenames — the signature of a camera roll, not a life: iPhone (IMG_),
+    /// Pixel (PXL_), generic cameras (DSC/DSCN/DSCF), GoPro (GOPR), panoramas, motion photos, burst
+    /// shots, and WhatsApp media (IMG-…-WA…). Screenshots are deliberately excluded (kept as keepers).
+    private static func isCameraRollName(_ name: String) -> Bool {
+        let base = (name as NSString).deletingPathExtension.lowercased()
+        let camera = ["img_", "img-", "pxl_", "dsc", "mvimg", "pano", "gopr", "burst"]
+        return camera.contains { base.hasPrefix($0) }
+    }
+
     // MARK: Pointer encoding — "(epochSeconds|path)", path = same-second tiebreak
 
     static func pointerValue(date: Date, path: String) -> String {
@@ -169,7 +214,7 @@ struct FilesSource: Sendable {
 
     /// The current eligible set for this root, for the iterative system (IterativeRun via
     /// FilesConnector). Same
-    /// skip rules (`pruneReason`) and caps (`cappedNewestFirst`: 1,000/root · 300/dir · Downloads
+    /// skip rules (`pruneReason`) and caps (`cappedNewestFirst`: 1,000/root · 100/dir · Downloads
     /// 1-yr) as `scan`, but deliberately DIFFERENT in two ways:
     ///   • keyed on PURE `addedToDirectoryDate` (a file's "date added" — what Finder shows), NOT
     ///     scan's max(dateAdded, mtime, ancestor). The interval pointer reprocesses nothing on
@@ -179,8 +224,9 @@ struct FilesSource: Sendable {
     /// (itemDate, path)). Reuse `load(_:)` for content extraction.
     func eligibleFiles() -> [Candidate] {
         let now = Date()
-        let keys: Set<URLResourceKey> = [.isRegularFileKey, .isDirectoryKey,
-                                         .creationDateKey, .addedToDirectoryDateKey]
+        let rootDepth = root.pathComponents.count
+        let keys: Set<URLResourceKey> = [.isRegularFileKey, .isDirectoryKey, .isSymbolicLinkKey,
+                                         .fileSizeKey, .creationDateKey, .addedToDirectoryDateKey]
         guard let enumerator = FileManager.default.enumerator(
             at: root, includingPropertiesForKeys: Array(keys),
             options: [.skipsHiddenFiles, .skipsPackageDescendants]
@@ -189,12 +235,23 @@ struct FilesSource: Sendable {
         var rows: [(candidate: Candidate, sortKey: Double)] = []
         for case let url as URL in enumerator {
             let vals = try? url.resourceValues(forKeys: keys)
+            // Never follow symlinks — they can form loops that never finish the walk.
+            if vals?.isSymbolicLink == true { enumerator.skipDescendants(); continue }
             if vals?.isDirectory == true {
-                if Self.pruneReason(url) != nil { enumerator.skipDescendants() }
+                // Skip the subtree if it's noise (pruneReason) OR too deep (bounds a pathological tree).
+                if Self.pruneReason(url) != nil
+                    || url.pathComponents.count - rootDepth > Self.maxWalkDepth {
+                    enumerator.skipDescendants()
+                }
                 continue   // directories are never candidates themselves
             }
-            guard vals?.isRegularFile == true,
-                  Self.allowedExtensions.contains(url.pathExtension.lowercased()) else { continue }
+            guard vals?.isRegularFile == true else { continue }
+            let ext = url.pathExtension.lowercased()
+            guard Self.allowedExtensions.contains(ext) else { continue }
+            // Content-free per-file rejects (camera roll, lock/temp, boilerplate, empty, oversize).
+            if Self.fileRejectReason(name: url.lastPathComponent, ext: ext, size: vals?.fileSize) != nil {
+                continue
+            }
 
             // Pure date added, future-clamped. A file with no recorded date-added sorts to the
             // bottom (.distantPast) rather than poisoning the newest end.
@@ -219,7 +276,7 @@ struct FilesSource: Sendable {
 
     /// Newest-first selection under the connector caps (June 10–11 decisions):
     ///  • optional age cutoff (Downloads: 1 year — downloads age into junk; keepers elsewhere don't)
-    ///  • per-directory cap (300, every root) — the bulk-dump backstop
+    ///  • per-directory cap (100, every root) — the bulk-dump backstop
     ///  • `budget` — the per-root cap, or what's left of a backfill's descent budget
     private func cappedNewestFirst(_ rows: [(candidate: Candidate, sortKey: Double)],
                                    budget: Int, now: Date) -> [Candidate] {


### PR DESCRIPTION
## What & why

Downloads is the default source and the worst-case folder for noise — camera rolls, software boilerplate, giant files, deeply nested dumps. This cuts that noise **before** it reaches the on-device model (every item skipped here is one inference call saved) and hardens the run against ever hanging.

Built from the trimmed strategy doc (`Our_Stuff/Pruning Strategy — What Sentient Should NOT Process.md`). All filtering is **content-free** — name/size/structure only, never reading a file to classify it.

## Changes (all in `FilesSource.swift` + one wrap in `IterativeRun.swift`)

**New per-file rejects — `fileRejectReason(name:ext:size:)`:**
- **Camera roll** → drop `IMG_`/`IMG-`/`PXL_`/`DSC*`/`MVIMG`/`PANO`/`GOPR`/`BURST` images outright. **Screenshots are deliberately kept** (a screenshot can hold a ticket/address/confirmation).
- **Lock/temp** → drop `~$…` / `.~…` (e.g. Word's `~$Report.docx`).
- **Boilerplate** → drop `README`/`LICENSE`/`COPYING`/`NOTICE`/`CHANGELOG`/`AUTHORS`/`CONTRIBUTING`/`CODE_OF_CONDUCT`/`EULA` (any extension).
- **Empty** → drop 0-byte files.
- **Oversize** → drop files >100 MB (hang guard — never even opens a giant PDF).

**Walk bounds (never-finishes guards):**
- Max depth **3** subfolder levels; **symlinks skipped** (no loops).
- **30s per-item extraction timeout** in `IterativeRun` (`withExtractionTimeout`) — a corrupt file abandons instead of hanging.

**Tuning:**
- Code-density now also prunes folders dominated by **bulk data/markup** (`json/html/htm/css/scss/less/ipynb/xml/yaml/yml/toml`) — these never reach the model anyway, so a folder that's mostly them is a project/dump, not a life.
- Per-directory cap **300 → 100** (per the strategy doc; reverts the brief June-11 raise).

**Docs:** rewrote `Documentation/Files Source (Skipping & Caps).md` (three layers + walk bounds) and the stale `FilesSource.swift` header (killed the dead `scan`/`BackfillCursor` description).

## Testing

Confirmed working on a real Mac (Aditya): camera-roll photos no longer processed, screenshots still are, `README`/`~$`/oversize files skipped, deep folders not descended, ≤100 files/subfolder.

## Out of scope

Does **not** fix the separate name-blocklist over-skip bug (English-word folder names like `target`/`build`/`vendor`) — that's untouched and still open.
