### PR TITLE
Sentry: remove the debug bypass (Release-only, verified end-to-end)

### DIFF
--- a/Sentient OS macOS/CrashReporting.swift
+++ b/Sentient OS macOS/CrashReporting.swift
@@ -9,8 +9,8 @@
 //  report arrives carrying the recent log trail that led to it.
 //
 //  Two hard gates decide whether ANYTHING reaches Sentry (Documentation/Source Diagnostics …):
-//   1. RELEASE builds only — `start()` no-ops in DEBUG (dev crashes / self-test noise never ship).
-//      `startForDevTest()` is the one DEBUG escape hatch, for verifying the pipeline by hand.
+//   1. RELEASE builds only — `start()` no-ops in DEBUG. There is NO debug bypass: Sentry never
+//      initializes in a Debug build, so verify the pipeline from a Release build.
 //   2. Opt-OUT switch — `diagnosticsEnabled` (default ON); the single "Share anonymous diagnostics"
 //      toggle in Settings gates ALL reporting, crashes included.
 //  Privacy is upheld by construction, not by the switch: `captureEvent` only ever takes
@@ -18,7 +18,7 @@
 //  backstop. Events carry an anonymous per-install id (a random UUID, never the mirror token).
 //
 //  Key members:
-//   - start(_:) / startForDevTest()   → boot Sentry (gated) / boot for a DEBUG hand-test
+//   - start(_:)                       → boot Sentry (Release-only, opt-out gated)
 //   - captureEvent(_:level:tags:extra:fingerprint:)  → structured, PII-free diagnostics event
 //   - capture(_:) / breadcrumb(_:)    → non-fatal error / the Log() trail
 //   - diagnosticsEnabled              → the opt-out reader (off-main safe)
@@ -81,19 +81,14 @@ enum CrashReporting {
             return
         }
         #if DEBUG
-        Log("CrashReporting: DEBUG build — Sentry disabled (use startForDevTest() to verify the pipeline)")
+        Log("CrashReporting: DEBUG build — Sentry disabled (Release-only; verify from a Release build)")
         #else
         boot(role)
         #endif
     }
 
-    #if DEBUG
-    /// The one DEBUG escape hatch: boot Sentry regardless of the release/opt-out gates so a dev can
-    /// verify the pipeline from a Debug build (the SENTRY dev pane). Never called in normal flow.
-    static func startForDevTest() { boot(.app) }
-    #endif
-
-    /// The actual SDK boot. Bypasses the release/opt-out gates (its callers apply them).
+    /// The actual SDK boot. Reached ONLY via `start()` in a Release build (there is no DEBUG bypass —
+    /// Sentry never initializes in Debug; verify the pipeline from a Release build).
     private static func boot(_ role: Role) {
         guard !started else { return }
         guard !dsn.isEmpty, !dsn.hasPrefix("PASTE_") else {
@@ -244,23 +239,4 @@ enum CrashReporting {
             (re("[A-Za-z0-9_\\-]{24,}"), "<token>"),                          // long tokens / base64 blobs
         ]
     }()
-
-    #if DEBUG
-    /// DEV verification: send a non-fatal test event (lands in the dashboard within seconds).
-    static func sendTestEvent() {
-        startForDevTest()
-        guard started else { Log("CrashReporting.sendTestEvent: Sentry not started (no DSN?)"); return }
-        SentrySDK.capture(message: "Sentry test event from DEV TOOLS")
-        Log("CrashReporting: sent test event")
-    }
-
-    /// DEV verification: hard-crash so the native crash handler fires. The report lands on the NEXT
-    /// launch (that's how crash capture works). Only ever called from the DEBUG dev button.
-    static func forceCrash() {
-        startForDevTest()
-        guard started else { Log("CrashReporting.forceCrash: Sentry not started (no DSN?)"); return }
-        Log("CrashReporting: forcing a test crash now")
-        SentrySDK.crash()
-    }
-    #endif
 }

--- a/Sentient OS macOS/Documentation/Source Diagnostics & Hardening (Sentry).md
+++ b/Sentient OS macOS/Documentation/Source Diagnostics & Hardening (Sentry).md
@@ -41,7 +41,7 @@ This is NOT "catch every error." It is: **total crash coverage (already live) + 
 - `start(_ role: Role)` — boots Sentry once per process (`app` / `wakeHelper`), sets options inside `SentrySDK.start { options in … }`. DSN is a public-safe constant. Guarded by a `private static var started` bool.
 - `breadcrumb(_ message:)` — called by **every** `Log()` call (`Log.swift`), so the recent log trail rides every event. `guard started else { return }`.
 - `capture(_ error: Error)` — non-fatal error capture. **Called from nowhere in the engine today.**
-- `sendTestEvent()` / `forceCrash()` — DEBUG-only dev buttons (DevToolsView SENTRY pane).
+- *(Removed 2026-07-01: the `sendTestEvent()`/`forceCrash()` DEBUG dev buttons + the `startForDevTest()` bypass — Sentry is Release-only with no debug path; verify from a Release build.)*
 
 The whole diagnostics build is: **wire the failure points into `capture`/a new `captureEvent`, add the accumulator + storage + opt-in + scrubber, and fix the bugs.**
 
@@ -133,7 +133,7 @@ Reads/writes are sync + thread-safe (UserDefaults) so the off-main decoders and 
 
 **DECIDED (2026-07-01): Sentry runs in RELEASE builds only, never DEBUG.** A build-config gate that sits **on top of** the opt-out flag — both must pass for anything to reach Sentry. Our own dev machines run the Debug build day-to-day (Dev Notes §two-builds), and we don't want dev crashes, self-test noise, or half-finished-feature errors polluting the production dashboard (or the release-health / session metrics).
 - **Implementation:** wrap the actual `SentrySDK.start` body in `#if !DEBUG`. In DEBUG, `start()` returns early *without* setting `started = true`, so every downstream call stays a zero-cost no-op via the existing `guard started`. (Today `start()` sets `options.environment = "debug"/"release"` but boots the SDK either way — the change is to not boot at all in DEBUG.)
