### PR TITLE
Sentry crash logs + dSYM upload (+ TimeoutBox Release-build fix)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ build/
 # On-device model weights (3.66 GB; bundled locally for dev, downloaded by users — never committed)
 *.litertlm
 
+# Sentry CLI config — holds the dSYM-upload AUTH TOKEN (a real bearer secret; NEVER commit).
+# Each dev/CI keeps their own; the Release build phase reads it. org/project are non-secret.
+.sentryclirc
+

--- a/Sentient OS macOS.xcodeproj/project.pbxproj
+++ b/Sentient OS macOS.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		5AB7600E2FD12ABE00149A7F /* LiteRTLM in Frameworks */ = {isa = PBXBuildFile; productRef = 5AB7600D2FD12ABE00149A7F /* LiteRTLM */; };
+		5AE5710001000000000000A1 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 5AE5710001000000000000A2 /* Sentry */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -28,6 +29,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5AB7600E2FD12ABE00149A7F /* LiteRTLM in Frameworks */,
+				5AE5710001000000000000A1 /* Sentry in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -61,6 +63,7 @@
 				5A3F390E2FD0F43300DD835E /* Frameworks */,
 				5A3F390F2FD0F43300DD835E /* Resources */,
 				5AAAA0012FD0F43300DD835E /* Trim app bundle (thin LiteRT-LM, drop docs) */,
+				5AE5710001000000000000B1 /* Upload dSYMs to Sentry */,
 			);
 			buildRules = (
 			);
@@ -72,6 +75,7 @@
 			name = "Sentient OS macOS";
 			packageProductDependencies = (
 				5AB7600D2FD12ABE00149A7F /* LiteRTLM */,
+				5AE5710001000000000000A2 /* Sentry */,
 			);
 			productName = "Sentient OS macOS";
 			productReference = 5A3F39112FD0F43300DD835E /* Sentient OS.app */;
