### PR TITLE
iMessage: exclude spam + iOS SMS-filter category chats from the picker & pipeline

### DIFF
--- a/Sentient OS macOS/Documentation/iMessage Source (chat.db).md
+++ b/Sentient OS macOS/Documentation/iMessage Source (chat.db).md
@@ -29,6 +29,16 @@ the iterative pipeline. Needs Full Disk Access.
 - **Group vs DM:** `chat.style` 43 = group, 45 = DM. Opt-in key = `chat.guid` (stable).
   Sender per message via `handle.id` (E.164 phone or email — chat.db stores **no names**, hence
   AddressBookNames). Unnamed groups get a participant roll-up name ("Alex, Sam & 2 others").
+- **Hidden chats: `chat.is_filtered` is a category code, NOT a bool** — 0 = known sender,
+  1 = unknown sender (both shown in Messages' main list), 2 = Spam, 3+ = the iOS SMS-filter
+  category chats (Promotions / Transactions + Finance/Orders/Reminders subtypes; the category is
+  baked into `chat_identifier` as a suffix — `56249(smsfp)`, `53849(smsft_fi)` — one chat row per
+  sender-category). iOS 26 rolled those folders out to everyone (not just India SIMs), and Messages
+  in iCloud syncs the rows into the Mac's chat.db even though **no Mac UI ever shows them**.
+  `chats()` therefore keeps only `is_filtered <= 1` (+ `is_blackholed = 0` defensively) — the
+  iMessage twin of WhatsApp's `ZSESSIONTYPE` whitelist. Without it, OTP/promo shortcodes flood the
+  picker and the pipeline. [MEASURED on a real dual-SIM DB: 749 chat rows, only 164 Messages-visible;
+  the picker collapsed 106 → 45 active chats, matching the Messages sidebar exactly.]
 - **Limits (`ChatWindowing`):** 90-day floor AND newest-100k cap, both in SQL — an inner subquery
   filters to the opted-in chats, applies `WHERE date >= floor`, then `ORDER BY date DESC LIMIT
   100000` to cap across them; the outer `ORDER BY chat_id, ROWID` restores per-chat ascending

--- a/Sentient OS macOS/Sources/iMessageSource.swift
+++ b/Sentient OS macOS/Sources/iMessageSource.swift
@@ -15,8 +15,9 @@
 //
 //  Key methods: listChats() (picker rows) · eligibleWindows(). Limits per ChatWindowing:
 //  90-day floor AND newest-100k cap. Tapbacks (associated_message_type != 0) and system items
-//  (item_type != 0) are filtered in SQL — they'd spam every window otherwise. Incrementality:
-//  a per-chat high-water mark (max ROWID) per bucket "imessage:<guid>", held in CycleStore.
+//  (item_type != 0) are filtered in SQL — they'd spam every window otherwise. Chats Messages
+//  hides are excluded too (chat.is_filtered >= 2: Spam + the iOS SMS-filter category chats).
+//  Incrementality: a per-chat high-water mark (max ROWID) per bucket "imessage:<guid>", in CycleStore.
 //
 
 import Foundation
@@ -98,8 +99,16 @@ struct iMessageSource: Sendable {
             if let handle = r.text(1) { members[r.int(0), default: []].append(handle) }
         }
 
+        // Only chats Messages itself shows: is_filtered 0 (known sender) / 1 (unknown sender).
+        // 2 = Spam; 3+ = the iOS SMS-filter category chats (Promotions "(smsfp)", Transactions
+        // "(smsft*)") — synced into chat.db by Messages in iCloud but hidden by every Apple UI
+        // on the Mac. Without this guard OTP/promo shortcodes flood the picker and the pipeline
+        // (iMessage's equivalent of WhatsApp's ZSESSIONTYPE whitelist). is_blackholed is defensive.
         var out: [Int64: Chat] = [:]
-        try reader.forEachRow("SELECT ROWID, guid, style, display_name, chat_identifier FROM chat") { r in
+        try reader.forEachRow("""
+            SELECT ROWID, guid, style, display_name, chat_identifier FROM chat
+            WHERE COALESCE(is_filtered, 0) <= 1 AND COALESCE(is_blackholed, 0) = 0
+            """) { r in
             guard let guid = r.text(1) else { return }
             let isGroup = r.int(2) == 43
             let explicit = (r.text(3) ?? "").trimmingCharacters(in: .whitespaces)


### PR DESCRIPTION
## The bug

The chat listing read **every row of `chat.db`'s `chat` table**. But `chat.is_filtered` is a category code, not a bool:

| value | meaning | shown by Messages? |
|---|---|---|
| 0 | known sender | ✅ |
| 1 | unknown sender | ✅ |
| 2 | Spam | hidden (Spam view) |
| 3 / 4 / 36 / 52 / 68 | iOS SMS-filter categories — Promotions `(smsfp)`, Transactions `(smsft)` + Finance/Orders/Reminders | **hidden — no Mac UI at all** |

iOS 26 rolled the Transactions/Promotions folders out to everyone (not just India SIMs), and Messages in iCloud syncs those chat rows into the Mac's chat.db. Result on a real DB: 749 chat rows, only 164 Messages-visible — the picker showed **106 "active" chats of which 61 were OTP/promo shortcodes** (`56249(smsfp)`, `53849(smsft_fi)`, …) ranked above real conversations, and "All DMs" would opt them all into overnight analysis.

## The fix

One guard at the single choke point (`iMessageSource.chats()`): `WHERE COALESCE(is_filtered, 0) <= 1 AND COALESCE(is_blackholed, 0) = 0` — exactly what Messages itself shows. Both `listChats()` (picker) and `eligibleWindows()` (pipeline) resolve chats through that dictionary, so one clause covers both. iMessage's twin of WhatsApp's `ZSESSIONTYPE IN (0,1)` whitelist. Stale opt-ins to hidden GUIDs die naturally (the GUID no longer resolves).

## Verified

- Guarded query against a real dual-SIM chat.db copy: **106 → 45 active chats**, top-10 matches the Messages sidebar 1:1, zero `(sms*)`/spam survivors.
- Tested in-app: picker shows only real conversations.
- `xcodebuild` (isolated DerivedData): BUILD SUCCEEDED.
- Docs updated: `Documentation/iMessage Source (chat.db).md` (+ the architecture context file, synced outside git).

https://claude.ai/code/session_01PK9EUdUgSHZXsZexeKdG3z