### PR TITLE
Overnight scheduler: production wiring + 18h auto-enable

### DIFF
--- a/Sentient OS macOS.xcodeproj/project.pbxproj
+++ b/Sentient OS macOS.xcodeproj/project.pbxproj
@@ -8,13 +8,29 @@
 
 /* Begin PBXBuildFile section */
 		5A7E1D0002000000000000B1 /* TelemetryDeck in Frameworks */ = {isa = PBXBuildFile; productRef = 5A7E1D0002000000000000B2 /* TelemetryDeck */; };
+		5A7E1D0003000000000000C2 /* jesai.Sentient-OS-macOS.WakeHelper.plist in Copy wake-helper daemon plist */ = {isa = PBXBuildFile; fileRef = 5A7E1D0003000000000000C3 /* jesai.Sentient-OS-macOS.WakeHelper.plist */; };
 		5AB7600E2FD12ABE00149A7F /* LiteRTLM in Frameworks */ = {isa = PBXBuildFile; productRef = 5AB7600D2FD12ABE00149A7F /* LiteRTLM */; };
 		5AE5710001000000000000A1 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 5AE5710001000000000000A2 /* Sentry */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		5A7E1D0003000000000000C1 /* Copy wake-helper daemon plist */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = Contents/Library/LaunchDaemons;
+			dstSubfolderSpec = 1;
+			files = (
+				5A7E1D0003000000000000C2 /* jesai.Sentient-OS-macOS.WakeHelper.plist in Copy wake-helper daemon plist */,
+			);
+			name = "Copy wake-helper daemon plist";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		5A3F39112FD0F43300DD835E /* Sentient OS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Sentient OS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5A5167160C0F16AB00000001 /* Signing.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Signing.xcconfig; sourceTree = "<group>"; };
+		5A7E1D0003000000000000C3 /* jesai.Sentient-OS-macOS.WakeHelper.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "jesai.Sentient-OS-macOS.WakeHelper.plist"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -44,6 +60,7 @@
 			children = (
 				5A3F39132FD0F43300DD835E /* Sentient OS macOS */,
 				5A5167160C0F16AB00000001 /* Signing.xcconfig */,
+				5A7E1D0003000000000000C3 /* jesai.Sentient-OS-macOS.WakeHelper.plist */,
 				5A3F39122FD0F43300DD835E /* Products */,
 			);
 			sourceTree = "<group>";
@@ -66,6 +83,7 @@
 				5A3F390D2FD0F43300DD835E /* Sources */,
 				5A3F390E2FD0F43300DD835E /* Frameworks */,
 				5A3F390F2FD0F43300DD835E /* Resources */,
+				5A7E1D0003000000000000C1 /* Copy wake-helper daemon plist */,
 				5AAAA0012FD0F43300DD835E /* Trim app bundle (thin LiteRT-LM, drop docs) */,
 				5AE5710001000000000000B1 /* Upload dSYMs to Sentry */,
 			);

--- a/Sentient OS macOS/AppState.swift
+++ b/Sentient OS macOS/AppState.swift
@@ -46,6 +46,7 @@ final class AppState {
         self.hasCompletedOnboarding = UserDefaults.standard.bool(forKey: Self.onboardingKey)
         self.notch = NotchWindowController(coordinator: commandCoordinator)
         scheduler.reevaluate()   // arm if the dev setting was left on; otherwise a no-op
+        scheduler.maybeAutoEnable()   // 18h after initial: flip the overnight scheduler on (or arm the timer)
         commandCoordinator.start()   // arm right-⌘ hold-to-talk + warm the speech model
         notch.start()                // raise the notch overlay window
     }

