### PR TITLE
Your AIs: value-first story + glowing Connect hero + real guided setup

### DIFF
--- a/Sentient OS macOS/Documentation/Home — Proactive Intelligence (For You).md
+++ b/Sentient OS macOS/Documentation/Home — Proactive Intelligence (For You).md
@@ -13,7 +13,7 @@ stats were reused in this surface and its popovers. Arch §10.)*
 The main window's content (rendered by `RootView`). Layers, bottom-to-top:
 
 - **Chrome (on top, so the nav stays clickable):** a slim top bar — `OrbMark` + "Sentient OS"
-  wordmark on the left; on the right four **doors** — `Analysis ▾` · `Your AIs ▾` (quick popovers)
+  wordmark on the left; on the right four **doors** — `Analysis ▾` (popover) · `Knowledge` · `Connect AIs ▾` (popover)
   · `Knowledge` · `⚙` (their own windows). Below it, the editorial voice: an hour-aware serif-italic
   greeting ("Good evening, Jesai.") over a mono-caps read-line.
 - **The scatter:** the suggestion cards, dealt in from above the header with staggered springs into
@@ -74,7 +74,7 @@ a STOP button. (Computer use is the WIP Codex-CLI path.)
 ## The other windows
 
 - **`Views/Settings/SettingsView.swift`** (`windowID "settings"`, the gear) — the REAL two-pane