@@ -103,6 +107,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				5AB7600C2FD12ABE00149A7F /* XCLocalSwiftPackageReference "Vendor/LiteRTLM" */,
+				5AE5710001000000000000A3 /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 5A3F39122FD0F43300DD835E /* Products */;
@@ -143,6 +148,25 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "# Sentient OS bundle-trim phase (runs before the final app code-sign, so the seal stays\n# valid). Two jobs, both shrinking the shipped .app:\n#\n# 1) Thin the prebuilt LiteRT-LM dylib to the app's ARCHS. Google ships CLiteRTLM_mac as a\n#    fat arm64+x86_64 binary (~127MB); arm64-only roughly halves the .app. ARCHS=arm64\n#    only governs code Xcode COMPILES -- a checksum-pinned remote SwiftPM binary is copied\n#    in whole, so we strip it here. Idempotent (skips an already-thin slice) + re-signs.\n# 2) Drop the internal engineering docs the synchronized file group sweeps in from\n#    Documentation/. They're public in the repo and never read at runtime; ~150KB of dead\n#    weight. Globbed so future docs are dropped automatically.\nset -e\n\nDYLIB=\"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/libCLiteRTLM_mac.dylib\"\nif [ -f \"$DYLIB\" ]; then\n  THINNED=0\n  for arch in $(lipo -archs \"$DYLIB\"); do\n    case \" $ARCHS \" in\n      *\" $arch \"*) ;;\n      *) echo \"Thinning libCLiteRTLM_mac.dylib: removing $arch\"; lipo -remove \"$arch\" \"$DYLIB\" -output \"$DYLIB\"; THINNED=1 ;;\n    esac\n  done\n  if [ \"$THINNED\" = \"1\" ]; then\n    # Re-sign with the SAME options Xcode used, so a notarized Release stays valid: hardened\n    # runtime when enabled, plus a secure timestamp for Developer ID (distribution) signing\n    # only -- Apple Development / adhoc dev builds need neither (and skip the network round-trip).\n    SIGN_OPTS=\"\"\n    [ \"$ENABLE_HARDENED_RUNTIME\" = \"YES\" ] && SIGN_OPTS=\"--options runtime\"\n    case \"${EXPANDED_CODE_SIGN_IDENTITY:--}\" in \"Developer ID\"*) SIGN_OPTS=\"$SIGN_OPTS --timestamp\" ;; esac\n    echo \"Re-signing thinned libCLiteRTLM_mac.dylib ($SIGN_OPTS)\"\n    codesign --force $SIGN_OPTS --sign \"${EXPANDED_CODE_SIGN_IDENTITY:--}\" \"$DYLIB\"\n  fi\nelse\n  echo \"warning: libCLiteRTLM_mac.dylib not found at $DYLIB -- skipping arch thinning\"\nfi\n\nRES=\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}\"\nif [ -d \"$RES\" ]; then\n  find \"$RES\" -name \"*.md\" -print -delete\nfi\n";
+		};
+		5AE5710001000000000000B1 /* Upload dSYMs to Sentry */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Upload dSYMs to Sentry";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Upload the app's dSYM to Sentry so RELEASE crash reports symbolicate to real function\n# names + line numbers (Debug builds have symbols locally, so this is Release-only). Reads\n# auth + org/project from the gitignored .sentryclirc at SRCROOT. Every guard EXITS 0 so a\n# missing token, missing sentry-cli, or a failed upload NEVER breaks the build -- Debug\n# builds, OSS clones, and CI without the config just skip it. Doc: Documentation/Crash Reporting (Sentry).md\nif [ \"${CONFIGURATION}\" != \"Release\" ]; then\n  echo \"Sentry: skipping dSYM upload (CONFIGURATION=${CONFIGURATION})\"\n  exit 0\nfi\nSENTRY_CLI=\"$(command -v sentry-cli || echo /opt/homebrew/bin/sentry-cli)\"\nif [ ! -x \"$SENTRY_CLI\" ]; then\n  echo \"warning: sentry-cli not found -- skipping Sentry dSYM upload (brew install getsentry/tools/sentry-cli)\"\n  exit 0\nfi\ncd \"${SRCROOT}\" || exit 0\nif [ ! -f .sentryclirc ] && [ -z \"${SENTRY_AUTH_TOKEN}\" ]; then\n  echo \"warning: no .sentryclirc or SENTRY_AUTH_TOKEN -- skipping Sentry dSYM upload\"\n  exit 0\nfi\necho \"Sentry: uploading dSYMs from ${DWARF_DSYM_FOLDER_PATH}\"\n\"$SENTRY_CLI\" debug-files upload --include-sources \"${DWARF_DSYM_FOLDER_PATH}\" || echo \"warning: Sentry dSYM upload failed (continuing build)\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -383,10 +407,26 @@
 		};
 /* End XCLocalSwiftPackageReference section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		5AE5710001000000000000A3 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/getsentry/sentry-cocoa.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 8.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		5AB7600D2FD12ABE00149A7F /* LiteRTLM */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = LiteRTLM;