--- a/Sentient OS macOS/Documentation/Overnight Scheduler (Production Wiring & 18h Auto-Enable).md
+++ b/Sentient OS macOS/Documentation/Overnight Scheduler (Production Wiring & 18h Auto-Enable).md
@@ -1,0 +1,103 @@
+# Overnight Scheduler — Production Wiring & 18h Auto-Enable
+
+The overnight scheduler wakes the Mac at 3am (lid shut), runs the exact same pipeline as the home's
+Analyze Now (`IterativeRun .auto` → `ProactiveCycle`), then sleeps — so a fresh "For You" briefing is
+waiting when you open the lid. The wake *mechanism* was already proven on real hardware; this doc
+covers the **production wiring** that turns it from a dev toggle into something that arms itself:
+
+1. **A** — the root helper installs via **SMAppService** (one-click System Settings approval).
+2. **B** — the app registers as a **login item** so it's alive at 3am to host the run.
+3. **C** — a **production enable flag** (separate from the dev toggle).
+4. **D+E** — the app **auto-enables the scheduler 18 hours after the first full cycle**.
+
+The in-app scheduler lives in `OvernightScheduler` (owned by `AppState`); it only runs while Sentient
+is open. Everything logs to `~/Library/Logs/SentientOS/scheduler.log`.
+
+## The 18h auto-enable — why, and how
+
+Right after the first big **initial** processing run, everything is caught up — there's nothing new
+to chew on. If we armed the 3am wake immediately and initial finished at, say, 10pm, the run five
+hours later would find almost nothing → a wasted wake and an **empty morning briefing**. So we wait
+**18 hours after the first full cycle finishes**, by which point a full day of real life has piled up,
+and *then* turn the scheduler on. The very first automatic overnight run has something worth surfacing.
+
+- **"Initial finished" = the first full `ProactiveCycle`.** `ProactiveCycle.run()` calls
+  `OvernightScheduler.noteFirstCycleCompleted()` on its success path, which stamps
+  `firstCycleCompletedAt` **once** (later calls are ignored, so the clock starts at the true first finish).
+- **The checker — `maybeAutoEnable()`** runs at launch (`AppState.init`), after every cycle
+  (`RootView`'s processing `onDone`), and from a one-shot timer it arms for the 18h mark (so it fires
+  even if the app just sits open). It is idempotent and:
+  - **Latches** (`autoEnableFired`) so it acts at most once and never re-enables after a user turns it off.
+  - **Never fights the user** — if the scheduler is already on (dev or prod flag), it just latches.
+  - **Gates on prerequisites** — only flips production ON once the root helper is **approved** *and*
+    launch-at-login is on. If the 18h has elapsed but prerequisites aren't met, it sets
+    `needsSchedulerSetup` (published, for the setup UX) and retries on the next tick — it never
+    silently half-enables.
+- **The wait is 18h** (`defaultAutoEnableDelay`); a dev key (`autoEnableDelaySeconds`) shortens it for testing.
+
+## A — SMAppService daemon (production install)
+
+The root wake helper is the same app binary relaunched with `--wake-helper` (main.swift branches
+before SwiftUI). Production installs it via **`SMAppService.daemon`** instead of the old
+admin-password path:
+
+- A LaunchDaemon plist is **bundled** at `Contents/Library/LaunchDaemons/jesai.Sentient-OS-macOS.WakeHelper.plist`
+  (repo file at the project root, copied in by a "Copy wake-helper daemon plist" build phase). It uses
+  `BundleProgram` (the bundle-relative main executable) + `ProgramArguments` to pass `--wake-helper`,
+  and `MachServices` for the XPC name. Label/service name match `WakeHelperConfig`.
+- `WakeHelperClient.register()` registers it; `.status`/`.isReady` read the live state
+  (`.enabled` = approved & ready · `.requiresApproval` = registered, awaiting the user ·
+  `.notRegistered`/`.notFound` = not yet / not bundled / unsigned build).
+  `openLoginItemsSettings()` deep-links to where the user approves.
+- `OvernightScheduler.ensureHelperReady()` gates every arm: `.enabled` → go; `.requiresApproval` →
+  flag setup and bail (approval is async + user-driven). **DEBUG dev builds** (unsigned → `.notFound`)
+  fall back to the proven admin-password `WakeHelperInstaller`, so testing works without a signed build.
+
+> ⚠️ SMAppService approval only works on a **signed Developer ID build launched from `/Applications`** —
+> not an unsigned dev binary. The registration *logic* is complete and gated; the approval round-trip
+> lights up once the app is signed + distributed.
+
+## B — Launch at login
+
+`LoginItem.swift` wraps `SMAppService.mainApp`: `enable()` / `disable()` / `isEnabled` / `status`.
+Load-bearing because the scheduler lives inside the running app — no app open at 3am, no wake.
+`enable()` is silent (no approval); auto-enable calls it as part of flipping the scheduler on.
+
+## C — Production enable flag
+
+Two keys, either one runs the scheduler (`reevaluate()` ORs them):
+- `dbg.scheduler.enabled` — the DEV toggle (hand-flipped in DevToolsView for testing).
+- `scheduler.enabled` — the PRODUCTION flag, written by auto-enable and (later) a Settings toggle.
+
+Keeping them separate means a dev testing the toggle never trips the production auto-enable latch.
+
+## Dev UI
+
+DevToolsView → **OVERNIGHT PROCESSING** section (folds in the old scheduled-run time control):
+- Scheduled run toggle + wake time + status.
+- **Root wake helper** — Register/Approve, Open Login Items, live status, Refresh.
+- **Launch at login** — toggle + live status.
+- **18h auto-enable** — a live readout (initial-done time, fire time, fired/needs-setup), plus dev
+  buttons: *Simulate initial done*, *Run check now*, *Reset*, and a delay override (seconds, 0 = 18h).
+
+This is the dev cockpit; the shipping onboarding/Settings UX (Jesai) binds to the same seams.
+
+## Verification
+
+- The daemon plist **bundles correctly** at `Contents/Library/LaunchDaemons/` and passes `plutil -lint`.
+- The **auto-enable state machine** was driven headlessly (11/11 checks): stamp-once, delay math, the
+  "not yet" hold, the prerequisite gate (unmet → flags setup, does not flip, does not latch → retries),
+  the "user already enabled" latch, and latch-blocks-re-enable.
+- What needs a **signed build** to exercise (not verifiable on an unsigned dev binary): the actual
+  System Settings approval of the daemon and the login-item registration round-trip.
+
+## Files
+
+- `Scheduling/OvernightScheduler.swift` — the scheduler, the 18h auto-enable state machine, `ensureHelperReady`.
+- `Scheduling/LoginItem.swift` — launch-at-login via `SMAppService.mainApp`.
+- `Scheduling/WakeHelperClient.swift` — daemon register/status/deep-link + the four XPC ops.
+- `Scheduling/WakeHelperInstaller.swift` — DEBUG admin-password fallback installer.
+- `jesai.Sentient-OS-macOS.WakeHelper.plist` (project root) — the bundled SMAppService daemon plist + its Copy Files phase.
+- `Ingestion/ProactiveCycle.swift` — stamps "initial finished".
+- `AppState.swift` / `Views/RootView.swift` — call `maybeAutoEnable()` at launch / after each cycle.
+- `Views/DevToolsView.swift` — the OVERNIGHT PROCESSING dev section.

