### PR TITLE
Sidekick: attach a screen still to every command (computer-use context)

### DIFF
--- a/Sentient OS macOS/CodexCLI.swift
+++ b/Sentient OS macOS/CodexCLI.swift
@@ -331,15 +331,21 @@ actor CodexCLI {
     /// the sanitized-env / PATH / watchdog plumbing; the binary comes from the same discovery
     /// (`~/.local/bin/codex` first). The user's ~/.codex config + MCP servers load by default (no
     /// --ignore-user-config). Returns the full output. Computer use is the WIP CLI path.
-    func runAgentCommand(_ prompt: String, timeout: TimeInterval = 1_800,
+    ///
+    /// `imagePath` (optional): a screenshot of the user's screen, attached with `codex exec -i <file>`
+    /// so the agent SEES what they're looking at (the notch/command-bar path passes one; the proactive
+    /// executor doesn't). It's placed right before `--skip-git-repo-check` so the flag terminates
+    /// `-i`'s variadic `<FILE>...` and the prompt is never mistaken for a second image.
+    func runAgentCommand(_ prompt: String, imagePath: String? = nil, timeout: TimeInterval = 1_800,
                          onLine: @escaping @Sendable (String) -> Void) async throws -> String {
         let t0 = Date()
         do {
             guard let bin = Self.locateBinary() else { throw CLIError.notAvailable(.notInstalled) }
-            let args = ["exec", "--dangerously-bypass-approvals-and-sandbox",
+            var args = ["exec", "--dangerously-bypass-approvals-and-sandbox",
                         "-m", Model.gpt55.rawValue,
-                        "-c", "model_reasoning_effort=\"low\"",
-                        "--skip-git-repo-check", prompt]
+                        "-c", "model_reasoning_effort=\"low\""]
+            if let imagePath { args += ["-i", imagePath] }   // followed by a flag → variadic stops at one file
+            args += ["--skip-git-repo-check", prompt]
             let out = try await Self.executeStreaming(binary: bin, args: args, timeout: timeout, onLine: onLine)
             guard out.status == 0 else {
                 let detail = out.stderr.isEmpty ? out.stdout : out.stderr

--- a/Sentient OS macOS/Documentation/Notch Magic/Notch Magic.md
+++ b/Sentient OS macOS/Documentation/Notch Magic/Notch Magic.md
@@ -20,6 +20,8 @@ All funnel through **`CommandCoordinator` → `CommandRunModel` → `CodexCLI.ru
 
 Every command is **computer use** (the dedicated browser-use channel was removed — see the root architecture doc §7), and the notch shows for all of them.
 
+**The instant you fire a command, Sentient also snaps a still of your screen and hands it to the agent** (`codex exec -i`), so "finish this", "reply to this", "complete this form" resolve against the actual pixels you're looking at — computer use starts with eyes open, not blind. It rides Sentient's own Screen Recording grant; no grant → the command just runs text-only. See §6a. [✅ verified on hardware — §11.]
+
 ---
 
 ## 2. Architecture in one breath
@@ -48,7 +50,8 @@ Every command is **computer use** (the dedicated browser-use channel was removed
 | **`SpeechAnalyzerEngine.swift`** | macOS **26+** speech-to-text (`SpeechAnalyzer` + `SpeechTranscriber`, on-device, in-memory). |
 | **`SFSpeechRecognizerEngine.swift`** | macOS **15** fallback (`SFSpeechRecognizer`, server-capable). |
 | **`VoiceCapture.swift`** | Façade: mic + speech permissions, engine selection, `prewarm` / `start` / `stopAndTranscribe` / `cancel`. |
-| **`CommandRunModel.swift`** | Runs ONE codex task; **cleans codex's raw human-readable stream** into the bar's `statusLine` + the `remembering` state (§6); `stop()`, `onFinished(Outcome)`. |
+| **`CommandRunModel.swift`** | Runs ONE codex task; **cleans codex's raw human-readable stream** into the bar's `statusLine` + the `remembering` state (§6); `stop()`, `onFinished(Outcome)`. Grabs + attaches the screen still at run start (§6a). |
+| **`ScreenCapture.swift`** | Grabs the screen to a temp JPEG for computer-use context (`/usr/sbin/screencapture`, main display). `grab() -> URL?` (nil if no Screen Recording grant) · `discard(_:)`. §6a. |
 | **`CommandCoordinator.swift`** | The brain: owns the run + hotkey + voice, drives `phase` (`NotchPhase`), the press→branch flow, `submit()` / `submitTyped()` / `dismissTyping()` / `cancelCurrent()` / `stop()`. |
 | **`NotchSpace.swift`** | SkyLight private-API wrapper — pins the panel into a top-level window-server space so it's fixed over the notch on every Space. |
 | **`NotchWindowController.swift`** | The `NSPanel` host: a **fixed canvas** flush at the bezel; click-through by toggling `ignoresMouseEvents` per cursor position; all-Spaces; observers. Also `NotchPanel`, `NotchHostingView`, the `NSScreen.notchSize`/`displayID` extension. |
@@ -56,7 +59,7 @@ Every command is **computer use** (the dedicated browser-use channel was removed
 | **`SpinningLogo.swift`** | The 2D spectrum-ring logo (matches the app icon). |
 | **`NotchView.swift`** | `NotchView` (binder) + `NotchContent` (the pure visual: morph, phases, layered edge glow, the read-back / Remembering / status captions) + `NotchMetrics` (per-phase sizing) + `NotchStopButton` + the `.blurDissolve` transition. |
 
-Edits outside this folder: `AppState.swift` (owns/starts the two objects), `Views/HomeView.swift` (`PromptBar` drives `appState.commandCoordinator`), and the project's `INFOPLIST_KEY_NSMicrophoneUsageDescription` + `INFOPLIST_KEY_NSSpeechRecognitionUsageDescription` build settings.
+Edits outside this folder: `AppState.swift` (owns/starts the two objects), `Views/HomeView.swift` (`PromptBar` drives `appState.commandCoordinator`), `CodexCLI.swift` (`runAgentCommand` gained an optional `imagePath` → `codex exec -i`, §6a), `Permissions.swift` (`hasScreenRecording()`, already present), and the project's `INFOPLIST_KEY_NSMicrophoneUsageDescription` + `INFOPLIST_KEY_NSSpeechRecognitionUsageDescription` build settings.
 
 There is still a **DEV bench** `Views/HotkeyLabView.swift` (DEV TOOLS → HOTKEY LAB) — the original proof of the hotkey tap. It's superseded by `RightCommandMonitor`; **retire it** once you're confident (see §13).
 
@@ -135,6 +138,16 @@ Two routes feed it: the **global** Esc tap (`RightCommandMonitor.onEscape`, §4)
 - **track sections** by codex's bare headers (`user`/`codex`/`exec`/…) — show only codex's narration + tool/`mcp:` lines; drop the startup banner, the user-prompt echo, and raw shell output (`barLine`);
 - in the **`exec`** section, surface knowledge-base reads as the **`remembering`** state — `knowledgeBaseRead` slices the note path out of a `cat`/`grep`/`sed`/… command (command-agnostic: keys off the vault path, requires it shell-quoted so grep *output* isn't mistaken for a read). `setRemembering` holds it ≥1.5s (so the bloom completes for a single file);
 - replace the confirmation-policy `SKILL.md` dump's lingering tail ("…avoid redundant confirmations…") with **"Thinking through your task"**.
+
+### 6a. Screen context — the screenshot (`ScreenCapture.swift`)
+
+So the agent can act on what you're *actually looking at*, every command attaches a still of your screen. It's captured **inside `CommandRunModel.start`** (at the top of its run Task, so `isRunning` is already true — no re-entrancy gap): `await ScreenCapture.grab()` shells `/usr/sbin/screencapture -x -t jpg <temp>` (main display, silent, JPEG to stay compact vs a multi-MB Retina PNG), returns the temp `URL`, and a `defer { ScreenCapture.discard(shot) }` deletes it the moment codex is done.
+
+- **Permission-gated, never prompts:** `grab()` returns `nil` unless `Permissions.hasScreenRecording()` is already true — no grant → the command runs text-only exactly as before. (`CGPreflightScreenCaptureAccess`, so it never surfaces a dialog mid-command.)
+- **Into the prompt:** `CodexCLI.runAgentCommand(prompt, imagePath:)` adds `-i <path>` to the `codex exec` args, placed **right before `--skip-git-repo-check`** so that flag terminates `-i`'s variadic `<FILE>...` and the prompt is never mistaken for a second image. `commandPrompt(…, hasScreenshot:)` adds a line telling the agent to resolve "this"/"here" against the attached frame.
+- **The proactive executor passes nothing** (`imagePath` defaults to nil) — a background proactive action has no "current screen" to show; this is a Sidekick-only capture.
+- **Privacy note:** the frame goes to the user's OWN codex/OpenAI — the same trust boundary computer use already crosses (it reads the live screen anyway). It never touches Sentient servers, and only the file *size* is logged, never the pixels.
+- **Known rough edges (§13):** no downscale yet (~0.5–1.5 MB per frame) · our own notch overlay is *in* the shot (recordable window) · main-display only (multi-monitor grabs the wrong screen sometimes) · the **home command-bar path is weak** — Sentient is frontmost there, so the frame is often our own UI; the two *notch* doors (non-activating panel) are where the shot is genuinely useful.
 
 ---
 
@@ -228,6 +241,7 @@ All of the below is **confirmed working on Jesai's bezel** (live screenshots/rec
 - **The window:** fixed canvas, flush at the bezel (concave corners visible), no detach during morphs; **click-through bulletproof** (cursor-position toggle — verified clicks pass through the glow + everywhere but the notch); typing takes keystrokes without activating the app.
 - **The glow:** thick, vivid, layered, all around the silhouette (incl. corners), alive from the moment the notch appears.
 - **Remembering:** gradient "Remembering ‹note›" surfaces the knowledge-base reads; status stream is filtered clean (no CLI chrome / `stderr:` / prompt echo).
+- **Screen context (§6a):** [MEASURED, real hardware, 2026-07-04] on a "what do you see on my screen" command the log shows the full chain — `📸 screenshot captured (752 KB)` → `screenshot: true` → the prompt carries the screenshot line → `codex exec -i` → codex answered **"I see Google Chrome open to `x.com/home` on X in dark mode."** The still is captured, attached, and read. (Note: computer use ALSO has its own live screen access now, so a given answer may draw on either our still or its live view; codex's "using the screenshot as immediate context" confirms our image is ingested.)
 - **The logo** matches the app icon — twinned to the right control in a shared 17pt slot, the warm seam stop deepened to gold (no white spot), the white ring extra-fine, spinning 2× faster while processing.
 - **Dismiss & Esc:** the notch *retracts/merges into the cutout* on dismiss (no fade); Esc cancels globally (type field · listening · transcript), a right-⌘ tap closes the type field, and STOP/Esc dismiss the transcript instantly while still halting live computer use with the "Stopped" beat.
 - **Not yet done:** §12 polish backlog; productionization (§13). Reduced-motion + VoiceOver coded but unverified.
@@ -265,6 +279,7 @@ Esc cancels/dismisses globally via the zero-permission `keyDown` tap (§4) — t
 - **Confirm** the SkyLight pin + order-out never leaves the notch stuck visible when idle.
 - **Reduced-motion / VoiceOver** sanity pass.
 - **Retire the dev bench** `Views/HotkeyLabView.swift` + its DEV TOOLS → HOTKEY LAB button once the real hotkey is proven.
+- **Screenshot polish (§6a), each its own small pass:** downscale the frame (~1440px wide) to cut upload/latency/tokens · **exclude our own notch overlay** from the shot (ScreenCaptureKit `SCContentFilter` window-exclusion, vs the current `screencapture` CLI) · **multi-display** — capture the display the user is actually on (or attach all via `-i`'s variadic), not just the main one · reconsider the **home command-bar path**, where the frame is usually just Sentient's own UI (skip it there, or capture the display behind).
 
 ---
 

--- a/Sentient OS macOS/Notch Magic/CommandRunModel.swift
+++ b/Sentient OS macOS/Notch Magic/CommandRunModel.swift
@@ -10,7 +10,7 @@
 //  lets the coordinator move the notch from running → finishing. Everything also tees to Log()
 //  (tail /tmp/sentient-dev.log). Doc: Documentation/Notch Magic/.
 //
-//  Key methods: start(_:mode:) · stop() · commandPrompt(task:mode:).
+//  Key methods: start(_:mode:) · stop() · commandPrompt(task:mode:hasScreenshot:).
 //
 
 import Foundation
@@ -51,18 +51,22 @@ final class CommandRunModel {
         remembering = nil
         rememberClear?.cancel()
         statusLine = "Starting \(mode.promptPhrase)…"
-        let prompt = Self.commandPrompt(task: task0, mode: mode)
         Log("──────── 🤖 \(mode.label.uppercased()) · command ────────")
-        Log("CMD: launching codex exec (gpt-5.5 · \(mode.promptPhrase) · bypass sandbox)…")
-        #if DEBUG   // B7: prompt + live output + final carry the user's command, KB context, and codex
-                    // play-by-play — DEBUG-only so they can never become a Release breadcrumb.
-        Log("CMD: prompt ↓\n\(prompt)")
-        #endif
-        Log("──────────────── live codex output ↓ ────────────────")
         let started = Date()
         task = Task { [weak self] in
+            // Snap the screen NOW so computer use sees exactly what the user is looking at (nil if the
+            // Screen Recording grant is missing → runs text-only). Deleted the moment codex is done.
+            let shot = await ScreenCapture.grab()
+            defer { ScreenCapture.discard(shot) }
+            let prompt = Self.commandPrompt(task: task0, mode: mode, hasScreenshot: shot != nil)
+            Log("CMD: launching codex exec (gpt-5.5 · \(mode.promptPhrase) · bypass sandbox · screenshot: \(shot != nil))…")
+            #if DEBUG   // B7: prompt + live output + final carry the user's command, KB context, and codex
+                        // play-by-play — DEBUG-only so they can never become a Release breadcrumb.
+            Log("CMD: prompt ↓\n\(prompt)")
+            #endif
+            Log("──────────────── live codex output ↓ ────────────────")
             do {
-                let out = try await CodexCLI.shared.runAgentCommand(prompt) { line in
+                let out = try await CodexCLI.shared.runAgentCommand(prompt, imagePath: shot?.path) { line in
                     Task { @MainActor in
                         #if DEBUG
                         Log("CMD │ \(line)")
@@ -204,11 +208,15 @@ final class CommandRunModel {
     /// Build the command prompt: `mode.promptPhrase` ("computer use") leads and the typed/spoken task fills
     /// the rest. The agent is told to do the TASK via computer use (not AppleScript GUI-scripting), and to
     /// read the knowledge base (path resolved from `~`) with its shell/file tools — NOT by opening it in a
-    /// GUI app like Obsidian.
-    nonisolated static func commandPrompt(task: String, mode: AgentMode) -> String {
-        """
+    /// GUI app like Obsidian. When `hasScreenshot`, a frame of the user's live screen is attached (via
+    /// `codex exec -i`), so the prompt tells the agent to ground "this"/"here" in what it can see.
+    nonisolated static func commandPrompt(task: String, mode: AgentMode, hasScreenshot: Bool) -> String {
+        let screenLine = hasScreenshot
+            ? "\nAttached is a screenshot of my screen exactly as it looks right now. Use it to see what I'm currently looking at — resolve any \"this\", \"here\", \"that form\", etc. against what's on screen before you act.\n"
+            : ""
+        return """
         Using \(mode.promptPhrase), \(task)
-
+        \(screenLine)
         Carry out the task itself with \(mode.promptPhrase) — drive the real apps and websites directly (open them, click, type, navigate). Do NOT fake it with AppleScript, osascript, or other GUI-scripting shortcuts.
 
         For context about me, my knowledge base is a folder of markdown files at '\(VaultGenerator.vaultRoot.path)'. When you need it, read it directly with your shell/file tools — `ls`, `cat`, and `grep` the .md files. Do NOT open it in Obsidian or any GUI app to read it.

--- a/Sentient OS macOS/Notch Magic/ScreenCapture.swift
+++ b/Sentient OS macOS/Notch Magic/ScreenCapture.swift
@@ -1,0 +1,68 @@
+//
+//  ScreenCapture.swift
+//  Sentient OS macOS
+//
+//  Grabs a still of the user's screen at the moment they invoke a command, so computer use SEES
+//  exactly what they're looking at — "finish this form", "reply to this", "complete this" all resolve
+//  against the real pixels. The frame is attached to the codex prompt (`codex exec -i <file>`).
+//
+//  Uses `/usr/sbin/screencapture` (main display, no shutter sound, JPEG) — it rides Sentient's own
+//  Screen Recording grant. No grant → returns nil and the command runs text-only (never prompts here).
+//  The file is a short-lived temp: the caller passes its path to codex, then calls `discard`. Note: the
+//  screen goes to the user's OWN codex/OpenAI (the same trust boundary computer use already crosses).
+//  Doc: Documentation/Notch Magic/.
+//
+//  Key methods: grab() -> URL? · discard(_:).
+//
+
+import Foundation
+
+enum ScreenCapture {
+    /// Capture the main display to a temp JPEG for computer-use context. nil = no Screen Recording grant
+    /// or the capture failed (the command then runs without a screenshot). Never prompts.
+    static func grab() async -> URL? {
+        guard Permissions.hasScreenRecording() else {
+            Log("📸 screenshot skipped — no Screen Recording grant")
+            return nil
+        }
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("sentient-shot-\(UUID().uuidString).jpg")
+        //  -x : silent (no camera sound)   -t jpg : compact vs a multi-MB Retina PNG
+        let ok = await runCapture(["-x", "-t", "jpg", url.path])
+        guard ok, FileManager.default.fileExists(atPath: url.path) else {
+            Log("📸 screenshot capture failed")
+            try? FileManager.default.removeItem(at: url)
+            return nil
+        }
+        let kb = ((try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int) ?? 0) / 1024
+        Log("📸 screenshot captured (\(kb) KB)")   // size only — never the pixels
+        return url
+    }
+
+    /// Delete the temp frame once codex has consumed it (safe on nil).
+    static func discard(_ url: URL?) {
+        guard let url else { return }
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    /// Run `screencapture` off the main actor; true iff it exited cleanly.
+    private static func runCapture(_ args: [String]) async -> Bool {
+        await withCheckedContinuation { cont in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let p = Process()
+                p.executableURL = URL(fileURLWithPath: "/usr/sbin/screencapture")
+                p.arguments = args
+                p.standardOutput = FileHandle.nullDevice
+                p.standardError = FileHandle.nullDevice
+                do {
+                    try p.run()
+                    p.waitUntilExit()
+                    cont.resume(returning: p.terminationStatus == 0)
+                } catch {
+                    Log("📸 screencapture launch failed — \(error.localizedDescription)")
+                    cont.resume(returning: false)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What
Every command-bar / notch / voice command now captures the screen and attaches it to `codex exec` (`-i`), so computer use resolves "this" / "here" / "that form" against what's actually on screen instead of acting blind.

## Changes
- **`ScreenCapture.swift`** (new) — `/usr/sbin/screencapture -x -t jpg` → temp JPEG (main display, silent). Gated on Sentient's own Screen Recording grant (no grant → `nil` → command runs text-only, never prompts). Deleted right after the run.
- **`CommandRunModel.start`** — grabs + attaches the still at run start (inside the run Task, after `isRunning` is set, so no re-entrancy gap); the prompt tells the agent about the frame when present.
- **`CodexCLI.runAgentCommand`** — optional `imagePath` → `codex exec -i`, placed before `--skip-git-repo-check` so the variadic `-i` can't swallow the prompt. `ProactiveExecutor` untouched (defaults to nil — no 'current screen' for background actions).

## Verified on hardware (2026-07-04, from the dev log)
`what do you see on my screen` → `📸 screenshot captured (752 KB)` → `screenshot: true` → prompt carries the screenshot line → `codex exec -i` → codex answered **"I see Google Chrome open to `x.com/home` on X in dark mode."**

## Privacy
The frame goes to the user's **own** codex/OpenAI — same trust boundary computer use already crosses (it reads the live screen anyway). Never touches Sentient servers; only the file *size* is logged, never pixels.

## Follow-ups (Notch Magic §13)
Downscale · exclude our own notch from the frame · multi-display · the home-command-bar path (Sentient is frontmost there, so the frame is often our own UI).

Doc: `Documentation/Notch Magic/Notch Magic.md` §6a.