### PR TITLE
Sparkle auto-update (mandatory, OLED gate fallback) + ModelLocator dev-fallback fix

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!--
+	  Sparkle auto-update configuration.
+
+	  This partial Info.plist carries ONLY the Sparkle keys. Everything else (bundle id, name,
+	  versions, the NS*UsageDescription strings) is still synthesized by GENERATE_INFOPLIST_FILE=YES
+	  and the INFOPLIST_KEY_* build settings — Xcode MERGES the generated keys on top of this file
+	  (that's why INFOPLIST_FILE + GENERATE_INFOPLIST_FILE coexist here). Do NOT duplicate generated
+	  keys in this file. Doc: Documentation/Auto-Update (Sparkle).md
+
+	  ⚠️ SUPublicEDKey below is a PLACEHOLDER (32 zero-bytes). It MUST be replaced with the real
+	  EdDSA public key BEFORE the first public release — run `generate_keys` once on Jesai's Mac
+	  (the paid Developer-ID team), which prints the real SUPublicEDKey and stores the private seed
+	  in that Mac's login Keychain. The private key NEVER lives in the repo. Until it's replaced,
+	  update checks can't verify anything (harmless: there's no appcast live yet either).
+	-->
+
+	<!-- The appcast Sparkle polls. Hosted on our own domain (Vercel) — a permanent contract, since
+	     every shipped build bakes this URL in forever. The DMG downloads live on GitHub Releases. -->
+	<key>SUFeedURL</key>
+	<string>https://sentient-os.ai/appcast.xml</string>
+
+	<!-- PLACEHOLDER — replace with the real key from `generate_keys` before first release. -->
+	<key>SUPublicEDKey</key>
+	<string>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</string>
+
+	<!-- Check automatically once a day. No second-launch permission prompt (updates are mandatory,
+	     so there's nothing to opt out of). -->
+	<key>SUEnableAutomaticChecks</key>
+	<true/>
+	<key>SUScheduledCheckInterval</key>
+	<integer>86400</integer>
+
+	<!-- Auto-update with our OLED gate as the FALLBACK: Sparkle silently downloads and installs
+	     updates on its own (applied on quit/relaunch — you can't swap a running bundle underneath the
+	     user). Zero taps in the normal case. Our custom forced-update gate (SentientUpdateDriver /
+	     UpdateGateView — no skip, no remind) only appears when a silent install CAN'T happen: macOS
+	     needs an admin password (app in /Applications), an install error, or the impatient window
+	     below elapses without the app being quit. -->
+	<key>SUAllowsAutomaticUpdates</key>
+	<true/>
+	<key>SUAutomaticallyUpdate</key>
+	<true/>
+
+	<!-- Sentient lives in the menu bar and may run for days, so "install on quit" can be slow to fire.
+	     If a silently-downloaded update still hasn't installed after this window, Sparkle surfaces it —
+	     i.e. our gate shows as the fallback. 2 days: current enough without nagging. Must exceed
+	     SUScheduledCheckInterval. -->
+	<key>SUScheduledImpatientCheckInterval</key>
+	<integer>172800</integer>
+
+	<!-- Privacy Constitution: send no system profile, and never run JavaScript in release notes.
+	     The only network exposure is the appcast GET (IP + User-Agent) over HTTPS — no account. -->
+	<key>SUEnableSystemProfiling</key>
+	<false/>
+	<key>SUSendProfileInfo</key>
+	<false/>
+	<key>SUEnableJavaScript</key>
+	<false/>
+</dict>
+</plist>

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+#
+# release.sh — cut a signed, notarized Sentient OS release and publish it for Sparkle auto-update.
+#
+# The whole pipeline, one command:
+#   archive → export (Developer ID) → DMG → notarize → staple → EdDSA-sign → appcast → GitHub Release
+#
+# Run this on JESAI'S Mac (the paid Developer-ID team YJ8AZR3G5Q) — Sparkle requires every update to
+# be signed with the SAME Team ID as the installed app, and only the paid account can notarize.
+#
+# ── ONE-TIME SETUP (do these once, ever) ────────────────────────────────────────────────────────
+#   1. EdDSA signing key:      ./release.sh keys
+#        → prints SUPublicEDKey. Paste it into ../Info.plist (replacing the placeholder), commit.
+#        → the private seed is stored in this Mac's login Keychain; NEVER put it in the repo.
+#   2. Notary credentials:     xcrun notarytool store-credentials "SentientNotary" \
+#                                --apple-id "you@apple.id" --team-id YJ8AZR3G5Q --password <app-specific-pw>
+#   3. Sparkle CLI tools:      brew install --cask sparkle   (or set SPARKLE_BIN to a Sparkle bin/ dir)
+#
+# ── EACH RELEASE ────────────────────────────────────────────────────────────────────────────────
+#   1. Bump MARKETING_VERSION and CURRENT_PROJECT_VERSION in the project (build number MUST increase —
+#      Sparkle compares CFBundleVersion). Commit.
+#   2. ./release.sh            (reads the version from the build)
+#   3. Publish the emitted appcast.xml to https://sentient-os.ai/appcast.xml (the SUFeedURL).
+#
+# Doc: Sentient OS macOS/Documentation/Auto-Update (Sparkle).md
+#
+set -euo pipefail
+
+# ── Config ───────────────────────────────────────────────────────────────────────────────────────
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"          # the app git repo root (has the .xcodeproj)
+PROJECT="$REPO_ROOT/Sentient OS macOS.xcodeproj"
+SCHEME="Sentient OS macOS"
+APP_NAME="Sentient OS"
+BUILD_DIR="$REPO_ROOT/build/release"
+GH_REPO="Sentient-OS-Labs/sentient-os"
+NOTARY_PROFILE="${NOTARY_PROFILE:-SentientNotary}"     # xcrun notarytool keychain profile name
+DEVELOPER_ID="${DEVELOPER_ID:-Developer ID Application}" # matched from the keychain by prefix
+KEYCHAIN_ACCOUNT="${KEYCHAIN_ACCOUNT:-ed25519}"        # Sparkle EdDSA Keychain account
+
+# ── Locate Sparkle's CLI tools (generate_keys / sign_update / generate_appcast) ──────────────────
+find_sparkle_bin() {
+  if [[ -n "${SPARKLE_BIN:-}" && -x "$SPARKLE_BIN/sign_update" ]]; then echo "$SPARKLE_BIN"; return; fi
+  # Homebrew cask lays them into the Sparkle.app or a caskroom bin.
+  for c in /Applications/Sparkle.app/Contents/Resources \
+           /opt/homebrew/Caskroom/sparkle/*/bin \
+           /usr/local/Caskroom/sparkle/*/bin; do
+    [[ -x "$c/sign_update" ]] && { echo "$c"; return; }
+  done
+  # Fall back to the resolved SwiftPM artifact in DerivedData.
+  local found
+  found="$(find "$HOME/Library/Developer/Xcode/DerivedData" -type f -name sign_update -path '*Sparkle*' 2>/dev/null | head -1)"
+  [[ -n "$found" ]] && { dirname "$found"; return; }
+  echo ""
+}
+
+# ── Subcommand: one-time key generation ──────────────────────────────────────────────────────────
+if [[ "${1:-}" == "keys" ]]; then
+  BIN="$(find_sparkle_bin)"
+  [[ -z "$BIN" ]] && { echo "❌ Sparkle tools not found. brew install --cask sparkle (or set SPARKLE_BIN)."; exit 1; }
+  echo "→ Generating / reading the EdDSA key (private seed stays in this Mac's Keychain)…"
+  "$BIN/generate_keys" --account "$KEYCHAIN_ACCOUNT"
+  echo ""
+  echo "☝️  Copy the SUPublicEDKey <string> above into $REPO_ROOT/Info.plist (replace the placeholder)."
+  exit 0
+fi
+
+BIN="$(find_sparkle_bin)"
+[[ -z "$BIN" ]] && { echo "❌ Sparkle tools not found. brew install --cask sparkle (or set SPARKLE_BIN)."; exit 1; }
+
+echo "──────────────────────────────────────────────────────────────────"
+echo " Sentient OS release  ·  tools: $BIN"
+echo "──────────────────────────────────────────────────────────────────"
+rm -rf "$BUILD_DIR"; mkdir -p "$BUILD_DIR"
+ARCHIVE="$BUILD_DIR/$APP_NAME.xcarchive"
+EXPORT_DIR="$BUILD_DIR/export"
+
+# ── 1. Archive (Release, Developer ID via Signing.xcconfig) ──────────────────────────────────────
+echo "→ [1/7] Archiving…"
+xcodebuild -project "$PROJECT" -scheme "$SCHEME" -configuration Release \
+  -archivePath "$ARCHIVE" archive | xcbeautify 2>/dev/null || \
+xcodebuild -project "$PROJECT" -scheme "$SCHEME" -configuration Release \
+  -archivePath "$ARCHIVE" archive
+
+# ── 2. Export a Developer-ID-signed .app ─────────────────────────────────────────────────────────
+echo "→ [2/7] Exporting (Developer ID)…"
+cat > "$BUILD_DIR/ExportOptions.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>method</key><string>developer-id</string>
+  <key>signingStyle</key><string>automatic</string>
+</dict></plist>
+PLIST
+xcodebuild -exportArchive -archivePath "$ARCHIVE" \
+  -exportOptionsPlist "$BUILD_DIR/ExportOptions.plist" -exportPath "$EXPORT_DIR"
+
+APP="$EXPORT_DIR/$APP_NAME.app"
+[[ -d "$APP" ]] || { echo "❌ Export produced no .app at $APP"; exit 1; }
+
+# Version from the built app (source of truth = what actually shipped).
+SHORT="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$APP/Contents/Info.plist")"
+BUILD="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$APP/Contents/Info.plist")"
+TAG="$SHORT"
+DMG="$BUILD_DIR/SentientOS-$SHORT.dmg"      # no spaces in the asset name (appcast URL encoding)
+echo "   version $SHORT ($BUILD) → tag $TAG"
+
+# ── 3. Build a DMG (Applications drag-target) ────────────────────────────────────────────────────
+echo "→ [3/7] Building DMG…"
+STAGE="$BUILD_DIR/dmg"; rm -rf "$STAGE"; mkdir -p "$STAGE"
+cp -R "$APP" "$STAGE/"
+ln -s /Applications "$STAGE/Applications"
+hdiutil create -volname "$APP_NAME" -srcfolder "$STAGE" -ov -format UDZO "$DMG"
+
+# ── 4. Notarize + 5. Staple ──────────────────────────────────────────────────────────────────────
+echo "→ [4/7] Notarizing (this waits on Apple)…"
+xcrun notarytool submit "$DMG" --keychain-profile "$NOTARY_PROFILE" --wait
+echo "→ [5/7] Stapling…"
+xcrun stapler staple "$DMG"
+xcrun stapler validate "$DMG"
+
+# ── 6. EdDSA-sign the DMG for Sparkle + generate the appcast ─────────────────────────────────────
+echo "→ [6/7] Signing (EdDSA) + generating appcast…"
+"$BIN/sign_update" "$DMG" --account "$KEYCHAIN_ACCOUNT"    # prints edSignature (also folded into appcast)
+FEED_PREFIX="https://github.com/$GH_REPO/releases/download/$TAG/"
+"$BIN/generate_appcast" "$BUILD_DIR" \
+  --account "$KEYCHAIN_ACCOUNT" \
+  --download-url-prefix "$FEED_PREFIX" \
+  -o "$BUILD_DIR/appcast.xml"
+echo "   appcast → $BUILD_DIR/appcast.xml"
+
+# ── 7. GitHub Release (uploads the DMG the appcast points at) ────────────────────────────────────
+echo "→ [7/7] Creating GitHub release $TAG…"
+gh release create "$TAG" "$DMG" \
+  --repo "$GH_REPO" --title "$APP_NAME $SHORT" \
+  --notes "Sentient OS $SHORT ($BUILD)" || \
+  echo "   (release may already exist — upload manually with: gh release upload $TAG \"$DMG\")"
+
+echo "──────────────────────────────────────────────────────────────────"
+echo " ✅ Built, notarized, signed, and released $APP_NAME $SHORT."
+echo ""
+echo " NEXT (manual, load-bearing): publish the appcast so installed apps see the update —"
+echo "   copy  $BUILD_DIR/appcast.xml"
+echo "   to    https://sentient-os.ai/appcast.xml   (the SUFeedURL every build polls)."
+echo "──────────────────────────────────────────────────────────────────"