--- a/Sentient OS macOS/Ingestion/ProactiveCycle.swift
+++ b/Sentient OS macOS/Ingestion/ProactiveCycle.swift
@@ -117,6 +117,7 @@ actor ProactiveCycle {
         // 4) Wipe this cycle's summaries — the knowledge base is the durable memory now. Success only.
         await CycleStore.shared.wipeAllNotes()
         UserDefaults.standard.set(Date(), forKey: Self.lastCycleKey)
+        OvernightScheduler.noteFirstCycleCompleted()   // "initial processing ended" → start the 18h auto-enable clock (once)
         progress(.done(ready: ProactiveResearch.latest()?.ready.count ?? 0))
         return nil
     }

--- a/Sentient OS macOS/Scheduling/LoginItem.swift
+++ b/Sentient OS macOS/Scheduling/LoginItem.swift
@@ -1,0 +1,41 @@
+//
+//  LoginItem.swift
+//  Sentient OS macOS  ·  Scheduling/
+//
+//  Launch-at-login for the MAIN app, via SMAppService.mainApp. Load-bearing for the overnight
+//  scheduler: the scheduler lives INSIDE the running app (OvernightScheduler), so if Sentient isn't
+//  open at 3am nothing wakes. Registering the app as a login item is how it's alive to host the run.
+//
+//  Pure logic — enable / disable / read status. No UI (a dev toggle in DevToolsView drives it today;
+//  onboarding wires the real toggle later). enable() is silent (no password/approval); macOS may show
+//  a one-time "item added" notification and the user can revoke it in System Settings > General >
+//  Login Items, which is why `isEnabled` reads the live status rather than a cached bool.
+//
+
+import Foundation
+import ServiceManagement
+
+enum LoginItem {
+
+    private static var service: SMAppService { .mainApp }
+
+    /// Live status straight from the framework (the user can revoke in System Settings at any time).
+    static var status: SMAppService.Status { service.status }
+
+    /// True when the app is registered to launch at login.
+    static var isEnabled: Bool { service.status == .enabled }
+
+    /// Register the app as a login item. Idempotent; silent (no approval prompt). Returns success.
+    @discardableResult
+    static func enable() -> Bool {
+        guard service.status != .enabled else { return true }
+        do { try service.register(); Log("LoginItem: registered (status=\(service.status.rawValue))"); return true }
+        catch { Log("LoginItem: register failed — \(error)"); return false }
+    }
+
+    /// Unregister the login item. Best-effort.
+    static func disable() async {
+        do { try await service.unregister(); Log("LoginItem: unregistered") }
+        catch { Log("LoginItem: unregister failed — \(error)") }
+    }
+}

--- a/Sentient OS macOS/Scheduling/OvernightScheduler.swift
+++ b/Sentient OS macOS/Scheduling/OvernightScheduler.swift
@@ -20,6 +20,7 @@
 //
 
 import Foundation
+import ServiceManagement
 
 @MainActor
 @Observable
