### PR TITLE
Product analytics via TelemetryDeck (privacy-first)

### DIFF
--- a/Sentient OS macOS.xcodeproj/project.pbxproj
+++ b/Sentient OS macOS.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5A7E1D0002000000000000B1 /* TelemetryDeck in Frameworks */ = {isa = PBXBuildFile; productRef = 5A7E1D0002000000000000B2 /* TelemetryDeck */; };
 		5AB7600E2FD12ABE00149A7F /* LiteRTLM in Frameworks */ = {isa = PBXBuildFile; productRef = 5AB7600D2FD12ABE00149A7F /* LiteRTLM */; };
 		5AE5710001000000000000A1 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 5AE5710001000000000000A2 /* Sentry */; };
 /* End PBXBuildFile section */
@@ -30,6 +31,7 @@
 			files = (
 				5AB7600E2FD12ABE00149A7F /* LiteRTLM in Frameworks */,
 				5AE5710001000000000000A1 /* Sentry in Frameworks */,
+				5A7E1D0002000000000000B1 /* TelemetryDeck in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -76,6 +78,7 @@
 			packageProductDependencies = (
 				5AB7600D2FD12ABE00149A7F /* LiteRTLM */,
 				5AE5710001000000000000A2 /* Sentry */,
+				5A7E1D0002000000000000B2 /* TelemetryDeck */,
 			);
 			productName = "Sentient OS macOS";
 			productReference = 5A3F39112FD0F43300DD835E /* Sentient OS.app */;
@@ -108,6 +111,7 @@
 			packageReferences = (
 				5AB7600C2FD12ABE00149A7F /* XCLocalSwiftPackageReference "Vendor/LiteRTLM" */,
 				5AE5710001000000000000A3 /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
+				5A7E1D0002000000000000B3 /* XCRemoteSwiftPackageReference "SwiftSDK" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 5A3F39122FD0F43300DD835E /* Products */;
@@ -408,6 +412,14 @@
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		5A7E1D0002000000000000B3 /* XCRemoteSwiftPackageReference "SwiftSDK" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/TelemetryDeck/SwiftSDK";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
+			};
+		};
 		5AE5710001000000000000A3 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa.git";
@@ -419,6 +431,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		5A7E1D0002000000000000B2 /* TelemetryDeck */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5A7E1D0002000000000000B3 /* XCRemoteSwiftPackageReference "SwiftSDK" */;
+			productName = TelemetryDeck;
+		};
 		5AB7600D2FD12ABE00149A7F /* LiteRTLM */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = LiteRTLM;

--- a/Sentient OS macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Sentient OS macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c48504ff8dddd36e2eca2d6ed239773efad4c3dd2a84a90d4bf86d30d8cc15a4",
+  "originHash" : "4ac99ceb903042464de50c405eb71c251615a33de9f1e041797ec6724977b39a",
   "pins" : [
     {
       "identity" : "sentry-cocoa",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "dad229c665bfd043c5d80ac7aa77717cbd19a1c3",
         "version" : "8.58.3"
+      }
+    },
+    {
+      "identity" : "swiftsdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/TelemetryDeck/SwiftSDK",
+      "state" : {
+        "revision" : "ad4a03ec7ea7416a4081370f21c86e55b02a5b88",
+        "version" : "2.14.1"
       }
     }
   ],