--- a/Sentient OS macOS.xcodeproj/project.pbxproj
+++ b/Sentient OS macOS.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5A5A9A0001000000000000A1 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 5A5A9A0001000000000000A2 /* Sparkle */; };
 		5A7E1D0002000000000000B1 /* TelemetryDeck in Frameworks */ = {isa = PBXBuildFile; productRef = 5A7E1D0002000000000000B2 /* TelemetryDeck */; };
 		5A7E1D0003000000000000C2 /* jesai.Sentient-OS-macOS.WakeHelper.plist in Copy wake-helper daemon plist */ = {isa = PBXBuildFile; fileRef = 5A7E1D0003000000000000C3 /* jesai.Sentient-OS-macOS.WakeHelper.plist */; };
 		5AB7600E2FD12ABE00149A7F /* LiteRTLM in Frameworks */ = {isa = PBXBuildFile; productRef = 5AB7600D2FD12ABE00149A7F /* LiteRTLM */; };
@@ -49,6 +50,7 @@
 				5AB7600E2FD12ABE00149A7F /* LiteRTLM in Frameworks */,
 				5AE5710001000000000000A1 /* Sentry in Frameworks */,
 				5A7E1D0002000000000000B1 /* TelemetryDeck in Frameworks */,
+				5A5A9A0001000000000000A1 /* Sparkle in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -99,6 +101,7 @@
 				5AB7600D2FD12ABE00149A7F /* LiteRTLM */,
 				5AE5710001000000000000A2 /* Sentry */,
 				5A7E1D0002000000000000B2 /* TelemetryDeck */,
+				5A5A9A0001000000000000A2 /* Sparkle */,
 			);
 			productName = "Sentient OS macOS";
 			productReference = 5A3F39112FD0F43300DD835E /* Sentient OS.app */;
@@ -132,6 +135,7 @@
 				5AB7600C2FD12ABE00149A7F /* XCLocalSwiftPackageReference "Vendor/LiteRTLM" */,
 				5AE5710001000000000000A3 /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 				5A7E1D0002000000000000B3 /* XCRemoteSwiftPackageReference "SwiftSDK" */,