@@ -28,20 +29,63 @@ final class OvernightScheduler {
     /// One-line status for the dev UI ("off" / "armed for 4:00 PM" / "running…").
     var statusLine = "off"
 
-    static let enabledKey = "dbg.scheduler.enabled"
-    static let minutesKey = "dbg.scheduler.minutes"   // minutes since midnight
-    static let defaultMinutes = 3 * 60                // 3:00 AM — the production overnight time (the dev
-                                                     // UI can override `minutesKey` for testing)
+    /// Set true when the 18h auto-enable wants to arm but the prerequisites (approved root helper +
+    /// launch-at-login) aren't in place yet. The setup UX (dev section today, onboarding later) reads
+    /// this to prompt the user; it clears itself once auto-enable succeeds.
+    var needsSchedulerSetup = false
+
+    // The DEV toggle (testing) and the PRODUCTION flag are separate keys but either one runs the
+    // scheduler. The dev toggle is hand-flipped in DevToolsView; the production flag is what the 18h
+    // auto-enable (and a future Settings switch) writes. Keeping them apart means a dev testing the
+    // toggle never trips the production auto-enable latch, and vice-versa.
+    static let enabledKey = "dbg.scheduler.enabled"        // DEV toggle
+    static let prodEnabledKey = "scheduler.enabled"         // PRODUCTION flag (auto-enable / Settings)
+    static let minutesKey = "dbg.scheduler.minutes"        // minutes since midnight
+    static let defaultMinutes = 3 * 60                     // 3:00 AM — the production overnight time (the dev
+                                                          // UI can override `minutesKey` for testing)
+
+    // 18h auto-enable state (all UserDefaults; survive restarts).
+    static let firstCycleAtKey = "scheduler.firstCycleCompletedAt"   // Double epoch — set ONCE
+    static let autoEnableFiredKey = "scheduler.autoEnableFired"      // latch — flip prod ON at most once
+    static let autoEnableDelayKey = "scheduler.autoEnableDelaySeconds"  // dev override of the 18h wait
+    static let defaultAutoEnableDelay: TimeInterval = 18 * 3600      // 18 hours after initial finishes
 
     /// The configured time-of-day in minutes since midnight (shared default so the UI and the loop agree).
-    static var configuredMinutes: Int { (UserDefaults.standard.object(forKey: minutesKey) as? Int) ?? defaultMinutes }
+    nonisolated static var configuredMinutes: Int { (UserDefaults.standard.object(forKey: minutesKey) as? Int) ?? defaultMinutes }
+
+    /// The auto-enable wait (default 18h; a dev key shortens it for testing). (Pure UserDefaults read.)
+    nonisolated static var autoEnableDelay: TimeInterval {
+        let v = UserDefaults.standard.double(forKey: autoEnableDelayKey)
+        return v > 0 ? v : defaultAutoEnableDelay
+    }
+
+    /// When the first full ProactiveCycle finished (nil until it has). Set once via `noteFirstCycleCompleted`.
+    nonisolated static var firstCycleCompletedAt: Date? {
+        let t = UserDefaults.standard.double(forKey: firstCycleAtKey)
+        return t > 0 ? Date(timeIntervalSince1970: t) : nil
+    }
+
+    /// The instant the scheduler should auto-enable (first-cycle-completion + the wait). Nil until initial done.
+    nonisolated static var autoEnableFireDate: Date? { firstCycleCompletedAt.map { $0.addingTimeInterval(autoEnableDelay) } }
+
+    /// Stamp "initial processing finished" exactly once — called from ProactiveCycle on the first full,
+    /// successful cycle (knowledge base now exists). Nonisolated: it's a single UserDefaults write, safe
+    /// from the cycle actor. Later calls are ignored, so the 18h clock starts at the TRUE first finish.
+    nonisolated static func noteFirstCycleCompleted() {
+        let d = UserDefaults.standard
+        guard d.double(forKey: firstCycleAtKey) == 0 else { return }
+        d.set(Date().timeIntervalSince1970, forKey: firstCycleAtKey)
+        Log("Scheduler: first full cycle done — 18h auto-enable clock started (fires \(Date().addingTimeInterval(autoEnableDelay)))")
+    }
 
     private var loopTask: Task<Void, Never>?
+    private var autoEnableTask: Task<Void, Never>?
     private var everArmed = false
 
-    /// Re-read the dev settings and (re)start or stop. Call on launch and on the on/off toggle.
+    /// Run if EITHER the dev toggle or the production flag is on. Call on launch and on any toggle.
     func reevaluate() {
-        if UserDefaults.standard.bool(forKey: Self.enabledKey) { start() } else { stop() }
+        let on = UserDefaults.standard.bool(forKey: Self.enabledKey) || UserDefaults.standard.bool(forKey: Self.prodEnabledKey)
+        if on { start() } else { stop() }
     }
 
     /// "Done" — finalize the chosen time: restart the loop, which wipes EVERY scheduled wake (clears
@@ -63,20 +107,104 @@ final class OvernightScheduler {
             everArmed = false
             Task { _ = await WakeHelperClient.shared.cancelWake() }
         }
+        // NB: the auto-enable timer is deliberately NOT cancelled here — it must keep waiting to flip
+        // the scheduler ON even while it's currently off (that's the whole point of auto-enable).
+    }
+
+    // MARK: - 18h auto-enable
+
+    /// Decide whether to auto-enable the production scheduler. Idempotent + safe to call repeatedly —
+    /// from launch (AppState.init), right after any cycle finishes, and from the one-shot timer it arms.
+    /// Fires at most once (a latch), never fights a user who toggled the scheduler off, and only arms
+    /// when the prerequisites (approved root helper + launch-at-login) are in place — otherwise it flags
+    /// `needsSchedulerSetup` for the setup UX and retries on the next tick.
+    func maybeAutoEnable() {
+        let d = UserDefaults.standard
+        guard !d.bool(forKey: Self.autoEnableFiredKey) else { return }      // already handled once
+
+        // The user already turned the scheduler on (dev or prod) — latch and never auto-touch it.
+        if d.bool(forKey: Self.enabledKey) || d.bool(forKey: Self.prodEnabledKey) {
+            d.set(true, forKey: Self.autoEnableFiredKey); return
+        }
+
+        guard let fireAt = Self.autoEnableFireDate else { return }          // initial not finished yet
+        if Date() < fireAt { armAutoEnableTimer(at: fireAt); return }       // not time yet — wait
+
+        // Time's up. Only enable if the overnight run can actually happen: approved helper + login item.
+        guard WakeHelperClient.shared.isReady else {
+            needsSchedulerSetup = true                                      // surface setup; retry next tick
+            Log("Scheduler: 18h elapsed but root helper not approved — awaiting setup")
+            return
+        }
+        LoginItem.enable()                                                  // ensure the app relaunches to host 3am
+        d.set(true, forKey: Self.prodEnabledKey)
+        d.set(true, forKey: Self.autoEnableFiredKey)
+        needsSchedulerSetup = false
+        Log("Scheduler: 18h elapsed + prerequisites met — auto-enabled overnight processing")
+        Analytics.signal("Scheduler.autoEnabled")
+        reevaluate()
+    }
+
+    /// Arm a one-shot wake-up for the auto-enable moment (so it fires even if the app just sits open
+    /// past the 18h mark). Replaces any pending timer; the timer just re-invokes maybeAutoEnable().
+    private func armAutoEnableTimer(at fireAt: Date) {
+        autoEnableTask?.cancel()
+        let delay = max(1, fireAt.timeIntervalSinceNow)
+        autoEnableTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(delay))
+            guard !Task.isCancelled else { return }
+            self?.maybeAutoEnable()
+        }
+    }
+
+    // MARK: - Helper readiness
+
+    /// Ensure the root daemon is registered & approved before arming. Returns true when it's ready to
+    /// accept XPC. PRODUCTION path: SMAppService (one-click System Settings approval, no password) —
+    /// `.enabled` means go, `.requiresApproval` bails and lets the setup UX walk the user through it.
+    /// DEBUG dev builds (unsigned, or the plist not bundled → `.notFound`) fall back to the proven
+    /// admin-password installer so testing keeps working without a signed distribution build.
+    private func ensureHelperReady(log: SchedulerLog) async -> Bool {
+        let client = WakeHelperClient.shared
+        if client.isReady { return true }
+
+        let status = client.register()   // may surface the System Settings approval prompt
+        log.line("helper SMAppService status after register: \(status.rawValue)")
+        switch status {
+        case .enabled:
+            try? await Task.sleep(for: .seconds(1))   // let launchd settle before the first connection
+            needsSchedulerSetup = false
+            return true
+        case .requiresApproval:
+            needsSchedulerSetup = true
+            statusLine = "approve in System Settings"
+            log.line("helper needs approval in System Settings > Login Items — awaiting user")
+            return false
+        default:   // .notRegistered / .notFound — plist not bundled or build not signed for SMAppService
+            #if DEBUG
+            log.line("SMAppService unavailable (\(status.rawValue)) — DEBUG fallback to admin-password installer")
+            if !WakeHelperInstaller.isInstalledAndCurrent() {
+                statusLine = "installing helper…"
+                let ok = await WakeHelperInstaller.installAsync()
+                log.line("helper install (admin): \(ok ? "OK" : "declined/failed")")
+                guard ok else { statusLine = "needs your password — toggle off then on to retry"; return false }
+                try? await Task.sleep(for: .seconds(1))
+            }
+            return true
+            #else
+            needsSchedulerSetup = true
+            statusLine = "helper unavailable"
+            log.line("helper unavailable in Release (status \(status.rawValue)) — awaiting setup")
+            return false
+            #endif
+        }
     }
 
     private func loop() async {
         let log = SchedulerLog()
 
-        // Make sure the root helper is installed — one-time native password prompt, no Terminal.
-        if !WakeHelperInstaller.isInstalledAndCurrent() {
-            statusLine = "installing helper…"
-            log.line("helper not installed/current — requesting install (admin prompt)")
-            let ok = await WakeHelperInstaller.installAsync()
-            log.line("helper install: \(ok ? "OK" : "declined/failed")")
-            guard ok else { statusLine = "needs your password — toggle off then on to retry"; return }
-            try? await Task.sleep(for: .seconds(1))   // let launchd settle before the first connection
-        }
+        // Make sure the root wake helper is installed & approved before arming any wake.
+        guard await ensureHelperReady(log: log) else { return }
 
         // Clean slate: wipe every existing scheduled wake (duplicates / stale), then arm exactly one.
         everArmed = true

--- a/Sentient OS macOS/Scheduling/WakeHelperClient.swift
+++ b/Sentient OS macOS/Scheduling/WakeHelperClient.swift
@@ -41,6 +41,19 @@ final class WakeHelperClient {
         try? await service.unregister()
     }
 
+    /// Live registration status of the root daemon (`.enabled` = approved & ready · `.requiresApproval`
+    /// = registered, waiting for the user in System Settings · `.notRegistered` = never registered ·
+    /// `.notFound` = the bundled plist is missing / the build isn't signed for it). Read on every check
+    /// so a mid-session approval/revoke in System Settings is seen immediately.
+    var status: SMAppService.Status { SMAppService.daemon(plistName: WakeHelperConfig.daemonPlistName).status }
+
+    /// True once the user has approved the daemon and it's ready to accept XPC.
+    var isReady: Bool { status == .enabled }
+
+    /// Open System Settings > General > Login Items, where the user approves the daemon. Called by the
+    /// setup UX when `register()` returns `.requiresApproval`.
+    func openLoginItemsSettings() { SMAppService.openSystemSettingsLoginItems() }
+
     // MARK: - The four ops
 
     func beginAwake(timeout: Int = 7200) async -> Bool { await call { $0.beginAwake(timeoutSeconds: timeout, withReply: $1) } }

--- a/Sentient OS macOS/Views/DevToolsView.swift
+++ b/Sentient OS macOS/Views/DevToolsView.swift
@@ -26,6 +26,7 @@
 
 import SwiftUI
 import AppKit
+import ServiceManagement
 
 /// One-shot reader of the dev source-picker prefs (same keys as the @AppStorage below; defaults
 /// must match: folder toggles ON, DB sources OFF). RootView uses it for Analyze Now; this sheet
@@ -124,6 +125,10 @@ struct DevToolsView: View {
     // Scheduled run (dev testing — drives OvernightScheduler).
     @AppStorage(OvernightScheduler.enabledKey) private var schedEnabled = false
     @AppStorage(OvernightScheduler.minutesKey) private var schedMinutes = OvernightScheduler.defaultMinutes
+    // 18h auto-enable dev override (0 = the real 18h) + live prerequisite statuses (refreshed on appear).
+    @AppStorage(OvernightScheduler.autoEnableDelayKey) private var autoEnableDelayOverride: Double = 0
+    @State private var helperStatusLabel = "—"
+    @State private var loginItemEnabled = false
 
     // MCP mirror (the hosted Render copy). Local mirrors of MirrorClient's actor state, refreshed
     // when "More" opens and after each action.
@@ -158,10 +163,16 @@ struct DevToolsView: View {
             })
     }
 