-  Settings window: five live panes (Knowledge Sources · Proactive & Sidekick · Your AIs · System ·
+  Settings window: five live panes (Knowledge Sources · Proactive & Sidekick · Connect AIs to Knowledge · System ·
   Permissions & Health). Doc: `Documentation/Settings.md`.
 - **`Views/ConnectAIsView.swift`** (`windowID "connect-ais"`) — the deferred setup guide (stub): the
   real two-step flow (copy your MCP URL → add the line to your AI's instructions) lands later.

--- a/Sentient OS macOS/Documentation/MCP Mirror Client.md
+++ b/Sentient OS macOS/Documentation/MCP Mirror Client.md
@@ -58,11 +58,13 @@ auto-push-after-KB-update, call `await Self.pushIfDirty()` from `VaultCloud.mark
 
 ## Turning the mirror on (today)
 
-The user-facing opt-in is **Settings → Your AIs** (`Views/Settings/YourAIsPane.swift`): the share
-toggle (ON = `enable()` + a first push; OFF = a confirm dialog, then `disable()`), the masked
-secret link with **Copy** and **Regenerate** (`regenerateToken()` — the remediation if a link ever
-leaks: old cloud copy deleted, new identity minted, re-pushed), live `stats()` activity, and the
-connect-guide / system-prompt links. The onboarding opt-in moment is still to build.
+The user-facing opt-in is **Settings → Your AIs** (`Views/Settings/YourAIsPane.swift`): the
+value/privacy story, the share toggle (ON = `enable()` + a first push; OFF = a confirm dialog,
+then `disable()`), the glowing **Connect your AIs** hero → `ConnectAIsView`, the REAL guided
+setup (masked link + Copy · Copy-the-system-prompt · the "what do you know about me?" closer),
+and live `stats()` activity. **Regenerate is backend-only** (`regenerateToken()` stays as the
+support remediation if a link leaks; the UI button was removed — it bricks every connector the
+user set up). The onboarding opt-in moment is still to build.
 
 The **DEV TOOLS** panel (`DevToolsView`) keeps its own controls, while the mirror is ON:
 - **MCP TOGGLE** — ON mints the token (if absent) + pushes the current vault; OFF deletes the cloud copy but **keeps the token**, so re-enabling reuses the same share link.

--- a/Sentient OS macOS/Documentation/MCP Mirror Client.md
+++ b/Sentient OS macOS/Documentation/MCP Mirror Client.md
@@ -13,7 +13,7 @@ await mirror.isEnabled                 // is mirroring ON? (the toggle flag — 
 let url = await mirror.enable()        // opt in → mints token if absent → returns the share URL
 await mirror.shareURL                  // the "Copy MCP Link" value, or nil
 try await mirror.push()                // zip the vault + replace the mirror (call after any change)
-let s = try await mirror.stats()       // {notesRead24h, toolCalls24h, lastAccess} for "Your AIs"
+let s = try await mirror.stats()       // {notesRead24h, toolCalls24h, lastAccess} for "Connect AIs"
 try await mirror.deleteRemote()        // delete the cloud copy (keeps the token → stable URL)
 await mirror.disable()                 // opt out: flip OFF + delete remote, but KEEP the token (stable link)
 let u2 = try await mirror.regenerateToken()  // leak remediation: delete old copy, mint NEW token, re-push
@@ -58,7 +58,7 @@ auto-push-after-KB-update, call `await Self.pushIfDirty()` from `VaultCloud.mark
 
 ## Turning the mirror on (today)
 
-The user-facing opt-in is **Settings → Your AIs** (`Views/Settings/YourAIsPane.swift`): the
+The user-facing opt-in is **Settings → Connect AIs to Knowledge** (`Views/Settings/YourAIsPane.swift`): the
 value/privacy story, the share toggle (ON = `enable()` + a first push; OFF = a confirm dialog,
 then `disable()`), the glowing **Connect your AIs** hero → `ConnectAIsView`, the REAL guided
 setup (masked link + Copy · Copy-the-system-prompt · the "what do you know about me?" closer),
@@ -91,7 +91,7 @@ Runs enable → push → stats → delete → disable. Needs a knowledge base on
 ## Not built here (downstream)
 
 The production opt-in surfaces — the MCP opt-in onboarding screen (step ⑨) with the
-no-account/token/30-day-lease explainer, the "Your AIs" satellite (access-log line), and the
+no-account/token/30-day-lease explainer, the "Connect AIs" glance (access-log line), and the
 menu-bar Copy MCP Link — are Phase-5 work that calls into this client (the DEV TOOLS MCP TOGGLE is
 the interim dogfood stand-in). Auto-push *after vault changes* is now wired (see Sync above); the
 editor-idle gate (`VaultActivity.editorBusy`) still awaits the Phase-5 vault editor.

--- a/Sentient OS macOS/Documentation/Settings.md
+++ b/Sentient OS macOS/Documentation/Settings.md
@@ -14,7 +14,7 @@ pieces (`SettingsComponents.swift`).
    consumes the values yet**. The proactive/Sidekick prompts learn to read them with the
    prompt-refinement work, and the Right ⌥ choice additionally needs `RightCommandMonitor`
    support (it listens for right-⌘ only today).
-2. **The E2E encryption claim front-runs the code** — the Your AIs privacy blurb says the cloud
+2. **The E2E encryption claim front-runs the code** — the Connect-AIs privacy blurb says the cloud
    copy is end-to-end encrypted and unreadable even by Sentient's devs. That is LAUNCH truth,
    decided 2026-07-04: the mirror stores plaintext markdown today, and the "mcp encryption"
    backlog item (Aditya) MUST ship before launch or the copy must change. Do not soften the copy;
@@ -74,7 +74,7 @@ sees custom folders. Verified by a headless selftest (7/7) on ship day.
 Autosaving standing instructions + Sidekick's shortcut key and standing context. Stored, not yet
 consumed — see the NOT-wired list above.
 
-### Your AIs (`YourAIsPane.swift`)
+### Connect AIs to Knowledge (`YourAIsPane.swift`)
 The story leads: a value blurb (your ChatGPT/Claude, phone apps included, read the knowledge
 base and choose what's relevant) then the plain-language privacy explainer (local-first,
 PII-stripped summaries only, E2E-encrypted [see the NOT-wired list], no accounts, the 30-day

--- a/Sentient OS macOS/Documentation/Settings.md
+++ b/Sentient OS macOS/Documentation/Settings.md
@@ -14,9 +14,11 @@ pieces (`SettingsComponents.swift`).
    consumes the values yet**. The proactive/Sidekick prompts learn to read them with the
    prompt-refinement work, and the Right ⌥ choice additionally needs `RightCommandMonitor`
    support (it listens for right-⌘ only today).
-2. **"How to connect your AIs"** (Your AIs pane) — opens `ConnectAIsView`, which is a pretty
-   explainer stub, self-labeled "Guided setup · coming soon". The real two-step guided flow is
-   future work.
+2. **The E2E encryption claim front-runs the code** — the Your AIs privacy blurb says the cloud
+   copy is end-to-end encrypted and unreadable even by Sentient's devs. That is LAUNCH truth,
+   decided 2026-07-04: the mirror stores plaintext markdown today, and the "mcp encryption"
+   backlog item (Aditya) MUST ship before launch or the copy must change. Do not soften the copy;
+   ship the encryption.
 3. **The morning notification** — the Notifications permission row is real, but nothing in the app
    *sends* notifications yet (`Notify.now()` has zero call sites). The "Proactive Intelligence is
    ready" morning note ships with the reminders/scheduler work; the permission ask then moves to
@@ -73,11 +75,18 @@ Autosaving standing instructions + Sidekick's shortcut key and standing context.
 consumed — see the NOT-wired list above.
 
 ### Your AIs (`YourAIsPane.swift`)
-`MirrorClient` end-to-end: the share toggle (OFF = confirm dialog → `disable()`, which deletes
-the cloud copy but keeps the token), the masked secret link (Copy + **Regenerate** →
-`regenerateToken()`, the leak remediation: old copy deleted, new identity minted, re-pushed),
-live `stats()` activity, connect-guide links, and the local-only story when sharing is off.
-⚠️ The maskedURL must search "/mcp" BACKWARDS: the host `https://mcp.sentient-os.ai` itself
+The story leads: a value blurb (your ChatGPT/Claude, phone apps included, read the knowledge
+base and choose what's relevant) then the plain-language privacy explainer (local-first,
+PII-stripped summaries only, E2E-encrypted [see the NOT-wired list], no accounts, the 30-day
+self-delete in plain words, open-source backend). Then the share toggle (OFF = confirm dialog →
+`disable()`, which deletes the cloud copy but keeps the token), and the pane's HERO: the glowing
+**Connect your AIs** `GlowButton` → **`ConnectAIsView`, now the REAL guided setup**: step 1 =
+the masked link (`MirrorClient.maskedURL`) + Copy, step 2 = Copy the system prompt, closing with
+the magic line ("ask it: what do you know about me?"); a sharing-off state points back at
+Settings. Live `stats()` activity below; local-only story when sharing is off.
+**Regenerate was removed from the UI** (a footgun that bricks every connector the user set up) —
+`MirrorClient.regenerateToken()` remains as a backend/support remediation.
+⚠️ `maskedURL` must search "/mcp" BACKWARDS: the host `https://mcp.sentient-os.ai` itself
 contains "/mcp", and a forward hit inverts the range (a shipped-then-fixed crash).
 
 ### System (`SystemPane.swift`)

--- a/Sentient OS macOS/MirrorClient.swift
+++ b/Sentient OS macOS/MirrorClient.swift
@@ -115,6 +115,21 @@ actor MirrorClient {
         return "\(Self.baseURL)/u/\(token)/mcp"
     }
 
+    /// A display-safe version of the share URL (token masked to its first 4 chars). ⚠️ "/mcp" must
+    /// be searched BACKWARDS: the host "https://mcp.sentient-os.ai" itself contains "/mcp", and a
+    /// forward hit put the end before the token — an inverted range that once crashed Settings.
+    nonisolated static func maskedURL(_ url: String?) -> String {
+        guard let url,
+              let start = url.range(of: "/u/"),
+              let end = url.range(of: "/mcp", options: .backwards),
+              start.upperBound <= end.lowerBound else { return "mcp.sentient-os.ai/u/…/mcp" }
+        let token = url[start.upperBound..<end.lowerBound]
+        let host = url.replacingOccurrences(of: "https://", with: "")
+            .replacingOccurrences(of: "http://", with: "")     // dev SENTIENT_MIRROR_BASE override
+            .prefix(while: { $0 != "/" })
+        return "\(host)/u/\(token.prefix(4))••••••••/mcp"
+    }
+
     // MARK: Push / delete / stats
 
     /// Zip the local vault and replace the mirror with it. Renews the 30-day lease.

--- a/Sentient OS macOS/Views/ConnectAIsView.swift
+++ b/Sentient OS macOS/Views/ConnectAIsView.swift
@@ -2,18 +2,26 @@
 //  ConnectAIsView.swift
 //  Sentient OS macOS
 //
-//  The "Connect your AIs" window — opened by the glowing CTA in the Your AIs popover. This is
-//  the DEFERRED setup guide (intentionally a stub for now): the real two-step flow lands later
-//   ① copy your private MCP URL and add it as a connector,
-//   ② add a line to your AI's system prompt telling it to use your Sentient MCP.
-//  Kept as a tasteful placeholder so the CTA opens something real, not a dead control.
+//  The "Connect your AIs" window — the REAL two-step guided setup (was a stub until 2026-07-04),
+//  opened by the glowing CTA in Settings → Your AIs and the home's Your AIs popover:
+//   ① copy your private MCP link (masked here; the real one lands on the clipboard) and add it
+//     as a connector in ChatGPT / Claude,
+//   ② copy the coached system prompt (MirrorClient.systemPrompt) into the AI's instructions.
+//  Closes with the magic demo line: ask it "What do you know about me?". If sharing is off, the
+//  window says so and points at Settings instead of showing dead controls.
 //  (Uses the static OrbMark glyph, not the living Orb — the orb lives only on the empty home.)
 //
 
 import SwiftUI
+import AppKit
 
 struct ConnectAIsView: View {
     static let windowID = "connect-ais"
+
+    @State private var shareURL: String?
+    @State private var loaded = false
+    @State private var copiedLink = false
+    @State private var copiedPrompt = false
 
     var body: some View {
         ZStack {
@@ -23,41 +31,100 @@ struct ConnectAIsView: View {
                 Text("Connect your AIs.")
                     .font(.system(size: 25, design: .serif).italic())
                     .foregroundStyle(Theme.Ink.statusInk)
-                Text("Offer your knowledge base to ChatGPT, Claude, and every AI you use — privately, over MCP, in two simple steps.")
+                Text("Offer your knowledge base to ChatGPT, Claude, and every AI you use. Private, over MCP, in two simple steps.")
                     .font(.system(size: 13)).foregroundStyle(Theme.Ink.body)
                     .multilineTextAlignment(.center).lineSpacing(3.5)
                     .frame(maxWidth: 380)
 
-                VStack(spacing: 11) {
-                    step(1, "Copy your private MCP link", "Add it as a connector in ChatGPT or Claude.")
-                    step(2, "Tell your AI to use it", "One line in its instructions — and it knows your whole life.")
-                }
-                .padding(.top, 8)
+                if loaded, shareURL != nil {
+                    VStack(spacing: 11) {
+                        linkStep
+                        promptStep
+                    }
+                    .padding(.top, 8)
 
-                MonoCaps("Guided setup · coming soon", size: 9, tracking: 2.0, color: Theme.Ink.deepMuted)
-                    .padding(.top, 6)
+                    Text("Then ask it: \u{201C}What do you know about me?\u{201D}")
+                        .font(.serif(13, weight: .regular)).italic()
+                        .foregroundStyle(Theme.Ink.body)
+                        .padding(.top, 10)
+                } else if loaded {
+                    Text("Sharing is off. Turn on \u{201C}Offer your knowledge base to your AIs\u{201D} in Settings → Your AIs first.")
+                        .font(.system(size: 12)).foregroundStyle(Theme.Ink.amber)
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: 360)
+                        .padding(.top, 12)
+                }
             }
             .padding(44)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        .frame(minWidth: 480, minHeight: 520)
+        .frame(minWidth: 480, minHeight: 540)
+        .task {
+            if await MirrorClient.shared.isEnabled {
+                shareURL = await MirrorClient.shared.shareURL
+            }
+            loaded = true
+        }
     }
 
-    private func step(_ n: Int, _ title: String, _ sub: String) -> some View {
+    // MARK: - Step 1: the private link
+
+    private var linkStep: some View {
+        step(1, "Copy your private link", "In ChatGPT or Claude, add it as a connector (Settings → Connectors).") {
+            HStack(spacing: 9) {
+                Text(MirrorClient.maskedURL(shareURL))
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(Theme.Ink.bright)
+                    .lineLimit(1)
+                    .padding(.horizontal, 11).padding(.vertical, 6)
+                    .background(Color.white.opacity(0.03), in: Capsule())
+                    .overlay(Capsule().strokeBorder(Theme.stroke, lineWidth: 1))
+                SettingsPillButton(title: copiedLink ? "Copied ✓" : "Copy",
+                                   tint: copiedLink ? Theme.Ink.green : Theme.Ink.bright) {
+                    copy(shareURL ?? "", flag: $copiedLink)
+                }
+            }
+        }
+    }
+
+    // MARK: - Step 2: the system prompt
+
+    private var promptStep: some View {
+        step(2, "Tell your AI to use it", "Paste this into your AI's instructions so it checks your knowledge base.") {
+            SettingsPillButton(title: copiedPrompt ? "Copied ✓" : "Copy the instructions",
+                               tint: copiedPrompt ? Theme.Ink.green : Theme.Ink.bright) {
+                copy(MirrorClient.systemPrompt, flag: $copiedPrompt)
+            }
+        }
+    }
+
+    private func copy(_ text: String, flag: Binding<Bool>) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+        flag.wrappedValue = true
+        Task { try? await Task.sleep(for: .seconds(1.8)); flag.wrappedValue = false }
+    }
+
+    // MARK: - The step card
+
+    private func step<Controls: View>(_ n: Int, _ title: String, _ sub: String,
+                                      @ViewBuilder controls: () -> Controls) -> some View {
         HStack(alignment: .top, spacing: 13) {
             Text("\(n)")
                 .font(.system(size: 12, weight: .bold, design: .monospaced))
                 .foregroundStyle(Theme.Ink.bright)
                 .frame(width: 24, height: 24)
                 .overlay(Circle().strokeBorder(.white.opacity(0.14), lineWidth: 1))
-            VStack(alignment: .leading, spacing: 3) {
+            VStack(alignment: .leading, spacing: 8) {
                 Text(title).font(.system(size: 13.5, weight: .medium)).foregroundStyle(.white)
+                controls()
                 Text(sub).font(.system(size: 11.5)).foregroundStyle(Theme.Ink.body)
+                    .fixedSize(horizontal: false, vertical: true)
             }
             Spacer(minLength: 0)
         }
         .padding(14)
-        .frame(width: 380, alignment: .leading)
+        .frame(width: 400, alignment: .leading)
         .background(Theme.Ink.cardBG, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
         .overlay(RoundedRectangle(cornerRadius: 12, style: .continuous)
             .strokeBorder(.white.opacity(0.06), lineWidth: 1))
@@ -65,5 +132,5 @@ struct ConnectAIsView: View {
 }
 
 #Preview("Connect your AIs") {
-    ConnectAIsView().frame(width: 520, height: 560)
+    ConnectAIsView().frame(width: 520, height: 580)
 }

--- a/Sentient OS macOS/Views/ConnectAIsView.swift
+++ b/Sentient OS macOS/Views/ConnectAIsView.swift
@@ -48,7 +48,7 @@ struct ConnectAIsView: View {
                         .foregroundStyle(Theme.Ink.body)
                         .padding(.top, 10)
                 } else if loaded {
-                    Text("Sharing is off. Turn on \u{201C}Offer your knowledge base to your AIs\u{201D} in Settings → Your AIs first.")
+                    Text("Sharing is off. Turn on \u{201C}Offer your knowledge base to your AIs\u{201D} in Settings → Connect AIs to Knowledge first.")
                         .font(.system(size: 12)).foregroundStyle(Theme.Ink.amber)
                         .multilineTextAlignment(.center)
                         .frame(maxWidth: 360)

--- a/Sentient OS macOS/Views/HomePopovers.swift
+++ b/Sentient OS macOS/Views/HomePopovers.swift
@@ -170,7 +170,7 @@ struct YourAIsPopover: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack {
-                MonoCaps("Your AIs", size: 10, tracking: 2.4, color: Theme.Ink.label)
+                MonoCaps("Connect AIs", size: 10, tracking: 2.4, color: Theme.Ink.label)
                 Spacer()
                 togglePill
             }

--- a/Sentient OS macOS/Views/HomeView.swift
+++ b/Sentient OS macOS/Views/HomeView.swift
@@ -9,7 +9,7 @@
 //  bar at the foot lets you ask it to DO anything (computer use).
 //
 //  The chrome is deliberately quiet: a wordmark, and four doors at the top-right —
-//  Analysis ▾ and Your AIs ▾ (glanceable popovers, HomePopovers.swift) · Knowledge and
+//  Analysis ▾ and Connect AIs ▾ (glanceable popovers, HomePopovers.swift) · Knowledge and
 //  Settings (their own windows). Status lives inside Analysis, never cluttering the home.
 //
 //  WHEN THERE ARE NO CARDS, the living Orb blooms into the vacated center with "I'm here to
@@ -120,9 +120,9 @@ struct HomeView: View {
             Spacer()
             NavItem(title: "Analysis", dot: Theme.Ink.green) { showAnalysis = true }
                 .popover(isPresented: $showAnalysis) { analysisPopover }
-            NavItem(title: "Your AIs") { showYourAIs = true }
-                .popover(isPresented: $showYourAIs) { yourAIsPopover }
             NavItem(title: "Knowledge") { openWindow(id: KnowledgeView.windowID) }
+            NavItem(title: "Connect AIs") { showYourAIs = true }
+                .popover(isPresented: $showYourAIs) { yourAIsPopover }
             NavItem(icon: "gearshape") { openWindow(id: SettingsView.windowID) }
         }
         .padding(.horizontal, 30).padding(.top, 18)

--- a/Sentient OS macOS/Views/Settings/SettingsView.swift
+++ b/Sentient OS macOS/Views/Settings/SettingsView.swift
@@ -23,7 +23,7 @@ struct SettingsView: View {
             switch self {
             case .sources:   return "Knowledge Sources"
             case .proactive: return "Proactive & Sidekick"
-            case .yourAIs:   return "Your AIs"
+            case .yourAIs:   return "Connect AIs to Knowledge"
             case .system:    return "System"
             case .health:    return "Permissions & Health"
             }

--- a/Sentient OS macOS/Views/Settings/YourAIsPane.swift
+++ b/Sentient OS macOS/Views/Settings/YourAIsPane.swift
@@ -28,6 +28,7 @@ struct YourAIsPane: View {
             VStack(alignment: .leading, spacing: 30) {
                 intro
                 cloudSyncGroup
+                    .padding(.top, 10)    // same breath as before Activity — the blurb block stands alone
                 if enabled && loaded {
                     heroButton
                         .padding(.top, -14)   // belongs to the Cloud Sync group, not floating between groups

--- a/Sentient OS macOS/Views/Settings/YourAIsPane.swift
+++ b/Sentient OS macOS/Views/Settings/YourAIsPane.swift
@@ -44,15 +44,33 @@ struct YourAIsPane: View {
         .task { await refresh() }
     }
 
-    // MARK: - The story (value first, then the privacy explainer)
+    // MARK: - The story (value first, then four scannable privacy pillars — never a wall of text)
 
     private var intro: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: 16) {
             Text("Your ChatGPT and Claude, phone apps included, can read your Sentient knowledge base and decide what's relevant, making them dramatically more helpful about your actual life.")
                 .font(.system(size: 12.5)).foregroundStyle(Theme.Ink.statusInk)
                 .lineSpacing(3)
                 .fixedSize(horizontal: false, vertical: true)
-            SettingsProse("Private by design: your real files never leave this Mac. Your AIs only ever see short summaries with personal details stripped out, organized into your knowledge base. It's end-to-end encrypted; no one, not even Sentient's developers, can read it. There is no account, one secret link only you hold is the key, and if you stop using Sentient, your cloud copy deletes itself within 30 days. Even the cloud backend is open source, so anyone can verify all of this.")
+            VStack(alignment: .leading, spacing: 9) {
+                pillar("lock.shield", "Your real files never leave this Mac. Your AIs only see short summaries, personal details stripped.")
+                pillar("lock.fill", "End-to-end encrypted: no one, not even Sentient's developers, can read your knowledge base.")
+                pillar("key.fill", "No account. One secret link only you hold; leave Sentient and the cloud copy deletes itself in 30 days.")
+                pillar("chevron.left.forwardslash.chevron.right", "Even the cloud backend is open source. Verify everything.")
+            }
+        }
+    }
+
+    private func pillar(_ icon: String, _ text: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 9) {
+            Image(systemName: icon)
+                .font(.system(size: 10))
+                .foregroundStyle(Theme.Ink.green.opacity(0.8))
+                .frame(width: 15)
+            Text(text)
+                .font(.system(size: 11.5)).foregroundStyle(Theme.Ink.body)
+                .lineSpacing(2.5)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 
@@ -104,13 +122,10 @@ struct YourAIsPane: View {
         }
     }
 
-    // MARK: - The hero: the guided setup
+    // MARK: - The hero: the guided setup (settings-scale glow — a gradient ring, not the home's sun)
 
     private var heroButton: some View {
-        GlowButton(title: "Connect your AIs", systemImage: "sparkles") {
-            openWindow(id: ConnectAIsView.windowID)
-        }
-        .frame(maxWidth: 340)
+        ConnectCTA { openWindow(id: ConnectAIsView.windowID) }
     }
 
     // MARK: - Activity
@@ -149,6 +164,32 @@ struct YourAIsPane: View {
         enabled = await MirrorClient.shared.isEnabled
         loaded = true
         if enabled { stats = try? await MirrorClient.shared.stats() }
+    }
+}
+
+/// The pane's compact glow CTA: a dark capsule with the AI-gradient as a thin ring + a soft
+/// halo behind it. Jewelry at settings scale — deliberately NOT the home's big white GlowButton.
+private struct ConnectCTA: View {
+    let action: () -> Void
+
+    private var gradient: AngularGradient {
+        AngularGradient(colors: GlowHalo.stops, center: .center)
+    }
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                Image(systemName: "sparkles").font(.system(size: 12, weight: .semibold))
+                Text("Connect your AIs").font(.system(size: 13, weight: .semibold))
+            }
+            .foregroundStyle(.white)
+            .padding(.horizontal, 22).padding(.vertical, 10)
+            .background(Capsule().fill(Theme.Ink.cardBG))
+            .overlay(Capsule().strokeBorder(gradient, lineWidth: 1.2))
+            .background(Capsule().fill(gradient).blur(radius: 9).opacity(0.38))
+            .contentShape(Capsule())
+        }
+        .buttonStyle(PressScaleStyle())
     }
 }
 

--- a/Sentient OS macOS/Views/Settings/YourAIsPane.swift
+++ b/Sentient OS macOS/Views/Settings/YourAIsPane.swift
@@ -48,7 +48,7 @@ struct YourAIsPane: View {
 
     private var intro: some View {
         VStack(alignment: .leading, spacing: 16) {
-            Text("Your ChatGPT and Claude, phone apps included, can read your Sentient knowledge base, making them dramatically more helpful about your actual life.")
+            Text("Your ChatGPT and Claude, phone apps included, can read your Sentient knowledge base, making them dramatically more helpful.")
                 .font(.system(size: 12.5)).foregroundStyle(Theme.Ink.statusInk)
                 .lineSpacing(3)
                 .fixedSize(horizontal: false, vertical: true)

--- a/Sentient OS macOS/Views/Settings/YourAIsPane.swift
+++ b/Sentient OS macOS/Views/Settings/YourAIsPane.swift
@@ -30,6 +30,7 @@ struct YourAIsPane: View {
                 cloudSyncGroup
                 if enabled && loaded {
                     heroButton
+                        .padding(.top, -14)   // belongs to the Cloud Sync group, not floating between groups
                     activityGroup
                 } else if loaded {
                     localOnlyProse

--- a/Sentient OS macOS/Views/Settings/YourAIsPane.swift
+++ b/Sentient OS macOS/Views/Settings/YourAIsPane.swift
@@ -2,10 +2,11 @@
 //  YourAIsPane.swift
 //  Sentient OS macOS
 //
-//  Settings → Your AIs: the hosted MCP mirror, wired to MirrorClient. The share toggle (off =
-//  deletes the cloud copy, token kept so the URL survives re-enabling), the secret URL (masked;
-//  copy + regenerate), the connect guide + system prompt, and the live activity stats. When
-//  sharing is off, the local-only story takes the stage.
+//  Settings → Your AIs: the value + privacy story up top, the share toggle (off = confirm, then
+//  the cloud copy is deleted; the token is kept so the link survives re-enabling), and the HERO:
+//  the glowing "Connect your AIs" button → the real guided setup (ConnectAIsView), which owns the
+//  secret link + system prompt. Live activity from /stats below. Regenerate lives in MirrorClient
+//  only (a support/dev remediation; a UI button was a footgun that bricks every connector).
 //
 
 import SwiftUI
@@ -15,22 +16,20 @@ struct YourAIsPane: View {
     @Environment(\.openWindow) private var openWindow
 
     @State private var enabled = false
-    @State private var shareURL: String?
     @State private var stats: MirrorClient.Stats?
     @State private var loaded = false
     @State private var busy = false                // a network call is in flight — freeze the toggle
     @State private var confirmOff = false
-    @State private var confirmRegenerate = false
-    @State private var copied = false
     @State private var errorLine: String?
 
     var body: some View {
         SettingsPane(title: "Your AIs.",
                      whisper: "Your knowledge base, offered to every AI you already use.") {
             VStack(alignment: .leading, spacing: 30) {
+                intro
                 cloudSyncGroup
                 if enabled && loaded {
-                    urlGroup
+                    heroButton
                     activityGroup
                 } else if loaded {
                     localOnlyProse
@@ -45,12 +44,24 @@ struct YourAIsPane: View {
         .task { await refresh() }
     }
 
+    // MARK: - The story (value first, then the privacy explainer)
+
+    private var intro: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Your ChatGPT and Claude, phone apps included, can read your Sentient knowledge base and decide what's relevant, making them dramatically more helpful about your actual life.")
+                .font(.system(size: 12.5)).foregroundStyle(Theme.Ink.statusInk)
+                .lineSpacing(3)
+                .fixedSize(horizontal: false, vertical: true)
+            SettingsProse("Private by design: your real files never leave this Mac. Your AIs only ever see short summaries with personal details stripped out, organized into your knowledge base. It's end-to-end encrypted; no one, not even Sentient's developers, can read it. There is no account, one secret link only you hold is the key, and if you stop using Sentient, your cloud copy deletes itself within 30 days. Even the cloud backend is open source, so anyone can verify all of this.")
+        }
+    }
+
     // MARK: - The share toggle
 
     private var cloudSyncGroup: some View {
         SettingsGroup(label: "Cloud Sync") {
             SettingToggleLine(title: "Offer your knowledge base to your AIs",
-                              sub: "ChatGPT and Claude read it over MCP. No account, just a secret link with a 30-day lease that cleans up after itself.",
+                              sub: "ChatGPT and Claude read it over MCP. No account, just a private link that only you hold.",
                               isOn: $enabled)
                 .disabled(busy || !loaded)
         }
@@ -73,9 +84,8 @@ struct YourAIsPane: View {
         busy = true; errorLine = nil
         Task {
             do {
-                let url = try await MirrorClient.shared.enable()
+                _ = try await MirrorClient.shared.enable()
                 try? await MirrorClient.shared.push()      // best-effort first fill (no vault yet is fine)
-                shareURL = url
             } catch {
                 enabled = false
                 errorLine = (error as? LocalizedError)?.errorDescription ?? "\(error)"
@@ -94,72 +104,13 @@ struct YourAIsPane: View {
         }
     }
 
-    // MARK: - The secret URL
+    // MARK: - The hero: the guided setup
 
-    private var urlGroup: some View {
-        SettingsGroup(label: "Your Secret Link") {
-            VStack(alignment: .leading, spacing: 12) {
-                HStack(spacing: 9) {
-                    Text(maskedURL)
-                        .font(.system(size: 11.5, design: .monospaced))
-                        .foregroundStyle(Theme.Ink.bright)
-                        .lineLimit(1)
-                        .padding(.horizontal, 12).padding(.vertical, 7)
-                        .background(Color.white.opacity(0.03), in: Capsule())
-                        .overlay(Capsule().strokeBorder(Theme.stroke, lineWidth: 1))
-                    SettingsPillButton(title: copied ? "Copied ✓" : "Copy",
-                                       tint: copied ? Theme.Ink.green : Theme.Ink.bright) { copyURL() }
-                    SettingsPillButton(title: "Regenerate…") { confirmRegenerate = true }
-                        .disabled(busy)
-                }
-                SettingsProse("This link is your whole identity; there's no account behind it. Paste it into ChatGPT or Claude as a connector, and treat it like a password.")
-                HStack(spacing: 16) {
-                    quietLink("How to connect your AIs") { openWindow(id: ConnectAIsView.windowID) }
-                    quietLink("Copy the system prompt") {
-                        NSPasteboard.general.clearContents()
-                        NSPasteboard.general.setString(MirrorClient.systemPrompt, forType: .string)
-                    }
-                }
-            }
+    private var heroButton: some View {
+        GlowButton(title: "Connect your AIs", systemImage: "sparkles") {
+            openWindow(id: ConnectAIsView.windowID)
         }
-        .alert("Regenerate your secret link?", isPresented: $confirmRegenerate) {
-            Button("Cancel", role: .cancel) {}
-            Button("Regenerate", role: .destructive) { regenerate() }
-        } message: {
-            Text("The old link stops working immediately, and every AI you've connected will need the new one. Do this if the link ever leaks.")
-        }
-    }
-
-    private var maskedURL: String {
-        // ⚠️ "/mcp" must be searched BACKWARDS: the host "https://mcp.sentient-os.ai" itself
-        // contains "/mcp" (second slash + host), and a forward hit put `end` before the token —
-        // an inverted range that crashed the pane. Guard the order defensively regardless.
-        guard let url = shareURL,
-              let range = url.range(of: "/u/"),
-              let end = url.range(of: "/mcp", options: .backwards),
-              range.upperBound <= end.lowerBound else { return "mcp.sentient-os.ai/u/…/mcp" }
-        let token = url[range.upperBound..<end.lowerBound]
-        let host = url.replacingOccurrences(of: "https://", with: "")
-            .replacingOccurrences(of: "http://", with: "")     // dev SENTIENT_MIRROR_BASE override
-            .prefix(while: { $0 != "/" })
-        return "\(host)/u/\(token.prefix(4))••••••••/mcp"
-    }
-
-    private func copyURL() {
-        guard let url = shareURL else { return }
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(url, forType: .string)
-        copied = true
-        Task { try? await Task.sleep(for: .seconds(1.8)); copied = false }
-    }
-
-    private func regenerate() {
-        busy = true; errorLine = nil
-        Task {
-            do { shareURL = try await MirrorClient.shared.regenerateToken() }
-            catch { errorLine = (error as? LocalizedError)?.errorDescription ?? "\(error)" }
-            busy = false
-        }
+        .frame(maxWidth: 340)
     }
 
     // MARK: - Activity
@@ -192,22 +143,10 @@ struct YourAIsPane: View {
         }
     }
 
-    // MARK: - Helpers
-
-    private func quietLink(_ title: String, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            HStack(spacing: 4) {
-                Text(title).font(.system(size: 11, weight: .medium))
-                Image(systemName: "chevron.right").font(.system(size: 7.5, weight: .semibold))
-            }
-            .foregroundStyle(Theme.Ink.label)
-        }
-        .buttonStyle(PressScaleStyle())
-    }
+    // MARK: - Probes
 
     private func refresh() async {
         enabled = await MirrorClient.shared.isEnabled
-        shareURL = await MirrorClient.shared.shareURL
         loaded = true
         if enabled { stats = try? await MirrorClient.shared.stats() }
     }

--- a/Sentient OS macOS/Views/Settings/YourAIsPane.swift
+++ b/Sentient OS macOS/Views/Settings/YourAIsPane.swift
@@ -81,20 +81,22 @@ struct YourAIsPane: View {
 
     private var cloudSyncGroup: some View {
         SettingsGroup(label: "Cloud Sync") {
+            // A custom binding, NOT $enabled + onChange: the setter fires only when the USER flips
+            // the control, so programmatic `enabled =` writes can't re-trigger the confirm flow.
+            // (The old onChange guard checked `busy`, but turnOff() cleared `busy` in the same
+            // transaction as `enabled = false` — onChange then read busy == false, mistook the
+            // write for a user flip, and re-showed the dialog forever.)
             SettingToggleLine(title: "Offer your knowledge base to your AIs",
                               sub: "ChatGPT and Claude read it over MCP. No account, just a private link that only you hold.",
-                              isOn: $enabled)
+                              isOn: Binding(
+                                  get: { enabled },
+                                  set: { requested in
+                                      if requested { turnOn() } else { confirmOff = true }
+                                  }))
                 .disabled(busy || !loaded)
         }
-        .onChange(of: enabled) { was, now in
-            guard loaded, !busy else { return }
-            if now { turnOn() } else if was {
-                enabled = true                     // hold until the user confirms the delete
-                confirmOff = true
-            }
-        }
         .alert("Stop sharing your knowledge base?", isPresented: $confirmOff) {
-            Button("Keep Sharing", role: .cancel) {}
+            Button("Keep Sharing", role: .cancel) {}       // switch never changed — stays on
             Button("Stop & Delete Cloud Copy", role: .destructive) { turnOff() }
         } message: {
             Text("The cloud copy is deleted immediately and your AIs lose access. Your knowledge base stays safe on this Mac, and turning sharing back on restores the same link.")
@@ -102,6 +104,7 @@ struct YourAIsPane: View {
     }
 
     private func turnOn() {
+        enabled = true                                     // optimistic — the switch answers instantly
         busy = true; errorLine = nil
         Task {
             do {

--- a/Sentient OS macOS/Views/Settings/YourAIsPane.swift
+++ b/Sentient OS macOS/Views/Settings/YourAIsPane.swift
@@ -23,7 +23,7 @@ struct YourAIsPane: View {
     @State private var errorLine: String?
 
     var body: some View {
-        SettingsPane(title: "Your AIs.",
+        SettingsPane(title: "ChatGPT & Claude.",
                      whisper: "Your knowledge base, offered to every AI you already use.") {
             VStack(alignment: .leading, spacing: 30) {
                 intro

--- a/Sentient OS macOS/Views/Settings/YourAIsPane.swift
+++ b/Sentient OS macOS/Views/Settings/YourAIsPane.swift
@@ -32,6 +32,7 @@ struct YourAIsPane: View {
                     heroButton
                         .padding(.top, -14)   // belongs to the Cloud Sync group, not floating between groups
                     activityGroup
+                        .padding(.top, 10)    // extra breath after the hero
                 } else if loaded {
                     localOnlyProse
                 }

--- a/Sentient OS macOS/Views/Settings/YourAIsPane.swift
+++ b/Sentient OS macOS/Views/Settings/YourAIsPane.swift
@@ -48,7 +48,7 @@ struct YourAIsPane: View {
 
     private var intro: some View {
         VStack(alignment: .leading, spacing: 16) {
-            Text("Your ChatGPT and Claude, phone apps included, can read your Sentient knowledge base and decide what's relevant, making them dramatically more helpful about your actual life.")
+            Text("Your ChatGPT and Claude, phone apps included, can read your Sentient knowledge base, making them dramatically more helpful about your actual life.")
                 .font(.system(size: 12.5)).foregroundStyle(Theme.Ink.statusInk)
                 .lineSpacing(3)
                 .fixedSize(horizontal: false, vertical: true)
@@ -56,7 +56,7 @@ struct YourAIsPane: View {
                 pillar("lock.shield", "Your real files never leave this Mac. Your AIs only see short summaries, personal details stripped.")
                 pillar("lock.fill", "End-to-end encrypted: no one, not even Sentient's developers, can read your knowledge base.")
                 pillar("key.fill", "No account. One secret link only you hold; leave Sentient and the cloud copy deletes itself in 30 days.")
-                pillar("chevron.left.forwardslash.chevron.right", "Even the cloud backend is open source. Verify everything.")
+                pillar("chevron.left.forwardslash.chevron.right", "Even the cloud backend is open source. Everything's verifiable.")
             }
         }
     }


### PR DESCRIPTION
Value blurb + plain-language privacy explainer up top (E2E copy is launch-truth; the mcp-encryption backlog item must ship before launch — recorded in Settings.md and the arch file). Lease jargon gone. One glowing Connect-your-AIs hero opens ConnectAIsView, now the real two-step guide (link + system prompt + the magic closer). Regenerate removed from UI, kept in MirrorClient. Builds clean.