### PR TITLE
Gift card: real 'letter from Sentient' from the knowledge base

### DIFF
--- a/Sentient OS macOS/Ingestion/GiftLetter.swift
+++ b/Sentient OS macOS/Ingestion/GiftLetter.swift
@@ -1,0 +1,171 @@
+//
+//  GiftLetter.swift
+//  Sentient OS macOS  ·  Ingestion/
+//
+//  The welcome "gift" — the day-one "letter from Sentient" card (Arch §6). One Codex call
+//  (gpt-5.5, high, workspace-write over the user's OWN knowledge base) reads the synthesized
+//  cross-life portrait and WRITES the finished letter as "Gift from Sentient.md" in the vault folder.
+//  We read that file back, persist it, and delete it so nothing strays into the user's notes. The
+//  letter is plain-English Markdown (a title, a couple of sections, ✦ bullets) — rendered by the
+//  welcome/envelope card via `Briefing(fromGiftMarkdown:)`. Hermetic: no web, no MCP — grounded only
+//  in their own life.
+//
+//  Key methods:
+//   - generate() async throws -> String   (reads the KB, runs Codex, reads back the letter, persists)
+//   - latest() -> String?                 (the last generated letter; nil if never run)
+//
+//  The prompt is iterated by the team in Our_Stuff/Gift Card Prompt.md — keep the two in sync.
+//
+
+import Foundation
+
+actor GiftLetter {
+
+    static let shared = GiftLetter()
+
+    /// The file the model writes the letter into (inside the knowledge-base folder, per the prompt).
+    static let fileName = "Gift from Sentient.md"
+
+    enum GiftError: LocalizedError {
+        case noVault
+        case empty
+        case usageLimit(String)
+        case failed(String)
+        var errorDescription: String? {
+            switch self {
+            case .noVault:           return "No knowledge base on disk yet — build it first, then the welcome gift can be written."
+            case .empty:             return "The model didn't produce a letter."
+            case .usageLimit(let m): return "Your AI hit its usage limit — try again later. (\(m.prefix(160)))"
+            case .failed(let m):     return m
+            }
+        }
+    }
+
+    /// Read the knowledge base and write the welcome gift letter. The model writes it to
+    /// "Gift from Sentient.md" in the vault folder; we read it back, persist it, and DELETE the file so
+    /// no stray note ever lingers (or gets mirrored). Hermetic — no web, no user MCP. Throws on
+    /// no-vault / empty / usage-limit / failure.
+    @discardableResult
+    func generate() async throws -> String {
+        let vault = VaultGenerator.vaultRoot
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: vault.path) else { throw GiftError.noVault }
+
+        let giftFile = vault.appendingPathComponent(Self.fileName)
+        try? fm.removeItem(at: giftFile)               // clear any stale copy before the run
+        defer { try? fm.removeItem(at: giftFile) }     // never leave it behind, on ANY exit path
+
+        var inv = CodexCLI.Invocation(prompt: Self.prompt(vaultPath: vault.path))
+        inv.effort = .high                  // the gift should feel like magic — give it the deep pass
+        inv.sandbox = .workspaceWrite       // it WRITES "Gift from Sentient.md" into the vault folder
+        inv.cwd = vault.path                // the knowledge base is the working dir → reads + writes here
+        inv.webSearch = false               // grounded ONLY in their own life — no external facts
+        inv.includeUserConfig = false       // hermetic — no user MCP servers, nothing leaks in
+        inv.timeout = 1_200
+
+        Log("GiftLetter: writing the welcome gift from the knowledge base at \(vault.lastPathComponent)…")
+        do {
+            let env = try await CodexCLI.shared.run(inv)
+            // The letter is the file the model wrote; fall back to its final message if it skipped it.
+            let fromFile = (try? String(contentsOf: giftFile, encoding: .utf8)) ?? ""
+            let letter = Self.cleanMarkdown(fromFile.isEmpty ? env.result : fromFile)
+            guard !letter.isEmpty else { throw GiftError.empty }
+            Log("GiftLetter: ✅ welcome letter (\(letter.count) chars, turns \(env.numTurns ?? -1), \(env.outputTokens ?? -1) out-tokens)")
+            Self.saveLatest(letter)
+            return letter
+        } catch let CodexCLI.CLIError.usageLimit(message, _) {
+            throw GiftError.usageLimit(message)
+        } catch let e as GiftError {
+            throw e
+        } catch {
+            throw GiftError.failed("\(error)")
+        }
+    }
+
+    // MARK: Persistence (the home reads this to render the welcome card)
+
+    private static let latestKey = "gift.latestLetter"
+
+    static func saveLatest(_ letter: String) {
+        UserDefaults.standard.set(letter, forKey: latestKey)
+    }
+
+    /// The last generated letter (markdown), or nil if it's never run (so the cycle writes it once).
+    static func latest() -> String? {
+        let s = UserDefaults.standard.string(forKey: latestKey)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return (s?.isEmpty == false) ? s : nil
+    }
+
+    // MARK: Output cleanup
+
+    /// Strip a wrapping ```/```markdown fence if the model added one around the whole letter.
+    private static func cleanMarkdown(_ raw: String) -> String {
+        var s = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if s.hasPrefix("```") {
+            if let firstNL = s.firstIndex(of: "\n") { s = String(s[s.index(after: firstNL)...]) }
+            if let fence = s.range(of: "```", options: .backwards) { s = String(s[..<fence.lowerBound]) }
+        }
+        return s.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    // MARK: The prompt (team-iterated in Our_Stuff/Gift Card Prompt.md — keep in sync)
+
+    private static func prompt(vaultPath: String) -> String {
+        """
+        You are the heart of Sentient OS — an AI that lives on the user's own Mac and has quietly read their ENTIRE life: their files, messages, notes, calendar, email, etc. You're about to use that to give them a small, delightful gift (a "letter from Sentient") that shows up the first time they open Sentient after its knowledge base creation is complete.
+
+        THE KNOWLEDGE BASE — GO READ IT WELL!
+        The user's whole life has been synthesized into a knowledge base: a folder of markdown notes at this exact path on this Mac (it is also your current working directory):
+
+            \(vaultPath)
+
+        Read it thoroughly FIRST — open README.md, then read the notes across EVERY folder — before you write a single word. Every claim in your letter MUST be grounded in what you actually find there. If it isn't in the knowledge base, you may not say it. Never invent.
+
+        YOUR TASK
+        Find a few of the most interesting, genuinely true **delightful** patterns about this person — the kind they would never have noticed themselves, because each one only becomes visible when everything about their life sits in one place. Then write them up as a short letter.
+
+        WHAT MAKES A GREAT PATTERN
+        - It connects different corners of their life (e.g. a trait at work shows up again in a hobby; a habit in their messages echoes in their files). Single-topic observations are weak — reach across.
+        - It is genuinely surprising — something they probably haven't put into words about themselves. NOT obvious filler like "you work hard" or "you care about your family."
+        - It is specific and unmistakably about THEM. Name the real things — the actual project, person, place, app, habit — so it reads as obviously true, not generic.
+        - It's delightful -- reading this "letter from Sentient" must make them smile :D
+        - It's personal!
+
+        LANGUAGE
+        No using buzz words nor AI-isms:
+        - No em-dashes
+        - No "it's not just x, it's y"
+        - A genuine feeling letter that a 25 year old may have written. No buzzwords nor jargon. Understandable by a 12 year old.
+        - Each pattern = a short bold headline (about 3–7 words, ending in a period) then ONE sentence (about 15–25 words) that explains it with a concrete real detail.
+        - These are real examples of the BAD writing we are fixing — NEVER write like this: "You spec hardware in numbers and music in feelings." / "Your optimization points outward." They sound clever and say almost nothing. Banned.
+        - Talk to the user as "you." Warm and plain, like a friend who noticed something cool about them.
+
+        Explore a **ton** of MD files, and think **deep** about the most delightful, incredible letter before you write anything.
+
+        **Important: quality matters much more than quantity! 3-4 high-quality points are wayy better than 6 points you aren't as confident about (the disconnect would ruin the whole point).**
+
+        OUTPUT — A SINGLE MARKDOWN LETTER
+
+        Example of a great result:
+        ```
+        # The System Builder's Map
+
+        I just analyzed your entire digital life to understand you. So much stands out :)
+        ### Something you might not know about yourself
+
+        **Your real pattern is not just building AI products; it is turning recurring ambiguity into reusable systems.**
+        In IB Math AA HL, you made decision-tree guides for integration, trig, logs, complex numbers, and proofs. For Jacob, you made timetables, exam calendars, custom AI prompts, and even an ICSE CS textbook. Sentient OS is the same reflex at startup scale: take the chaos of screenshots, files, notes, and messages, then compress it into a queryable vault.
+
+        ## Also noticed
+
+        ✦ Your breakout projects keep starting from Apple-shaped constraints: Writing Tools as an open-source Apple Intelligence port, iPadOS on iPhone, and Sentient's on-device macOS/iOS layer.
+        ✦ You care about assistants having the right "operating manual" for a person: you maintain prompts across ChatGPT, Claude, Gemini, Perplexity, and tailored prompts for Jacob.
+        ✦ Your public technical credibility is unusually concrete: 30,000+ Writing Tools users, 28+ publications, WIRED coverage, and a 2025 UMass Tech Challenge win.
+
+        -- Your Sentient
+        ```
+
+        When you're done reading and thinking, write this as `Gift from Sentient.md` in this directory. It'll be displayed in the Sentient UI.
+        """
+    }
+}