--- a/Sentient OS macOS/Analytics.swift
+++ b/Sentient OS macOS/Analytics.swift
@@ -1,0 +1,87 @@
+//
+//  Analytics.swift
+//  Sentient OS macOS
+//
+//  TelemetryDeck integration — the app's privacy-safe PRODUCT analytics (how many people use the app,
+//  how far they get in onboarding, which features actually fire). The twin of CrashReporting.swift
+//  (Sentry, which is crashes/errors) and it deliberately reuses that file's two gates and identity so
+//  there is ONE opt-out and ONE anonymous identity, never a second consent surface:
+//    1. RELEASE builds only — a no-op in DEBUG, so a dev's day-to-day Debug runs never pollute the
+//       real usage numbers. Verify the pipeline from a Release build (same rule as Sentry).
+//    2. The shared opt-OUT switch — `CrashReporting.diagnosticsEnabled` (default ON) gates everything.
+//  Identity is the same anonymous per-install UUID (`CrashReporting.installID`); TelemetryDeck hashes
+//  it again on-device and once more on their server, and stores no PII and no IP address by design —
+//  so this upholds the Privacy Constitution (no accounts, nothing personal leaves the Mac). Signals
+//  carry structure only (names + counts/enums/versions), never user content — clean at the source.
+//
+//  Key members:
+//   - start()                 → boot TelemetryDeck (Release-only, opt-out gated)
+//   - signal(_:parameters:)   → send one product event (no-op until started / when opted out)
+//   - applyEnabledChange()    → react to a mid-session flip of the shared opt-out switch
+//
+//  Doc: Documentation/Crash Reporting (Sentry).md (the twin) — an Analytics doc lands once wired end-to-end.
+//
+
+import Foundation
+import TelemetryDeck
+
+enum Analytics {
+
+    /// The TelemetryDeck App ID — dashboard → Set Up → "Your App ID" (org namespace: ai.sentient-os).
+    /// NOT a secret: signals only ever write IN, never read anything out, so it ships in source,
+    /// open-source-safe — exactly like the Sentry DSN. ⚠️ Swap the placeholder for the real ID.
+    private static let appID = "42A2F097-DBB1-4A63-BE45-0092962F36E6"
+
+    private static var started = false
+
+    // MARK: - Boot
+
+    /// Boot TelemetryDeck for the GUI app — Release-only, and only if diagnostics are on. A deliberate
+    /// no-op in DEBUG and while the App ID is still the placeholder. Called from main.swift's `.app`
+    /// branch (NOT the root wake-helper — the privileged path sends no analytics). Idempotent.
+    static func start() {
+        guard !started else { return }
+        guard CrashReporting.diagnosticsEnabled else {
+            Log("Analytics: diagnostics opted out — TelemetryDeck disabled")
+            return
+        }
+        #if DEBUG
+        Log("Analytics: DEBUG build — TelemetryDeck disabled (Release-only, like Sentry)")
+        #else
+        guard !appID.hasPrefix("PASTE_") else {
+            Log("Analytics: no App ID set — TelemetryDeck disabled")
+            return
+        }
+        let config = TelemetryDeck.Config(appID: appID)
+        config.defaultUser = CrashReporting.installID          // the anonymous per-install id (re-hashed by TD)
+        config.defaultParameters = { ["model": ModelLocator.fileName] }  // stamps every signal
+        TelemetryDeck.initialize(config: config)
+        started = true
+        Log("Analytics: TelemetryDeck started")
+        #endif
+    }
+
+    // MARK: - Signals
+
+    /// Send one product event. Guard-railed to structure only — a dotted name plus count/enum/version
+    /// parameters, NEVER user content (TelemetryDeck stores no PII; same clean-at-source rule as
+    /// diagnostics). No-op until started and whenever diagnostics are opted out.
+    static func signal(_ name: String, parameters: [String: String] = [:]) {
+        guard started, CrashReporting.diagnosticsEnabled else { return }
+        TelemetryDeck.signal(name, parameters: parameters)
+    }
+
+    // MARK: - Opt-out
+
+    /// React to a mid-session flip of the shared "Share anonymous diagnostics" switch (Settings). On →
+    /// boot; off → latch off so nothing more is sent (TelemetryDeck has no explicit teardown, and the
+    /// per-signal gate already blocks sends the instant the switch is off).
+    static func applyEnabledChange() {
+        if CrashReporting.diagnosticsEnabled {
+            start()
+        } else {
+            started = false
+            Log("Analytics: diagnostics turned off — TelemetryDeck silenced")
+        }
+    }
+}