+				5A5A9A0001000000000000A3 /* XCRemoteSwiftPackageReference "Sparkle" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 5A3F39122FD0F43300DD835E /* Products */;
@@ -342,6 +346,7 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_NSAppleEventsUsageDescription = "Sentient OS uses Automation so the computer-use agent you ask it to run can control apps on your Mac on your behalf.";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Sentient OS listens when you hold the right Command key, so you can speak the task you want done.";
@@ -379,6 +384,7 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_NSAppleEventsUsageDescription = "Sentient OS uses Automation so the computer-use agent you ask it to run can control apps on your Mac on your behalf.";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Sentient OS listens when you hold the right Command key, so you can speak the task you want done.";
@@ -432,6 +438,14 @@
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		5A5A9A0001000000000000A3 /* XCRemoteSwiftPackageReference "Sparkle" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sparkle-project/Sparkle";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.9.4;
+			};
+		};
 		5A7E1D0002000000000000B3 /* XCRemoteSwiftPackageReference "SwiftSDK" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/TelemetryDeck/SwiftSDK";
@@ -451,6 +465,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		5A5A9A0001000000000000A2 /* Sparkle */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5A5A9A0001000000000000A3 /* XCRemoteSwiftPackageReference "Sparkle" */;
+			productName = Sparkle;
+		};
 		5A7E1D0002000000000000B2 /* TelemetryDeck */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 5A7E1D0002000000000000B3 /* XCRemoteSwiftPackageReference "SwiftSDK" */;