-    private var schedulerSection: some View {
-        VStack(alignment: .leading, spacing: 10) {
+    // The whole overnight-processing dev surface: the scheduled-run time control PLUS the production
+    // prerequisites (root helper approval, launch-at-login) and the 18h auto-enable state + overrides.
+    // The real UX ships in onboarding/Settings later; this is the dev cockpit for all of it.
+    private var overnightSection: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("OVERNIGHT PROCESSING").font(.caption2.weight(.bold)).tracking(2).foregroundStyle(Theme.faint)
+
+            // 1) Scheduled run — the dev toggle + wake time (moved here from the old "SCHEDULED RUN" card).
             HStack {
-                Text("SCHEDULED RUN").font(.caption2.weight(.bold)).tracking(2).foregroundStyle(Theme.faint)
+                Text("Scheduled run (dev)").font(.caption.weight(.semibold)).foregroundStyle(.white.opacity(0.8))
                 Spacer()
                 Toggle("", isOn: $schedEnabled).labelsHidden().toggleStyle(.switch).controlSize(.small)
             }
@@ -177,14 +188,106 @@ struct DevToolsView: View {
                 Text(schedEnabled ? appState.scheduler.statusLine : "off")
                     .font(.caption2.monospaced()).foregroundStyle(Theme.faint)
             }
-            Text("Wakes the Mac at this time with the lid shut, runs .auto over the selected sources, then sleeps. Runs ONLY while Sentient is open — quit it and the wake is cancelled.")
+
+            Divider().overlay(.white.opacity(0.06))
+
+            // 2) Root wake helper — the SMAppService daemon (production install path). register() may
+            //    surface the System Settings approval; the deep-link button jumps there.
+            HStack {
+                Text("Root wake helper").font(.caption.weight(.semibold)).foregroundStyle(.white.opacity(0.8))
+                Spacer()
+                Text(helperStatusLabel).font(.caption2.monospaced()).foregroundStyle(Theme.faint)
+            }
+            HStack(spacing: 8) {
+                Button("Register / Approve") { _ = WakeHelperClient.shared.register(); refreshStatuses() }
+                    .controlSize(.small)
+                Button("Open Login Items") { WakeHelperClient.shared.openLoginItemsSettings() }
+                    .controlSize(.small)
+                Button("Refresh") { refreshStatuses() }.controlSize(.small)
+            }
+
+            // 3) Launch at login — the app must be running at 3am to host the scheduler.
+            HStack {
+                Text("Launch at login").font(.caption.weight(.semibold)).foregroundStyle(.white.opacity(0.8))
+                Spacer()
+                Toggle("", isOn: $loginItemEnabled).labelsHidden().toggleStyle(.switch).controlSize(.small)
+                    .onChange(of: loginItemEnabled) { _, on in
+                        if on { LoginItem.enable() } else { Task { await LoginItem.disable() } }
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { refreshStatuses() }
+                    }
+            }
+
+            Divider().overlay(.white.opacity(0.06))
+
+            // 4) 18h auto-enable — the actual feature: flip production ON 18h after the first full cycle,
+            //    once the helper is approved + launch-at-login is on. Dev buttons make it testable now.
+            Text("18h auto-enable").font(.caption.weight(.semibold)).foregroundStyle(.white.opacity(0.8))
+            Text(autoEnableStatusText).font(.caption2.monospaced()).foregroundStyle(Theme.faint)
+                .fixedSize(horizontal: false, vertical: true)
+            HStack(spacing: 8) {
+                Button("Simulate initial done") {
+                    UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: OvernightScheduler.firstCycleAtKey)
+                    appState.scheduler.maybeAutoEnable(); refreshStatuses()
+                }.controlSize(.small)
+                Button("Run check now") { appState.scheduler.maybeAutoEnable(); refreshStatuses() }.controlSize(.small)
+                Button("Reset") { resetAutoEnable() }.controlSize(.small)
+            }
+            HStack(spacing: 8) {
+                Text("Delay override (sec, 0 = 18h)").font(.caption2).foregroundStyle(Theme.faint)
+                TextField("0", value: $autoEnableDelayOverride, format: .number)
+                    .frame(width: 80).textFieldStyle(.roundedBorder).controlSize(.small)
+            }
+
+            Text("Auto-enables the overnight scheduler 18h after the first full cycle — but only once the root helper is approved AND launch-at-login is on (else it flags \"needs setup\" and retries). Runs ONLY while Sentient is open. Toggles above are dev overrides.")
                 .font(.caption2).foregroundStyle(Theme.faint.opacity(0.7))
                 .fixedSize(horizontal: false, vertical: true)
         }
         .padding(12)
         .background(.white.opacity(0.03), in: RoundedRectangle(cornerRadius: 12))
         .onChange(of: schedEnabled) { _, _ in appState.scheduler.reevaluate() }
