### PR TITLE
Docs: settings-era truth pass

### DIFF
--- a/Sentient OS macOS/Documentation/Diagnostics (Sentry).md
+++ b/Sentient OS macOS/Documentation/Diagnostics (Sentry).md
@@ -24,8 +24,10 @@ Everything funnels through `CrashReporting` (`CrashReporting.swift`), a caseless
    **no debug bypass** (the old `startForDevTest` / dev-pane buttons were removed). To test the
    pipeline you build a Release app; Sentry then boots through the normal `start(.app)` path.
 2. **Opt-OUT switch, default ON.** `diagnosticsEnabled` (UserDefaults key `diagnosticsEnabled`,
-   treats unset as `true`). One "Share anonymous diagnostics" toggle in **Settings** gates **all**
-   reporting — crashes included. Flipping it live calls `applyEnabledChange()` (boots or `SentrySDK.close()`).
+   treats unset as `true`). The "Share anonymous crash reports" toggle in **Settings → System**
+   gates **all** Sentry reporting — crashes included. Flipping it live calls `applyEnabledChange()`
+   (boots or `SentrySDK.close()`). Product analytics (TelemetryDeck) has its OWN separate switch —
+   `analyticsEnabled`, the toggle beside it — see the Product Analytics doc.
 
 `main.swift` calls `CrashReporting.start(.app)` (GUI) / `.start(.wakeHelper)` (the root overnight
 helper) before anything else. Both are gated as above.

--- a/Sentient OS macOS/Documentation/Home — Proactive Intelligence (For You).md
+++ b/Sentient OS macOS/Documentation/Home — Proactive Intelligence (For You).md
@@ -73,8 +73,9 @@ a STOP button. (Computer use is the WIP Codex-CLI path.)
 
 ## The other windows
 