--- a/Sentient OS macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Sentient OS macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4ac99ceb903042464de50c405eb71c251615a33de9f1e041797ec6724977b39a",
+  "originHash" : "bd1f57a9acf3addf86152ee3f7b2fdb95cdbe330d09a07a861e46c91ae68cc06",
   "pins" : [
     {
       "identity" : "sentry-cocoa",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "dad229c665bfd043c5d80ac7aa77717cbd19a1c3",
         "version" : "8.58.3"
+      }
+    },
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
+        "version" : "2.9.4"
       }
     },
     {

--- a/Sentient OS macOS/App/AppState.swift
+++ b/Sentient OS macOS/App/AppState.swift
@@ -34,6 +34,10 @@ final class AppState {
     /// The notch overlay window — renders the coordinator's status phase as the living notch.
     private let notch: NotchWindowController
 
+    /// The Sparkle auto-updater + our OLED forced-update UI. Only ever built in the GUI app (this
+    /// whole object is), never the root wake-helper. Its `model` drives UpdateGateView. (Updates/)
+    let update = UpdateController()
+
     private static let onboardingKey = "hasCompletedOnboarding"
     var hasCompletedOnboarding: Bool {
         didSet {
@@ -49,5 +53,6 @@ final class AppState {
         scheduler.maybeAutoEnable()   // 18h after initial: flip the overnight scheduler on (or arm the timer)
         commandCoordinator.start()   // arm right-⌘ hold-to-talk + warm the speech model
         notch.start()                // raise the notch overlay window
+        update.start()               // start Sparkle + one silent launch check (gates a mandatory update)
     }
 }

--- a/Sentient OS macOS/Documentation/Auto-Update (Sparkle).md
+++ b/Sentient OS macOS/Documentation/Auto-Update (Sparkle).md
@@ -1,0 +1,139 @@
+# Auto-Update (Sparkle)
+
+How Sentient OS keeps itself current: [Sparkle 2](https://sparkle-project.org) delivers signed,
+notarized updates. Sentient **auto-updates silently** in the normal case, and falls back to its **own
+OLED forced-update UI** (no skip, no "remind me later") when a silent install can't happen.
+
+> **Status:** ✅ verified end-to-end on real hardware (2026-07-05). Both paths were exercised with a
+> real local appcast + a real EdDSA-signed update: (1) **silent auto-update** — an installed build 1
+> self-updated to build 2 with zero interaction ("EdDSA signature is correct", installed on quit); and
+> (2) the **fallback gate** — with silent install off, the OLED gate appeared, and "Update Now"
+> downloaded → installed → relaunched to the new version. See "Testing" for the harness. Still pending:
+> a real notarized-DMG release via `release.sh` (needs the paid team + notary creds).
+
+---
+
+## The shape
+
+- **Framework:** Sparkle 2.9.4, added via SwiftPM (remote package, "Embed & Sign"). Runtime min is
+  macOS 12 — under our 15.0 floor, no conflict. Because the app is **non-sandboxed**, Sparkle's XPC
+  services (`Installer.xpc` / `Downloader.xpc`) ship inside the framework but are **never used** —
+  we must NOT set `SUEnableInstallerLauncherService` / `SUEnableDownloaderService`.
+- **Security:** every update is verified twice — an **EdDSA (Ed25519)** signature (our key) AND
+  Apple's Developer-ID code signature. Sparkle enforces that an update carries the **same Team ID**
+  as the installed app, so all releases must be signed with the paid team (`YJ8AZR3G5Q`, Jesai's).
+- **Privacy:** no system profile is ever sent (`SUEnableSystemProfiling`/`SUSendProfileInfo` = NO),
+  no JavaScript in release notes. The only network call is the appcast GET (IP + User-Agent) over
+  HTTPS — no account, consistent with the Privacy Constitution.
+
+## Code — `Updates/`
+
+| File | Job |
+|---|---|
+| `UpdateController.swift` | Owns the `SPUUpdater` (targets the main bundle), the driver, and the model. `AppState` holds one and calls `start()` on launch — **GUI path only**, never the root wake-helper. Exposes `checkForUpdatesNow()` + version/last-checked for the menu and Settings. Also the (logging-only) `SPUUpdaterDelegate`. |
+| `SentientUpdateDriver.swift` | Our custom `SPUUserDriver`. Translates Sparkle's callbacks into `UpdateModel` state and stashes the reply closures. **Mandatory:** `showUpdateFound…` only ever replies `.install`; `showReady(toInstallAndRelaunch:)` auto-installs. ⚠️ The method labels must match Sparkle's imported Swift signatures exactly (Swift matches these witnesses by signature, not `@objc` selector). |
+| `UpdateModel.swift` | `@Observable` bridge between the driver and the UI. A `Phase` state machine (idle → checking → found → downloading → extracting → installing / failed) and a `Surface` (`none` / `gate` / `info`). The UI reads `phase`/`surface`; `installNow()`/`dismissInfo()`/`quit()` fire the stashed closures back. |
+| `UpdateGateView.swift` | The OLED UI. Two faces: the full-screen **gate** (mandatory — Update / Quit, no skip/remind) and a small dismissible **info card** (user-initiated "Checking…" / "You're up to date" / "Couldn't check"). Reuses `Theme`, `GlowButton`, `SpinningLogo`. Presented as an overlay by `RootView`; draws nothing at rest. |
+
+**Wiring:** `App/AppState.swift` (owns + `start()`s) · `Views/RootView.swift` (`.overlay { UpdateGateView() }`)
+· `Views/MenuBarView.swift` ("Check for Updates…") · `Views/Settings/SystemPane.swift` (Updates group).
+
+## The update model — auto-update, gate as fallback
+
+- **Normal case → silent, zero taps.** With `SUAutomaticallyUpdate`/`SUAllowsAutomaticUpdates` on,
+  Sparkle silently downloads new versions and installs them on quit/relaunch (a running bundle can't
+  be swapped underneath the user). The gate never appears.
+- **Fallback → the gate.** Our custom forced-update UI only shows when a silent install *can't*
+  happen: macOS needs an **admin password** (app in a non-user-writable dir like `/Applications`), an
+  install error, or the **impatient window** (`SUScheduledImpatientCheckInterval`, 2 days) elapses
+  without the app being quit — important because Sentient lives in the menu bar and may run for days,
+  so "install on quit" alone could otherwise stall. When it shows, it's **mandatory**: Update / Quit,
+  no skip, no remind.
+- **Fail-open.** If the feed is unreachable (offline, server down), Sparkle never surfaces anything —
+  nobody is locked out of their own local AI.
+- **Info card** shows only for *user-initiated* checks (menu / Settings): "Checking…" / "You're up to
+  date" / "Couldn't check". A silent background check that finds nothing shows nothing.
+
+Same custom `SPUUserDriver` drives both: whenever Sparkle needs UI, it's our gate — never Sparkle's
+stock windows, and never a skip/remind button.
+
+⚠️ **Known limitation:** the gate overlays the **main window**. If the user has a secondary window
+(Settings/Knowledge) focused, they could keep using it during a found-update gate. Bringing the app
+forward (`NSApplication.activate`) mitigates it. A true all-window blocker (a floating panel like the
+notch) is a possible future hardening.
+
+## Config — `Info.plist`
+
+The app uses `GENERATE_INFOPLIST_FILE=YES`, so the Sparkle keys live in a **partial** `Info.plist`
+(repo root, next to the `.xcodeproj`) referenced by `INFOPLIST_FILE`; Xcode merges the generated keys
+on top. Keys: `SUFeedURL` (`https://sentient-os.ai/appcast.xml`), `SUPublicEDKey`, `SUEnableAutomaticChecks`,
+`SUScheduledCheckInterval` (86400), `SUAllowsAutomaticUpdates`/`SUAutomaticallyUpdate` = YES (silent
+auto-install; the gate is the fallback), `SUScheduledImpatientCheckInterval` (172800 = 2 days, the
+menu-bar-app fallback trigger), and the privacy-off trio.
+
+## Versioning
+
+Sparkle compares `CFBundleVersion` (= `CURRENT_PROJECT_VERSION`). **Every release must bump it** (a
+monotonically increasing build number); bump `MARKETING_VERSION` for the human-facing version. The
+appcast's `sparkle:version` must exceed the installed build for an update to be offered.
+
+## Releasing — `Scripts/release.sh`
+
+One command does: archive → export (Developer ID) → DMG → notarize → staple → EdDSA-sign →
+`generate_appcast` → GitHub Release. Run it on **Jesai's Mac** (paid team + notary creds). Then
+publish the emitted `appcast.xml` to `https://sentient-os.ai/appcast.xml`. DMGs are uploaded as
+GitHub Release assets; the appcast's enclosure URLs point at them via `--download-url-prefix`.
+
+## Before first release (one-time, load-bearing)
+
+1. **EdDSA key:** `Scripts/release.sh keys` → paste the printed `SUPublicEDKey` into `Info.plist`
+   (replacing the `AAAA…=` placeholder) and commit. The private seed stays in the Mac's Keychain,
+   **never** the repo. ⚠️ The very first public build MUST already carry the real key — an update can
+   only be verified by a build that shipped with the matching public key.
+2. **Notary profile:** `xcrun notarytool store-credentials "SentientNotary" --apple-id … --team-id YJ8AZR3G5Q --password <app-specific>`.
+3. **Sparkle tools:** `brew install --cask sparkle` (or set `SPARKLE_BIN`).
+4. **Host `appcast.xml`** at the `SUFeedURL` (own domain via Vercel — a permanent URL; every shipped
+   build polls it forever, so it must never move).
+
+## Testing (the harness that proved it — 2026-07-05)
+
+No Developer ID or notarization is needed to test locally: Sparkle validates the **EdDSA signature
+first** and only falls back to a Developer-ID code-signing check if EdDSA *fails*
+(`SUUpdateValidator.validateDownloadPathWithFallbackOnCodeSigning:`). So a locally-signed build with a
+valid EdDSA signature updates for real. The harness:
+
+1. `generate_keys --account <throwaway>` → put the printed `SUPublicEDKey` in `Info.plist`.
+2. Build the app (a **throwaway bundle id** like `com.sentient.updatetest` avoids colliding with your
+   running dev instance) → this is "build 1". Derive "build 2" by copying it, bumping `CFBundleVersion`
+   (+ `CFBundleShortVersionString`) with PlistBuddy, and re-signing (`codesign -f -s <identity>`).
+3. `ditto -c -k --keepParent` build 2 → a zip; `sign_update <zip> --account <throwaway>` → EdDSA sig.
+4. Write a local `appcast.xml` (enclosure `url` = `http://localhost:PORT/…zip`, with that sig + length);
+   serve the folder with `python3 -m http.server PORT`.
+5. Install build 1 to a **user-writable** dir (so the silent path needs no admin password), then
+   `defaults write <bundleid> SUFeedURL http://localhost:PORT/appcast.xml`. (Localhost HTTP is fine —
+   Sparkle warns but allows it, and ATS permits localhost.)
+6. **Silent path:** `SUAutomaticallyUpdate = YES` → launch → it downloads + installs on quit → relaunch
+   is build 2. **Gate path:** `SUAutomaticallyUpdate = NO` → launch → the gate appears → "Update Now"
+   downloads + installs + relaunches. Watch `log stream --predicate 'senderImagePath CONTAINS "Sparkle"'`
+   and the `http.server` access log (appcast-only fetch = gate is waiting; appcast **+** zip = it downloaded).
+
+Clean up after: quit the app, kill the server/log-stream, `security delete-generic-password -s
+"https://sparkle-project.org" -a <throwaway>`, `defaults delete <bundleid>`, remove the temp dirs +
+`~/Library/Caches/<bundleid>`, and restore the `Info.plist` placeholder key.
+
+## Verified so far
+
+- ✅ SPM resolves Sparkle 2.9.4; the app **compiles** clean with the framework, custom driver, gate,
+  and all wiring (`BUILD SUCCEEDED`).
+- ✅ **Silent auto-update** (2026-07-05, real hardware): installed build 1 → build 2 with zero
+  interaction; log showed "OK: EdDSA signature is correct for update"; installed on quit.
+- ✅ **Fallback gate** (2026-07-05): with silent install off, the OLED gate appeared, and "Update Now"
+  downloaded → installed → relaunched to build 2 (confirmed on screen).
+- ⬜ Notarized DMG + `generate_appcast` via `release.sh` — pending a real Developer-ID signing run.
+
+⚠️ **Atomic-swap caveat seen in testing:** in a plain **Debug** build the embedded Sparkle helper
+(`Sparkle.framework/…/Autoupdate`) is **ad-hoc** signed, not the app's team — so Sparkle logs "Skipping
+atomic rename/swap … because Autoupdate is not signed with same identity" and uses a (still-working)
+non-atomic install. A proper **Developer-ID Release** (via `release.sh`, Embed & Sign) re-signs the
+nested helpers with the app's identity, restoring the atomic swap + Gatekeeper pre-scan. Confirm this on
+the first real Release build (check `codesign -dv Autoupdate` matches the app's Team ID).

--- a/Sentient OS macOS/Engine/ModelLocator.swift
+++ b/Sentient OS macOS/Engine/ModelLocator.swift
@@ -34,13 +34,16 @@ enum ModelLocator {
         if fm.fileExists(atPath: appSupport) { return appSupport }
 
         #if DEBUG
-        // This file lives at <repo>/Sentient OS macOS/ModelLocator.swift; the model sits at the
-        // repo root next to the .xcodeproj (per the team onboarding checklist).
-        let repoRoot = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()   // …/<repo>/Sentient OS macOS/
-            .deletingLastPathComponent()   // …/<repo>/
-        let dev = repoRoot.appendingPathComponent(fileName).path
-        if fm.fileExists(atPath: dev) { return dev }
+        // The model sits at the repo root next to the .xcodeproj (team onboarding checklist). Walk
+        // UP from this source file until we find it — robust to wherever this file lives in the
+        // tree, so a future reshuffle (e.g. moving it into Engine/) can't silently break the dev
+        // fallback the way a fixed number of parent hops did.
+        var dir = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        while dir.path != "/" {
+            let candidate = dir.appendingPathComponent(fileName).path
+            if fm.fileExists(atPath: candidate) { return candidate }
+            dir = dir.deletingLastPathComponent()
+        }
         #endif
 
         return nil

--- a/Sentient OS macOS/Updates/SentientUpdateDriver.swift
+++ b/Sentient OS macOS/Updates/SentientUpdateDriver.swift
@@ -1,0 +1,126 @@
+//
+//  SentientUpdateDriver.swift
+//  Sentient OS macOS
+//
+//  Our custom Sparkle user driver — Sentient renders its OWN OLED update UI instead of Sparkle's
+//  stock AppKit windows. Sparkle's internal drivers call these callbacks to say "show checking",
+//  "an update was found", "download progress", etc.; we translate each into UpdateModel state that
+//  UpdateGateView draws, and stash the reply/acknowledge closures for the user's tap.
+//
+//  MANDATORY updates: `showUpdateFound…` only ever replies `.install` (never skip/dismiss), and
+//  `showReady(toInstallAndRelaunch:)` auto-installs — so a found update is one tap to update, with
+//  no way to defer. Nothing here can hard-lock an offline user: with no reachable feed, Sparkle
+//  simply never calls `showUpdateFound…`, so the gate never appears.
+//
+//  The method names/labels below MUST match Sparkle's imported Swift signatures exactly (Swift
+//  matches these protocol witnesses by signature). Doc: Documentation/Auto-Update (Sparkle).md
+//
+
+import Foundation
+import Sparkle
+
+final class SentientUpdateDriver: NSObject, SPUUserDriver {
+    private let model: UpdateModel
+
+    init(model: UpdateModel) {
+        self.model = model
+        super.init()
+    }
+
+    // MARK: Permission (normally unused — SUEnableAutomaticChecks is set in Info.plist)
+
+    func show(_ request: SPUUpdatePermissionRequest,
+              reply: @escaping (SUUpdatePermissionResponse) -> Void) {
+        // Updates are mandatory, so there's nothing to opt out of: accept checks, send no profile.
+        reply(SUUpdatePermissionResponse(automaticUpdateChecks: true, sendSystemProfile: false))
+    }
+
+    // MARK: Checking
+
+    func showUserInitiatedUpdateCheck(cancellation: @escaping () -> Void) {
+        model.beganCheck(cancel: cancellation)
+    }
+
+    func showUpdateFound(with appcastItem: SUAppcastItem,
+                         state: SPUUserUpdateState,
+                         reply: @escaping (SPUUserUpdateChoice) -> Void) {
+        model.foundUpdate(version: appcastItem.displayVersionString, reply: reply)
+    }
+
+    func showUpdateReleaseNotes(with downloadData: SPUDownloadData) {
+        // The gate shows a short "what's new" from the appcast version, not fetched HTML notes.
+    }
+
+    func showUpdateReleaseNotesFailedToDownloadWithError(_ error: any Error) { }
+
+    func showUpdateNotFoundWithError(_ error: any Error, acknowledgement: @escaping () -> Void) {
+        model.notFound(acknowledge: acknowledgement)
+    }
+
+    func showUpdaterError(_ error: any Error, acknowledgement: @escaping () -> Void) {
+        // If we were mid-update, keep the gate (Try Again / Quit). If it's just a check that couldn't
+        // reach the feed, it stays quiet unless the user asked — fail-open, never lock anyone out.
+        model.failed(friendly(error), duringUpdate: model.isMidUpdate, acknowledge: acknowledgement)
+    }
+
+    // MARK: Downloading & extracting
+
+    func showDownloadInitiated(cancellation: @escaping () -> Void) {
+        model.downloadStarted()
+    }
+
+    func showDownloadDidReceiveExpectedContentLength(_ expectedContentLength: UInt64) {
+        model.expected(bytes: expectedContentLength)
+    }
+
+    func showDownloadDidReceiveData(ofLength length: UInt64) {
+        model.received(bytes: length)
+    }
+
+    func showDownloadDidStartExtractingUpdate() {
+        model.extractingStarted()
+    }
+
+    func showExtractionReceivedProgress(_ progress: Double) {
+        model.extracting(progress)
+    }
+
+    // MARK: Installing & relaunching
+
+    func showReady(toInstallAndRelaunch reply: @escaping (SPUUserUpdateChoice) -> Void) {
+        // Mandatory: no second confirmation — install and relaunch immediately.
+        model.installingNow()
+        reply(.install)
+    }
+
+    func showInstallingUpdate(withApplicationTerminated applicationTerminated: Bool,
+                              retryTerminatingApplication: @escaping () -> Void) {
+        model.installingNow()
+    }
+
+    func showUpdateInstalledAndRelaunched(_ relaunched: Bool, acknowledgement: @escaping () -> Void) {
+        // The old bundle is gone; just acknowledge so Sparkle finishes.
+        acknowledgement()
+    }
+
+    func dismissUpdateInstallation() {
+        model.reset()
+    }
+
+    // MARK: Optional
+
+    func showUpdateInFocus() {
+        // Our gate window already floats above everything; nothing to bring forward.
+    }
+
+    // MARK: - Helpers
+
+    /// A short, human message from a Sparkle NSError (its recovery suggestion if present).
+    private func friendly(_ error: any Error) -> String {
+        let nsError = error as NSError
+        if let recovery = nsError.localizedRecoverySuggestion, !recovery.isEmpty {
+            return recovery
+        }
+        return nsError.localizedDescription
+    }
+}

--- a/Sentient OS macOS/Updates/UpdateController.swift
+++ b/Sentient OS macOS/Updates/UpdateController.swift
@@ -1,0 +1,81 @@
+//
+//  UpdateController.swift
+//  Sentient OS macOS
+//
+//  Owns the Sparkle updater and wires it to our own UI. Creates one SPUUpdater targeting the app's
+//  main bundle, driven by SentientUpdateDriver (our OLED gate) with this object as the (optional)
+//  delegate for logging. AppState holds one of these and calls `start()` — GUI path only (never the
+//  root wake-helper). The menu bar and Settings call `checkForUpdatesNow()`.
+//
+//  Config (feed URL, EdDSA key, daily interval, mandatory model) lives in Info.plist — see
+//  Documentation/Auto-Update (Sparkle).md. This file is just the runtime glue.
+//
+
+import Foundation
+import Sparkle
+
+@MainActor
+final class UpdateController: NSObject, SPUUpdaterDelegate {
+
+    /// The observable state our OLED update UI (UpdateGateView) reads and drives.
+    let model = UpdateModel()
+
+    private let driver: SentientUpdateDriver
+    private var updater: SPUUpdater!
+
+    override init() {
+        let model = self.model
+        driver = SentientUpdateDriver(model: model)
+        super.init()
+        updater = SPUUpdater(hostBundle: .main,
+                             applicationBundle: .main,
+                             userDriver: driver,
+                             delegate: self)
+    }
+
+    /// Start scheduling checks, and immediately do one silent background check so a mandatory update
+    /// gates at launch. With no reachable feed this is a no-op (fail-open — nobody gets locked out).
+    func start() {
+        do {
+            try updater.start()
+            if updater.automaticallyChecksForUpdates {
+                updater.checkForUpdatesInBackground()
+            }
+        } catch {
+            Log("Sparkle: updater failed to start — \(error.localizedDescription)")
+        }
+    }
+
+    /// A user-asked check (menu bar / Settings). Shows the small info card for "checking" and
+    /// "you're up to date"; escalates to the full gate if a real update is found.
+    func checkForUpdatesNow() {
+        guard updater.canCheckForUpdates else { return }
+        model.userInitiated = true
+        updater.checkForUpdates()
+    }
+
+    // MARK: - Read-only surface for Settings
+
+    var canCheckForUpdates: Bool { updater.canCheckForUpdates }
+    var lastCheckDate: Date? { updater.lastUpdateCheckDate }
+
+    /// The installed version, formatted for display, e.g. "1.2.0 (42)".
+    static var currentVersionString: String {
+        let info = Bundle.main.infoDictionary
+        let short = info?["CFBundleShortVersionString"] as? String ?? "?"
+        let build = info?["CFBundleVersion"] as? String
+        if let build, build != short { return "\(short) (\(build))" }
+        return short
+    }
+
+    // MARK: - SPUUpdaterDelegate (optional — logging only)
+
+    @objc(updater:didFinishUpdateCycleForUpdateCheck:error:)
+    func updater(_ updater: SPUUpdater,
+                 didFinishUpdateCycleFor updateCheck: SPUUpdateCheck,
+                 error: Error?) {
+        if let error {
+            Log("Sparkle: update cycle finished with error — \((error as NSError).localizedDescription)")
+        }
+    }
+}

--- a/Sentient OS macOS/Updates/UpdateGateView.swift
+++ b/Sentient OS macOS/Updates/UpdateGateView.swift
@@ -1,0 +1,305 @@
+//
+//  UpdateGateView.swift
+//  Sentient OS macOS
+//
+//  The OLED forced-update surface. Two faces, chosen by UpdateModel.surface:
+//   • gate — a full-screen, non-dismissible takeover when a mandatory update is found or installing.
+//     One action: Update. (Plus Quit, so a modal never traps the user.) No "skip" / "remind me".
+//   • info — a small dismissible card for a user-initiated check: "Checking…", "You're up to date",
+//     or "Couldn't check". Never shown for a silent background check.
+//  Rendered as an overlay by RootView; draws nothing when surface == .none.
+//
+//  Design bar: true-black, editorial serif titles, mono-caps whispers, the spinning AI-spectrum
+//  logo as the living mark, the glow CTA. Reuses Theme / GlowButton / SpinningLogo.
+//
+
+import SwiftUI
+import AppKit
+
+struct UpdateGateView: View {
+    @Environment(AppState.self) private var appState
+    private var model: UpdateModel { appState.update.model }
+
+    var body: some View {
+        ZStack {
+            switch model.surface {
+            case .none:
+                Color.clear.allowsHitTesting(false)
+            case .gate:
+                gate.transition(.opacity)
+            case .info:
+                infoCard.transition(.opacity)
+            }
+        }
+        .animation(.easeInOut(duration: 0.3), value: model.surface)
+        .animation(.easeInOut(duration: 0.35), value: model.phase)
+        .onChange(of: model.surface) { _, surface in
+            // A gate or info surface just appeared — bring Sentient forward so it's seen even if it
+            // was in the background or the user triggered the check from the Settings window.
+            if surface != .none { NSApplication.shared.activate(ignoringOtherApps: true) }
+        }
+    }
+
+    // MARK: - The mandatory full-screen gate
+
+    private var gate: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                Spacer()
+
+                SpinningLogo(size: 66, fast: isWorking)
+                    .padding(.bottom, 30)
+
+                MonoCaps("Software Update", size: 10, tracking: 2.6, color: Theme.Ink.label)
+                    .padding(.bottom, 14)
+
+                Text(gateTitle)
+                    .font(.serif(30)).italic()
+                    .foregroundStyle(Theme.Ink.statusInk)
+                    .multilineTextAlignment(.center)
+
+                Text(gateBody)
+                    .font(.system(size: 13)).foregroundStyle(Theme.Ink.body)
+                    .lineSpacing(3.5)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 400)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.top, 12)
+
+                gateStatus
+                    .padding(.top, 28)
+
+                Spacer()
+
+                footer
+            }
+            .padding(.horizontal, 28)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    /// Progress + actions, per phase.
+    @ViewBuilder private var gateStatus: some View {
+        switch model.phase {
+        case .found(let version):
+            VStack(spacing: 16) {
+                MonoCaps("Required to keep going · v\(version)", size: 9, tracking: 2, color: Theme.Ink.deepMuted)
+                GlowButton(title: "Update Now", systemImage: "arrow.down.circle.fill") {
+                    model.installNow()
+                }
+                .frame(maxWidth: 320)
+                quitButton
+            }
+
+        case .downloading(let fraction):
+            VStack(spacing: 18) {
+                UpdateProgressBar(value: fraction).frame(maxWidth: 340)
+                MonoCaps(downloadLabel(fraction), size: 9, tracking: 2, color: Theme.Ink.label)
+                quitButton
+            }
+
+        case .extracting(let fraction):
+            VStack(spacing: 18) {
+                UpdateProgressBar(value: fraction).frame(maxWidth: 340)
+                MonoCaps("Preparing update", size: 9, tracking: 2, color: Theme.Ink.label)
+                quitButton
+            }
+
+        case .installing:
+            VStack(spacing: 18) {
+                UpdateProgressBar(value: nil).frame(maxWidth: 340)
+                MonoCaps("Installing · Sentient will restart", size: 9, tracking: 2, color: Theme.Ink.label)
+            }
+
+        case .failed(let message, _):
+            VStack(spacing: 16) {
+                Text(message)
+                    .font(.system(size: 12)).foregroundStyle(Theme.Ink.amber)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 360)
+                    .fixedSize(horizontal: false, vertical: true)
+                GlowButton(title: "Try Again", systemImage: "arrow.clockwise") {
+                    model.dismissInfo()                 // acknowledge the error, reset
+                    appState.update.checkForUpdatesNow()
+                }
+                .frame(maxWidth: 320)
+                quitButton
+            }
+
+        default:
+            EmptyView()
+        }
+    }
+
+    // MARK: - The small info card (user-initiated check)
+
+    private var infoCard: some View {
+        ZStack {
+            Color.black.opacity(0.55).ignoresSafeArea()
+                .onTapGesture { if canDismissInfo { model.dismissInfo() } }
+
+            VStack(spacing: 16) {
+                switch model.phase {
+                case .checking:
+                    ProgressView().controlSize(.small).tint(.white.opacity(0.5))
+                    Text("Checking for updates…")
+                        .font(.serif(17)).italic().foregroundStyle(Theme.Ink.statusInk)
+                    Button("Cancel") { model.dismissInfo() }
+                        .buttonStyle(.plain)
+                        .font(.system(size: 11.5)).foregroundStyle(Theme.Ink.label)
+                        .padding(.top, 2)
+
+                case .upToDate:
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 26)).foregroundStyle(Theme.Ink.green)
+                    Text("You're up to date.")
+                        .font(.serif(19)).italic().foregroundStyle(Theme.Ink.statusInk)
+                    Text("Sentient is on version \(UpdateController.currentVersionString).")
+                        .font(.system(size: 12)).foregroundStyle(Theme.Ink.body)
+                    doneButton
+
+                case .failed(let message, _):
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.system(size: 22)).foregroundStyle(Theme.Ink.amber)
+                    Text("Couldn't check for updates.")
+                        .font(.serif(18)).italic().foregroundStyle(Theme.Ink.statusInk)
+                    Text(message)
+                        .font(.system(size: 11.5)).foregroundStyle(Theme.Ink.body)
+                        .multilineTextAlignment(.center).frame(maxWidth: 280)
+                        .fixedSize(horizontal: false, vertical: true)
+                    doneButton
+
+                default:
+                    EmptyView()
+                }
+            }
+            .padding(.horizontal, 34).padding(.vertical, 30)
+            .frame(width: 360)
+            .background(Color(white: 0.05), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+            .overlay(RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .strokeBorder(Theme.stroke, lineWidth: 1))
+            .shadow(color: .black.opacity(0.6), radius: 40, y: 16)
+        }
+    }
+
+    // MARK: - Shared bits
+
+    private var quitButton: some View {
+        Button(action: { model.quit() }) {
+            Text("Quit Sentient")
+                .font(.system(size: 12.5, weight: .medium)).foregroundStyle(.white.opacity(0.7))
+                .padding(.horizontal, 22).padding(.vertical, 9)
+                .background(Capsule().fill(.white.opacity(0.06)))
+                .overlay(Capsule().strokeBorder(.white.opacity(0.14)))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var doneButton: some View {
+        Button(action: { model.dismissInfo() }) {
+            Text("Done")
+                .font(.system(size: 12.5, weight: .semibold)).foregroundStyle(.black)
+                .padding(.horizontal, 26).padding(.vertical, 8)
+                .background(Capsule().fill(.white))
+        }
+        .buttonStyle(PressScaleStyle())
+        .padding(.top, 4)
+    }
+
+    private var footer: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "shield").font(.system(size: 10.5)).foregroundStyle(Theme.Ink.label)
+            Text("Private by design. Your files never leave this Mac.")
+                .font(.system(size: 11.5)).foregroundStyle(Theme.Ink.label)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 13)
+        .overlay(alignment: .top) { Rectangle().fill(.white.opacity(0.05)).frame(height: 1) }
+    }
+
+    // MARK: - Copy & state helpers
+
+    private var isWorking: Bool {
+        switch model.phase {
+        case .downloading, .extracting, .installing: return true
+        default: return false
+        }
+    }
+
+    private var canDismissInfo: Bool {
+        switch model.phase {
+        case .upToDate, .failed: return true
+        default: return false     // don't let a tap dismiss the "checking…" spinner
+        }
+    }
+
+    private var gateTitle: String {
+        switch model.phase {
+        case .found:        return "A new Sentient is ready."
+        case .downloading:  return "Updating Sentient…"
+        case .extracting:   return "Almost there…"
+        case .installing:   return "Installing…"
+        case .failed:       return "Update didn't finish."
+        default:            return ""
+        }
+    }
+
+    private var gateBody: String {
+        switch model.phase {
+        case .found:
+            return "To keep doing things for you safely, Sentient always runs the latest version. This one's quick — one tap and you're set."
+        case .downloading, .extracting:
+            return "Hang tight while Sentient updates itself."
+        case .installing:
+            return "Sentient is installing the update and will reopen in a moment."
+        case .failed:
+            return "Something interrupted the update. Let's try that again."
+        default:
+            return ""
+        }
+    }
+
+    private func downloadLabel(_ fraction: Double?) -> String {
+        guard let fraction else { return "Downloading update" }
+        return "Downloading · \(Int(fraction * 100))%"
+    }
+}
+
+/// A slim OLED progress bar in the AI spectrum. `value` nil = indeterminate (a segment sliding on a
+/// loop); otherwise a determinate gradient fill with a soft tip glow.
+private struct UpdateProgressBar: View {
+    var value: Double?
+
+    var body: some View {
+        GeometryReader { geo in
+            let w = geo.size.width
+            ZStack(alignment: .leading) {
+                Capsule().fill(.white.opacity(0.08))
+
+                if let value {
+                    Capsule()
+                        .fill(LinearGradient(colors: GlowHalo.stops, startPoint: .leading, endPoint: .trailing))
+                        .frame(width: max(6, w * max(0, min(1, value))))
+                        .shadow(color: Color(red: 0.61, green: 0.28, blue: 0.83).opacity(0.6), radius: 8)
+                        .animation(.easeInOut(duration: 0.25), value: value)
+                } else {
+                    TimelineView(.animation(minimumInterval: 1.0 / 60.0)) { ctx in
+                        let seg = w * 0.34
+                        let period = 1.25
+                        let t = ctx.date.timeIntervalSinceReferenceDate.truncatingRemainder(dividingBy: period) / period
+                        let x = (w + seg) * t - seg
+                        Capsule()
+                            .fill(LinearGradient(colors: GlowHalo.stops, startPoint: .leading, endPoint: .trailing))
+                            .frame(width: seg)
+                            .offset(x: x)
+                            .shadow(color: Color(red: 0.61, green: 0.28, blue: 0.83).opacity(0.5), radius: 8)
+                    }
+                    .mask(Capsule())
+                }
+            }
+        }
+        .frame(height: 8)
+    }
+}