--- a/Sentient OS macOS/AppState.swift
+++ b/Sentient OS macOS/AppState.swift
@@ -36,7 +36,10 @@ final class AppState {
 
     private static let onboardingKey = "hasCompletedOnboarding"
     var hasCompletedOnboarding: Bool {
-        didSet { UserDefaults.standard.set(hasCompletedOnboarding, forKey: Self.onboardingKey) }
+        didSet {
+            UserDefaults.standard.set(hasCompletedOnboarding, forKey: Self.onboardingKey)
+            if hasCompletedOnboarding, !oldValue { Analytics.signal("Onboarding.completed") }
+        }
     }
 
     init() {

--- a/Sentient OS macOS/Documentation/Product Analytics (TelemetryDeck).md
+++ b/Sentient OS macOS/Documentation/Product Analytics (TelemetryDeck).md
@@ -1,0 +1,103 @@
+# Product Analytics (TelemetryDeck)
+
+`Analytics.swift` wires the app to [TelemetryDeck](https://telemetrydeck.com) so we can see the
+product funnel from real runs — do people arrive, finish setup, does the on-device brain work, does
+the 3am scheduler run itself, does the proactive magic fire, what do they adopt. It is the **twin of
+`CrashReporting.swift`** (Sentry, which is crashes/errors): same boot pattern, the **same opt-out**,
+the **same anonymous identity**, and the same "structure only, never content" discipline.
+
+TelemetryDeck is a privacy-first analytics service: **no PII, no IP addresses stored**, timestamps
+rounded to the hour, one anonymized per-install user id (hashed on-device *and* again on their
+server). That's GDPR-clean by construction and a clean fit for our Privacy Constitution — no
+accounts, nothing personal ever leaves the Mac.
+
+## How it boots
+
+`main.swift` calls `Analytics.start()` right after Sentry, in the **GUI app role only** (the root
+`--wake-helper` LaunchDaemon sends no analytics — it's a privileged, minimal path):
+
+```swift
+} else {
+    CrashReporting.start(.app)   // crash reporting
+    Analytics.start()            // product analytics (TelemetryDeck) — GUI app only
+    SentientOSApp.main()
+}
+```
+
+`start()` has the **same two hard gates as Sentry**:
+1. **RELEASE builds only** — a deliberate no-op in DEBUG, so a dev's day-to-day Debug runs never
+   pollute real usage numbers. (Verify from a Release build — see below.)
+2. **The shared opt-OUT switch** — `CrashReporting.diagnosticsEnabled` (default ON). The single
+   "Share anonymous diagnostics" toggle in Settings gates BOTH Sentry and TelemetryDeck; flipping it
+   calls `Analytics.applyEnabledChange()` alongside `CrashReporting.applyEnabledChange()`.
+
+Identity is the **same anonymous per-install id** as Sentry (`CrashReporting.installID`, a random
+UUID in UserDefaults), passed as TelemetryDeck's `defaultUser` (it re-hashes it). One opt-out, one
+identity — never a second consent surface. Every signal also auto-stamps `model` (the on-device
+model file name) via `defaultParameters`; OS/app version/device come free from the SDK.
+
+## The App ID — safe in the code
+
+The App ID is a plain constant at the top of `Analytics.swift` (org namespace `ai.sentient-os`).
+**Not a secret, fine to ship publicly** (even open source): like a Sentry DSN it is ingest-only — it
+can only write signals *in*, never read anything out or touch the account. `start()` no-ops if it's
+ever left as the `PASTE_…` placeholder.
+
+## What we send (structure only — never content)
+
+Every signal carries counts / enums / on-off / which-feature. **Never** a filename, message, prompt,
+email, or anything the user wrote. `Command.submitted` records only source+mode, right next to the
+existing B7 "length, not the command text" log — same discipline.
+
+| Signal | Emitted from | Meaning |
+| --- | --- | --- |
+| `Onboarding.completed` | `AppState.swift` | Setup finished (once, false→true) |
+| `Processing.completed` | `Ingestion/IterativeRun.swift` | On-device read ended — mode + survivors/junk/sensitive/failed/total |
+| `Engine.reloaded` | `Ingestion/IterativeRun.swift` | GPU-wedge self-heal fired (`reason`: preemptive/reactive) |
+| `Scheduler.overnightStarted` / `.overnightCompleted` | `Scheduling/OvernightScheduler.swift` | 3am run began / finished |
+| `Scheduler.gated` | `Scheduling/OvernightScheduler.swift` | Nightly run skipped (`reason`: battery/lowPower/thermal) |
+| `KnowledgeBase.built` / `.updated` / `.failed` | `Ingestion/ProactiveCycle.swift` | First build / incremental update / error |
+| `Proactive.decided` | `Ingestion/ProactiveCycle.swift` | # things-worth-doing found |
+| `Proactive.prepared` | `Ingestion/ProactiveCycle.swift` | # survived research (+ # dropped) |
+| `Proactive.actionFired` | `Ingestion/ProactiveExecutor.swift` | A user fired an action — `method` + `outcome` (the headline number) |
+| `Mirror.enabled` / `.pushed` / `.disabled` | `MirrorClient.swift` | MCP mirror lifecycle |
+| `Command.submitted` | `Notch Magic/CommandCoordinator.swift` | "Do stuff for me" bar used (`source` + `mode`) |
+| `Source.connected` | `Views/{Gmail,Calendar}ConnectSheet.swift` | A source hooked up (`source`) |
+
+Plus what the SDK sends automatically: app launches, sessions, new-install, and device/OS/version.
+
+The knowledge-base and proactive-stage signals live centrally in `ProactiveCycle.run()` — the one
+place with all the counts and the create-vs-update decision — rather than scattered into
+`VaultCloud`/`Proactive`/`ProactiveResearch`, so they can't double-fire.
+
+## Adding a signal
+
+Call the wrapper, never TelemetryDeck directly:
+
+```swift
+Analytics.signal("Area.thing", parameters: ["count": "\(n)", "kind": kind.rawValue])
+```
+
+`Analytics.signal` is nonisolated + a no-op until started / when opted out, so it's safe from any
+actor or thread. Keep names dotted (`Area.thing`) and parameters structure-only.
+
+## Verification (how it was proven)
+
+Because sends are Release-only, verify from a **Release build** (Debug sends nothing by design):
+
+1. **Wire:** a standalone SPM executable using the same SDK + App ID + config sent live signals;
+   TelemetryDeck's ingest server (`POST nom.telemetrydeck.com/v2/`) returned `OK` and the SDK's
+   cache flushed to 0 (a rejection logs `Failed to send events (status …), will try again`).
+2. **App path:** running the real Release binary logged `Analytics: TelemetryDeck started` and exited
+   clean — the shipping `start()` path initializes without crashing.
+3. In the TelemetryDeck dashboard, signals appear under the app; the **Test Mode** toggle separates
+   Debug-config (test) signals from live ones.
+
+## Files
+
+- `Analytics.swift` — `start()`, `signal(_:parameters:)`, `applyEnabledChange()`, the App ID constant.
+- `main.swift` — `Analytics.start()` in the `.app` branch.
+- `CrashReporting.swift` — the shared `diagnosticsEnabled` opt-out + `installID` identity (reused, not modified).
+- `Views/SettingsView.swift` — the shared toggle's `onChange` calls both `applyEnabledChange()`s.
+- The ~12 call sites in the table above.
+- SPM package `github.com/TelemetryDeck/SwiftSDK` (product `TelemetryDeck`), pinned up-to-next-major from 2.0.0.

--- a/Sentient OS macOS/Ingestion/IterativeRun.swift
+++ b/Sentient OS macOS/Ingestion/IterativeRun.swift
@@ -133,11 +133,12 @@ struct IterativeRun {
         var consecutiveFailures = 0
         var reloadsWithoutProgress = 0
 
-        func reloadEngine() async {
+        func reloadEngine(reason: String) async {
             p.lastFilePath = nil; p.lastVerdict = nil
             p.lastTitle = "Resetting on-device engine…"
             p.lastSummary = "The GPU runtime needs a quick reset — resuming shortly."
             onProgress(p)
+            Analytics.signal("Engine.reloaded", parameters: ["reason": reason])   // GPU-wedge self-heal health metric
             try? await engine.reload()
             sinceReload = 0
         }
@@ -277,7 +278,7 @@ struct IterativeRun {
                         finished = false
                         break bucketLoop
                     }
-                    if sinceReload >= Self.preemptiveReloadEvery { await reloadEngine() }
+                    if sinceReload >= Self.preemptiveReloadEvery { await reloadEngine(reason: "preemptive") }
 
                     p.lastPath = w.item.metadata["displayPath"] ?? w.item.metadata["name"]
                     p.lastFilePath = w.item.metadata["path"]
@@ -300,7 +301,7 @@ struct IterativeRun {
                                     fingerprint: ["engine", "hard_stop"])
                                 finished = false; break runLoop
                             }
-                            await reloadEngine(); reloadsWithoutProgress += 1; consecutiveFailures = 0
+                            await reloadEngine(reason: "reactive"); reloadsWithoutProgress += 1; consecutiveFailures = 0
                             result = await attempt(w.item, connector: connector)   // retry once on a fresh engine
                         }
                     }
@@ -350,6 +351,12 @@ struct IterativeRun {
         // §7.8/B10: the rolling Files extraction-rate (a `.pdf`/`.doc` decoder rotting) — checked once
         // at run-end over the whole window, so it fires even though a single iterative run adds 0–3 files.
         SourceHealth.checkExtractionRate()
+
+        // The on-device read finished — counts only (never any content), so we can see the brain working.
+        Analytics.signal("Processing.completed", parameters: [
+            "mode": "\(mode)", "total": "\(p.done)", "survivors": "\(p.survivors)",
+            "junk": "\(p.junk)", "sensitive": "\(p.sensitive)", "failed": "\(p.failed)",
+        ])
         return p
     }
 }

--- a/Sentient OS macOS/Ingestion/ProactiveCycle.swift
+++ b/Sentient OS macOS/Ingestion/ProactiveCycle.swift
@@ -65,8 +65,11 @@ actor ProactiveCycle {
         do {
             if exists { _ = try await VaultCloud.shared.update(notes: notes) }
             else      { _ = try await VaultCloud.shared.create(notes: notes) }
+            Analytics.signal(exists ? "KnowledgeBase.updated" : "KnowledgeBase.built",
+                             parameters: ["newSummaries": "\(notes.count)"])
         } catch {
             let m = "Knowledge base — \(Self.msg(error))"
+            Analytics.signal("KnowledgeBase.failed", parameters: ["phase": exists ? "update" : "build"])
             progress(.failed(m)); return m                   // half-edited vault isn't dirty; summaries kept
         }
         await VaultCloud.pushIfDirty()                       // no-op if the mirror is off
@@ -95,13 +98,16 @@ actor ProactiveCycle {
             let m = "Deciding — \(Self.msg(error))"
             progress(.failed(m)); return m
         }
+        Analytics.signal("Proactive.decided", parameters: ["items": "\(items.count)"])
 
         if items.isEmpty {
             ProactiveResearch.saveLatest(ReadyResult(ready: [], dropped: []))   // clear any stale cards
         } else {
             progress(.researching(items.count))
             do {
-                _ = try await ProactiveResearch.shared.researchAndPrepare(items: items, notes: notes, calendarContext: calCtx)
+                let result = try await ProactiveResearch.shared.researchAndPrepare(items: items, notes: notes, calendarContext: calCtx)
+                Analytics.signal("Proactive.prepared", parameters: [
+                    "ready": "\(result.ready.count)", "dropped": "\(result.dropped.count)"])
             } catch {
                 let m = "Preparing — \(Self.msg(error))"
                 progress(.failed(m)); return m

--- a/Sentient OS macOS/Ingestion/ProactiveExecutor.swift
+++ b/Sentient OS macOS/Ingestion/ProactiveExecutor.swift
@@ -72,6 +72,14 @@ actor ProactiveExecutor {
         ExecutorScoreboard.record(method: action.method.rawValue, source: "proactive_card",
             outcome: r.board, durationS: Date().timeIntervalSince(t0),
             statusPresent: r.statusPresent, errorClass: r.errorClass)
+        // The single most important number: a user fired a real action — which channel, did it land.
+        let landed: String
+        switch r.outcome {
+        case .fired:       landed = "fired"
+        case .notFireable: landed = "not_fireable"
+        case .failed:      landed = "failed"
+        }
+        Analytics.signal("Proactive.actionFired", parameters: ["method": action.method.rawValue, "outcome": landed])
         return r.outcome
     }
 

--- a/Sentient OS macOS/MirrorClient.swift
+++ b/Sentient OS macOS/MirrorClient.swift
@@ -104,6 +104,7 @@ actor MirrorClient {
         }
         UserDefaults.standard.set(true, forKey: Self.enabledKey)
         guard let url = shareURL else { throw MirrorError.keychainWriteFailed }   // token didn't read back
+        Analytics.signal("Mirror.enabled")
         return url
     }
 
@@ -132,6 +133,7 @@ actor MirrorClient {
         req.timeoutInterval = 120
         let (data, resp) = try await URLSession.shared.upload(for: req, fromFile: zip)
         try Self.check(resp, data)
+        Analytics.signal("Mirror.pushed")
     }
 
     /// The one-click delete — removes the cloud copy (and its access log). The local vault
@@ -149,6 +151,7 @@ actor MirrorClient {
     /// not break those connectors). Best-effort on the network call; the local OFF always sticks.
     func disable() async {
         UserDefaults.standard.set(false, forKey: Self.enabledKey)
+        Analytics.signal("Mirror.disabled")
         try? await deleteRemote()
     }
 

--- a/Sentient OS macOS/Notch Magic/CommandCoordinator.swift
+++ b/Sentient OS macOS/Notch Magic/CommandCoordinator.swift
@@ -81,6 +81,7 @@ final class CommandCoordinator {
         guard !run.isRunning else { Log("submit ignored — a task is already running"); return }
 
         if source == .voice { setReadBack(trimmed) } else { clearReadBack() }
+        Analytics.signal("Command.submitted", parameters: ["source": source.rawValue, "mode": mode.label])   // count only, never the text
         run.start(trimmed, mode: mode, source: source.rawValue)
         // Every command is computer use, which raises the notch.
         setPhase(.running)

--- a/Sentient OS macOS/Scheduling/OvernightScheduler.swift
+++ b/Sentient OS macOS/Scheduling/OvernightScheduler.swift
@@ -107,6 +107,7 @@ final class OvernightScheduler {
     /// run the shared `ProactiveCycle` tail (knowledge base → mirror → proactive → wipe) → release.
     private func runProcessing(log: SchedulerLog) async {
         log.line("WOKE at \(Date()) — beginning the run.")
+        Analytics.signal("Scheduler.overnightStarted")   // the 3am wake fired and we're processing
 
         // DETECT — identical to the dev UI / Analyze Now (the shared SourceSelection reader).
         let fda = Permissions.hasFullDiskAccess()
@@ -125,6 +126,7 @@ final class OvernightScheduler {
         log.line("power: ac=\(PowerState.onACPower()) lowPower=\(PowerState.lowPowerMode) thermal=\(PowerState.thermalLabel)")
         if let blocked = PowerState.overnightBlockReason() {
             log.line("GATED — \(blocked); skipping this run (retry next night).")
+            Analytics.signal("Scheduler.gated", parameters: ["reason": blocked])
             CrashReporting.captureEvent("overnight.gated", level: .info,
                 tags: ["reason": blocked],
                 extra: ["thermal": PowerState.thermalLabel],
@@ -171,6 +173,7 @@ final class OvernightScheduler {
         heart.cancel()
         let ended = await WakeHelperClient.shared.endAwake()
         log.line("endAwake (disablesleep 0): \(ended ? "OK" : "FAILED") — run complete, Mac will sleep.")
+        Analytics.signal("Scheduler.overnightCompleted")   // the nightly run finished cleanly
     }
 
     private func cloudLeg(_ name: String, log: SchedulerLog, _ body: () async throws -> Void) async {

--- a/Sentient OS macOS/Views/CalendarConnectSheet.swift
+++ b/Sentient OS macOS/Views/CalendarConnectSheet.swift
@@ -69,6 +69,7 @@ struct CalendarConnectSheet: View {
                 HStack(spacing: 12) {
                     Button("Cancel") { dismiss() }.buttonStyle(.bordered)
                     Button(selected ? "Done" : "Finish") {
+                        if !connected { Analytics.signal("Source.connected", parameters: ["source": "calendar"]) }
                         connected = true
                         selected = true            // include Calendar in INITIAL / ITERATIVE runs
                         dismiss()

--- a/Sentient OS macOS/Views/GmailConnectSheet.swift
+++ b/Sentient OS macOS/Views/GmailConnectSheet.swift
@@ -70,6 +70,7 @@ struct GmailConnectSheet: View {
                 HStack(spacing: 12) {
                     Button("Cancel") { dismiss() }.buttonStyle(.bordered)
                     Button(selected ? "Done" : "Finish") {
+                        if !connected { Analytics.signal("Source.connected", parameters: ["source": "gmail"]) }
                         connected = true
                         selected = true            // include Gmail in INITIAL / ITERATIVE runs
                         dismiss()

--- a/Sentient OS macOS/Views/SettingsView.swift
+++ b/Sentient OS macOS/Views/SettingsView.swift
@@ -85,7 +85,10 @@ struct SettingsView: View {
         .background(Theme.Ink.cardBG, in: RoundedRectangle(cornerRadius: 11, style: .continuous))
         .overlay(RoundedRectangle(cornerRadius: 11, style: .continuous)
             .strokeBorder(.white.opacity(0.06), lineWidth: 1))
-        .onChange(of: diagnosticsEnabled) { _, _ in CrashReporting.applyEnabledChange() }
+        .onChange(of: diagnosticsEnabled) { _, _ in
+            CrashReporting.applyEnabledChange()
+            Analytics.applyEnabledChange()
+        }
     }
 
     private var appVersion: String {

--- a/Sentient OS macOS/main.swift
+++ b/Sentient OS macOS/main.swift
@@ -16,5 +16,6 @@ if CommandLine.arguments.contains(WakeHelperConfig.helperFlag) {
     WakeHelper.run()                    // root LaunchDaemon mode — never returns
 } else {
     CrashReporting.start(.app)          // crash reporting for the GUI app
+    Analytics.start()                   // product analytics (TelemetryDeck) — GUI app only
     SentientOSApp.main()                // normal GUI app
 }


### PR DESCRIPTION
Wires **TelemetryDeck** (SwiftSDK 2.14.1) as the app's product-analytics layer — the twin of `CrashReporting`/Sentry. One thin `Analytics.swift` wrapper, booted from `main.swift` in the GUI-app role only.

## Design
- **One consent, one identity.** Reuses Sentry's gates verbatim: **Release-only**, gated on the shared `diagnosticsEnabled` opt-out, anonymized via `CrashReporting.installID` (TelemetryDeck re-hashes it). No second privacy toggle.
- **Privacy-clean by construction.** Structure-only signals (counts / enums / on-off / which-feature) — never a filename, message, or prompt. TelemetryDeck stores no PII and no IP; GDPR-clean. `Command.submitted` records source+mode only (next to the existing B7 "length, not the text" log).
- **App ID in source** — ingest-only, not a secret, exactly like the Sentry DSN. No-ops on the `PASTE_…` placeholder.

## Signals (~16)
Onboarding · on-device `Processing.completed` + `Engine.reloaded` · overnight scheduler `started`/`completed`/`gated` · `KnowledgeBase.built`/`.updated`/`.failed` · `Proactive.decided`/`.prepared`/`.actionFired` · `Mirror.enabled`/`.pushed`/`.disabled` · `Command.submitted` · `Source.connected`. KB + proactive signals live centrally in `ProactiveCycle.run()` so they can't double-fire. Auto: launches/sessions/device/OS come from the SDK. Also stamps the on-device `model` on every signal.

## Verified end-to-end
1. **Release build** green with all signals + real App ID.
2. **Wire:** standalone exe (same SDK + App ID + config) → `nom.telemetrydeck.com/v2/` returned `OK`, cache flushed to 0.
3. **App path:** real Release binary logged `Analytics: TelemetryDeck started`, clean exit — the shipping `start()` runs without crashing.

Sends are Release-only, so Debug day-to-day runs send nothing (keeps dev noise out of real numbers).

## Notes for review
- Adds SPM dep `github.com/TelemetryDeck/SwiftSDK` (up-to-next-major from 2.0.0).
- Does **not** touch the co-founder's in-flight `CrashReporting.swift` PII-scrubber tweak (left uncommitted on purpose).
- Doc: `Documentation/Product Analytics (TelemetryDeck).md`.