-- **`Views/SettingsView.swift`** (`windowID "settings"`, the gear) — a tasteful placeholder for now:
-  an About block + the coming sections (sources · cloud mirror · compute · notifications).
+- **`Views/Settings/SettingsView.swift`** (`windowID "settings"`, the gear) — the REAL two-pane
+  Settings window: five live panes (Knowledge Sources · Proactive & Sidekick · Your AIs · System ·
+  Permissions & Health). Doc: `Documentation/Settings.md`.
 - **`Views/ConnectAIsView.swift`** (`windowID "connect-ais"`) — the deferred setup guide (stub): the
   real two-step flow (copy your MCP URL → add the line to your AI's instructions) lands later.
 - **Knowledge** = the existing `DatabaseView` window (`windowID "knowledge"`) — a reader today; the

--- a/Sentient OS macOS/Documentation/MCP Mirror Client.md
+++ b/Sentient OS macOS/Documentation/MCP Mirror Client.md
@@ -16,6 +16,7 @@ try await mirror.push()                // zip the vault + replace the mirror (ca
 let s = try await mirror.stats()       // {notesRead24h, toolCalls24h, lastAccess} for "Your AIs"
 try await mirror.deleteRemote()        // delete the cloud copy (keeps the token → stable URL)
 await mirror.disable()                 // opt out: flip OFF + delete remote, but KEEP the token (stable link)
+let u2 = try await mirror.regenerateToken()  // leak remediation: delete old copy, mint NEW token, re-push
 ```
 
 ## The single token
@@ -57,8 +58,13 @@ auto-push-after-KB-update, call `await Self.pushIfDirty()` from `VaultCloud.mark
 
 ## Turning the mirror on (today)
 
-The opt-in is "mint a token" — `enable()`. The real onboarding/Settings opt-in UI is Phase 5, so
-ahead of that the **DEV TOOLS** panel (`DevToolsView`) exposes, while the mirror is ON:
+The user-facing opt-in is **Settings → Your AIs** (`Views/Settings/YourAIsPane.swift`): the share
+toggle (ON = `enable()` + a first push; OFF = a confirm dialog, then `disable()`), the masked
+secret link with **Copy** and **Regenerate** (`regenerateToken()` — the remediation if a link ever
+leaks: old cloud copy deleted, new identity minted, re-pushed), live `stats()` activity, and the
+connect-guide / system-prompt links. The onboarding opt-in moment is still to build.
+
+The **DEV TOOLS** panel (`DevToolsView`) keeps its own controls, while the mirror is ON:
 - **MCP TOGGLE** — ON mints the token (if absent) + pushes the current vault; OFF deletes the cloud copy but **keeps the token**, so re-enabling reuses the same share link.
 - **Copy MCP Link** / **Copy System Prompt** — the share URL and the coached connector prompt to paste into ChatGPT/Claude.
 - **MCP SYNC** — force-push the current vault to the mirror (sync is a separate manual step now; see Sync above).

--- a/Sentient OS macOS/Documentation/Product Analytics (TelemetryDeck).md
+++ b/Sentient OS macOS/Documentation/Product Analytics (TelemetryDeck).md
@@ -24,16 +24,19 @@ accounts, nothing personal ever leaves the Mac.
 }
 ```
 
-`start()` has the **same two hard gates as Sentry**:
+`start()` has **two hard gates**, mirroring Sentry's shape:
 1. **RELEASE builds only** — a deliberate no-op in DEBUG, so a dev's day-to-day Debug runs never
    pollute real usage numbers. (Verify from a Release build — see below.)
-2. **The shared opt-OUT switch** — `CrashReporting.diagnosticsEnabled` (default ON). The single
-   "Share anonymous diagnostics" toggle in Settings gates BOTH Sentry and TelemetryDeck; flipping it
-   calls `Analytics.applyEnabledChange()` alongside `CrashReporting.applyEnabledChange()`.
+2. **Its OWN opt-OUT switch** — `Analytics.analyticsEnabled` (UserDefaults key `analyticsEnabled`,
+   default ON, unset-reads-true). The "Share anonymous analytics" toggle in **Settings → System**
+   gates TelemetryDeck only; crash reports keep their separate switch (`CrashReporting.
+   diagnosticsEnabled`, the "Share anonymous crash reports" toggle beside it). The two consents
+   split when the real Settings shipped, so a user can keep crash reports on while opting out of
+   usage analytics — or vice versa. Flipping the toggle calls `Analytics.applyEnabledChange()`.
 
 Identity is the **same anonymous per-install id** as Sentry (`CrashReporting.installID`, a random
-UUID in UserDefaults), passed as TelemetryDeck's `defaultUser` (it re-hashes it). One opt-out, one
-identity — never a second consent surface. Every signal also auto-stamps `model` (the on-device
+UUID in UserDefaults), passed as TelemetryDeck's `defaultUser` (it re-hashes it). One identity,
+two independent switches. Every signal also auto-stamps `model` (the on-device
 model file name) via `defaultParameters`; OS/app version/device come free from the SDK.
 
 ## The App ID — safe in the code
@@ -95,9 +98,9 @@ Because sends are Release-only, verify from a **Release build** (Debug sends not
 
 ## Files
 
-- `Analytics.swift` — `start()`, `signal(_:parameters:)`, `applyEnabledChange()`, the App ID constant.
+- `Analytics.swift` — `start()`, `signal(_:parameters:)`, `applyEnabledChange()`, the `analyticsEnabled` opt-out, the App ID constant.
 - `main.swift` — `Analytics.start()` in the `.app` branch.
-- `CrashReporting.swift` — the shared `diagnosticsEnabled` opt-out + `installID` identity (reused, not modified).
-- `Views/SettingsView.swift` — the shared toggle's `onChange` calls both `applyEnabledChange()`s.
+- `CrashReporting.swift` — the `installID` identity (shared) + Sentry's separate `diagnosticsEnabled` opt-out.
+- `Views/Settings/SystemPane.swift` — the two Privacy toggles; each `onChange` calls its own `applyEnabledChange()`.
 - The ~12 call sites in the table above.
 - SPM package `github.com/TelemetryDeck/SwiftSDK` (product `TelemetryDeck`), pinned up-to-next-major from 2.0.0.

--- a/Sentient OS macOS/Documentation/Settings.md
+++ b/Sentient OS macOS/Documentation/Settings.md
@@ -1,0 +1,84 @@
+# Settings — the two-pane window
+
+The real Settings (shipped 2026-07-04, PR #107): a modern two-pane window in the OLED-editorial
+design language. Sidebar of five sections on the left (plus the About footer: version, GitHub,
+report-an-issue), the selected pane on the right, the trust ribbon riding the foot. Opened from the
+home's top-bar gear (`windowID "settings"`, 940×660 default).
+
+Everything lives in `Views/Settings/`: the shell (`SettingsView.swift`), one file per pane, and the
+shared pieces (`SettingsComponents.swift`).
+
+## The design philosophy: form encodes content
+
+No uniform card rows. Each kind of content wears its natural form:
+- **Prose** for stories (the overnight explainer, the privacy pledge) — naked editorial text, no box.
+- **Hairline toggle lines** for switches — title + quiet subtitle + a green switch, separated by hairlines.
+- **Chips** for sources — capsule pills that light green (wash + ring + dot) when selected; counts
+  ride inline ("12 chats"). Action chips (`isAction`, e.g. "+ Add Folder") wear a dashed border and
+  no dot: an invitation, not a source.
+- **Status LEDs** for health — glowing verdict dots (green/amber/red, bright core + double bloom)
+  with mono-caps states and a "Fix…" pill only when something needs one.
+- **Bordered surfaces only for real input** — the multiline text boxes and the secret-link capsule.
+- Bold serif-italic pane titles ("System."), mono-caps group labels, a 640pt editorial measure.
+
+Shared components: `SettingsPane` (scaffold) · `SettingsGroup` · `SettingsProse` ·
+`SettingToggleLine` · `SettingsPillButton` · `ChipFlow` (a wrapping `Layout`) · `SettingsChip` ·
+`StatusLine` · `SettingsTextBox` · `SettingsHairline`.
+
+## The five panes
+
+### Knowledge Sources (`SourcesPane.swift`)
+The real source picker, on the SAME keys as Analyze Now / Dev Tools / the 3am run
+(`SourceSelection`, `Sources/SourceSelection.swift`). Three groups: **Folders** (Desktop/Downloads/
+Documents toggles + persistent custom roots + Add Folder), **Chats & Notes** (WhatsApp — hidden
+when not installed — and iMessage open the shared `ChatPicker`; Apple Notes toggles), **Through
+Your ChatGPT** (Gmail / Calendar open their connect sheets). A fix-it `StatusLine` appears when
+Full Disk Access is missing. The **three-connector minimum** guards direct toggles on the 3→2 drop
+only (all folders together count as ONE connector; a pre-onboarding state below three is never
+trapped); a violation flashes the bottom whisper amber.
+
+**`CustomRoots`** (in `Sources/SourceSelection.swift`) is the persistent store for user-added
+folders — one newline-joined UserDefaults string (`files.customRoots`) so views react via plain
+`@AppStorage`. This replaced the old session-only `@State customRoots`; the overnight run now sees
+custom folders (the old §9 caveat is dead). Verified by a headless selftest (7/7) on ship day.
+
+### Proactive & Sidekick (`ProactivePane.swift`)
+Autosaving standing instructions for the proactive suggestion writer + Sidekick's shortcut key and
+standing context. Keys: `proactive.instructions` · `sidekick.hotkey` ("rightCommand" /
+"rightOption") · `sidekick.context`. ⚠️ Stored but not yet consumed — the prompts pick them up with
+the prompt-refinement work, and Right ⌥ additionally awaits `RightCommandMonitor` support.
+
+### Your AIs (`YourAIsPane.swift`)
+`MirrorClient` end-to-end: the share toggle (OFF = confirm dialog → `disable()`, which deletes the
+cloud copy but keeps the token), the masked secret link (Copy + **Regenerate** →
+`regenerateToken()`), live `stats()` activity, connect-guide links, and the local-only story when
+sharing is off. ⚠️ The maskedURL must search "/mcp" BACKWARDS — the host `https://mcp.sentient-os.ai`
+itself contains "/mcp", and a forward hit inverts the range (a shipped-then-fixed crash).
+
+### System (`SystemPane.swift`)
+The overnight-intelligence story (prose — 3 AM is our taste, not a dial), launch-at-login
+(`LoginItem`) with a keep-Sentient-alive confirm on the way off, and the privacy pledge with the
+two split consents: crash reports (`diagnosticsEnabled` → Sentry) and analytics
+(`analyticsEnabled` → TelemetryDeck), each calling its own `applyEnabledChange()`. The Sparkle
+auto-update group (with its own keep-it-on message) lands here when Sparkle ships.
+
+### Permissions & Health (`HealthPane.swift`)
+The health board: live status LEDs for Full Disk Access (grant deep-link + relaunch link),
+Notifications (requests when never-asked; deep-links when denied), launch-at-login, and the Codex
+stack via `CodexSetup.shared` (installed / logged in / computer use — every fix opens the shared
+`CodexSetupView`). Statuses re-probe on every app foreground. All-green flips the pane whisper to
+"All clear." The **Danger Zone** holds Reset: an honest confirm, then `FactoryReset.run()`.
+
+**`FactoryReset`** (`Ingestion/FactoryReset.swift`) is the ONE full wipe — cycle store, knowledge
+base folder, proactive traces, lifetime counters — shared by this pane and Dev Tools' "Reset
+everything" so the destructive sequences can never drift. Deliberately NOT touched: the cloud
+mirror (the next push whole-replaces it; the 30-day lease is the backstop), the mirror token, and
+the source selections. Post-reset the user lands on the empty home today; routing to onboarding
+arrives with onboarding itself.
+
+## Copy rules learned here
+
+No em dashes in user-facing settings copy (reads as AI slop — use commas/semicolons/colons/breaks).
+Guilt-trip confirms on the toggles that keep Sentient alive (launch-at-login; auto-update later).
+One green everywhere: `Theme.Ink.green` (#4ade80) — selection chips, switches, status dots, and
+every formerly-mint accent in the app.

--- a/Sentient OS macOS/Views/PermissionsView.swift
+++ b/Sentient OS macOS/Views/PermissionsView.swift
@@ -11,10 +11,12 @@
 //  CODEX COMPUTER USE — the helper's Accessibility (move mouse / type) + Screen Recording (see the
 //    screen). These belong to Codex's helper app, not Sentient.
 //
-//  The Automation + both Codex grants are written straight into the user's TCC database using the Full
-//  Disk Access Sentient already holds (device-/signer-agnostic — the code-requirement blobs are made
-//  from the live apps). Mic uses the normal request API; screen recording uses CGRequestScreenCapture;
-//  the daemon uses SMAppService. Every pane also has a Settings deep-link fallback + a re-check.
+//  The Automation grant is written straight into the user's TCC database using the Full Disk
+//  Access Sentient already holds (device-/signer-agnostic — the code-requirement blobs are made
+//  from the live apps). The two Codex grants (Accessibility + Screen Recording) live in the
+//  SIP-protected SYSTEM TCC db — no app can write those, so their panes are STATUS-ONLY (read via
+//  FDA) + a Settings deep-link. Mic uses the normal request API; screen recording uses
+//  CGRequestScreenCapture; the daemon uses SMAppService. Every pane also has a re-check.
 //
 
 import SwiftUI


### PR DESCRIPTION
Docs-only (+one comment fix). Brings Documentation/ in line with the shipped Settings window: new Settings.md, split privacy consents in the Sentry/TelemetryDeck docs, regenerateToken + the Settings opt-in surface in the mirror doc, and the PermissionsView header no longer claims we can write the system TCC db. (The Our_Stuff context files were updated in parallel — not git.)