--- a/Sentient OS macOS/Updates/UpdateModel.swift
+++ b/Sentient OS macOS/Updates/UpdateModel.swift
@@ -1,0 +1,154 @@
+//
+//  UpdateModel.swift
+//  Sentient OS macOS
+//
+//  The observable bridge between Sparkle's update flow and our OLED forced-update UI. Sparkle's
+//  custom user driver (SentientUpdateDriver) pushes state in through the `began…/found…/…` methods
+//  and stashes its reply/acknowledge closures here; the SwiftUI gate (UpdateGateView) reads `phase`
+//  and calls `installNow()/dismissInfo()/quit()` to fire those closures back. One live update flow
+//  at a time. Owned by UpdateController. Doc: Documentation/Auto-Update (Sparkle).md
+//
+
+import SwiftUI
+import AppKit
+import Sparkle
+
+@MainActor
+@Observable
+final class UpdateModel {
+
+    /// Where the update flow is right now — drives the whole UI.
+    enum Phase: Equatable {
+        case idle
+        case checking                         // user asked; waiting on the feed
+        case upToDate                         // user asked; nothing newer
+        case found(version: String)           // a mandatory update is available — the gate
+        case downloading(fraction: Double?)   // nil = indeterminate (no content-length yet)
+        case extracting(fraction: Double)
+        case installing
+        case failed(message: String, duringUpdate: Bool)
+    }
+
+    /// Which surface to present over the app, if any.
+    enum Surface: Equatable { case none, gate, info }
+
+    private(set) var phase: Phase = .idle
+
+    /// Was the in-flight check user-triggered? Governs whether "checking"/"up to date"/"check
+    /// failed" surface a small info card (yes) or stay silent (a background check finding nothing).
+    var userInitiated = false
+
+    // Download byte accounting (feeds the determinate progress bar).
+    private var expectedBytes: UInt64 = 0
+    private var receivedBytes: UInt64 = 0
+
+    // Sparkle callbacks we stash to fire on a user action.
+    private var reply: ((SPUUserUpdateChoice) -> Void)?
+    private var acknowledge: (() -> Void)?
+    private var cancelCheck: (() -> Void)?
+
+    /// True once an update has actually been offered/started (found → installing) — used to decide
+    /// whether a Sparkle error is a gate-blocking update failure or just a quiet check failure.
+    var isMidUpdate: Bool {
+        switch phase {
+        case .found, .downloading, .extracting, .installing: return true
+        default: return false
+        }
+    }
+
+    /// The full-screen mandatory gate, a small dismissible info card, or nothing. A failure DURING
+    /// an update keeps the gate (the app still can't be trusted on the old version); a failed plain
+    /// check only shows the info card, and only when the user asked.
+    var surface: Surface {
+        switch phase {
+        case .idle:
+            return .none
+        case .found, .downloading, .extracting, .installing:
+            return .gate
+        case .failed(_, let duringUpdate):
+            return duringUpdate ? .gate : (userInitiated ? .info : .none)
+        case .checking, .upToDate:
+            return userInitiated ? .info : .none
+        }
+    }
+
+    // MARK: - Driver → model (called by SentientUpdateDriver on the main thread)
+
+    func beganCheck(cancel: @escaping () -> Void) {
+        cancelCheck = cancel
+        phase = .checking
+    }
+
+    func foundUpdate(version: String, reply: @escaping (SPUUserUpdateChoice) -> Void) {
+        clearClosures()
+        self.reply = reply
+        phase = .found(version: version)
+    }
+
+    func notFound(acknowledge: @escaping () -> Void) {
+        clearClosures()
+        self.acknowledge = acknowledge
+        phase = .upToDate
+    }
+
+    func failed(_ message: String, duringUpdate: Bool, acknowledge: (() -> Void)?) {
+        clearClosures()
+        self.acknowledge = acknowledge
+        phase = .failed(message: message, duringUpdate: duringUpdate)
+    }
+
+    func downloadStarted() {
+        expectedBytes = 0
+        receivedBytes = 0
+        phase = .downloading(fraction: nil)
+    }
+
+    func expected(bytes: UInt64) {
+        expectedBytes = bytes
+        receivedBytes = 0
+    }
+
+    func received(bytes: UInt64) {
+        receivedBytes &+= bytes
+        if expectedBytes > 0 {
+            phase = .downloading(fraction: min(1.0, Double(receivedBytes) / Double(expectedBytes)))
+        }
+    }
+
+    func extractingStarted() { phase = .extracting(fraction: 0) }
+    func extracting(_ fraction: Double) { phase = .extracting(fraction: max(0, min(1, fraction))) }
+    func installingNow() { phase = .installing }
+
+    /// Sparkle tore the flow down (aborted or finished). Back to a blank slate.
+    func reset() {
+        clearClosures()
+        phase = .idle
+    }
+
+    // MARK: - UI → model (called by UpdateGateView)
+
+    /// The one mandatory action: begin (or resume) the install. Optimistically flips to the
+    /// downloading state so the tap feels instant; Sparkle then drives the real progress.
+    func installNow() {
+        guard let reply else { return }
+        self.reply = nil
+        phase = .downloading(fraction: nil)
+        reply(.install)
+    }
+
+    /// Dismiss the small info card (up-to-date / a plain check failure / cancel an in-flight check).
+    func dismissInfo() {
+        acknowledge?()
+        cancelCheck?()
+        clearClosures()
+        phase = .idle
+    }
+
+    func quit() { NSApplication.shared.terminate(nil) }
+
+    private func clearClosures() {
+        reply = nil
+        acknowledge = nil
+        cancelCheck = nil
+    }
+}