-- **⚠️ Dev-button interaction:** the DEBUG-only `sendTestEvent()` / `forceCrash()` (SENTRY dev pane) need `started == true`, so a plain `#if !DEBUG` guard would make them dead. Keep them testable by having those two dev entry points call a **`startForDevTest()`** that boots the SDK explicitly (bypassing both the `#if !DEBUG` and the opt-out flag) — so a dev can still verify the Sentry pipeline from a Debug build on demand, but nothing auto-reports in DEBUG. Alternatively drop the dev buttons entirely and verify only from a Release/TestFlight build; confirm which you prefer.
+- **No debug bypass (DECIDED 2026-07-01, verified):** Sentry NEVER initializes in a Debug build — `boot()` is reachable only via `start()` under `#if !DEBUG`. The old `startForDevTest()` escape hatch and the DEBUG-only `sendTestEvent()`/`forceCrash()` dev buttons (DevToolsView SENTRY pane) were **removed**. Verify the pipeline from a **Release build** (the diagnostics self-test proved: a Release build boots Sentry via the real `start(.app)` and events land in the dashboard; a Debug build sends zero).
 - The `environment` tag stays (`"debug"` only ever appears via the explicit dev-test path, `"release"` for real traffic), so the dashboard can still filter.
 
 ### 4.6 The `beforeSend` scrubber (the bouncer — defense in depth)
@@ -505,7 +505,7 @@ Each phase → build → **remind Aditya/Jesai to test it** → they confirm →
 3. **Curated + catch-all vs more-exhaustive throw-site coverage?** (§1) — ✅ **Curated + catch-all.**
 4. **Identity: mirror token (hashed), a separate anonymous install-id, or fully unlinked?** — ✅ **Separate anonymous install-id** (a random UUID, independent of the mirror token; §4.11).
 5. **Where should this doc ultimately live?** — ✅ **Stays in `Documentation/`.** It's the plan; once P0–P3 ship, fold the true per-feature docs alongside `Crash Reporting (Sentry).md` and keep this as the archived design record.
-6. **Which build configs report to Sentry?** — ✅ **Release only, never Debug** (§4.5). Build-config gate on top of the opt-out flag; dev buttons keep an explicit `startForDevTest()` escape hatch. *(Confirm the dev-button choice — keep-with-escape-hatch vs remove entirely.)*
+6. **Which build configs report to Sentry?** — ✅ **Release only, never Debug** (§4.5), with **NO debug bypass** (the `startForDevTest()` hatch + `sendTestEvent()`/`forceCrash()` dev buttons were removed — verified: Release sends, Debug sends zero). Build-config gate sits on top of the opt-out flag.
 
 ---
 

--- a/Sentient OS macOS/Views/DevToolsView.swift
+++ b/Sentient OS macOS/Views/DevToolsView.swift
@@ -716,36 +716,11 @@ struct DevToolsView: View {
 
                     fdaPane
                     mirrorPane
-                    #if DEBUG
-                    crashTestPane
-                    #endif
                 }
                 .padding(.top, 4)
             }
         }
     }
-
-    #if DEBUG
-    /// Sentry verification (DEBUG only): one tap to confirm crash reports actually reach the
-    /// dashboard once a real DSN is pasted into CrashReporting.swift. "Send test event" reports a
-    /// non-fatal error; "Force crash" hard-crashes the app so the native crash handler fires —
-    /// the report lands on the NEXT launch. Both no-op silently if no DSN is set.
-    private var crashTestPane: some View {
-        VStack(spacing: 4) {
-            Text("SENTRY").font(.system(.caption2, design: .monospaced)).foregroundStyle(Theme.secondary)
-            HStack(spacing: 8) {
-                Button { CrashReporting.sendTestEvent() } label: {
-                    Label("Send test event", systemImage: "paperplane")
-                }
-                .buttonStyle(.bordered)
-                Button(role: .destructive) { CrashReporting.forceCrash() } label: {
-                    Label("Force crash", systemImage: "exclamationmark.triangle")
-                }
-                .buttonStyle(.bordered)
-            }
-        }
-    }
-    #endif
 
     // MARK: MCP mirror (opt-in toggle + manual sync — dogfood ahead of the Phase-5 onboarding screen)
 


### PR DESCRIPTION
Per request: Sentry must not be present in Debug builds. Removed the `startForDevTest()` escape hatch and the DEBUG-only `sendTestEvent()`/`forceCrash()` dev buttons — `boot()` is now reachable only via `start()` under `#if !DEBUG`.

## Verified end-to-end (headless self-test through the real start(.app) path)
- **Release build**: Sentry boots (`Sentry started (process=app)`), events land in the dashboard — confirmed via the Sentry API (run `selftest-1782947297`: 2 events). **Server-side PII scrub confirmed**: `selftest.scrub_check /Users/<redacted>/x.pdf <email> <token>`.
- **Debug build**: `DEBUG build — Sentry disabled`, zero events reached Sentry (run `selftest-1782947417`: 0 events).
- All diagnostic logic (Triage reasons, SourceHealth collapse, FDA probe) passed in both builds.

Also verified in this session: the P1/P2/P3 diagnostics logic works; ingestion reachable via `sentry-cli send-event`. Doc updated (§2/§4.5/§13.6).