### PR TITLE
Settings: final Permissions & Health board (all lights wired)

### DIFF
--- a/Sentient OS macOS/Documentation/Settings.md
+++ b/Sentient OS macOS/Documentation/Settings.md
@@ -1,84 +1,124 @@
 # Settings — the two-pane window
 
-The real Settings (shipped 2026-07-04, PR #107): a modern two-pane window in the OLED-editorial
-design language. Sidebar of five sections on the left (plus the About footer: version, GitHub,
-report-an-issue), the selected pane on the right, the trust ribbon riding the foot. Opened from the
-home's top-bar gear (`windowID "settings"`, 940×660 default).
+The real Settings (shipped 2026-07-04, PRs #107 + #109): a modern two-pane window in the
+OLED-editorial design language. Sidebar of five sections on the left (plus the About footer:
+version, GitHub, report-an-issue), the selected pane on the right, the trust ribbon riding the
+foot. Opened from the home's top-bar gear (`windowID "settings"`, 940×660 default). Everything
+lives in `Views/Settings/`: the shell (`SettingsView.swift`), one file per pane, and the shared
+pieces (`SettingsComponents.swift`).
 
-Everything lives in `Views/Settings/`: the shell (`SettingsView.swift`), one file per pane, and the
-shared pieces (`SettingsComponents.swift`).
+## ⚠️ NOT wired up yet (read this first)
+
+1. **Proactive instructions + Sidekick context/hotkey** (`ProactivePane`) — the controls work and
+   persist (`proactive.instructions` · `sidekick.context` · `sidekick.hotkey`), but **nothing
+   consumes the values yet**. The proactive/Sidekick prompts learn to read them with the
+   prompt-refinement work, and the Right ⌥ choice additionally needs `RightCommandMonitor`
+   support (it listens for right-⌘ only today).
+2. **"How to connect your AIs"** (Your AIs pane) — opens `ConnectAIsView`, which is a pretty
+   explainer stub, self-labeled "Guided setup · coming soon". The real two-step guided flow is
+   future work.
+3. **The morning notification** — the Notifications permission row is real, but nothing in the app
+   *sends* notifications yet (`Notify.now()` has zero call sites). The "Proactive Intelligence is
+   ready" morning note ships with the reminders/scheduler work; the permission ask then moves to
+   onboarding's notifications step.
+4. **The Updates group** (System pane) — doesn't exist until Sparkle lands; it brings its own
+   keep-it-on message.
+5. **Privacy toggles transmit only in RELEASE builds** — by design (Sentry/TelemetryDeck never
+   boot in DEBUG), so a Debug QA can verify persistence but not transmission.
+6. **Small known holes, accepted for now:** removing the LAST custom folder can bypass the
+   three-connector minimum (the guard covers chip toggle-offs only) · the reset-vs-run race has
+   only the UI guard (see Reset below; the Layer-2 generation counter is deferred hardening) ·
+   three Settings deep-link anchors (Speech Recognition, Accessibility, Screen Recording) are
+   standard but unverified on Tahoe specifically.
 
 ## The design philosophy: form encodes content
 
 No uniform card rows. Each kind of content wears its natural form:
-- **Prose** for stories (the overnight explainer, the privacy pledge) — naked editorial text, no box.
-- **Hairline toggle lines** for switches — title + quiet subtitle + a green switch, separated by hairlines.
-- **Chips** for sources — capsule pills that light green (wash + ring + dot) when selected; counts
-  ride inline ("12 chats"). Action chips (`isAction`, e.g. "+ Add Folder") wear a dashed border and
-  no dot: an invitation, not a source.
-- **Status LEDs** for health — glowing verdict dots (green/amber/red, bright core + double bloom)
-  with mono-caps states and a "Fix…" pill only when something needs one.
-- **Bordered surfaces only for real input** — the multiline text boxes and the secret-link capsule.
-- Bold serif-italic pane titles ("System."), mono-caps group labels, a 640pt editorial measure.
+- **Prose** for stories (the overnight explainer, the privacy pledge); no boxes.
+- **Hairline toggle lines** for switches: title + quiet subtitle + a green switch.
+- **Chips** for sources: capsule pills that light green (wash + ring + dot) when selected; counts
+  ride inline ("12 chats"). Action chips (`isAction`, e.g. "+ Add Folder") wear a dashed border
+  and no dot: an invitation, not a source.
+- **Status LEDs** for health: glowing verdict dots (`HealthDot` — bright core + double bloom),
+  mono-caps states, a pill fix button only when something needs one.
+- **Bordered surfaces only for real input**: the text boxes and the secret-link capsule.
+- Serif-italic pane titles ("System."), mono-caps group labels, a 640pt editorial measure, and
+  one green everywhere (`Theme.Ink.green`, #4ade80).
 
-Shared components: `SettingsPane` (scaffold) · `SettingsGroup` · `SettingsProse` ·
-`SettingToggleLine` · `SettingsPillButton` · `ChipFlow` (a wrapping `Layout`) · `SettingsChip` ·
-`StatusLine` · `SettingsTextBox` · `SettingsHairline`.
+Shared components (`SettingsComponents.swift`): `SettingsPane` · `SettingsGroup` · `SettingsProse`
+· `SettingToggleLine` · `SettingsPillButton` · `ChipFlow` (a wrapping `Layout`) · `SettingsChip` ·
+`HealthDot` · `StatusLine` · `InfoTip`/`TipWarmth` · `SettingsTextBox` · `SettingsHairline`.
 
 ## The five panes
 
 ### Knowledge Sources (`SourcesPane.swift`)
 The real source picker, on the SAME keys as Analyze Now / Dev Tools / the 3am run
-(`SourceSelection`, `Sources/SourceSelection.swift`). Three groups: **Folders** (Desktop/Downloads/
-Documents toggles + persistent custom roots + Add Folder), **Chats & Notes** (WhatsApp — hidden
-when not installed — and iMessage open the shared `ChatPicker`; Apple Notes toggles), **Through
-Your ChatGPT** (Gmail / Calendar open their connect sheets). A fix-it `StatusLine` appears when
-Full Disk Access is missing. The **three-connector minimum** guards direct toggles on the 3→2 drop
-only (all folders together count as ONE connector; a pre-onboarding state below three is never
-trapped); a violation flashes the bottom whisper amber.
+(`SourceSelection`, `Sources/SourceSelection.swift`). Three groups: **Folders**
+(Desktop/Downloads/Documents toggles + persistent custom roots + Add Folder), **Chats & Notes**
+(WhatsApp — hidden when not installed — and iMessage open the shared `ChatPicker`; Apple Notes
+toggles), **Through Your ChatGPT** (Gmail / Calendar open their real connect sheets; note:
+connecting ARMS the source — the initial read happens on the next run, same as connecting from
+the Home popover). A fix-it `StatusLine` appears when Full Disk Access is missing. The
+**three-connector minimum** guards chip toggle-offs on the 3→2 drop only (all folders together
+count as ONE connector; a pre-onboarding state below three is never trapped); violations flash
+the bottom whisper amber.
 
 **`CustomRoots`** (in `Sources/SourceSelection.swift`) is the persistent store for user-added
-folders — one newline-joined UserDefaults string (`files.customRoots`) so views react via plain
-`@AppStorage`. This replaced the old session-only `@State customRoots`; the overnight run now sees
-custom folders (the old §9 caveat is dead). Verified by a headless selftest (7/7) on ship day.
+folders: one newline-joined UserDefaults string (`files.customRoots`) so views react via plain
+`@AppStorage`. This replaced the old session-only `@State customRoots`; the overnight run now
+sees custom folders. Verified by a headless selftest (7/7) on ship day.
 
 ### Proactive & Sidekick (`ProactivePane.swift`)
-Autosaving standing instructions for the proactive suggestion writer + Sidekick's shortcut key and
-standing context. Keys: `proactive.instructions` · `sidekick.hotkey` ("rightCommand" /
-"rightOption") · `sidekick.context`. ⚠️ Stored but not yet consumed — the prompts pick them up with
-the prompt-refinement work, and Right ⌥ additionally awaits `RightCommandMonitor` support.
+Autosaving standing instructions + Sidekick's shortcut key and standing context. Stored, not yet
+consumed — see the NOT-wired list above.
 
 ### Your AIs (`YourAIsPane.swift`)
-`MirrorClient` end-to-end: the share toggle (OFF = confirm dialog → `disable()`, which deletes the
-cloud copy but keeps the token), the masked secret link (Copy + **Regenerate** →
-`regenerateToken()`), live `stats()` activity, connect-guide links, and the local-only story when
-sharing is off. ⚠️ The maskedURL must search "/mcp" BACKWARDS — the host `https://mcp.sentient-os.ai`
-itself contains "/mcp", and a forward hit inverts the range (a shipped-then-fixed crash).
+`MirrorClient` end-to-end: the share toggle (OFF = confirm dialog → `disable()`, which deletes
+the cloud copy but keeps the token), the masked secret link (Copy + **Regenerate** →
+`regenerateToken()`, the leak remediation: old copy deleted, new identity minted, re-pushed),
+live `stats()` activity, connect-guide links, and the local-only story when sharing is off.
+⚠️ The maskedURL must search "/mcp" BACKWARDS: the host `https://mcp.sentient-os.ai` itself
+contains "/mcp", and a forward hit inverts the range (a shipped-then-fixed crash).
 
 ### System (`SystemPane.swift`)
-The overnight-intelligence story (prose — 3 AM is our taste, not a dial), launch-at-login
-(`LoginItem`) with a keep-Sentient-alive confirm on the way off, and the privacy pledge with the
-two split consents: crash reports (`diagnosticsEnabled` → Sentry) and analytics
-(`analyticsEnabled` → TelemetryDeck), each calling its own `applyEnabledChange()`. The Sparkle
-auto-update group (with its own keep-it-on message) lands here when Sparkle ships.
+The overnight-intelligence story (prose; 3 AM is our taste, not a dial), launch-at-login
+(`LoginItem`) with a keep-Sentient-alive confirm on the way off, the privacy pledge with the two
+split consents (crash reports `diagnosticsEnabled` → Sentry · analytics `analyticsEnabled` →
+TelemetryDeck, each with its own `applyEnabledChange()`), and the **Danger Zone**: Reset runs the
+shared `FactoryReset` (`Ingestion/FactoryReset.swift` — cycle store + knowledge-base folder +
+proactive traces + lifetime counters; same code path as Dev Tools' "Reset everything", so the
+wipes can never drift; the cloud mirror is deliberately untouched — the next push replaces it,
+the 30-day lease is the backstop). **The Reset button locks while the pipeline runs**
+(`Ingestion/PipelineActivity.swift`, a counter flag begun/ended by `IterativeRun` +
+`ProactiveCycle`) — wiping mid-run would leave high-water marks pointing past erased notes.
 
 ### Permissions & Health (`HealthPane.swift`)
-The health board: live status LEDs for Full Disk Access (grant deep-link + relaunch link),
-Notifications (requests when never-asked; deep-links when denied), launch-at-login, and the Codex
-stack via `CodexSetup.shared` (installed / logged in / computer use — every fix opens the shared
-`CodexSetupView`). Statuses re-probe on every app foreground. All-green flips the pane whisper to
-"All clear." The **Danger Zone** holds Reset: an honest confirm, then `FactoryReset.run()`.
+The health board. A spinner line ("Checking your Sentient…") holds the pane through the first
+probe (the codex login check shells out and takes seconds), then rows cascade in (a gentle
+staggered rise). Severity-ordered rows, each with an `InfoTip` (tiny info icon; hover 0.15s
+opens a popover to the right; `TipWarmth` makes sibling tips open instantly):
 
-**`FactoryReset`** (`Ingestion/FactoryReset.swift`) is the ONE full wipe — cycle store, knowledge
-base folder, proactive traces, lifetime counters — shared by this pane and Dev Tools' "Reset
-everything" so the destructive sequences can never drift. Deliberately NOT touched: the cloud
-mirror (the next push whole-replaces it; the 30-day lease is the backstop), the mirror token, and
-the source selections. Post-reset the user lands on the empty home today; routing to onboarding
-arrives with onboarding itself.
+- **SENTIENT:** Full Disk Access (grant deep-link + relaunch link) · Overnight wake (🟢 = the
+  installed daemon plist points at THIS binary; fix runs `WakeHelperInstaller.installAsync()` —
+  **[DECIDED 2026-07-04] the password install IS production**, no Login Items migration) ·
+  Launch at login (yellow when off) · Microphone & Speech (one row: `VoiceCapture.
+  requestPermissions()` asks both; denied deep-links to the actual blocker) · Notifications
+  (yellow when off, never red — the morning briefing is optional).
+- **SET UP CODEX:** CLI / ChatGPT account / computer use — all red when missing; every fix opens
+  the shared `CodexSetupView` (statuses re-probe when the sheet closes).
+- **CODEX PERMISSIONS:** the helper's Accessibility + Screen Recording — system-TCC, read via
+  our FDA, status + deep-link only; shown once computer use exists.
+- **The codex collapse:** when the WHOLE stack is green, the five codex rows fold into one line
+  ("Codex is all good. · Details"); expanding is a one-way door per visit. Anything unhealthy
+  keeps the full board open.
+- **Automation has NO row:** ~0.5s after the pane opens it probes the user-db grant and silently
+  re-runs `grantComputerUseAutomation()` if missing (idempotent, logged). The user has no job
+  there, so the UI gives them none.
+- Red = a core capability is broken · yellow = optional or fixable-later. Statuses re-probe on
+  every app foreground.
 
 ## Copy rules learned here
 
-No em dashes in user-facing settings copy (reads as AI slop — use commas/semicolons/colons/breaks).
-Guilt-trip confirms on the toggles that keep Sentient alive (launch-at-login; auto-update later).
-One green everywhere: `Theme.Ink.green` (#4ade80) — selection chips, switches, status dots, and
-every formerly-mint accent in the app.
+No em dashes in user-facing settings copy (reads as AI slop; use commas/semicolons/colons/
+breaks). Guilt-trip confirms on the toggles that keep Sentient alive. Info-tip copy is short,
+plain, and trust-first: who the grant belongs to, what it unlocks, what stays on the Mac.

--- a/Sentient OS macOS/Ingestion/IterativeRun.swift
+++ b/Sentient OS macOS/Ingestion/IterativeRun.swift
@@ -108,6 +108,8 @@ struct IterativeRun {
              onProgress: @Sendable @escaping (RunProgress) -> Void = { _ in }) async -> RunProgress {
         var p = RunProgress()
         guard !connectors.isEmpty else { return p }
+        PipelineActivity.begin()                 // Settings' Reset is disabled while we're mid-run
+        defer { PipelineActivity.end() }
 
         // §7.22: if this run includes a DB source (WhatsApp/iMessage/Notes need Full Disk Access),
         // report the FDA probe when it isn't cleanly granted — the top "empty morning" signal (a 3am

--- a/Sentient OS macOS/Ingestion/PipelineActivity.swift
+++ b/Sentient OS macOS/Ingestion/PipelineActivity.swift
@@ -1,0 +1,27 @@
+//
+//  PipelineActivity.swift
+//  Sentient OS macOS  ·  Ingestion/
+//
+//  A tiny "is the pipeline running?" flag, set by IterativeRun and ProactiveCycle (a counter, so
+//  overlapping legs nest safely). First user: Settings → System disables Reset while a run is
+//  active — wiping the store mid-run would leave high-water marks pointing past erased notes
+//  (history silently skipped forever). UI guard only; the hard generation-counter guarantee is
+//  the deferred Layer-2 hardening.
+//
+
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class PipelineActivity {
+    static let shared = PipelineActivity()
+    private init() {}
+
+    private(set) var activeRuns = 0
+    var isRunning: Bool { activeRuns > 0 }
+
+    /// Callable from any actor (the runs live off-main); hops to main for the observable write.
+    nonisolated static func begin() { Task { @MainActor in shared.activeRuns += 1 } }
+    nonisolated static func end() { Task { @MainActor in shared.activeRuns = max(0, shared.activeRuns - 1) } }
+}

--- a/Sentient OS macOS/Ingestion/ProactiveCycle.swift
+++ b/Sentient OS macOS/Ingestion/ProactiveCycle.swift
@@ -52,6 +52,8 @@ actor ProactiveCycle {
     /// Never throws — every failure is ALSO reported through `progress(.failed(…))` for the live UI.
     @discardableResult
     func run(progress: @escaping @Sendable (ProactiveCyclePhase) -> Void) async -> String? {
+        PipelineActivity.begin()                 // Settings' Reset is disabled while the tail runs
+        defer { PipelineActivity.end() }
         let notes = await CycleStore.shared.notes().map(CloudNote.init)
         guard !notes.isEmpty else {                          // nothing new this cycle — harmless no-op
             UserDefaults.standard.set(Date(), forKey: Self.lastCycleKey)

--- a/Sentient OS macOS/Permissions.swift
+++ b/Sentient OS macOS/Permissions.swift
@@ -171,6 +171,7 @@ enum Permissions {
     // MARK: - Settings deep-links (we can't flip these toggles; the user does)
 
     @MainActor static func openMicrophoneSettings() { openPrivacy("Privacy_Microphone") }
+    @MainActor static func openSpeechRecognitionSettings() { openPrivacy("Privacy_SpeechRecognition") }
     @MainActor static func openScreenRecordingSettings() { openPrivacy("Privacy_ScreenCapture") }
     @MainActor static func openAccessibilitySettings() { openPrivacy("Privacy_Accessibility") }
     @MainActor static func openAutomationSettings() { openPrivacy("Privacy_Automation") }

--- a/Sentient OS macOS/Scheduling/WakeHelperInstaller.swift
+++ b/Sentient OS macOS/Scheduling/WakeHelperInstaller.swift
@@ -8,8 +8,10 @@
 //    write the plist (with THIS app's current binary path) to a temp file → privileged cp into
 //    /Library/LaunchDaemons → chown/chmod → launchctl bootstrap.
 //
-//  This is the dev/testing path; production will swap it for SMAppService.daemon (a one-click
-//  System Settings approval, no password). Same daemon, same plist — only the install UX differs.
+//  [DECIDED 2026-07-04] This IS the production path. The SMAppService.daemon migration (Login
+//  Items toggle) was considered and rejected: this works, it's measured on real hardware, and one
+//  native password dialog beats sending users into System Settings. (WakeHelperClient keeps its
+//  SMAppService plumbing for the dev cockpit, but nothing user-facing routes there.)
 //
 
 import Foundation

--- a/Sentient OS macOS/Views/Settings/HealthPane.swift
+++ b/Sentient OS macOS/Views/Settings/HealthPane.swift
@@ -19,7 +19,6 @@ import AppKit
 import AVFoundation
 import Speech
 import UserNotifications
-import ServiceManagement   // SMAppService.Status — the wake daemon's registration state
 
 struct HealthPane: View {
     @State private var codex = CodexSetup.shared
@@ -40,7 +39,7 @@ struct HealthPane: View {
     @State private var checked = false        // first full probe done (codex login check is seconds)
     @State private var revealed = false       // drives the rise-in cascade after the first probe
 
-    private enum DaemonState { case ready, awaitingApproval, notSetUp }
+    private enum DaemonState { case ready, installing, notSetUp }
     private enum MicSpeechState { case granted, notAsked, denied }
 
     private var showCodexPermissions: Bool { fdaGranted && codex.computerUseReady }
@@ -138,7 +137,7 @@ struct HealthPane: View {
                 StatusLine(title: "Overnight wake",
                            health: daemon == .ready ? .ok : .bad,
                            note: daemonNote,
-                           fixTitle: daemon == .awaitingApproval ? "Approve…" : "Set Up…") {
+                           fixTitle: "Set Up…") {
                     fixDaemon()
                 }
                 .rise(1, revealed: revealed)
@@ -172,37 +171,26 @@ struct HealthPane: View {
 
     private var daemonNote: String {
         switch daemon {
-        case .ready:             return "ready"
-        case .awaitingApproval:  return "awaiting approval"
-        case .notSetUp:          return "not set up"
+        case .ready:      return "ready"
+        case .installing: return "installing…"
+        case .notSetUp:   return "not set up"
         }
     }
 
-    /// Awaiting approval → straight to Login Items. Not set up → register (the SMAppService path);
-    /// if that lands in requires-approval, open Login Items so the user can finish the click.
+    /// [DECIDED 2026-07-04] The password install IS the production path (no Login Items
+    /// migration — one native admin prompt, no trip to System Settings). Fix = run the installer.
     private func fixDaemon() {
-        switch daemon {
-        case .ready:
-            break
-        case .awaitingApproval:
-            WakeHelperClient.shared.openLoginItemsSettings()
-        case .notSetUp:
-            let status = WakeHelperClient.shared.register()
-            if status == .requiresApproval { WakeHelperClient.shared.openLoginItemsSettings() }
+        guard daemon == .notSetUp else { return }
+        daemon = .installing
+        Task {
+            _ = await WakeHelperInstaller.installAsync()
             refreshDaemon()
         }
     }
 
-    /// Green = the SMAppService daemon is approved OR the dev-installed plist exists and points at
-    /// this exact binary (the manual path still counts as a working heartbeat).
+    /// Green = the installed daemon plist exists AND points at this exact binary.
     private func refreshDaemon() {
-        if WakeHelperInstaller.isInstalledAndCurrent() || WakeHelperClient.shared.status == .enabled {
-            daemon = .ready
-        } else if WakeHelperClient.shared.status == .requiresApproval {
-            daemon = .awaitingApproval
-        } else {
-            daemon = .notSetUp
-        }
+        daemon = WakeHelperInstaller.isInstalledAndCurrent() ? .ready : .notSetUp
     }
 
     // MARK: Microphone & Speech (one row — one call asks for both)

--- a/Sentient OS macOS/Views/Settings/HealthPane.swift
+++ b/Sentient OS macOS/Views/Settings/HealthPane.swift
@@ -263,8 +263,13 @@ struct HealthPane: View {
                     .requestAuthorization(options: [.alert, .sound])
                 await refresh()
             }
-        } else if let url = URL(string: "x-apple.systempreferences:com.apple.preference.notifications") {
-            NSWorkspace.shared.open(url)
+        } else {
+            // Modern Settings pane first (Ventura+), legacy anchor as fallback — same pattern as
+            // Permissions.openFullDiskAccessSettings.
+            let modern = "x-apple.systempreferences:com.apple.Notifications-Settings.extension"
+            let legacy = "x-apple.systempreferences:com.apple.preference.notifications"
+            if let url = URL(string: modern), NSWorkspace.shared.open(url) { return }
+            if let url = URL(string: legacy) { NSWorkspace.shared.open(url) }
         }
     }
 

--- a/Sentient OS macOS/Views/Settings/HealthPane.swift
+++ b/Sentient OS macOS/Views/Settings/HealthPane.swift
@@ -118,7 +118,7 @@ struct HealthPane: View {
                     StatusLine(title: "Full Disk Access",
                                health: fdaGranted ? .ok : .bad,
                                note: fdaGranted ? "granted" : "not granted",
-                               tip: "Lets Sentient read the databases WhatsApp, iMessage, and Notes keep on this Mac. Everything is read locally; nothing leaves your Mac.",
+                               tip: "Lets Sentient read your files & folders, and the databases WhatsApp, iMessage, and Notes keep on this Mac. Everything is read locally; nothing leaves your Mac.",
                                fixTitle: "Grant…") {
                         Permissions.openFullDiskAccessSettings()
                     }
@@ -140,7 +140,7 @@ struct HealthPane: View {
                 StatusLine(title: "Overnight wake",
                            health: daemon == .ready ? .ok : .bad,
                            note: daemonNote,
-                           tip: "A tiny system helper that wakes your Mac at 3 AM so Sentient can work while you sleep. Installed once with your password.",
+                           tip: "A tiny system helper that wakes your Mac at 3 AM so Sentient can work while you sleep. It only runs while your Mac is plugged in and Sentient is open in your menu bar. Installed once with your password.",
                            fixTitle: "Set Up…") {
                     fixDaemon()
                 }
@@ -148,7 +148,7 @@ struct HealthPane: View {
                 StatusLine(title: "Launch at login",
                            health: loginOn ? .ok : .warn,
                            note: loginOn ? "on" : "off",
-                           tip: "Starts Sentient quietly in your menu bar when you log in, so the overnight run can happen.",
+                           tip: "Starts Sentient quietly in your menu bar when you log in, so the overnight run can happen and your Sentient can stay alive.",
                            fixTitle: "Turn On") {
                     LoginItem.enable()
                     loginOn = LoginItem.isEnabled
@@ -311,7 +311,7 @@ struct HealthPane: View {
                 StatusLine(title: "Codex CLI",
                            health: codex.installed ? .ok : .bad,
                            note: codex.installed ? "installed" : "not installed",
-                           tip: "OpenAI's Codex command line tool. Sentient runs its cloud steps through it, paid for by your own ChatGPT plan.",
+                           tip: "OpenAI's official Codex command line tool. Sentient runs its cloud steps through it, using your own ChatGPT subscription.",
                            fixTitle: "Install…") { showCodexSetup = true }
                 StatusLine(title: "ChatGPT account",
                            health: codex.loggedIn ? .ok : .bad,

--- a/Sentient OS macOS/Views/Settings/HealthPane.swift
+++ b/Sentient OS macOS/Views/Settings/HealthPane.swift
@@ -8,8 +8,10 @@
 //  via the shared CodexSetup engine), and CODEX PERMISSIONS (the helper's Accessibility + Screen
 //  Recording — system-TCC, status-only, shown once computer use exists). The Automation grant has
 //  NO row: it self-heals silently shortly after the pane opens (the user has no job there).
-//  Red = a core capability is broken · yellow = optional or fixable-later. Statuses re-probe on
-//  app foreground and after the codex sheet closes. The danger-zone Reset runs FactoryReset.
+//  Red = a core capability is broken · yellow = optional or fixable-later. When the whole codex
+//  stack is green it collapses to one glowing summary line (tap for details) — a browsing user
+//  shouldn't wade through five rows of "fine". Statuses re-probe on app foreground and after the
+//  codex sheet closes. (Reset lives in Settings → System.)
 //
 
 import SwiftUI
@@ -34,14 +36,19 @@ struct HealthPane: View {
     @State private var helperScreenRecording = false
 
     @State private var showCodexSetup = false
-    @State private var confirmReset = false
-    @State private var resetting = false
-    @State private var resetDone = false
+    @State private var codexExpanded = false
 
     private enum DaemonState { case ready, awaitingApproval, notSetUp }
     private enum MicSpeechState { case granted, notAsked, denied }
 
     private var showCodexPermissions: Bool { fdaGranted && codex.computerUseReady }
+
+    /// The whole codex stack, healthy — the CLI, the account, computer use, AND its two helper
+    /// grants (verifiable only with FDA; unverifiable never claims "all good").
+    private var codexAllGreen: Bool {
+        codex.installed && codex.loggedIn && codex.computerUseReady
+            && fdaGranted && helperAccessibility && helperScreenRecording
+    }
 
     private var allGreen: Bool {
         fdaGranted && daemon == .ready && loginOn && micSpeech == .granted
@@ -56,9 +63,16 @@ struct HealthPane: View {
                                        : "Everything green means everything works.") {
             VStack(alignment: .leading, spacing: 30) {
                 sentientGroup
-                codexSetupGroup
-                if showCodexPermissions { codexPermissionsGroup }
-                dangerGroup
+                if codexAllGreen {
+                    SettingsGroup(label: "Codex") { codexSummaryLine }
+                    if codexExpanded {
+                        codexSetupGroup
+                        codexPermissionsGroup
+                    }
+                } else {
+                    codexSetupGroup
+                    if showCodexPermissions { codexPermissionsGroup }
+                }
             }
         }
         .task {
@@ -239,6 +253,30 @@ struct HealthPane: View {
         }
     }
 
+    // MARK: - The collapsed codex summary (everything green = one quiet line, tap for details)
+
+    private var codexSummaryLine: some View {
+        Button {
+            withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) { codexExpanded.toggle() }
+        } label: {
+            HStack(spacing: 11) {
+                HealthDot(color: Theme.Ink.green)
+                Text("Codex is all good.")
+                    .font(.system(size: 12.5)).foregroundStyle(Theme.Ink.statusInk)
+                Spacer(minLength: 12)
+                MonoCaps(codexExpanded ? "Hide" : "Details", size: 8.5, tracking: 1.6,
+                         color: Theme.Ink.label)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(Theme.Ink.label)
+                    .rotationEffect(.degrees(codexExpanded ? 180 : 0))
+            }
+            .padding(.vertical, 6)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
     // MARK: - SET UP CODEX (the cloud brain — all three are core, red when missing)
 
     private var codexSetupGroup: some View {
@@ -299,39 +337,6 @@ struct HealthPane: View {
             } catch {
                 Log("HealthPane: automation self-heal failed — \(error)")
             }
-        }
-    }
-
-    // MARK: - Danger zone (the shared FactoryReset wipe)
-
-    private static let dangerRed = Color(red: 1.0, green: 0.36, blue: 0.36)
-
-    private var dangerGroup: some View {
-        SettingsGroup(label: "Danger Zone") {
-            VStack(alignment: .leading, spacing: 10) {
-                SettingsProse("Reset erases everything Sentient has learned: the knowledge base, every summary, and all suggestions. You'll start over from scratch, including the initial processing. Your cloud copy isn't touched; the next processing run simply replaces it.")
-                SettingsPillButton(title: resetting ? "Erasing…" : "Reset Sentient…",
-                                   tint: Self.dangerRed) { confirmReset = true }
-                    .disabled(resetting)
-                if resetDone {
-                    Text("Reset complete. Sentient is a blank slate.")
-                        .font(.serif(11.5, weight: .regular)).italic()
-                        .foregroundStyle(Theme.Ink.body)
-                }
-            }
-        }
-        .alert("Erase everything Sentient has learned?", isPresented: $confirmReset) {
-            Button("Cancel", role: .cancel) {}
-            Button("Erase Everything", role: .destructive) {
-                resetting = true
-                Task {
-                    await FactoryReset.run()
-                    resetting = false
-                    resetDone = true
-                }
-            }
-        } message: {
-            Text("Your knowledge base and everything Sentient understood is deleted from this Mac. This can't be undone; Sentient starts again from zero, beginning with the initial processing.")
         }
     }
 

--- a/Sentient OS macOS/Views/Settings/HealthPane.swift
+++ b/Sentient OS macOS/Views/Settings/HealthPane.swift
@@ -37,6 +37,8 @@ struct HealthPane: View {
 
     @State private var showCodexSetup = false
     @State private var codexExpanded = false
+    @State private var checked = false        // first full probe done (codex login check is seconds)
+    @State private var revealed = false       // drives the rise-in cascade after the first probe
 
     private enum DaemonState { case ready, awaitingApproval, notSetUp }
     private enum MicSpeechState { case granted, notAsked, denied }
@@ -61,18 +63,30 @@ struct HealthPane: View {
         SettingsPane(title: "Permissions & Health.",
                      whisper: allGreen ? "All clear. Your Sentient is healthy."
                                        : "Everything green means everything works.") {
-            VStack(alignment: .leading, spacing: 30) {
-                sentientGroup
-                if codexAllGreen {
-                    SettingsGroup(label: "Codex") { codexSummaryLine }
-                    if codexExpanded {
-                        codexSetupGroup
-                        codexPermissionsGroup
+            if !checked {
+                checkingLine
+            } else {
+                VStack(alignment: .leading, spacing: 30) {
+                    sentientGroup
+                    Group {
+                        if codexAllGreen {
+                            VStack(alignment: .leading, spacing: 30) {
+                                SettingsGroup(label: "Codex") { codexSummaryLine }
+                                if codexExpanded {
+                                    codexSetupGroup
+                                    codexPermissionsGroup
+                                }
+                            }
+                        } else {
+                            VStack(alignment: .leading, spacing: 30) {
+                                codexSetupGroup
+                                if showCodexPermissions { codexPermissionsGroup }
+                            }
+                        }
                     }
-                } else {
-                    codexSetupGroup
-                    if showCodexPermissions { codexPermissionsGroup }
+                    .rise(5, revealed: revealed)
                 }
+                .task { revealed = true }
             }
         }
         .task {
@@ -90,34 +104,50 @@ struct HealthPane: View {
 
     // MARK: - SENTIENT (severity order)
 
+    /// The first probe's stand-in — the codex login check shells out and takes seconds; without
+    /// this the full board flashes and re-collapses.
+    private var checkingLine: some View {
+        HStack(spacing: 10) {
+            ProgressView().controlSize(.small)
+            Text("Checking your Sentient…")
+                .font(.serif(12.5, weight: .regular)).italic()
+                .foregroundStyle(Theme.Ink.body)
+        }
+        .padding(.top, 10)
+    }
+
     private var sentientGroup: some View {
         SettingsGroup(label: "Sentient") {
             VStack(alignment: .leading, spacing: 2) {
-                StatusLine(title: "Full Disk Access",
-                           health: fdaGranted ? .ok : .bad,
-                           note: fdaGranted ? "granted" : "not granted",
-                           fixTitle: "Grant…") {
-                    Permissions.openFullDiskAccessSettings()
-                }
-                if !fdaGranted {
-                    HStack(spacing: 6) {
-                        SettingsProse("WhatsApp, iMessage & Notes stay unreadable without it. After granting:")
-                        Button { Permissions.relaunch() } label: {
-                            Text("Relaunch Sentient")
-                                .font(.system(size: 11, weight: .medium))
-                                .foregroundStyle(Theme.Ink.bright)
-                                .underline(true, color: Theme.Ink.deepMuted)
-                        }
-                        .buttonStyle(PressScaleStyle())
+                VStack(alignment: .leading, spacing: 2) {
+                    StatusLine(title: "Full Disk Access",
+                               health: fdaGranted ? .ok : .bad,
+                               note: fdaGranted ? "granted" : "not granted",
+                               fixTitle: "Grant…") {
+                        Permissions.openFullDiskAccessSettings()
                     }
-                    .padding(.bottom, 6)
+                    if !fdaGranted {
+                        HStack(spacing: 6) {
+                            SettingsProse("WhatsApp, iMessage & Notes stay unreadable without it. After granting:")
+                            Button { Permissions.relaunch() } label: {
+                                Text("Relaunch Sentient")
+                                    .font(.system(size: 11, weight: .medium))
+                                    .foregroundStyle(Theme.Ink.bright)
+                                    .underline(true, color: Theme.Ink.deepMuted)
+                            }
+                            .buttonStyle(PressScaleStyle())
+                        }
+                        .padding(.bottom, 6)
+                    }
                 }
+                .rise(0, revealed: revealed)
                 StatusLine(title: "Overnight wake",
                            health: daemon == .ready ? .ok : .bad,
                            note: daemonNote,
                            fixTitle: daemon == .awaitingApproval ? "Approve…" : "Set Up…") {
                     fixDaemon()
                 }
+                .rise(1, revealed: revealed)
                 StatusLine(title: "Launch at login",
                            health: loginOn ? .ok : .warn,
                            note: loginOn ? "on" : "off",
@@ -125,18 +155,21 @@ struct HealthPane: View {
                     LoginItem.enable()
                     loginOn = LoginItem.isEnabled
                 }
+                .rise(2, revealed: revealed)
                 StatusLine(title: "Microphone & Speech",
                            health: micSpeechHealth,
                            note: micSpeechNote,
                            fixTitle: micSpeech == .notAsked ? "Allow…" : "Fix…") {
                     fixMicSpeech()
                 }
+                .rise(3, revealed: revealed)
                 StatusLine(title: "Notifications",
                            health: notifHealth,
                            note: notifNote,
                            fixTitle: notifStatus == .notDetermined ? "Allow…" : "Fix…") {
                     fixNotifications()
                 }
+                .rise(4, revealed: revealed)
             }
         }
     }
@@ -359,6 +392,18 @@ struct HealthPane: View {
                 clientBundleID: Permissions.computerUseHelperBundleID)
         }
         await codex.refreshLoginStatus()   // last — it shells out to `codex login status`
+        withAnimation(.easeOut(duration: 0.2)) { checked = true }   // first probe done → reveal
+    }
+}
+
+/// The gentle rise-in: each element starts a touch lower and transparent, then swoops up into
+/// place with a small stagger — subtle, physics-flavored, over in under half a second.
+private extension View {
+    func rise(_ index: Int, revealed: Bool) -> some View {
+        self.opacity(revealed ? 1 : 0)
+            .offset(y: revealed ? 0 : 14)
+            .animation(.spring(response: 0.45, dampingFraction: 0.85)
+                .delay(Double(index) * 0.055), value: revealed)
     }
 }
 

--- a/Sentient OS macOS/Views/Settings/HealthPane.swift
+++ b/Sentient OS macOS/Views/Settings/HealthPane.swift
@@ -67,6 +67,8 @@ struct HealthPane: View {
             } else {
                 VStack(alignment: .leading, spacing: 30) {
                     sentientGroup
+                    SettingsHairline()
+                        .rise(5, revealed: revealed)
                     Group {
                         if codexAllGreen && !codexExpanded {
                             SettingsGroup(label: "Codex") { codexSummaryLine }
@@ -77,7 +79,7 @@ struct HealthPane: View {
                             }
                         }
                     }
-                    .rise(5, revealed: revealed)
+                    .rise(6, revealed: revealed)
                 }
                 .task { revealed = true }
             }
@@ -116,6 +118,7 @@ struct HealthPane: View {
                     StatusLine(title: "Full Disk Access",
                                health: fdaGranted ? .ok : .bad,
                                note: fdaGranted ? "granted" : "not granted",
+                               tip: "Lets Sentient read the databases WhatsApp, iMessage, and Notes keep on this Mac. Everything is read locally; nothing leaves your Mac.",
                                fixTitle: "Grant…") {
                         Permissions.openFullDiskAccessSettings()
                     }
@@ -137,6 +140,7 @@ struct HealthPane: View {
                 StatusLine(title: "Overnight wake",
                            health: daemon == .ready ? .ok : .bad,
                            note: daemonNote,
+                           tip: "A tiny system helper that wakes your Mac at 3 AM so Sentient can work while you sleep. Installed once with your password.",
                            fixTitle: "Set Up…") {
                     fixDaemon()
                 }
@@ -144,6 +148,7 @@ struct HealthPane: View {
                 StatusLine(title: "Launch at login",
                            health: loginOn ? .ok : .warn,
                            note: loginOn ? "on" : "off",
+                           tip: "Starts Sentient quietly in your menu bar when you log in, so the overnight run can happen.",
                            fixTitle: "Turn On") {
                     LoginItem.enable()
                     loginOn = LoginItem.isEnabled
@@ -152,6 +157,7 @@ struct HealthPane: View {
                 StatusLine(title: "Microphone & Speech",
                            health: micSpeechHealth,
                            note: micSpeechNote,
+                           tip: "Lets Sidekick hear you and turn your words into text when you hold the shortcut key. Transcription happens on this Mac.",
                            fixTitle: micSpeech == .notAsked ? "Allow…" : "Fix…") {
                     fixMicSpeech()
                 }
@@ -159,6 +165,7 @@ struct HealthPane: View {
                 StatusLine(title: "Notifications",
                            health: notifHealth,
                            note: notifNote,
+                           tip: "Lets Sentient send a morning note when new suggestions are ready. Optional; everything works without it.",
                            fixTitle: notifStatus == .notDetermined ? "Allow…" : "Fix…") {
                     fixNotifications()
                 }
@@ -304,14 +311,17 @@ struct HealthPane: View {
                 StatusLine(title: "Codex CLI",
                            health: codex.installed ? .ok : .bad,
                            note: codex.installed ? "installed" : "not installed",
+                           tip: "OpenAI's Codex command line tool. Sentient runs its cloud steps through it, paid for by your own ChatGPT plan.",
                            fixTitle: "Install…") { showCodexSetup = true }
                 StatusLine(title: "ChatGPT account",
                            health: codex.loggedIn ? .ok : .bad,
                            note: codex.loggedIn ? "logged in" : "not logged in",
+                           tip: "Your own OpenAI login for Codex. The sign in happens in your browser; Sentient never sees your password.",
                            fixTitle: "Log in…") { showCodexSetup = true }
                 StatusLine(title: "Computer use",
                            health: codex.computerUseReady ? .ok : .bad,
                            note: codex.computerUseReady ? "ready" : "not set up",
+                           tip: "The Codex add-on that can click, type, and act on your Mac when you fire an action. Downloaded once from OpenAI.",
                            fixTitle: "Set up…") { showCodexSetup = true }
             }
         }
@@ -325,12 +335,14 @@ struct HealthPane: View {
                 StatusLine(title: "Accessibility (move the mouse, type)",
                            health: helperAccessibility ? .ok : .bad,
                            note: helperAccessibility ? "granted" : "not granted",
+                           tip: "Lets Codex's helper app move the mouse and type for you. Granted to OpenAI's helper, not to Sentient.",
                            fixTitle: "Open Settings…") {
                     Permissions.openAccessibilitySettings()
                 }
                 StatusLine(title: "Screen Recording (see the screen)",
                            health: helperScreenRecording ? .ok : .bad,
                            note: helperScreenRecording ? "granted" : "not granted",
+                           tip: "Lets Codex's helper app see the screen so it acts on the right thing. Granted to OpenAI's helper, not to Sentient.",
                            fixTitle: "Open Settings…") {
                     Permissions.openScreenRecordingSettings()
                 }

--- a/Sentient OS macOS/Views/Settings/HealthPane.swift
+++ b/Sentient OS macOS/Views/Settings/HealthPane.swift
@@ -2,32 +2,52 @@
 //  HealthPane.swift
 //  Sentient OS macOS
 //
-//  Settings → Permissions & Health: the health board. Live verdict dots for the macOS
-//  permissions (Full Disk Access, Notifications, launch-at-login) and the Codex stack
-//  (installed · logged in · computer use — via the shared CodexSetup engine; every fix button
-//  opens the same guided CodexSetupView the dev tools and onboarding use). Statuses re-probe
-//  whenever the app comes to the foreground, so a fix made in System Settings shows up on
-//  return. The danger-zone Reset is the one part still to build.
+//  Settings → Permissions & Health: the health board. Live LED rows for every grant Sentient
+//  actually asks for, in severity order — SENTIENT (Full Disk Access · the overnight wake daemon ·
+//  launch-at-login · mic & speech · notifications), SET UP CODEX (CLI · account · computer use,
+//  via the shared CodexSetup engine), and CODEX PERMISSIONS (the helper's Accessibility + Screen
+//  Recording — system-TCC, status-only, shown once computer use exists). The Automation grant has
+//  NO row: it self-heals silently shortly after the pane opens (the user has no job there).
+//  Red = a core capability is broken · yellow = optional or fixable-later. Statuses re-probe on
+//  app foreground and after the codex sheet closes. The danger-zone Reset runs FactoryReset.
 //
 
 import SwiftUI
 import AppKit
+import AVFoundation
+import Speech
 import UserNotifications
+import ServiceManagement   // SMAppService.Status — the wake daemon's registration state
 
 struct HealthPane: View {
     @State private var codex = CodexSetup.shared
+
+    // Sentient's own grants
     @State private var fdaGranted = Permissions.hasFullDiskAccess()
-    @State private var notifStatus: UNAuthorizationStatus = .notDetermined
+    @State private var daemon: DaemonState = .notSetUp
     @State private var loginOn = LoginItem.isEnabled
+    @State private var micSpeech: MicSpeechState = .notAsked
+    @State private var notifStatus: UNAuthorizationStatus = .notDetermined
+
+    // The Codex helper's system-TCC grants (read via FDA; shown once computer use exists)
+    @State private var helperAccessibility = false
+    @State private var helperScreenRecording = false
+
     @State private var showCodexSetup = false
     @State private var confirmReset = false
     @State private var resetting = false
     @State private var resetDone = false
 
+    private enum DaemonState { case ready, awaitingApproval, notSetUp }
+    private enum MicSpeechState { case granted, notAsked, denied }
+
+    private var showCodexPermissions: Bool { fdaGranted && codex.computerUseReady }
+
     private var allGreen: Bool {
-        fdaGranted && loginOn
+        fdaGranted && daemon == .ready && loginOn && micSpeech == .granted
             && (notifStatus == .authorized || notifStatus == .provisional)
             && codex.installed && codex.loggedIn && codex.computerUseReady
+            && (!showCodexPermissions || (helperAccessibility && helperScreenRecording))
     }
 
     var body: some View {
@@ -35,22 +55,29 @@ struct HealthPane: View {
                      whisper: allGreen ? "All clear. Your Sentient is healthy."
                                        : "Everything green means everything works.") {
             VStack(alignment: .leading, spacing: 30) {
-                permissionsGroup
-                codexGroup
+                sentientGroup
+                codexSetupGroup
+                if showCodexPermissions { codexPermissionsGroup }
                 dangerGroup
             }
         }
-        .task { await refresh() }
+        .task {
+            await refresh()
+            try? await Task.sleep(for: .seconds(0.5))
+            selfHealAutomation()
+        }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             Task { await refresh() }   // the user may just have fixed something in System Settings
         }
-        .sheet(isPresented: $showCodexSetup) { CodexSetupView() }
+        .sheet(isPresented: $showCodexSetup, onDismiss: { Task { await refresh() } }) {
+            CodexSetupView()
+        }
     }
 
-    // MARK: - macOS permissions
+    // MARK: - SENTIENT (severity order)
 
-    private var permissionsGroup: some View {
-        SettingsGroup(label: "macOS Permissions") {
+    private var sentientGroup: some View {
+        SettingsGroup(label: "Sentient") {
             VStack(alignment: .leading, spacing: 2) {
                 StatusLine(title: "Full Disk Access",
                            health: fdaGranted ? .ok : .bad,
@@ -71,11 +98,11 @@ struct HealthPane: View {
                     }
                     .padding(.bottom, 6)
                 }
-                StatusLine(title: "Notifications",
-                           health: notifHealth,
-                           note: notifNote,
-                           fixTitle: notifStatus == .notDetermined ? "Allow…" : "Fix…") {
-                    fixNotifications()
+                StatusLine(title: "Overnight wake",
+                           health: daemon == .ready ? .ok : .bad,
+                           note: daemonNote,
+                           fixTitle: daemon == .awaitingApproval ? "Approve…" : "Set Up…") {
+                    fixDaemon()
                 }
                 StatusLine(title: "Launch at login",
                            health: loginOn ? .ok : .warn,
@@ -84,23 +111,119 @@ struct HealthPane: View {
                     LoginItem.enable()
                     loginOn = LoginItem.isEnabled
                 }
+                StatusLine(title: "Microphone & Speech",
+                           health: micSpeechHealth,
+                           note: micSpeechNote,
+                           fixTitle: micSpeech == .notAsked ? "Allow…" : "Fix…") {
+                    fixMicSpeech()
+                }
+                StatusLine(title: "Notifications",
+                           health: notifHealth,
+                           note: notifNote,
+                           fixTitle: notifStatus == .notDetermined ? "Allow…" : "Fix…") {
+                    fixNotifications()
+                }
             }
         }
     }
 
+    // MARK: Overnight wake daemon
+
+    private var daemonNote: String {
+        switch daemon {
+        case .ready:             return "ready"
+        case .awaitingApproval:  return "awaiting approval"
+        case .notSetUp:          return "not set up"
+        }
+    }
+
+    /// Awaiting approval → straight to Login Items. Not set up → register (the SMAppService path);
+    /// if that lands in requires-approval, open Login Items so the user can finish the click.
+    private func fixDaemon() {
+        switch daemon {
+        case .ready:
+            break
+        case .awaitingApproval:
+            WakeHelperClient.shared.openLoginItemsSettings()
+        case .notSetUp:
+            let status = WakeHelperClient.shared.register()
+            if status == .requiresApproval { WakeHelperClient.shared.openLoginItemsSettings() }
+            refreshDaemon()
+        }
+    }
+
+    /// Green = the SMAppService daemon is approved OR the dev-installed plist exists and points at
+    /// this exact binary (the manual path still counts as a working heartbeat).
+    private func refreshDaemon() {
+        if WakeHelperInstaller.isInstalledAndCurrent() || WakeHelperClient.shared.status == .enabled {
+            daemon = .ready
+        } else if WakeHelperClient.shared.status == .requiresApproval {
+            daemon = .awaitingApproval
+        } else {
+            daemon = .notSetUp
+        }
+    }
+
+    // MARK: Microphone & Speech (one row — one call asks for both)
+
+    private var micSpeechHealth: StatusLine.Health {
+        switch micSpeech {
+        case .granted:  return .ok
+        case .notAsked: return .warn
+        case .denied:   return .bad
+        }
+    }
+
+    private var micSpeechNote: String {
+        switch micSpeech {
+        case .granted:  return "granted"
+        case .notAsked: return "not asked yet"
+        case .denied:   return "denied"
+        }
+    }
+
+    private func fixMicSpeech() {
+        switch micSpeech {
+        case .granted:
+            break
+        case .notAsked:
+            Task { _ = await VoiceCapture.requestPermissions(); await refresh() }
+        case .denied:
+            // Deep-link to whichever grant is actually the blocker (mic first — it gates speech).
+            if AVCaptureDevice.authorizationStatus(for: .audio) != .authorized {
+                Permissions.openMicrophoneSettings()
+            } else {
+                Permissions.openSpeechRecognitionSettings()
+            }
+        }
+    }
+
+    private func refreshMicSpeech() {
+        let mic = AVCaptureDevice.authorizationStatus(for: .audio)
+        let speech = SFSpeechRecognizer.authorizationStatus()
+        if mic == .authorized && speech == .authorized {
+            micSpeech = .granted
+        } else if mic == .denied || mic == .restricted || speech == .denied || speech == .restricted {
+            micSpeech = .denied
+        } else {
+            micSpeech = .notAsked
+        }
+    }
+
+    // MARK: Notifications (yellow when off, never red — the morning briefing sleeps, the app works)
+
     private var notifHealth: StatusLine.Health {
         switch notifStatus {
         case .authorized, .provisional: return .ok
-        case .notDetermined:            return .warn
-        default:                        return .bad
+        default:                        return .warn
         }
     }
 
     private var notifNote: String {
         switch notifStatus {
-        case .authorized, .provisional: return "granted"
+        case .authorized, .provisional: return "on"
         case .notDetermined:            return "not asked yet"
-        default:                        return "denied"
+        default:                        return "off"
         }
     }
 
@@ -116,30 +239,72 @@ struct HealthPane: View {
         }
     }
 
-    // MARK: - Codex (the cloud brain)
+    // MARK: - SET UP CODEX (the cloud brain — all three are core, red when missing)
 
-    private var codexGroup: some View {
-        SettingsGroup(label: "Codex") {
+    private var codexSetupGroup: some View {
+        SettingsGroup(label: "Set Up Codex") {
             VStack(alignment: .leading, spacing: 2) {
                 StatusLine(title: "Codex CLI",
                            health: codex.installed ? .ok : .bad,
                            note: codex.installed ? "installed" : "not installed",
                            fixTitle: "Install…") { showCodexSetup = true }
                 StatusLine(title: "ChatGPT account",
-                           health: codex.loggedIn ? .ok : .warn,
+                           health: codex.loggedIn ? .ok : .bad,
                            note: codex.loggedIn ? "logged in" : "not logged in",
                            fixTitle: "Log in…") { showCodexSetup = true }
                 StatusLine(title: "Computer use",
-                           health: codex.computerUseReady ? .ok : .warn,
+                           health: codex.computerUseReady ? .ok : .bad,
                            note: codex.computerUseReady ? "ready" : "not set up",
                            fixTitle: "Set up…") { showCodexSetup = true }
             }
         }
     }
 
+    // MARK: - CODEX PERMISSIONS (the helper's hands and eyes — system TCC, status + deep-link only)
+
+    private var codexPermissionsGroup: some View {
+        SettingsGroup(label: "Codex Permissions") {
+            VStack(alignment: .leading, spacing: 2) {
+                StatusLine(title: "Accessibility (move the mouse, type)",
+                           health: helperAccessibility ? .ok : .bad,
+                           note: helperAccessibility ? "granted" : "not granted",
+                           fixTitle: "Open Settings…") {
+                    Permissions.openAccessibilitySettings()
+                }
+                StatusLine(title: "Screen Recording (see the screen)",
+                           health: helperScreenRecording ? .ok : .bad,
+                           note: helperScreenRecording ? "granted" : "not granted",
+                           fixTitle: "Open Settings…") {
+                    Permissions.openScreenRecordingSettings()
+                }
+                SettingsProse("These belong to Codex's Computer Use helper, not Sentient. Flip its switch in each list; macOS may also prompt on the first computer-use run.")
+                    .padding(.top, 6)
+            }
+        }
+    }
+
+    // MARK: - Automation: no row, just a quiet self-heal (the user has no job here)
+
+    /// Sentient drives Codex's helper over Apple Events; that grant lives in the USER TCC db,
+    /// which we can write with the FDA we already hold. Probe, and if it's missing while the
+    /// prerequisites exist, silently re-grant (idempotent INSERT OR REPLACE) — no UI, just a log.
+    private func selfHealAutomation() {
+        guard fdaGranted, Permissions.computerUseHelperURL() != nil else { return }
+        let bundleID = Bundle.main.bundleIdentifier ?? "jesai.Sentient-OS-macOS"
+        guard !Permissions.isTCCGranted(service: "kTCCServiceAppleEvents", clientBundleID: bundleID) else { return }
+        Task.detached {
+            do {
+                let receipt = try Permissions.grantComputerUseAutomation()
+                Log("HealthPane: automation self-heal — \(receipt)")
+            } catch {
+                Log("HealthPane: automation self-heal failed — \(error)")
+            }
+        }
+    }
+
     // MARK: - Danger zone (the shared FactoryReset wipe)
 
-    private static let dangerRed = Color(red: 1.0, green: 0.45, blue: 0.45)
+    private static let dangerRed = Color(red: 1.0, green: 0.36, blue: 0.36)
 
     private var dangerGroup: some View {
         SettingsGroup(label: "Danger Zone") {
@@ -175,15 +340,25 @@ struct HealthPane: View {
     private func refresh() async {
         fdaGranted = Permissions.hasFullDiskAccess()
         loginOn = LoginItem.isEnabled
+        refreshDaemon()
+        refreshMicSpeech()
         notifStatus = await UNUserNotificationCenter.current().notificationSettings().authorizationStatus
         codex.refreshInstalled()
         codex.refreshComputerUse()
-        await codex.refreshLoginStatus()
+        if fdaGranted {
+            helperAccessibility = Permissions.isTCCGranted(
+                service: "kTCCServiceAccessibility",
+                clientBundleID: Permissions.computerUseHelperBundleID)
+            helperScreenRecording = Permissions.isTCCGranted(
+                service: "kTCCServiceScreenCapture",
+                clientBundleID: Permissions.computerUseHelperBundleID)
+        }
+        await codex.refreshLoginStatus()   // last — it shells out to `codex login status`
     }
 }
 
 #Preview("Permissions & Health pane") {
     HealthPane()
         .background(Theme.bg)
-        .frame(width: 720, height: 640)
+        .frame(width: 720, height: 760)
 }

--- a/Sentient OS macOS/Views/Settings/HealthPane.swift
+++ b/Sentient OS macOS/Views/Settings/HealthPane.swift
@@ -69,14 +69,8 @@ struct HealthPane: View {
                 VStack(alignment: .leading, spacing: 30) {
                     sentientGroup
                     Group {
-                        if codexAllGreen {
-                            VStack(alignment: .leading, spacing: 30) {
-                                SettingsGroup(label: "Codex") { codexSummaryLine }
-                                if codexExpanded {
-                                    codexSetupGroup
-                                    codexPermissionsGroup
-                                }
-                            }
+                        if codexAllGreen && !codexExpanded {
+                            SettingsGroup(label: "Codex") { codexSummaryLine }
                         } else {
                             VStack(alignment: .leading, spacing: 30) {
                                 codexSetupGroup
@@ -286,23 +280,22 @@ struct HealthPane: View {
         }
     }
 
-    // MARK: - The collapsed codex summary (everything green = one quiet line, tap for details)
+    // MARK: - The collapsed codex summary (everything green = one quiet line; expanding REPLACES
+    // it — a one-way door per visit, so the detail view never carries an extra clutter line)
 
     private var codexSummaryLine: some View {
         Button {
-            withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) { codexExpanded.toggle() }
+            withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) { codexExpanded = true }
         } label: {
             HStack(spacing: 11) {
                 HealthDot(color: Theme.Ink.green)
                 Text("Codex is all good.")
                     .font(.system(size: 12.5)).foregroundStyle(Theme.Ink.statusInk)
                 Spacer(minLength: 12)
-                MonoCaps(codexExpanded ? "Hide" : "Details", size: 8.5, tracking: 1.6,
-                         color: Theme.Ink.label)
+                MonoCaps("Details", size: 8.5, tracking: 1.6, color: Theme.Ink.label)
                 Image(systemName: "chevron.down")
                     .font(.system(size: 9, weight: .semibold))
                     .foregroundStyle(Theme.Ink.label)
-                    .rotationEffect(.degrees(codexExpanded ? 180 : 0))
             }
             .padding(.vertical, 6)
             .contentShape(Rectangle())

--- a/Sentient OS macOS/Views/Settings/HealthPane.swift
+++ b/Sentient OS macOS/Views/Settings/HealthPane.swift
@@ -118,7 +118,7 @@ struct HealthPane: View {
                     StatusLine(title: "Full Disk Access",
                                health: fdaGranted ? .ok : .bad,
                                note: fdaGranted ? "granted" : "not granted",
-                               tip: "Lets Sentient read your files & folders, and the databases WhatsApp, iMessage, and Notes keep on this Mac. Everything is read locally; nothing leaves your Mac.",
+                               tip: "Lets Sentient's on-device LLM read your files & folders, and the databases WhatsApp, iMessage, and Notes keep on this Mac. Everything is read right here on your Mac; your data never leaves it.",
                                fixTitle: "Grant…") {
                         Permissions.openFullDiskAccessSettings()
                     }
@@ -140,7 +140,7 @@ struct HealthPane: View {
                 StatusLine(title: "Overnight wake",
                            health: daemon == .ready ? .ok : .bad,
                            note: daemonNote,
-                           tip: "A tiny system helper that wakes your Mac at 3 AM so Sentient can work while you sleep. It only runs while your Mac is plugged in and Sentient is open in your menu bar. Installed once with your password.",
+                           tip: "A tiny system helper that wakes your Mac at 3 AM so Sentient's on-device intelligence can work while you sleep. It only runs while your Mac is plugged in and Sentient is open in your menu bar. Installed once with your password.",
                            fixTitle: "Set Up…") {
                     fixDaemon()
                 }
@@ -157,7 +157,7 @@ struct HealthPane: View {
                 StatusLine(title: "Microphone & Speech",
                            health: micSpeechHealth,
                            note: micSpeechNote,
-                           tip: "Lets Sidekick hear you and turn your words into text when you hold the shortcut key. Transcription happens on this Mac.",
+                           tip: "Lets Sidekick hear you and turn your words into text when you hold the shortcut key. Your voice is heard and transcribed on this Mac, never in the cloud.",
                            fixTitle: micSpeech == .notAsked ? "Allow…" : "Fix…") {
                     fixMicSpeech()
                 }

--- a/Sentient OS macOS/Views/Settings/SettingsComponents.swift
+++ b/Sentient OS macOS/Views/Settings/SettingsComponents.swift
@@ -208,6 +208,58 @@ struct HealthDot: View {
     }
 }
 
+/// Shared "warmth" for the info tips: once one tip has opened, sibling tips open instantly for a
+/// short window (the native-menu feel) instead of each re-waiting the hover delay.
+@MainActor @Observable
+final class TipWarmth {
+    static let shared = TipWarmth()
+    private var lastInteraction = Date.distantPast
+
+    var isWarm: Bool { Date().timeIntervalSince(lastInteraction) < 0.5 }
+    func touch() { lastInteraction = Date() }
+}
+
+/// The tiny info icon beside a permission name. Hover 0.15s to open the explanation (a small
+/// popover); while any tip is warm, siblings open instantly.
+struct InfoTip: View {
+    let text: String
+    @State private var shown = false
+    @State private var hoverTask: Task<Void, Never>?
+
+    var body: some View {
+        Image(systemName: "info.circle")
+            .font(.system(size: 10))
+            .foregroundStyle(Theme.Ink.label.opacity(0.75))
+            .onHover { inside in
+                hoverTask?.cancel()
+                if inside {
+                    if TipWarmth.shared.isWarm {
+                        shown = true
+                        TipWarmth.shared.touch()
+                    } else {
+                        hoverTask = Task {
+                            try? await Task.sleep(for: .seconds(0.15))
+                            guard !Task.isCancelled else { return }
+                            shown = true
+                            TipWarmth.shared.touch()
+                        }
+                    }
+                } else {
+                    if shown { TipWarmth.shared.touch() }   // keep siblings warm on the way out
+                    shown = false
+                }
+            }
+            .popover(isPresented: $shown, arrowEdge: .bottom) {
+                Text(text)
+                    .font(.system(size: 11.5))
+                    .lineSpacing(2.5)
+                    .padding(.horizontal, 12).padding(.vertical, 9)
+                    .frame(width: 250, alignment: .leading)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+    }
+}
+
 /// One health line — a verdict dot, the thing being checked, its state in mono-caps, and a
 /// fix affordance when something's red. The Permissions & Health form.
 struct StatusLine: View {
@@ -216,6 +268,7 @@ struct StatusLine: View {
     let title: String
     let health: Health
     let note: String                    // "granted" / "not granted" / "logged in"
+    var tip: String? = nil              // the info-icon explanation (InfoTip)
     var fixTitle: String = "Fix…"
     var fix: (() -> Void)? = nil
 
@@ -231,7 +284,10 @@ struct StatusLine: View {
     var body: some View {
         HStack(spacing: 11) {
             HealthDot(color: dot)
-            Text(title).font(.system(size: 12.5)).foregroundStyle(Theme.Ink.statusInk)
+            HStack(spacing: 6) {
+                Text(title).font(.system(size: 12.5)).foregroundStyle(Theme.Ink.statusInk)
+                if let tip { InfoTip(text: tip) }
+            }
             Spacer(minLength: 12)
             MonoCaps(note, size: 8.5, tracking: 1.6,
                      color: health == .ok ? Theme.Ink.label : dot)

--- a/Sentient OS macOS/Views/Settings/SettingsComponents.swift
+++ b/Sentient OS macOS/Views/Settings/SettingsComponents.swift
@@ -193,6 +193,21 @@ struct SettingsChip: View {
     }
 }
 
+/// A lit status LED: bright core + double soft glow (tight halo, wide bloom). Shared by
+/// StatusLine and the collapsed codex summary.
+struct HealthDot: View {
+    let color: Color
+
+    var body: some View {
+        Circle()
+            .fill(color)
+            .overlay(Circle().fill(.white.opacity(0.35)).frame(width: 2.5, height: 2.5))
+            .frame(width: 6.5, height: 6.5)
+            .shadow(color: color.opacity(0.85), radius: 3)
+            .shadow(color: color.opacity(0.45), radius: 8)
+    }
+}
+
 /// One health line — a verdict dot, the thing being checked, its state in mono-caps, and a
 /// fix affordance when something's red. The Permissions & Health form.
 struct StatusLine: View {
@@ -215,13 +230,7 @@ struct StatusLine: View {
 
     var body: some View {
         HStack(spacing: 11) {
-            // A lit LED: bright core + double soft glow (tight halo, wide bloom).
-            Circle()
-                .fill(dot)
-                .overlay(Circle().fill(.white.opacity(0.35)).frame(width: 2.5, height: 2.5))
-                .frame(width: 6.5, height: 6.5)
-                .shadow(color: dot.opacity(0.85), radius: 3)
-                .shadow(color: dot.opacity(0.45), radius: 8)
+            HealthDot(color: dot)
             Text(title).font(.system(size: 12.5)).foregroundStyle(Theme.Ink.statusInk)
             Spacer(minLength: 12)
             MonoCaps(note, size: 8.5, tracking: 1.6,

--- a/Sentient OS macOS/Views/Settings/SettingsComponents.swift
+++ b/Sentient OS macOS/Views/Settings/SettingsComponents.swift
@@ -249,7 +249,7 @@ struct InfoTip: View {
                     shown = false
                 }
             }
-            .popover(isPresented: $shown, arrowEdge: .bottom) {
+            .popover(isPresented: $shown, arrowEdge: .trailing) {
                 Text(text)
                     .font(.system(size: 11.5))
                     .lineSpacing(2.5)

--- a/Sentient OS macOS/Views/Settings/SourcesPane.swift
+++ b/Sentient OS macOS/Views/Settings/SourcesPane.swift
@@ -56,11 +56,13 @@ struct SourcesPane: View {
         SettingsPane(title: "Knowledge Sources.",
                      whisper: "Your files never leave your Mac. Your Sentient uses an on-device LLM to understand your life overnight.") {
             VStack(alignment: .leading, spacing: 30) {
-                Text("Sentient needs at least three sources to truly know you.")
+                // Tucked tight under the whisper so the two lines read as ONE header block,
+                // with the full 30pt group gap only after it.
+                Text("Your Sentient needs at least three sources to truly know you.")
                     .font(.serif(11.5, weight: .regular)).italic()
                     .foregroundStyle(flashMinimum ? Theme.Ink.amber : Theme.Ink.deepMuted)
                     .animation(.easeInOut(duration: 0.25), value: flashMinimum)
-                    .padding(.top, -8)
+                    .padding(.top, -16)
                 if !fdaGranted { fdaLine }
                 foldersGroup
                 chatsGroup

--- a/Sentient OS macOS/Views/Settings/SourcesPane.swift
+++ b/Sentient OS macOS/Views/Settings/SourcesPane.swift
@@ -54,16 +54,17 @@ struct SourcesPane: View {
 
     var body: some View {
         SettingsPane(title: "Knowledge Sources.",
-                     whisper: "What Sentient reads: always locally, always yours.") {
+                     whisper: "Your files never leave your Mac. Your Sentient uses an on-device LLM to understand your life overnight.") {
             VStack(alignment: .leading, spacing: 30) {
-                if !fdaGranted { fdaLine }
-                foldersGroup
-                chatsGroup
-                cloudGroup
                 Text("Sentient needs at least three sources to truly know you.")
                     .font(.serif(11.5, weight: .regular)).italic()
                     .foregroundStyle(flashMinimum ? Theme.Ink.amber : Theme.Ink.deepMuted)
                     .animation(.easeInOut(duration: 0.25), value: flashMinimum)
+                    .padding(.top, -8)
+                if !fdaGranted { fdaLine }
+                foldersGroup
+                chatsGroup
+                cloudGroup
             }
         }
         .task { fdaGranted = Permissions.hasFullDiskAccess() }

--- a/Sentient OS macOS/Views/Settings/SystemPane.swift
+++ b/Sentient OS macOS/Views/Settings/SystemPane.swift
@@ -4,8 +4,9 @@
 //
 //  Settings → System: how Sentient lives on this Mac. The overnight-intelligence story (prose,
 //  not a control — 3 AM is our taste, not a dial), the launch-at-login toggle (LoginItem.swift)
-//  with its keep-Sentient-alive confirm, and the privacy pledge with the two anonymous-reporting
-//  switches (crash reports → CrashReporting/Sentry · analytics → Analytics/TelemetryDeck).
+//  with its keep-Sentient-alive confirm, the privacy pledge with the two anonymous-reporting
+//  switches (crash reports → CrashReporting/Sentry · analytics → Analytics/TelemetryDeck), and
+//  the danger-zone Reset (the shared FactoryReset wipe — a system-level act, so it lives here).
 //  The updates group lands here once Sparkle ships.
 //
 
@@ -19,6 +20,9 @@ struct SystemPane: View {
 
     @State private var launchAtLogin = LoginItem.isEnabled
     @State private var confirmLoginOff = false
+    @State private var confirmReset = false
+    @State private var resetting = false
+    @State private var resetDone = false
 
     var body: some View {
         SettingsPane(title: "System.", whisper: "How Sentient lives on this Mac.") {
@@ -26,6 +30,7 @@ struct SystemPane: View {
                 overnightGroup
                 startupGroup
                 privacyGroup
+                dangerGroup
             }
         }
         .task { launchAtLogin = LoginItem.isEnabled }   // live status — revocable in System Settings
@@ -94,6 +99,39 @@ struct SystemPane: View {
         }
         .onChange(of: crashReportsEnabled) { _, _ in CrashReporting.applyEnabledChange() }
         .onChange(of: analyticsEnabled) { _, _ in Analytics.applyEnabledChange() }
+    }
+
+    // MARK: - Danger zone (the shared FactoryReset wipe)
+
+    private static let dangerRed = Color(red: 1.0, green: 0.36, blue: 0.36)
+
+    private var dangerGroup: some View {
+        SettingsGroup(label: "Danger Zone") {
+            VStack(alignment: .leading, spacing: 10) {
+                SettingsProse("Reset erases everything Sentient has learned: the knowledge base, every summary, and all suggestions. You'll start over from scratch, including the initial processing. Your cloud copy isn't touched; the next processing run simply replaces it.")
+                SettingsPillButton(title: resetting ? "Erasing…" : "Reset Sentient…",
+                                   tint: Self.dangerRed) { confirmReset = true }
+                    .disabled(resetting)
+                if resetDone {
+                    Text("Reset complete. Sentient is a blank slate.")
+                        .font(.serif(11.5, weight: .regular)).italic()
+                        .foregroundStyle(Theme.Ink.body)
+                }
+            }
+        }
+        .alert("Erase everything Sentient has learned?", isPresented: $confirmReset) {
+            Button("Cancel", role: .cancel) {}
+            Button("Erase Everything", role: .destructive) {
+                resetting = true
+                Task {
+                    await FactoryReset.run()
+                    resetting = false
+                    resetDone = true
+                }
+            }
+        } message: {
+            Text("Your knowledge base and everything Sentient understood is deleted from this Mac. This can't be undone; Sentient starts again from zero, beginning with the initial processing.")
+        }
     }
 }
 

--- a/Sentient OS macOS/Views/Settings/SystemPane.swift
+++ b/Sentient OS macOS/Views/Settings/SystemPane.swift
@@ -23,6 +23,7 @@ struct SystemPane: View {
     @State private var confirmReset = false
     @State private var resetting = false
     @State private var resetDone = false
+    @State private var activity = PipelineActivity.shared   // Reset locks while a run is active
 
     var body: some View {
         SettingsPane(title: "System.", whisper: "How Sentient lives on this Mac.") {
@@ -111,7 +112,11 @@ struct SystemPane: View {
                 SettingsProse("Reset erases everything Sentient has learned: the knowledge base, every summary, and all suggestions. You'll start over from scratch, including the initial processing. Your cloud copy isn't touched; the next processing run simply replaces it.")
                 SettingsPillButton(title: resetting ? "Erasing…" : "Reset Sentient…",
                                    tint: Self.dangerRed) { confirmReset = true }
-                    .disabled(resetting)
+                    .disabled(resetting || activity.isRunning)
+                if activity.isRunning {
+                    Text("A run is in progress. Reset unlocks when it finishes.")
+                        .font(.system(size: 11)).foregroundStyle(Theme.Ink.amber)
+                }
                 if resetDone {
                     Text("Reset complete. Sentient is a blank slate.")
                         .font(.serif(11.5, weight: .regular)).italic()


### PR DESCRIPTION
The spec'd health board: severity-ordered Sentient rows (FDA, overnight wake, launch-at-login, mic & speech, notifications), the two codex clusters inline (Set Up Codex + Codex Permissions with progressive disclosure), red/yellow semantics per the core-vs-optional rule, and the invisible Automation self-heal on pane open. Builds clean; behavioral QA rides tonight's overnight-test session.