--- a/Sentient OS macOS/Views/MenuBarView.swift
+++ b/Sentient OS macOS/Views/MenuBarView.swift
@@ -21,6 +21,10 @@ struct MenuBarView: View {
         }
 
         Divider()
+        Button("Check for Updates…") { appState.update.checkForUpdatesNow() }
+        Text("Version \(UpdateController.currentVersionString)")
+
+        Divider()
         Button("Quit Sentient OS") { NSApplication.shared.terminate(nil) }
     }
 }

--- a/Sentient OS macOS/Views/RootView.swift
+++ b/Sentient OS macOS/Views/RootView.swift
@@ -57,6 +57,9 @@ struct RootView: View {
             }
         }
         .frame(minWidth: 1040, minHeight: 800)
+        // The mandatory update gate floats above everything (home, processing, dev sheet) — when a
+        // required update is found it takes over; otherwise it draws nothing. (Updates/)
+        .overlay { UpdateGateView() }
         .sheet(isPresented: $showDevTools) {
             DevToolsView()
         }

--- a/Sentient OS macOS/Views/Settings/SystemPane.swift
+++ b/Sentient OS macOS/Views/Settings/SystemPane.swift
@@ -13,6 +13,8 @@
 import SwiftUI
 
 struct SystemPane: View {
+    @Environment(AppState.self) private var appState   // for the updater (Check Now / version)
+
     /// Crash reports (Sentry) — the original `diagnosticsEnabled` key, kept so existing installs
     /// carry their choice over. Analytics has its own key since the two toggles split.
     @AppStorage("diagnosticsEnabled") private var crashReportsEnabled = true
@@ -30,6 +32,7 @@ struct SystemPane: View {
             VStack(alignment: .leading, spacing: 34) {
                 overnightGroup
                 startupGroup
+                updatesGroup
                 privacyGroup
                 dangerGroup
             }
@@ -79,6 +82,27 @@ struct SystemPane: View {
             }
         } message: {
             Text("To stay helpful, your Sentient runs its on-device intelligence every night at 3 AM, and that can only happen if Sentient is already running. It's heavily optimized and stays out of your RAM and CPU the rest of the time.\n\nWe recommend leaving this on to keep your Sentient alive.")
+        }
+    }
+
+    // MARK: - Updates (Sparkle — the story is "we keep you current", not a dial)
+
+    private var updatesGroup: some View {
+        SettingsGroup(label: "Updates") {
+            VStack(alignment: .leading, spacing: 10) {
+                SettingsProse("Sentient keeps itself up to date automatically. When a new version is ready, Sentient asks you to update before continuing — so you're always on the latest, safest version.")
+                HStack(spacing: 6) {
+                    Text("Version \(UpdateController.currentVersionString)")
+                        .font(.system(size: 12.5, weight: .medium)).foregroundStyle(.white)
+                    if let last = appState.update.lastCheckDate {
+                        Text("· checked \(last.formatted(date: .abbreviated, time: .shortened))")
+                            .font(.system(size: 11)).foregroundStyle(Theme.Ink.body)
+                    }
+                }
+                SettingsPillButton(title: "Check for Updates Now") {
+                    appState.update.checkForUpdatesNow()
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Sparkle auto-update
Adds **Sparkle 2.9.4** (SPM) with a **custom `SPUUserDriver` + our own OLED forced-update UI**.

- **Normal case:** silent auto-update (installs on quit/relaunch), zero taps.
- **Fallback:** a **mandatory gate** (Update / Quit — **no skip, no "remind me later"**) when a silent install can't happen (admin needed, error, or the impatient window elapses — matters since Sentient lives in the menu bar).
- **Fail-open** offline; nobody gets locked out.

New `Updates/`: `UpdateController` (AppState-owned, GUI path only), `SentientUpdateDriver`, `UpdateModel`, `UpdateGateView`. Config in a partial `Info.plist` merged over the generated one. Wired into `RootView`, the menu bar, and Settings → System. Plus `Scripts/release.sh` (archive → notarize → DMG → sign → appcast → GitHub Release) and `Documentation/Auto-Update (Sparkle).md`.

**Verified end-to-end on hardware:** silent update (build 1→2) *and* the gate fallback both work (real local appcast + EdDSA-signed update). `SUPublicEDKey` is a placeholder until the first real release; hosting `appcast.xml` at `sentient-os.ai` + a first `release.sh` run are the remaining one-time steps (documented).

## ModelLocator fix (separate commit)
The 'group by job' refactor moved `ModelLocator.swift` into `Engine/` (one folder deeper), but its `#filePath` walk still climbed only two levels → it stopped finding the model on **every dev build**. Replaced the fixed hop count with an upward search, robust to future moves.