+        .onAppear { refreshStatuses() }
         // Changing the time does NOT arm — the user presses "Done" to commit (no duplicate wakes).
+    }
+
+    /// Live prerequisite readout for the dev section (the user can approve/revoke in System Settings).
+    private func refreshStatuses() {
+        helperStatusLabel = Self.statusLabel(WakeHelperClient.shared.status)
+        loginItemEnabled = LoginItem.isEnabled
+    }
+
+    /// Clear every 18h auto-enable trace so the flow can be re-tested from scratch.
+    private func resetAutoEnable() {
+        let d = UserDefaults.standard
+        d.removeObject(forKey: OvernightScheduler.firstCycleAtKey)
+        d.removeObject(forKey: OvernightScheduler.autoEnableFiredKey)
+        d.removeObject(forKey: OvernightScheduler.prodEnabledKey)
+        appState.scheduler.needsSchedulerSetup = false
+        appState.scheduler.reevaluate()
+        refreshStatuses()
+    }
+
+    private var autoEnableStatusText: String {
+        let fired = UserDefaults.standard.bool(forKey: OvernightScheduler.autoEnableFiredKey)
+        guard let done = OvernightScheduler.firstCycleCompletedAt, let fireAt = OvernightScheduler.autoEnableFireDate else {
+            return "initial not finished yet — clock not started"
+        }
+        let firedTxt = fired ? " · fired ✓" : ""
+        let setupTxt = appState.scheduler.needsSchedulerSetup ? " · NEEDS SETUP" : ""
+        return "initial done \(Self.shortStamp(done)) · fires \(Self.shortStamp(fireAt))\(firedTxt)\(setupTxt)"
+    }
+
+    private static func statusLabel(_ s: SMAppService.Status) -> String {
+        switch s {
+        case .enabled:          return "enabled ✓"
+        case .requiresApproval: return "needs approval"
+        case .notRegistered:    return "not registered"
+        case .notFound:         return "not found (unsigned/dev)"
+        @unknown default:       return "unknown"
+        }
+    }
+
+    private static func shortStamp(_ d: Date) -> String {
+        let f = DateFormatter(); f.dateFormat = "MMM d, h:mm a"; return f.string(from: d)
     }
 
     /// Toggle: real For-You cards vs the demo deck. ON also makes Analyze Now run the full cycle.
