### PR TITLE
ChatPicker: default-off "Show unsaved numbers" checkbox (iMessage)

### DIFF
--- a/Sentient OS macOS/Documentation/iMessage Source (chat.db).md
+++ b/Sentient OS macOS/Documentation/iMessage Source (chat.db).md
@@ -13,7 +13,7 @@ the iterative pipeline. Needs Full Disk Access.
 | `Ingestion/Connectors/ChatConnectors.swift` | `iMessageConnector` (+ `WhatsAppConnector`): wraps `eligibleWindows()` for the `Connector` protocol; `load()` returns the window text |
 | `Sources/ChatWindowing.swift` | Shared chat machinery (WhatsApp + iMessage): `ChatMessage`, `ChatInfo`, byte-budget `windows()`, `format()`, the connector limits |
 | `Sources/AddressBookNames.swift` | Raw handles (`+1415…` / emails) → contact names, read straight from the AddressBook SQLite stores (FDA covers them — deliberately **no** Contacts-framework permission prompt) |
-| `Views/ChatPicker.swift` | The shared opt-in sheet; takes a source name + a `listChats` loader |
+| `Views/ChatPicker.swift` | The shared opt-in sheet; takes a source name + a `listChats` loader. Soft-hides unsaved-number DMs (below) behind a default-off "Show unsaved numbers" checkbox |
 
 ## chat.db facts (the ones that bite)
 
@@ -39,6 +39,14 @@ the iterative pipeline. Needs Full Disk Access.
   iMessage twin of WhatsApp's `ZSESSIONTYPE` whitelist. Without it, OTP/promo shortcodes flood the
   picker and the pipeline. [MEASURED on a real dual-SIM DB: 749 chat rows, only 164 Messages-visible;
   the picker collapsed 106 → 45 active chats, matching the Messages sidebar exactly.]
+- **Unsaved numbers are a second, softer tier** (survive the guard — Messages shows them — but are
+  rarely worth analyzing): a DM whose handle resolves to no contact AND has no explicit
+  `display_name` gets `ChatInfo.isSaved = false` (groups are always "saved" — deliberate). The
+  picker hides those rows behind its default-off "Show unsaved numbers" checkbox; an already-
+  selected chat is never hidden, and "All DMs" only sweeps the visible list. Data still flows if
+  opted in — this is picker presentation, not a pipeline filter. WhatsApp never sets the flag
+  (its names come from the DB), so the checkbox simply never appears there. Note Siri's
+  "Maybe: …" names live outside the AddressBook stores → those count as unsaved.
 - **Limits (`ChatWindowing`):** 90-day floor AND newest-100k cap, both in SQL — an inner subquery
   filters to the opted-in chats, applies `WHERE date >= floor`, then `ORDER BY date DESC LIMIT
   100000` to cap across them; the outer `ORDER BY chat_id, ROWID` restores per-chat ascending

--- a/Sentient OS macOS/Sources/ChatWindowing.swift
+++ b/Sentient OS macOS/Sources/ChatWindowing.swift
@@ -36,6 +36,10 @@ struct ChatInfo: Sendable, Identifiable {
     let isGroup: Bool
     let messageCount: Int
     let lastActive: Date
+    /// DM partner resolves to a contact (or the chat carries a real display name). Unsaved
+    /// numbers are hidden by default behind ChatPicker's "Unsaved numbers" toggle; groups
+    /// always count as saved. Defaulted true — WhatsApp names come from the DB itself.
+    var isSaved: Bool = true
 }
 
 enum ChatWindowing {

--- a/Sentient OS macOS/Sources/iMessageSource.swift
+++ b/Sentient OS macOS/Sources/iMessageSource.swift
@@ -57,6 +57,7 @@ struct iMessageSource: Sendable {
         let guid: String          // the stable opt-in key
         let name: String          // resolved display name (never a blank)
         let isGroup: Bool         // chat.style 43 = group, 45 = DM
+        let isSaved: Bool         // DM partner in contacts / explicit display_name; groups always true
     }
 
     /// Active chats (analyzable messages within the lookback) for the picker — newest first.
@@ -79,7 +80,8 @@ struct iMessageSource: Sendable {
                                  name: chat.name,
                                  isGroup: chat.isGroup,
                                  messageCount: Int(r.int(1)),
-                                 lastActive: Self.date(fromAppleNS: r.int(2))),
+                                 lastActive: Self.date(fromAppleNS: r.int(2)),
+                                 isSaved: chat.isSaved),
                         r.int(2)))
         }
         return out.map(\.info)