--- a/Sentient OS macOS/Ingestion/ProactiveCycle.swift
+++ b/Sentient OS macOS/Ingestion/ProactiveCycle.swift
@@ -61,6 +61,14 @@ actor ProactiveCycle {
         }
         await VaultCloud.pushIfDirty()                       // no-op if the mirror is off
 
+        // 2.5) The welcome "gift" — write it ONCE, the first time a knowledge base exists to read.
+        //      Best-effort: it's a delight, never load-bearing, so a failure never fails the cycle.
+        if GiftLetter.latest() == nil {
+            progress(.knowledgeBase("Writing your welcome…"))
+            do { _ = try await GiftLetter.shared.generate() }
+            catch { Log("GiftLetter: welcome skipped — \(Self.msg(error))") }
+        }
+
         // 3) Proactive — decide, then research + prepare. Inject the live calendar when connected.
         var calCtx: String?
         if UserDefaults.standard.bool(forKey: "dbg.calendar.connected") {

--- a/Sentient OS macOS/Views/Briefing.swift
+++ b/Sentient OS macOS/Views/Briefing.swift
@@ -101,6 +101,33 @@ struct Briefing: Identifiable {
             accent: Self.accentColor(for: a.method))
     }
 
+    /// The welcome "gift" card — built straight from the generated Markdown letter (`GiftLetter` writes
+    /// the whole thing: real cross-life patterns in plain English, title and all). The model opens with
+    /// its own "# Title"; we promote that to the card title so the expanded letter never shows two
+    /// titles, and the rest becomes the letter body. The envelope/letter UX keys off `kind == .welcome`.
+    init(fromGiftMarkdown markdown: String) {
+        var title = "A gift — connections across your life."
+        var lines = markdown.trimmingCharacters(in: .whitespacesAndNewlines).components(separatedBy: "\n")
+        if let i = lines.firstIndex(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty }) {
+            let head = lines[i].trimmingCharacters(in: .whitespaces)
+            if head.hasPrefix("# ") {
+                let t = String(head.dropFirst(2)).trimmingCharacters(in: .whitespaces)
+                if !t.isEmpty { title = t }
+                lines.removeSubrange(0...i)
+            }
+        }
+        let body = lines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+        self.init(
+            id: "welcome", kind: .welcome,
+            kicker: "Welcome · Read across your whole life",
+            title: title,
+            body: "A letter from your Sentient.",
+            letter: body,
+            detailLabel: "read it",
+            offer: nil,
+            doneTitle: "", doneBody: "")
+    }
+
     /// The clean mono-caps kicker: `METHOD · TARGET` (gmail/calendar/research name themselves).
     static func kickerLine(method: PreparedAction.Method, target: String) -> String {
         let t = target.trimmingCharacters(in: .whitespaces).uppercased()

--- a/Sentient OS macOS/Views/HomeView.swift
+++ b/Sentient OS macOS/Views/HomeView.swift
@@ -390,8 +390,15 @@ final class ForYouModel {
         let v = visit
         runTasks.values.forEach { $0.cancel() }; runTasks.removeAll()
         if realCards {
+            var built: [Entry] = []
+            // The day-one welcome "gift" leads the deck as a sealed envelope (generated from the user's
+            // own knowledge base by the proactive cycle; absent until that's run once).
+            if let gift = GiftLetter.latest() {
+                built.append(Entry(b: Briefing(fromGiftMarkdown: gift), action: nil, phase: .sealed))
+            }
             let ready = ProactiveResearch.latest()?.ready ?? []
-            entries = ready.map { Entry(b: Briefing(from: $0), action: $0, phase: .offer) }
+            built.append(contentsOf: ready.map { Entry(b: Briefing(from: $0), action: $0, phase: .offer) })
+            entries = built
         } else {
             entries = Briefing.demo.map { Entry(b: $0, action: nil, phase: $0.kind == .welcome ? .sealed : .offer) }
         }
@@ -752,22 +759,66 @@ private struct LetterView: View {
         .onChange(of: briefing.id) { _, _ in editedDraft = liveDraft; savedDraft = liveDraft; copied = false }
     }
 
+    /// The letter body, rendered line-by-line. Supports the editorial Markdown subset our letters use:
+    /// `##`/`###` section headings, `✦ ` accent bullets, a closing sign-off line, and plain paragraphs
+    /// (with `**bold**` inline). A blank line is a paragraph break. (`# H1` is promoted to the card
+    /// title upstream, but we still render one defensively.)
     @ViewBuilder
     private var paragraphs: some View {
-        let parts = (briefing.letter ?? briefing.body).components(separatedBy: "\n\n")
-        ForEach(Array(parts.enumerated()), id: \.offset) { item in
-            let text = item.element.trimmingCharacters(in: .whitespacesAndNewlines)
-            if text.hasPrefix("✦ ") {
-                HStack(alignment: .firstTextBaseline, spacing: 9) {
-                    Text("✦").font(.system(size: 12)).foregroundStyle(briefing.accent)
-                    Text(Self.inline(String(text.dropFirst(2))))
-                        .font(.system(size: 13.5)).foregroundStyle(.white.opacity(0.84)).lineSpacing(4.5)
-                }
-            } else {
-                Text(Self.inline(text))
-                    .font(.system(size: 14)).foregroundStyle(.white.opacity(0.84)).lineSpacing(5)
+        let lines = (briefing.letter ?? briefing.body).components(separatedBy: "\n")
+        VStack(alignment: .leading, spacing: 10) {
+            ForEach(Array(lines.enumerated()), id: \.offset) { _, raw in
+                letterBlock(raw.trimmingCharacters(in: .whitespaces))
             }
         }
+    }
+
+    @ViewBuilder
+    private func letterBlock(_ line: String) -> some View {
+        if line.isEmpty {
+            Color.clear.frame(height: 2)                              // a paragraph break
+        } else if line.hasPrefix("### ") {
+            Text(Self.inline(String(line.dropFirst(4))))             // soulful subhead (serif italic)
+                .font(.system(size: 16, design: .serif).italic())
+                .foregroundStyle(.white.opacity(0.92))
+                .padding(.top, 6)
+        } else if line.hasPrefix("## ") {
+            MonoCaps(String(line.dropFirst(3)).uppercased(), size: 10, tracking: 2.2,
+                     color: briefing.accent.opacity(0.95))           // section whisper (mono-caps)
+                .padding(.top, 12)
+        } else if line.hasPrefix("# ") {
+            Text(Self.inline(String(line.dropFirst(2))))             // a stray title, defensive
+                .font(.system(size: 22, design: .serif)).foregroundStyle(.white)
+                .padding(.top, 4)
+        } else if let bullet = Self.bulletText(line) {
+            HStack(alignment: .firstTextBaseline, spacing: 9) {
+                Text("✦").font(.system(size: 12)).foregroundStyle(briefing.accent)
+                Text(Self.inline(bullet))
+                    .font(.system(size: 13.5)).foregroundStyle(.white.opacity(0.84)).lineSpacing(4.5)
+            }
+        } else if Self.isSignoff(line) {
+            Text(Self.inline(line))                                  // "-- Your Sentient"
+                .font(.system(size: 13, design: .serif).italic())
+                .foregroundStyle(.white.opacity(0.55))
+                .padding(.top, 10)
+        } else {
+            Text(Self.inline(line))
+                .font(.system(size: 14)).foregroundStyle(.white.opacity(0.84)).lineSpacing(5)
+        }
+    }
+
+    /// "✦ …" (tolerating a stray word-joiner / nbsp the model sometimes slips in) → the bullet's text;
+    /// nil if the line isn't a bullet.
+    private static func bulletText(_ line: String) -> String? {
+        guard line.first == "✦" else { return nil }
+        let rest = line.dropFirst().drop { $0 == " " || $0 == "\t" || $0 == "\u{2060}" || $0 == "\u{00A0}" }
+        return rest.isEmpty ? nil : String(rest)
+    }
+
+    /// A closing line like "-- Your Sentient" / "— your Sentient" (line-start only, so inline em-dashes
+    /// mid-paragraph aren't mistaken for a sign-off).
+    private static func isSignoff(_ line: String) -> Bool {
+        line.hasPrefix("--") || line.hasPrefix("—") || line.hasPrefix("– ")
     }
 
     /// Inline-markdown parse (**bold** etc.) so letters can carry a skimmable bold rail.
@@ -851,4 +902,30 @@ private enum Demo {
              sources: .init(files: true, whatsapp: true, imessage: true, notes: true),
              modelMissing: false)
         .frame(width: 1180, height: 880)
+}
+
+#Preview("Gift letter") {
+    let sample = """
+    # The System Builder's Map
+
+    I just analyzed your entire digital life to understand you. So much stands out :)
+    ### Something you might not know about yourself
+
+    **Your real pattern is turning recurring ambiguity into reusable systems.**
+    In IB Math AA HL you built decision-tree guides; for Jacob you made timetables, exam calendars, and custom AI prompts. Sentient OS is the same reflex at startup scale.
+
+    ## Also noticed
+
+    ✦ Your breakout projects keep starting from Apple-shaped constraints: Writing Tools as an Apple Intelligence port, iPadOS on iPhone, and Sentient's on-device layer.
+    ✦ You care about assistants having the right operating manual: you maintain tailored prompts across ChatGPT, Claude, Gemini, and Perplexity.
+    ✦ Your public credibility is unusually concrete: 30,000+ Writing Tools users, 28+ publications, WIRED coverage, and a 2025 UMass Tech Challenge win.
+
+    -- Your Sentient
+    """
+    return ZStack { Color.black.ignoresSafeArea()
+        LetterView(briefing: Briefing(fromGiftMarkdown: sample), phase: .offer,
+                   onOffer: {}, onClose: {})
+            .frame(width: 560)
+            .padding(40)
+    }
 }


### PR DESCRIPTION
## What

Makes the day-one welcome **gift card** real. Until now the "A gift — connections across your life" card showed hard-coded demo text; this generates a genuine "letter from Sentient" from the user's own knowledge base and renders it in the existing envelope/letter UX.

## How

- **`Ingestion/GiftLetter.swift` (new)** — one codex pass (gpt-5.5, high, workspace-write, hermetic: no web/MCP) reads the user's knowledge base and writes the letter as `Gift from Sentient.md` in the vault. We read it back, persist it, and **delete the file** (a `defer`, so it's cleaned up on every exit) — nothing strays into the user's notes or the mirror.
- **`Views/Briefing.swift`** — `Briefing(fromGiftMarkdown:)` builds the welcome card from the letter; the model's own `# Title` is promoted to the card title (no double title).
- **`Views/HomeView.swift`** — richer `LetterView` renderer matched to the design bar: `##` → mono-caps section whisper, `###` → serif-italic subhead, `✦` bullets, quiet sign-off, `**bold**` inline. Backward compatible with existing letters. Added a `#Preview("Gift letter")`.
- **`Ingestion/ProactiveCycle.swift`** — generates the letter once, after the knowledge base exists (best-effort; a failure never fails the cycle).

The prompt is team-iterated in `Our_Stuff/Gift Card Prompt.md`.

## Testing

- ✅ Builds clean (isolated `xcodebuild`).
- ⏳ Not yet runtime-verified end-to-end (needs a real KB + cycle run). The `#Preview("Gift letter")` shows the new renderer in Xcode's canvas.