### PR TITLE
UI: launch focus lands on the command bar / Knowledge search

### DIFF
--- a/Sentient OS macOS/Views/Knowledge/KnowledgeView.swift
+++ b/Sentient OS macOS/Views/Knowledge/KnowledgeView.swift
@@ -46,6 +46,7 @@ struct KnowledgeView: View {
     @State private var pendingNav: PendingNav?
     @State private var showDiscardPrompt = false
     @FocusState private var editorFocused: Bool
+    @FocusState private var searchFocused: Bool
 
     // The new-note / new-folder name prompt (raised by the right-click menus).
     @State private var showCreatePrompt = false
@@ -66,6 +67,13 @@ struct KnowledgeView: View {
         .frame(minWidth: 900, minHeight: 600)
         .background(Theme.bg)
         .background(WindowChrome())   // transparent titlebar from launch (no "grey until resize")
+        // Window-open focus lands in the search box, not the sidebar's "+" button. defaultFocus
+        // declares it; the delayed onAppear claim backs it up (AppKit assigns the initial key
+        // view a beat after SwiftUI's appear — same pattern as PromptBar's launch focus).
+        .defaultFocus($searchFocused, true)
+        .onAppear {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { searchFocused = true }
+        }
         .task { await loadVault() }
         .alert("You have unsaved edits", isPresented: $showDiscardPrompt) {
             Button("Save") { promptSave() }
@@ -396,6 +404,7 @@ struct KnowledgeView: View {
             TextField("Search notes", text: $search)
                 .textFieldStyle(.plain).foregroundStyle(.white).font(.system(size: 13))
                 .tint(Theme.knowledgeAccent)
+                .focused($searchFocused)
             if !search.isEmpty {
                 Button { search = "" } label: {
                     Image(systemName: "xmark.circle.fill").font(.system(size: 12)).foregroundStyle(Theme.faint)

--- a/Sentient OS macOS/Views/PromptBar.swift
+++ b/Sentient OS macOS/Views/PromptBar.swift
@@ -59,6 +59,14 @@ struct PromptBar: View {
         .background(PromptGlow(intensity: isRunning ? 0.7 : (focused ? 0.55 : 0.32)))
         .animation(.easeInOut(duration: 0.4), value: focused)
         .animation(.easeInOut(duration: 0.35), value: isRunning)
+        // Launch focus lands HERE, not on the top bar's first button (the orange ring on
+        // "Analysis"). defaultFocus declares it; the delayed onAppear claim backs it up —
+        // AppKit assigns the window's initial key view a beat after SwiftUI's appear, so an
+        // immediate `focused = true` can get stomped.
+        .defaultFocus($focused, true)
+        .onAppear {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { focused = true }
+        }
     }
 
     /// Idle: the editable input (bright "DO" placeholder + the text field).


### PR DESCRIPTION
Two small focus-on-launch fixes (17 lines):

- **Home:** initial keyboard focus lands in the PromptBar's text field instead of the orange focus ring appearing on the top bar's "Analysis" button.
- **Knowledge window:** initial focus lands in the "Search notes" box instead of the sidebar's "+" button.

Both use the same pattern: `.defaultFocus` declares the intent, plus a 0.1s-delayed `onAppear` claim as backup (AppKit assigns the window's initial key view a beat after SwiftUI's appear, so an immediate set can get stomped).

Written on top of the merged #101; rebased onto today's main via stash — reapplied cleanly.