+		};
+		5AE5710001000000000000A2 /* Sentry */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5AE5710001000000000000A3 /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
+			productName = Sentry;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Sentient OS macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Sentient OS macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "c48504ff8dddd36e2eca2d6ed239773efad4c3dd2a84a90d4bf86d30d8cc15a4",
+  "pins" : [
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa.git",
+      "state" : {
+        "revision" : "dad229c665bfd043c5d80ac7aa77717cbd19a1c3",
+        "version" : "8.58.3"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Sentient OS macOS/CrashReporting.swift
+++ b/Sentient OS macOS/CrashReporting.swift
@@ -1,0 +1,111 @@
+//
+//  CrashReporting.swift
+//  Sentient OS macOS
+//
+//  Sentry integration — the app's crash-log + error + performance reporter. One entry
+//  point, `CrashReporting.start(process:)`, called from main.swift before anything else in
+//  BOTH process roles (the GUI app and the root --wake-helper LaunchDaemon), each tagged so a
+//  3am overnight-run crash is told apart from a UI crash. `Log()` (Log.swift) tees every line
+//  in as a breadcrumb, so a crash report arrives carrying the recent log trail that led to it.
+//
+//  Setup: paste your project DSN from sentry.io into `dsn` below (Settings → Projects →
+//  <project> → Client Keys (DSN)). Until then reporting stays off and we log a one-line notice.
+//
+
+import Foundation
+import Sentry
+
+enum CrashReporting {
+
+    /// The Sentry project DSN. NOT a secret — it can only write crash reports in, never read
+    /// anything out — so it lives in source, public-facing, even when the repo goes open source.
+    private static let dsn = "https://10ff4d2487c4913fcc9c61bd596bcf9f@o4511650390933504.ingest.us.sentry.io/4511651474636800"
+
+    /// Which process this is, used as the `process` tag on every event.
+    enum Role: String {
+        case app          // the normal GUI app
+        case wakeHelper   // the root LaunchDaemon (main.swift --wake-helper branch)
+    }
+
+    private static var started = false
+
+    /// Boot Sentry once for this process. Safe to call from either main.swift branch.
+    static func start(_ role: Role) {
+        guard !started else { return }
+        started = true
+
+        guard !dsn.isEmpty, !dsn.hasPrefix("PASTE_") else {
+            Log("CrashReporting: no DSN set — Sentry disabled (set Secrets.sentryDSN to enable)")
+            return
+        }
+
+        SentrySDK.start { options in
+            options.dsn = dsn
+
+            // Crashes: native signals + unhandled NSExceptions, with the full stack attached
+            // to every event (not just crashes).
+            options.attachStacktrace = true
+            options.enableCrashHandler = true
+
+            // Performance: trace + profile everything. This is a single-user desktop app, not a
+            // high-traffic server, so 100% sampling is cheap and gives complete pictures. Profiling
+            // uses the current trace-lifecycle API (tied to traces), not the deprecated rate knob.
+            options.tracesSampleRate = 1.0
+            options.configureProfiling = {
+                $0.sessionSampleRate = 1.0
+                $0.lifecycle = .trace
+            }
+
+            // Sessions (release health) + app-hang ("beachball") detection.
+            options.enableAutoSessionTracking = true
+            options.enableAppHangTracking = true
+
+            #if DEBUG
+            options.environment = "debug"
+            #else
+            options.environment = "release"
+            #endif
+
+            // We feed our own Log() breadcrumbs (below); the SDK's automatic console/UI
+            // breadcrumbs stay on too for extra context.
+        }
+
+        SentrySDK.configureScope { scope in
+            scope.setTag(value: role.rawValue, key: "process")
+        }
+
+        Log("CrashReporting: Sentry started (process=\(role.rawValue))")
+    }
+
+    /// Record a Log() line as a Sentry breadcrumb so crash reports carry the recent trail.
+    /// No-op until Sentry has started. Called from Log() (Log.swift).
+    static func breadcrumb(_ message: String) {
+        guard started else { return }
+        let crumb = Breadcrumb(level: .info, category: "log")
+        crumb.message = message
+        SentrySDK.addBreadcrumb(crumb)
+    }
+
+    /// Report a caught error that we still want visibility into (one that doesn't crash the app).
+    static func capture(_ error: Error) {
+        guard started else { return }
+        SentrySDK.capture(error: error)
+    }
+
+    #if DEBUG
+    /// DEV verification: send a non-fatal test event (lands in the dashboard within seconds).
+    static func sendTestEvent() {
+        guard started else { Log("CrashReporting.sendTestEvent: Sentry not started (no DSN?)"); return }
+        SentrySDK.capture(message: "Sentry test event from DEV TOOLS")
+        Log("CrashReporting: sent test event")
+    }
+
+    /// DEV verification: hard-crash so the native crash handler fires. The report lands on the
+    /// NEXT launch (that's how crash capture works). Only ever called from the DEBUG dev button.
+    static func forceCrash() {
+        guard started else { Log("CrashReporting.forceCrash: Sentry not started (no DSN?)"); return }
+        Log("CrashReporting: forcing a test crash now")
+        SentrySDK.crash()
+    }
+    #endif
+}

--- a/Sentient OS macOS/Documentation/Crash Reporting (Sentry).md
+++ b/Sentient OS macOS/Documentation/Crash Reporting (Sentry).md
@@ -1,0 +1,100 @@
+# Crash Reporting (Sentry)
+
+`CrashReporting.swift` wires the app to [Sentry](https://sentry.io) so we get crash logs,
+unhandled errors, and performance/profiling from real runs. It's the "black box" for diagnosing
+a crash we can't reproduce — including a crash during the root overnight run, when nobody's
+watching. Runtime reporting needs only the DSN (already in the code); readable production stack
+traces additionally need the Release dSYM-upload build phase (below).
+
+## How it boots
+
+`main.swift` calls `CrashReporting.start(_:)` first thing — in **both** process roles, before any
+other code runs:
+
+```swift
+if CommandLine.arguments.contains(WakeHelperConfig.helperFlag) {
+    CrashReporting.start(.wakeHelper)   // the root --wake-helper LaunchDaemon (overnight path)
+    WakeHelper.run()
+} else {
+    CrashReporting.start(.app)          // the normal GUI app
+    SentientOSApp.main()
+}
+```
+
+Each role tags every event with `process: app` or `process: wakeHelper`, so a 3am overnight-run
+crash is told apart from a UI crash in the dashboard.
+
+`start(_:)` boots Sentry with everything on: native crash handler + attached stack traces,
+app-hang ("beachball") detection, release-health sessions, 100% trace sampling, and trace-lifecycle
+profiling. It's idempotent (guarded by `started`) and a no-op if the DSN is blank.
+
+## The DSN — safe in the code
+
+The DSN is a plain constant at the top of `CrashReporting.swift`. **This is not a secret and is
+fine to ship publicly** (even when the repo goes open source): a DSN is write-only/ingest-only — it
+can only push crash events *in*, never read data out, touch the account, or delete anything. Every
+shipped Sentry app embeds its DSN in the binary anyway. The only abuse vector is event-quota spam,
+handled by Sentry's inbound filters + rate limits, and the DSN rotates in one click if needed.
+
+> Contrast with the **Auth Token** used for dSYM upload (below) — *that* one is a real bearer
+> credential (full read/write/delete on the org) and must NEVER be in the repo or the binary.
+
+## Breadcrumbs from `Log()`
+
+Every `Log()` call (Log.swift) also feeds a Sentry breadcrumb, so a crash report arrives carrying
+the recent log trail that led to it. No-op until Sentry has started.
+
+## Dev verification (DEBUG only)
+
+DEV TOOLS → **More** → **SENTRY** row:
+- **Send test event** → `CrashReporting.sendTestEvent()`, a non-fatal event; appears in Issues in
+  seconds. Good for confirming the pipeline + breadcrumbs.
+- **Force crash** → `CrashReporting.forceCrash()`, a hard crash. The report uploads on the **next
+  launch** (that's how native crash capture works).
+
+⚠️ **Sentry does not capture crashes while the Xcode debugger is attached** — LLDB eats the signal.
+To test a crash, run the built `.app` **standalone** (not ⌘R), crash, then relaunch.
+
+## Production stack traces — the dSYM upload
+
+A Release crash report only shows raw addresses (`0x1042f8a1c`) unless Sentry has the build's
+**dSYM** (debug symbol) files. A Run Script build phase, **"Upload dSYMs to Sentry"**, uploads them
+automatically — **Release only** (Debug has symbols locally; the phase skips with a log line).
+
+- Tool: `sentry-cli` (`brew install getsentry/tools/sentry-cli`).
+- Auth + org/project: read from **`.sentryclirc`** at the project root — **gitignored**, because it
+  holds the Auth Token (a real secret). Each dev/CI keeps their own copy. Format:
+  ```ini
+  [auth]
+  token=sntrys_...            # an Organization Auth Token from sentry.io/settings/auth-tokens
+  [defaults]
+  org=sentient-os
+  project=sentient-os
+  ```
+- The phase **fails safe**: every guard exits 0, so a missing token, missing `sentry-cli`, or a
+  failed upload never breaks the build — Debug builds, OSS clones, and CI without the config just
+  skip it.
+
+Build settings already cooperate: Release is `dwarf-with-dsym`, Debug is `dwarf` (no dSYM, fast),
+and user script sandboxing is off so the upload script can reach the network.
+
+## ⚠️ Gotcha: the `TimeoutBox` optimizer landmine (don't reintroduce)
+
+Wiring this surfaced a **pre-existing** Swift compiler crash (not Sentry's fault): a generic
+`TimeoutBox<T>` in `Ingestion/IterativeRun.swift` crashed the optimizer's `EarlyPerfInliner` pass on
+the generic class's `deinit` layout under `-O`. That segfaults swift-frontend and breaks **every
+Release/Archive build** — invisible in Debug (`-Onone`), so it hid until the first archive attempt.
+
+Fix: `TimeoutBox` is now **non-generic**, erasing the element type at the continuation boundary
+(it stores a `fire` closure that captures the typed continuation; only an erased `Result<Any, Error>`
+crosses the box). Same resume-exactly-once semantics. **Do not make it generic again** — the inline
+comment there says why.
+
+## Files
+
+- `CrashReporting.swift` — init, breadcrumbs, `capture(_:)`, dev test helpers.
+- `main.swift` — `start(.app)` / `start(.wakeHelper)`.
+- `Log.swift` — breadcrumb tee.
+- `Views/DevToolsView.swift` — the DEBUG SENTRY test buttons.
+- `.sentryclirc` (gitignored) — Auth Token + org/project for dSYM upload.
+- Build phase **"Upload dSYMs to Sentry"** in the app target (Release-only).

--- a/Sentient OS macOS/Ingestion/IterativeRun.swift
+++ b/Sentient OS macOS/Ingestion/IterativeRun.swift
@@ -28,13 +28,20 @@ private struct ExtractionTimeout: Error { let seconds: Double }
 
 /// Holds the racing continuation behind a lock so it resumes exactly once, and so the `@Sendable`
 /// dispatch closures capture this (`@unchecked Sendable`) box instead of the continuation directly.
-private final class TimeoutBox<T>: @unchecked Sendable {
+///
+/// Deliberately NON-GENERIC. A generic `TimeoutBox<T>` crashes the Swift optimizer — the
+/// `EarlyPerfInliner` pass infinite-recurses on the generic class's `deinit` layout under `-O`,
+/// which segfaults swift-frontend and breaks EVERY Release/Archive build (Debug is `-Onone`, so it
+/// builds fine — the bug hides until you ship). We erase the element type at the boundary below: the
+/// box stores a `fire` closure that already captures the typed continuation, so only an erased
+/// `Result<Any, Error>` crosses the box. The success value is always a `T`, so the downcast is total.
+private final class TimeoutBox: @unchecked Sendable {
     private let lock = NSLock()
-    private var cont: CheckedContinuation<T, Error>?
-    init(_ c: CheckedContinuation<T, Error>) { cont = c }
-    func resume(_ result: Result<T, Error>) {
-        lock.lock(); let c = cont; cont = nil; lock.unlock()
-        c?.resume(with: result)
+    private var fire: ((Result<Any, Error>) -> Void)?
+    init(_ fire: @escaping (Result<Any, Error>) -> Void) { self.fire = fire }
+    func resume(_ result: Result<Any, Error>) {
+        lock.lock(); let f = fire; fire = nil; lock.unlock()
+        f?(result)
     }
 }
 
@@ -46,8 +53,10 @@ private final class TimeoutBox<T>: @unchecked Sendable {
 private func withExtractionTimeout<T: Sendable>(_ seconds: Double,
                                                 _ work: @escaping @Sendable () throws -> T) async throws -> T {
     try await withCheckedThrowingContinuation { (cont: CheckedContinuation<T, Error>) in
-        let box = TimeoutBox(cont)
-        DispatchQueue.global(qos: .utility).async { box.resume(Result { try work() }) }
+        // Erase T here so TimeoutBox stays non-generic (see its note). The success value is always
+        // a T, so the downcast in `map` is total.
+        let box = TimeoutBox { result in cont.resume(with: result.map { $0 as! T }) }
+        DispatchQueue.global(qos: .utility).async { box.resume(Result { try work() as Any }) }
         DispatchQueue.global().asyncAfter(deadline: .now() + seconds) {
             box.resume(.failure(ExtractionTimeout(seconds: seconds)))
         }

--- a/Sentient OS macOS/Log.swift
+++ b/Sentient OS macOS/Log.swift
@@ -15,6 +15,7 @@ import Foundation
 func Log(_ items: Any..., separator: String = " ", terminator: String = "\n") {
     let message = items.map { String(describing: $0) }.joined(separator: separator)
     print(message, terminator: terminator)
+    CrashReporting.breadcrumb(message)   // trail of recent log lines, attached to any crash report
     #if DEBUG
     LogFile.shared.append(message)
     #endif

--- a/Sentient OS macOS/Views/DevToolsView.swift
+++ b/Sentient OS macOS/Views/DevToolsView.swift
@@ -716,11 +716,36 @@ struct DevToolsView: View {
 
                     fdaPane
                     mirrorPane
+                    #if DEBUG
+                    crashTestPane
+                    #endif
                 }
                 .padding(.top, 4)
             }
         }
     }
+
+    #if DEBUG
+    /// Sentry verification (DEBUG only): one tap to confirm crash reports actually reach the
+    /// dashboard once a real DSN is pasted into CrashReporting.swift. "Send test event" reports a
+    /// non-fatal error; "Force crash" hard-crashes the app so the native crash handler fires —
+    /// the report lands on the NEXT launch. Both no-op silently if no DSN is set.
+    private var crashTestPane: some View {
+        VStack(spacing: 4) {
+            Text("SENTRY").font(.system(.caption2, design: .monospaced)).foregroundStyle(Theme.secondary)
+            HStack(spacing: 8) {
+                Button { CrashReporting.sendTestEvent() } label: {
+                    Label("Send test event", systemImage: "paperplane")
+                }
+                .buttonStyle(.bordered)
+                Button(role: .destructive) { CrashReporting.forceCrash() } label: {
+                    Label("Force crash", systemImage: "exclamationmark.triangle")
+                }
+                .buttonStyle(.bordered)
+            }
+        }
+    }
+    #endif
 
     // MARK: MCP mirror (opt-in toggle + manual sync — dogfood ahead of the Phase-5 onboarding screen)
 

--- a/Sentient OS macOS/main.swift
+++ b/Sentient OS macOS/main.swift
@@ -12,7 +12,9 @@ import Foundation
 import SwiftUI
 
 if CommandLine.arguments.contains(WakeHelperConfig.helperFlag) {
-    WakeHelper.run()        // root LaunchDaemon mode — never returns
+    CrashReporting.start(.wakeHelper)   // crash reporting for the root overnight path
+    WakeHelper.run()                    // root LaunchDaemon mode — never returns
 } else {
-    SentientOSApp.main()    // normal GUI app
+    CrashReporting.start(.app)          // crash reporting for the GUI app
+    SentientOSApp.main()                // normal GUI app
 }


### PR DESCRIPTION
## What

Adds **Sentry** for crash logs, unhandled errors, and performance/profiling — plus a fix for a pre-existing compiler crash that was discovered along the way.

### Commits
1. **Fix Swift optimizer crash on `TimeoutBox<T>` deinit** (`abf2fa2`) — pre-existing, isolated for reviewability.
2. **Add Sentry crash + error + performance reporting with Release dSYM upload** (`86c3212`).

## Sentry integration
- `CrashReporting.swift` boots Sentry first thing in **both** process roles — the GUI app (`process: app`) and the root `--wake-helper` daemon (`process: wakeHelper`) — so an overnight-run crash is reported and distinguishable.
- Everything on: native crash handler + attached stacks, app-hang detection, release-health sessions, 100% trace sampling + trace-lifecycle profiling.
- **DSN** is a public-safe constant (write-only ingest — can't read data or touch the account; ships in every Sentry binary anyway).
- `Log()` tees every line into a Sentry **breadcrumb**, so crash reports carry the recent log trail.
- DEBUG-only **SENTRY** dev buttons (DEV TOOLS → More): *Send test event* / *Force crash*.

## Production stack traces — dSYM upload
- Release-only Run Script phase **"Upload dSYMs to Sentry"** (`sentry-cli`).
- Auth Token (a real secret, unlike the DSN) lives in a **gitignored `.sentryclirc`** — each dev/CI keeps their own.
- **Fails safe**: missing token / missing `sentry-cli` / failed upload never breaks the build (Debug, OSS clones, CI just skip).

## The TimeoutBox fix (why it's here)
Wiring this surfaced a **pre-existing** crash unrelated to Sentry: a generic `TimeoutBox<T>` in `IterativeRun.swift` crashed swift-frontend's `EarlyPerfInliner` on the generic class's `deinit` layout under `-O` — breaking **every Release/Archive build** (invisible in Debug `-Onone`). Verified identical crash on the pristine base commit. Made the box non-generic (element type erased at the continuation boundary); same resume-exactly-once semantics. **Unblocks the notarized-DMG path.**

## Verification
- ✅ Debug build green; Sentry phase correctly skips.
- ✅ Release build green; app dSYM generated + uploaded (7 dSYMs) to project `sentient-os`.
- ✅ Runtime confirmed live — a forced `EXC_BREAKPOINT` crash landed in the Sentry dashboard, symbolicated.

## Reviewer setup (one step)
To enable dSYM upload locally, create a gitignored `.sentryclirc` at the project root with an org Auth Token — see `Documentation/Crash Reporting (Sentry).md`. Runtime crash reporting needs nothing (DSN is in the code).

Closes the "Crash Logs → our own LOGGING" to-do.