@@ -114,14 +116,17 @@ struct iMessageSource: Sendable {
             let explicit = (r.text(3) ?? "").trimmingCharacters(in: .whitespaces)
             let identifier = r.text(4) ?? guid
             let name: String
+            var isSaved = true
             if !explicit.isEmpty {
                 name = explicit
             } else if isGroup {
                 name = ChatWindowing.groupName(of: (members[r.int(0)] ?? []).map { resolved($0, contacts) })
             } else {
-                name = resolved(identifier, contacts)
+                let contact = AddressBookNames.resolve(identifier, in: contacts)
+                name = contact ?? identifier
+                isSaved = contact != nil
             }
-            out[r.int(0)] = Chat(rowid: r.int(0), guid: guid, name: name, isGroup: isGroup)
+            out[r.int(0)] = Chat(rowid: r.int(0), guid: guid, name: name, isGroup: isGroup, isSaved: isSaved)
         }
         return out
     }

--- a/Sentient OS macOS/Views/ChatPicker.swift
+++ b/Sentient OS macOS/Views/ChatPicker.swift
@@ -6,6 +6,8 @@
 //  Lists the chats ACTIVE within the scan window (newest first, with message counts), with
 //  search + per-chat checkboxes + bulk All-DMs / All-groups / Clear. "Done" hands the selected
 //  chat ids (JIDs / GUIDs) back to the caller, which persists them and lights up the source chip.
+//  DMs from numbers not in the user's contacts (ChatInfo.isSaved == false — iMessage only) hide
+//  behind the "Show unsaved numbers" checkbox, off by default; a selected chat is never hidden.
 //
 
 import SwiftUI