@@ -226,7 +329,7 @@ struct DevToolsView: View {
             ScrollView {
                 VStack(spacing: 22) {
                     sourcePicker
-                    schedulerSection
+                    overnightSection
 
                     if Self.modelPath == nil {
                         Text("On-device model not found — place \(ModelLocator.fileName) next to the .xcodeproj, or set SENTIENT_MODEL_PATH.")

--- a/Sentient OS macOS/Views/RootView.swift
+++ b/Sentient OS macOS/Views/RootView.swift
@@ -12,6 +12,7 @@
 import SwiftUI
 
 struct RootView: View {
+    @Environment(AppState.self) private var appState
     @State private var isProcessing = false
     @State private var showDevTools = false
     @State private var customRoots: [URL] = []   // session-only custom folders (dev picker)
@@ -45,6 +46,7 @@ struct RootView: View {
                                runCalendar: calendarConnected && runCalendar,
                                fullCycle: realCards) {   // real mode → read + knowledge base + proactive + wipe
                     withAnimation(.easeInOut(duration: 0.3)) { isProcessing = false }
+                    appState.scheduler.maybeAutoEnable()   // a full cycle may have just stamped "initial done" → arm the 18h clock
                 }
                 .transition(.opacity)
             } else {

--- a/jesai.Sentient-OS-macOS.WakeHelper.plist
+++ b/jesai.Sentient-OS-macOS.WakeHelper.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  SMAppService LaunchDaemon plist for the root wake helper. Bundled into the app at
+  Contents/Library/LaunchDaemons/ (Copy Files build phase) so SMAppService.daemon(plistName:) can
+  find and register it — a one-click System Settings approval, no admin password.
+
+  The "helper" is THIS app's own executable relaunched with --wake-helper (main.swift branches on it
+  before SwiftUI), so BundleProgram points at the main binary and ProgramArguments passes the flag.
+  Label + MachServices must match WakeHelperConfig (machServiceName / daemonPlistName).
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>jesai.Sentient-OS-macOS.WakeHelper</string>
+    <key>BundleProgram</key>
+    <string>Contents/MacOS/Sentient OS</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>Contents/MacOS/Sentient OS</string>
+        <string>--wake-helper</string>
+    </array>
+    <key>MachServices</key>
+    <dict>
+        <key>jesai.Sentient-OS-macOS.WakeHelper</key>
+        <true/>
+    </dict>
+    <key>KeepAlive</key>
+    <false/>
+    <key>RunAtLoad</key>
+    <false/>
+</dict>
+</plist>


### PR DESCRIPTION
Turns the proven 3am wake *mechanism* into something that arms itself. Full working **logic**; the onboarding/Settings **UX** ships later (Jesai) against the seams below.

## The feature — 18h auto-enable
After the first big **initial** run, everything's caught up — arming the wake immediately risks a near-empty first morning. So we wait **18h after the first full `ProactiveCycle`**, then turn the scheduler on.

- `noteFirstCycleCompleted()` stamps `firstCycleCompletedAt` **once**.
- `maybeAutoEnable()` (launch + post-cycle + one-shot timer) flips the production flag 18h later — **latched** (acts once, never fights a user's manual toggle) and **gated** on prerequisites (approved helper + launch-at-login). If elapsed but prereqs unmet → sets `needsSchedulerSetup` and retries; never half-enables.

## The foundation it needed
- **A — SMAppService daemon:** bundle the LaunchDaemon plist at `Contents/Library/LaunchDaemons/` (new Copy Files phase, `BundleProgram` + `--wake-helper`); `WakeHelperClient.status`/`.isReady`/`.openLoginItemsSettings()`; scheduler `loop()` uses SMAppService, admin-password installer kept as a **DEBUG fallback**.
- **B — Launch-at-login:** new `LoginItem.swift` (`SMAppService.mainApp`).
- **C — Prod enable flag:** `scheduler.enabled` alongside the dev toggle (`reevaluate()` ORs).

## Dev UI
New **OVERNIGHT PROCESSING** section (folds in the old time control): helper Register/Approve + status + Open-Login-Items, launch-at-login toggle, and the full 18h auto-enable readout with dev overrides (simulate / run-now / reset / delay override).

## Verified
- Daemon plist **bundles** at `Contents/Library/LaunchDaemons/` + passes `plutil -lint`.
- Auto-enable state machine driven headlessly — **11/11**: stamp-once, delay math, the "not yet" hold, prerequisite gate (unmet → flags setup, no flip, no latch → retries), "user already enabled" latch, latch-blocks-re-enable.
- Release build green.

## Needs a signed build (not verifiable on an unsigned dev binary)
The actual System Settings **approval** of the daemon + the login-item registration round-trip. Logic is complete and gated; it lights up once the app is signed + in `/Applications`. (Handy: `Signing.xcconfig` just landed.)

## Seams for Jesai's UX
`WakeHelperClient.register()/.status/.openLoginItemsSettings()` · `LoginItem.enable()/.isEnabled` · bind a Settings toggle to `OvernightScheduler.prodEnabledKey` · read the published `needsSchedulerSetup` to know when to prompt.

Doc: `Documentation/Overnight Scheduler (Production Wiring & 18h Auto-Enable).md`.