@@ -20,6 +22,7 @@ struct ChatPicker: View {
     @State private var chats: [ChatInfo] = []
     @State private var selection: Set<String>
     @State private var search = ""
+    @State private var showUnsaved = false
     @State private var loaded = false
     @State private var loadError: String?
 
@@ -32,9 +35,15 @@ struct ChatPicker: View {
         _selection = State(initialValue: initialSelection)
     }
 
-    private var filtered: [ChatInfo] {
-        search.isEmpty ? chats : chats.filter { $0.name.localizedCaseInsensitiveContains(search) }
+    /// What the list shows: saved chats always; unsaved numbers only with the toggle on —
+    /// except ones already selected, which must never be invisibly opted in.
+    private var visible: [ChatInfo] {
+        chats.filter { showUnsaved || $0.isSaved || selection.contains($0.id) }
     }
+    private var filtered: [ChatInfo] {
+        search.isEmpty ? visible : visible.filter { $0.name.localizedCaseInsensitiveContains(search) }
+    }
+    private var unsavedCount: Int { chats.count { !$0.isSaved } }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -53,7 +62,7 @@ struct ChatPicker: View {
         VStack(alignment: .leading, spacing: 4) {
             Text("Choose chats & groups").font(.serif(24)).italic().foregroundStyle(.white)
             Text(loaded
-                 ? "\(selection.count) selected · \(chats.count) active in the last \(ChatWindowing.lookbackDays) days"
+                 ? "\(selection.count) selected · \(visible.count) active in the last \(ChatWindowing.lookbackDays) days"
                  : "Reading your chats…")
                 .font(.footnote).foregroundStyle(Theme.secondary)
         }
@@ -74,9 +83,24 @@ struct ChatPicker: View {
                 bulk("All groups") { for c in filtered where c.isGroup  { selection.insert(c.id) } }
                 bulk("Clear")      { selection.removeAll() }
                 Spacer()
+                if unsavedCount > 0 { unsavedToggle }
             }
         }
         .padding(.horizontal, 20).padding(.bottom, 12)
+    }
+
+    /// The "show unsaved numbers" checkbox — mirrors the row checkmarks (accent when on).
+    private var unsavedToggle: some View {
+        Button { withAnimation(.easeOut(duration: 0.15)) { showUnsaved.toggle() } } label: {
+            HStack(spacing: 6) {
+                Image(systemName: showUnsaved ? "checkmark.square.fill" : "square")
+                    .font(.system(size: 13)).foregroundStyle(showUnsaved ? Theme.accent : Theme.faint)
+                Text("Show unsaved numbers (\(unsavedCount))")
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(showUnsaved ? .white : Theme.secondary)
+            }
+        }
+        .buttonStyle(.plain)
     }
 
     private func bulk(_ title: String, _ action: @escaping () -> Void) -> some View {
@@ -103,6 +127,15 @@ struct ChatPicker: View {
             centered {
                 Image(systemName: "bubble.left.and.bubble.right").font(.largeTitle).foregroundStyle(Theme.faint)
                 Text("No active chats in the last \(ChatWindowing.lookbackDays) days").foregroundStyle(Theme.secondary)
+            }
+        } else if filtered.isEmpty {
+            centered {
+                Image(systemName: "person.crop.circle.badge.questionmark").font(.largeTitle).foregroundStyle(Theme.faint)
+                Text(search.isEmpty
+                     ? "Only unsaved numbers were active — tap “Unsaved numbers” to show them"
+                     : "No chats match “\(search)”")
+                    .font(.callout).foregroundStyle(Theme.secondary)
+                    .multilineTextAlignment(.center).padding(.horizontal, 40)
             }
         } else {
             ScrollView {
@@ -167,4 +200,27 @@ struct ChatPicker: View {
         }
         loaded = true
     }
+}
+
+#Preview("Mixed saved & unsaved (iMessage)") {
+    ChatPicker(
+        sourceName: "iMessage",
+        loadChats: { [
+            ChatInfo(id: "1", name: "Jesai UMass USA", isGroup: false, messageCount: 16,
+                     lastActive: .now.addingTimeInterval(-3 * 86400)),
+            ChatInfo(id: "2", name: "+14154042744", isGroup: false, messageCount: 2,
+                     lastActive: .now.addingTimeInterval(-7 * 86400), isSaved: false),
+            ChatInfo(id: "3", name: "+917428192241 & +19121366030", isGroup: true, messageCount: 1,
+                     lastActive: .now.addingTimeInterval(-8 * 86400)),
+            ChatInfo(id: "4", name: "Aryaman UMass, Gurmeher SF Ditto & 1 others", isGroup: true,
+                     messageCount: 50, lastActive: .now.addingTimeInterval(-14 * 86400)),
+            ChatInfo(id: "5", name: "Aarit UMass", isGroup: false, messageCount: 19,
+                     lastActive: .now.addingTimeInterval(-21 * 86400)),
+            ChatInfo(id: "6", name: "262966", isGroup: false, messageCount: 1,
+                     lastActive: .now.addingTimeInterval(-40 * 86400), isSaved: false),
+            ChatInfo(id: "7", name: "39781", isGroup: false, messageCount: 1,
+                     lastActive: .now.addingTimeInterval(-42 * 86400), isSaved: false),
+        ] },
+        initialSelection: ["2"],   // a selected unsaved number — must stay visible with the toggle off
+        onDone: { _ in })
 }


### PR DESCRIPTION
## What

Follow-up to #102. The hidden-chat guard removed the spam/category chats, but the picker still ranks raw unsaved numbers (Mangomint, Dasher, stray shortcodes that Messages shows as unknown senders) alongside real people. This hides them by default behind a checkbox.

- `ChatInfo.isSaved` (default `true` — WhatsApp call site untouched). iMessage sets it per DM: `false` when the handle resolves to no AddressBook contact and the chat has no explicit `display_name` (RCS bots like "Snapchat" keep their name → saved). **Groups always count as saved** (decided: DMs only).
- `ChatPicker`: a checkbox at the right of the filter row — `square` → accent `checkmark.square.fill`, "Show unsaved numbers (N)" — rendered only when unsaved chats exist, so the WhatsApp picker never changes. Off by default on every open.
- Guarantees: an already-selected chat is never hidden (a persisted opt-in can't be invisibly active) · All DMs / All groups sweep only the visible list · header count tracks visibility · an all-unsaved result shows a hint instead of a blank list.
- Presentation only: opted-in chats flow to analysis regardless of the toggle.
- New `#Preview` with mixed saved/unsaved data incl. a pre-selected unsaved number.

## Verified

- Tested in-app on a real DB: unsaved DMs hide by default, checkbox restores them, groups exempt.
- `xcodebuild` (isolated DerivedData): BUILD SUCCEEDED.
- Docs: `Documentation/iMessage Source (chat.db).md` (+ the architecture context file outside git).

https://claude.ai/code/session_01PK9EUdUgSHZXsZexeKdG3z