### PR TITLE
Constellation View: the Knowledge window's night-sky graph (new default face)

### DIFF
--- a/Sentient OS macOS/Documentation/Knowledge Viewer.md
+++ b/Sentient OS macOS/Documentation/Knowledge Viewer.md
@@ -1,50 +1,93 @@
-# Knowledge Viewer (reader · editor · manager)
+# Knowledge Viewer (Constellation View · reader · editor · manager)
 
-The **Knowledge** window — what the home's "Knowledge" nav item opens. A minimal Obsidian-style
-surface over the real on-disk vault (`~/Sentient OS - Knowledge Base/`, resolved via
-`VaultGenerator.vaultRoot`). It replaced the old `DatabaseView` (a dev CycleStore-summaries
-inspector; that job still lives in Dev Tools via `Views/Dev/SummariesView.swift`).
+The **Knowledge** window — what the home's "Knowledge" nav item opens. Two faces over the real
+on-disk vault (`~/Sentient OS - Knowledge Base/`, resolved via `VaultGenerator.vaultRoot`):
+
+- **The Constellation View — the window's DEFAULT face.** The knowledge base as a living
+  night-sky graph: every note a star (sized by wikilink degree, twinkling on a stable per-note
+  phase), every resolved `[[wikilink]]` a thread, top-level folders as hue-tinted labeled
+  constellations, and the root README as the sun — the notch's `SpinningLogo`, slow, floating on
+  the pinned center. The assembly entrance (stars glide in from beyond the rim and settle)
+  replays on every window open; within a session the sky keeps its camera and star positions
+  across reader trips.
+- **The reader** — the minimal Obsidian-style split view: folder-tree sidebar + rendered
+  markdown.
+
+Glowing **SkyDoor** capsules swap between them — sky: top-center "Reader View" · reader:
+top-left "Constellation View" · **⌘⇧G** either way · **Esc** leaves the sky. Clicking a star
+opens that note in the reader; **Back** walks the wikilink trail and, when the trip began with a
+star click, one more Back returns to the sky with that star glowing amber for a beat
+(`cameFromSky`). Mode switches funnel through the same unsaved-edits guard as every other
+navigation. *(This window replaced the old `DatabaseView` — that dev job still lives in Dev
+Tools via `Views/Dev/SummariesView.swift`.)*
 
 **Files (`Views/Knowledge/`):**
 - `VaultTree.swift` — data. Scans the vault into a `VaultNode` tree (folders incl. empty ones,
-  `.md` notes; `.obsidian`/dotfiles skipped; README pinned out as "Overview"), builds
-  `titleIndex` (lowercased filename stem → URL — the wikilink resolver, and the edge set a future
-  graph view needs), and `read()` (strips YAML frontmatter, promotes the first `# H1` to title).
+  `.md` notes; dotfiles skipped; README pinned out as "Overview"), builds `titleIndex`
+  (lowercased filename stem → URL — the wikilink resolver AND the graph's edge resolver), and
+  `read()` (strips YAML frontmatter, promotes the first `# H1` to title).
 - `MarkdownView.swift` — rendering. A hand-rolled block renderer for the vault's small verified
-  subset (`#/##/###`, paragraphs, `- ` bullets, `---` rules) — no markdown dependency. Inline text
-  goes through `AttributedString`; `[[wikilinks]]` are pre-split and rendered as accent links over
-  a custom `sentient-wiki:` URL scheme (unresolved → dimmed, inert). `OpenURLAction` routes wiki
-  links to navigation and `http(s)` to the browser.
-- `KnowledgeView.swift` — the window (`windowID = "knowledge"`). Sidebar (header + search + tree)
-  and the reader column; titlebar toolbar = Back (only after a wikilink jump — tree clicks reset
-  the trail) · Edit⟷Save · Move to Trash · Reveal in Finder.
+  subset — no markdown dependency. `[[wikilinks]]` render as accent links over a custom
+  `sentient-wiki:` URL scheme (unresolved → dimmed, inert).
+- `KnowledgeView.swift` — the window (`windowID = "knowledge"`). Owns the mode switch, the
+  reader split view, the editor, create/delete, and the sky↔reader navigation loop.
+- **`Graph/` — the Constellation View** (each file's top comment carries the deep detail):
+  - `SkyGraph.swift` — nodes/edges in one pass over the vault: body `[[wikilinks]]` resolved
+    through `titleIndex` (frontmatter is ignored on purpose), domains = top-level folders
+    biggest-first (stable palette assignment), hover-preview lines, and "changed in the last
+    36h" flags with a bulk-change guard (a full vault rebuild must not shimmer the whole sky).
+    Plus the seeded mock graph the previews render.
+  - `SkySimulation.swift` — the physics: spring threads, pairwise repulsion, per-constellation
+    ring anchors, pinned root, a cooling alpha (the entrance), heavy damping + a
+    terminal-velocity cap (stars glide, never boing). ⚠️ `SkyTuning`'s force constants are a
+    BALANCED SET — scale them together or the settled composition changes.
+  - `NightSkyModel.swift` — the brain: camera (pan / zoom-at-cursor), hit-testing, hover/focus/
+    highlight blends, photon-pulse scheduling, and `load()` — rebuilds match star positions by
+    URL, so re-entering the sky never replays the entrance.
+  - `SkyRenderer.swift` — all Canvas drawing, painter's order: parallax stardust →
+    constellation watermarks → the ~11s center breath → threads (resting ones batch into two
+    stroked paths; the hovered star's ignite as domain→domain gradients; root-incident threads
+    stop at the sun's rim, and a soft black disc under the logo keeps passing threads out of
+    its face) → photon pulses (one synapse firing every ~5–8s) → stars → titles. Titles are
+    zoom-gated at rest and COLLISION-AWARE always: candidates place greedily by priority
+    (hovered star → highlight → busiest), and any label whose measured rect would overlap an
+    already-placed label or the hover card simply isn't drawn. ⚠️ No per-frame blur filters —
+    Orb.swift's 8-fps lesson; every glow is a layered gradient.
+  - `NightSkyView.swift` — TimelineView + Canvas, the AppKit event catcher (two-finger scroll
+    pans · pinch / mouse-wheel / ⌘-scroll zoom at cursor · star drag reheats the springs ·
+    hover · still-click opens · Esc exits), the `SpinningLogo` sun overlay, the hover card
+    (frame shared with the renderer via `hoverCardRect`), HUD whispers + "Private by design."
+    footer, and `SkyDoor` — REAL Liquid Glass on macOS 26 (own capsule;
+    `sharedBackgroundVisibility(.hidden)` prevents the toolbar's glass-on-glass double wrap;
+    the 15 floor gets a dark capsule) with the warm gold→ember→violet edge-flow current.
 
 **Editing:** Edit opens the RAW file (frontmatter included) in a `TextEditor`; Save writes
 atomically and refreshes the render. Navigating away with unsaved edits raises Save / Discard /
-Cancel (all sidebar clicks, wikilinks, and Back funnel through guards). `VaultActivity.editorBusy`
-is set while editing (the updater-skip seam). Esc cancels.
+Cancel (all sidebar clicks, wikilinks, Back, AND sky-mode switches funnel through the guards).
+`VaultActivity.editorBusy` is set while editing (the updater-skip seam). Esc cancels.
 
-**Create / delete:** three creation affordances — the header "+" (root), a hover "+" on folder
-rows (inside that folder), and right-click menus (folders, notes, empty root space). New notes are
-seeded `# Title` and open straight into edit mode; names are sanitized + uniqued (never
-overwrite). Delete = **move to macOS Trash** (toolbar trash icon or right-click; recoverable, no
-confirm). The README/Overview can't be deleted. Empty folders show in the tree.
+**Create / delete:** three creation affordances — the header "+", a hover "+" on folder rows,
+and right-click menus. New notes are seeded `# Title` and open straight into edit mode; names
+are sanitized + uniqued. Delete = **move to macOS Trash** (recoverable, no confirm) for notes
+AND folders — the toolbar trash icon (reading mode; hidden for the README/Overview, which can't
+be deleted) or right-click. Trashing the folder that contained the open note lands back on
+Overview.
 
 **Cloud sync (debounced):** every change (save / create / delete) calls
 `VaultActivity.markChanged()` → sets the persisted `vaultDirty`, and ONE mirror push fires **30s
-after the last change** (`VaultCloud.pushIfDirty` → `MirrorClient.push`) — a spree coalesces into
-a single push. The timer lives in the `VaultActivity` singleton, so it survives closing the
-window; a quit mid-debounce is caught by the on-launch `pushIfDirty()` (the dirty flag persists).
-The sidebar header shows the state (mirror on): dot + "Synced to Cloud MCP │ 🔒 E2E Encrypted" /
-"Will sync soon" / spinner + "Syncing…"; mirror off → "Saved locally on this Mac". *(E2E
-Encrypted is surfaced now, implemented later.)* The concurrent-writer seam (an editor save landing
-during a KB update) is handled by VaultCloud's swap-time freshness check (B11, PR #96).
+after the last change** — a spree coalesces into a single push. The timer lives in the
+`VaultActivity` singleton, so it survives closing the window; a quit mid-debounce is caught by
+the on-launch `pushIfDirty()`. The sidebar header shows the state (mirror on): a calm white dot
+— **deliberately never colored**, an amber "will sync" read as a warning — + "Synced to Cloud
+MCP / Will sync soon / Syncing…" with the inline "🔒 E2E Encrypted" tag; mirror off → "Saved
+locally on this Mac". *(E2E Encrypted is surfaced now, implemented later.)* The
+concurrent-writer seam is handled by VaultCloud's swap-time freshness check (B11, PR #96).
 
 **Design notes:** OLED-black reading pane vs a warm-tinted sidebar (`Theme.panel`);
-`Theme.knowledgeAccent` (amber-orange) for wikilinks/selection/bullets; sidebar disclosure uses a
-clipped accordion (children retract up under the folder line, opacity on an exponential curve) over
-a plain `VStack` — **not LazyVStack** (it mangles the transitions). `WindowChrome` forces the
-transparent titlebar at launch (otherwise it's grey until the first resize).
+`Theme.knowledgeAccent` (amber-orange) for wikilinks/selection/bullets — and the sky's
+"changed last night" shimmer + return-highlight, so both faces share the warm identity. The
+sidebar disclosure uses a clipped accordion over a plain `VStack` — **not LazyVStack** (it
+mangles the transitions). `WindowChrome` forces the transparent titlebar at launch.
 
-**To build later:** the graph view (edges = `titleIndex`) · folder rename/move · a visible
-"sync failed" state (today a failed push just stays pending and auto-retries).
+**To build later:** folder rename/move · a visible "sync failed" state (today a failed push just
+stays pending and auto-retries) · sky ideas parked: remember-last-view, a per-note local graph.

--- a/Sentient OS macOS/Views/Knowledge/Graph/NightSkyModel.swift
+++ b/Sentient OS macOS/Views/Knowledge/Graph/NightSkyModel.swift
@@ -1,0 +1,300 @@
+//
+//  NightSkyModel.swift
+//  Sentient OS macOS
+//
+//  The Night Sky's brain: owns the graph + simulation + camera, advances everything once per
+//  frame (tick — called from the Canvas closure, so there are NO per-frame @State/@Published
+//  writes; see Orb.swift's performance rules), and answers all interaction math (hit-testing,
+//  pan/zoom-at-cursor, star dragging, hover focus, the photon pulses, the back-from-reader
+//  highlight). Published state is only what SwiftUI overlays need at human speed: the loaded
+//  graph and the hover card.
+//
+//  Key methods: load(vault:) · tick(now:size:) · toScreen/toWorld · hitTest ·
+//  updateHover/clearHover · panBy/zoom(by:at:) · beginDrag/dragStar/endDrag · highlight(url:).
+//
+
+import SwiftUI
+import Combine
+
+/// The viewport: `pan` is the screen-space offset of the world origin from the viewport center.
+struct SkyCamera {
+    var pan: CGPoint = .zero
+    var zoom: CGFloat = 1
+    var initialized = false
+}
+
+/// One photon traveling along one thread — the rare "synapse fires" moment.
+struct SkyPulse {
+    let edge: Int
+    let start: TimeInterval
+    let duration: TimeInterval
+}
+
+/// What the hover card shows (published only when the hovered star changes).
+struct SkyHoverInfo: Equatable {
+    let url: URL
+    let title: String
+    let domainName: String
+    let preview: String
+    let recentlyChanged: Bool
+    let anchor: CGPoint          // the star's screen position when hover began
+}
+
+final class NightSkyModel: ObservableObject {
+    @Published private(set) var graph: SkyGraph?
+    @Published private(set) var hoverInfo: SkyHoverInfo?
+
+    private(set) var sim: SkySimulation?
+    var camera = SkyCamera()
+
+    // Per-star ignite blend (0…1), eased every tick — hover, neighbors, and the highlight ride it.
+    private(set) var glow: [Double] = []
+    private(set) var hoverIndex: Int?
+    private(set) var focusIndex: Int?          // outlives hover until the blend fades out
+    private(set) var focusNeighbors: Set<Int> = []
+    private(set) var focusBlend: Double = 0    // global dim-the-rest amount
+
+    // The "you were just reading this" glow when returning from the reader.
+    private var pendingHighlightURL: URL?
+    private(set) var highlightIndex: Int?
+    private var highlightBlend: Double = 0
+
+    private(set) var pulses: [SkyPulse] = []
+    private var nextPulseAt: TimeInterval = .infinity
+    let dust = SkyRenderer.makeDust()
+
+    private var lastTick: TimeInterval?
+    private var dragging = false
+
+    // MARK: Loading
+
+    /// Build (or refresh) the graph from the vault. First load runs the assembly entrance;
+    /// re-entries keep every star exactly where the user left it.
+    @MainActor
+    func load(vault: KnowledgeVault?) async {
+        // No vault → keep whatever sky exists (a fresh model shows the empty state anyway; the
+        // preview factory's mock galaxy must survive the view's load-on-appear task).
+        guard let vault else { return }
+        let g = await Task.detached(priority: .userInitiated) { SkyGraph.build(from: vault) }.value
+        if let old = graph, let oldSim = sim {
+            let positions = Dictionary(uniqueKeysWithValues: zip(old.nodes.map(\.url), oldSim.pos))
+            let s = SkySimulation(graph: g, entrance: true)
+            s.restore(positions: positions)
+            sim = s
+        } else {
+            sim = SkySimulation(graph: g, entrance: true)      // the assembly moment
+            Log("Night Sky: \(g.nodes.count) stars · \(g.edges.count) threads · \(g.domains.count) constellations")
+        }
+        graph = g
+        glow = [Double](repeating: 0, count: g.nodes.count)
+        clearFocus()
+        resolvePendingHighlight()
+    }
+
+    // MARK: The frame tick (called from the Canvas closure — main thread, no published writes)
+
+    func tick(now: TimeInterval, size: CGSize) {
+        guard let sim, let graph else { return }
+        if !camera.initialized {
+            camera.zoom = min(max(min(size.width, size.height) / (SkyTuning.ringRadius * 2 * 1.55), 0.35), 1.1)
+            camera.initialized = true
+        }
+        let dt = lastTick.map { min(max(now - $0, 0), 1.0 / 20) } ?? 1.0 / 60
+        lastTick = now
+
+        sim.step(elapsed: dt)
+
+        // Ease the ignite blends toward their targets (breathe in ~fast, out soft).
+        let rate = 1 - exp(-dt * 9)
+        for i in glow.indices {
+            var target: Double = 0
+            if i == hoverIndex { target = 1 }
+            else if hoverIndex != nil && focusNeighbors.contains(i) { target = 0.75 }
+            if i == highlightIndex { target = max(target, highlightBlend) }
+            glow[i] += (target - glow[i]) * rate
+        }
+        let globalTarget: Double = hoverIndex != nil ? 1 : 0
+        focusBlend += (globalTarget - focusBlend) * rate
+        if hoverIndex == nil && focusBlend < 0.02 { focusIndex = nil; focusNeighbors = [] }
+
+        // The return-from-reader highlight decays over ~2.6s.
+        if highlightIndex != nil {
+            highlightBlend -= dt / 2.6
+            if highlightBlend <= 0 { highlightBlend = 0; highlightIndex = nil }
+        }
+
+        // Photon pulses: rare, deliberate, and only once the sky is calm.
+        if sim.alpha < 0.25, !graph.edges.isEmpty {
+            if nextPulseAt == .infinity { nextPulseAt = now + Double.random(in: 2.0...4.0) }
+            if now >= nextPulseAt {
+                pulses.append(SkyPulse(edge: Int.random(in: 0..<graph.edges.count), start: now, duration: 1.35))
+                nextPulseAt = now + Double.random(in: 4.5...8.5)
+            }
+        }
+        pulses.removeAll { now - $0.start > $0.duration }
+    }
+
+    // MARK: Camera math
+
+    func toScreen(_ w: CGPoint, size: CGSize) -> CGPoint {
+        CGPoint(x: size.width / 2 + camera.pan.x + w.x * camera.zoom,
+                y: size.height / 2 + camera.pan.y + w.y * camera.zoom)
+    }
+
+    func toWorld(_ s: CGPoint, size: CGSize) -> CGPoint {
+        CGPoint(x: (s.x - size.width / 2 - camera.pan.x) / camera.zoom,
+                y: (s.y - size.height / 2 - camera.pan.y) / camera.zoom)
+    }
+
+    func panBy(dx: CGFloat, dy: CGFloat) {
+        camera.pan.x += dx
+        camera.pan.y += dy
+        clampPan()
+        dismissHover()
+    }
+
+    /// Zoom keeping the world point under the cursor fixed (Figma-style).
+    func zoom(by factor: CGFloat, at s: CGPoint, size: CGSize) {
+        let newZoom = min(max(camera.zoom * factor, 0.35), 4.0)
+        let w = toWorld(s, size: size)
+        camera.zoom = newZoom
+        camera.pan = CGPoint(x: s.x - size.width / 2 - w.x * newZoom,
+                             y: s.y - size.height / 2 - w.y * newZoom)
+        clampPan()
+        dismissHover()
+    }
+
+    private func clampPan() {
+        let limit = SkyTuning.ringRadius * 2.3 * camera.zoom + 200
+        camera.pan.x = min(max(camera.pan.x, -limit), limit)
+        camera.pan.y = min(max(camera.pan.y, -limit), limit)
+    }
+
+    // MARK: Hit testing + hover
+
+    /// Nearest star within a forgiving reach of the cursor (screen point), or nil.
+    func hitTest(_ s: CGPoint, size: CGSize) -> Int? {
+        guard let sim, let graph else { return nil }
+        let w = toWorld(s, size: size)
+        let reach = max(16 / camera.zoom, 10)
+        var best: (i: Int, d: CGFloat)?
+        for i in graph.nodes.indices {
+            let d = (sim.pos[i] - w).length
+            if d < reach && d < (best?.d ?? .infinity) { best = (i, d) }
+        }
+        return best?.i
+    }
+
+    func updateHover(_ s: CGPoint, size: CGSize) {
+        guard !dragging else { return }
+        let hit = hitTest(s, size: size)
+        guard hit != hoverIndex else { return }
+        hoverIndex = hit
+        if let h = hit, let graph, let sim {
+            focusIndex = h
+            focusNeighbors = Set(graph.adjacency[h])
+            let n = graph.nodes[h]
+            hoverInfo = SkyHoverInfo(url: n.url,
+                                     title: n.title,
+                                     domainName: n.isRoot ? "You" : (n.domain >= 0 ? graph.domains[n.domain] : "Root"),
+                                     preview: n.preview,
+                                     recentlyChanged: n.recentlyChanged,
+                                     anchor: toScreen(sim.pos[h], size: size))
+        } else {
+            hoverInfo = nil
+        }
+    }
+
+    func clearHover() { dismissHover() }
+
+    private func dismissHover() {
+        guard hoverIndex != nil || hoverInfo != nil else { return }
+        hoverIndex = nil
+        hoverInfo = nil
+    }
+
+    // MARK: Star dragging
+
+    func beginDrag(_ i: Int) {
+        dragging = true
+        dismissHover()
+        sim?.beginDrag(i)
+    }
+
+    func dragStar(to s: CGPoint, size: CGSize) { sim?.drag(to: toWorld(s, size: size)) }
+
+    func endDrag() {
+        dragging = false
+        sim?.endDrag()
+    }
+
+    func nodeURL(_ i: Int) -> URL? {
+        guard let graph, graph.nodes.indices.contains(i) else { return nil }
+        return graph.nodes[i].url
+    }
+
+    /// The hover card's frame — ONE source of truth shared by the SwiftUI overlay (position) and
+    /// the renderer (so star labels never slide underneath the card). Prefers below-right of the
+    /// star, flipping near the window's edges.
+    func hoverCardRect(in size: CGSize) -> CGRect? {
+        guard let info = hoverInfo else { return nil }
+        let w: CGFloat = 250, h: CGFloat = 96
+        var x = info.anchor.x + 24
+        if x + w > size.width - 16 { x = info.anchor.x - 24 - w }
+        var y = info.anchor.y + 26
+        if y + h > size.height - 16 { y = info.anchor.y - 26 - h }
+        return CGRect(x: x, y: y, width: w, height: h)
+    }
+
+    /// Where the sun's SpinningLogo overlay belongs this frame (screen center, diameter, opacity).
+    /// The canvas draws only the sun's light bed; the actual brand mark floats above it.
+    func sunOverlay(size: CGSize) -> (center: CGPoint, diameter: CGFloat, opacity: Double)? {
+        guard let graph, let sim, let root = graph.rootIndex, camera.initialized else { return nil }
+        let zf = CGFloat(pow(Double(camera.zoom), 0.62))
+        let reveal = min(1, (1 - sim.alpha) * 3 + 0.15)
+        return (toScreen(sim.pos[root], size: size), 30 * zf, reveal)
+    }
+
+    // MARK: The back-from-reader highlight
+
+    /// Make this note's star glow for a beat when the sky next appears ("you were just here").
+    func highlight(_ url: URL) {
+        pendingHighlightURL = url
+        resolvePendingHighlight()
+    }
+
+    private func resolvePendingHighlight() {
+        guard let url = pendingHighlightURL, let graph else { return }
+        pendingHighlightURL = nil
+        guard let i = graph.nodes.firstIndex(where: { $0.url == url }) else { return }
+        highlightIndex = i
+        highlightBlend = 1.0
+    }
+
+    // MARK: Preview factory (deterministic — renders the mock galaxy already settled)
+
+    static func preview(hovering: Int? = nil) -> NightSkyModel {
+        let m = NightSkyModel()
+        let g = SkyGraph.mock()
+        m.graph = g
+        m.sim = SkySimulation(graph: g, entrance: false)
+        m.glow = [Double](repeating: 0, count: g.nodes.count)
+        if let h = hovering, g.nodes.indices.contains(h) {
+            m.hoverIndex = h
+            m.focusIndex = h
+            m.focusNeighbors = Set(g.adjacency[h])
+            m.focusBlend = 1
+            m.glow[h] = 1
+            for n in g.adjacency[h] { m.glow[n] = 0.75 }
+        }
+        return m
+    }
+
+    private func clearFocus() {
+        hoverIndex = nil
+        hoverInfo = nil
+        focusIndex = nil
+        focusNeighbors = []
+        focusBlend = 0
+    }
+}

--- a/Sentient OS macOS/Views/Knowledge/Graph/NightSkyView.swift
+++ b/Sentient OS macOS/Views/Knowledge/Graph/NightSkyView.swift
@@ -1,0 +1,391 @@
+//
+//  NightSkyView.swift
+//  Sentient OS macOS
+//
+//  The Night Sky — the Knowledge window's graph view (user-facing name: "Constellation View";
+//  it's the window's DEFAULT face). Your knowledge base as a private galaxy:
+//  notes are twinkling stars sized by connection count, top-level folders are labeled
+//  constellations, wikilinks are threads that ignite on hover, and the root README is the sun.
+//  TimelineView(.animation) + Canvas render (SkyRenderer); an AppKit event catcher gives real
+//  pan (two-finger scroll) / zoom (pinch, mouse wheel, ⌘-scroll) / star dragging / hover / click
+//  (→ open the note in the reader) / Esc (→ back to the reader).
+//
+//  Data: SkyGraph · physics: SkySimulation · brain: NightSkyModel · drawing: SkyRenderer.
+//  Doc: Documentation/Knowledge Viewer.md
+//
+
+import SwiftUI
+import AppKit
+
+struct NightSkyView: View {
+    let vault: KnowledgeVault?
+    var vaultLoaded = true       // false only while KnowledgeView's vault scan is still in flight
+    @ObservedObject var model: NightSkyModel
+    var onOpen: (URL) -> Void
+    var onExit: () -> Void
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack {
+                if let graph = model.graph, !graph.nodes.isEmpty {
+                    TimelineView(.animation(minimumInterval: 1.0 / 60.0)) { tl in
+                        ZStack {
+                            Canvas { ctx, size in
+                                let t = tl.date.timeIntervalSinceReferenceDate
+                                model.tick(now: t, size: size)
+                                SkyRenderer.draw(ctx, size: size, model: model, t: t)
+                            }
+                            // The sun IS the brand mark: the notch's SpinningLogo, slow, riding
+                            // the root star's screen position (the canvas draws its light bed).
+                            if let sun = model.sunOverlay(size: geo.size) {
+                                SpinningLogo(size: sun.diameter, fast: false)
+                                    .position(sun.center)
+                                    .opacity(sun.opacity)
+                            }
+                        }
+                    }
+                    SkyEventCatcher(model: model, onOpen: onOpen, onExit: onExit)
+                    hud(graph: graph)
+                    if model.hoverInfo != nil, let card = model.hoverCardRect(in: geo.size) {
+                        SkyHoverCard(info: model.hoverInfo!)
+                            .position(x: card.midX, y: card.midY)
+                            .transition(.opacity.combined(with: .scale(scale: 0.97)))
+                    }
+                } else if model.graph != nil || (vaultLoaded && vault == nil) {
+                    emptyState
+                } else {
+                    Color.clear      // vault scan / graph build in flight — the entrance covers the gap
+                }
+            }
+            .animation(.easeOut(duration: 0.16), value: model.hoverInfo)
+        }
+        .background(Theme.bg)
+        // Reruns on every sky entry (silent refresh) AND when the vault first arrives — with the
+        // Constellation View as the window's default, this view mounts before the async vault
+        // scan finishes, so the graph must build the moment the vault lands.
+        .task(id: vault?.root) { await model.load(vault: vault) }
+    }
+
+    // MARK: HUD (whispers — none of it intercepts the cursor)
+
+    private func hud(graph: SkyGraph) -> some View {
+        ZStack {
+            Color.clear
+            VStack(alignment: .leading, spacing: 5) {
+                MonoCaps("Constellation View", size: 9, tracking: 3, color: Theme.Ink.label)
+                Text("Your life, from above.")
+                    .font(.system(size: 16, design: .serif)).italic()
+                    .foregroundStyle(Theme.Ink.statusInk.opacity(0.85))
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            .padding(.top, 14).padding(.leading, 22)
+
+            MonoCaps("\(graph.nodes.count) notes · \(graph.edges.count) threads · \(graph.domains.count) constellations",
+                     size: 9.5, tracking: 2, color: Theme.Ink.label)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
+                .padding(.bottom, 16).padding(.leading, 22)
+
+            HStack(spacing: 8) {
+                Image(systemName: "shield").font(.system(size: 11)).foregroundStyle(Theme.Ink.label)
+                Text("Private by design.")
+                    .font(.system(size: 12)).foregroundStyle(Theme.Ink.label)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+            .padding(.bottom, 16)
+        }
+        .allowsHitTesting(false)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 14) {
+            Orb(size: 92)
+            Text("Your sky is still forming.")
+                .font(.system(size: 20, design: .serif).italic())
+                .foregroundStyle(Theme.Ink.statusInk)
+            Text("Once Sentient has read your life, every note becomes a star.")
+                .font(.system(size: 13)).foregroundStyle(Theme.secondary)
+                .multilineTextAlignment(.center).frame(maxWidth: 340)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+// MARK: - The door (shared by both sides: "Constellation View" in the reader, "Reader" in the sky)
+
+/// The mode switch, front and center in the titlebar (both KnowledgeView toolbars mount one via
+/// SkyDoorToolbarItem, .principal placement). On macOS 26 the body is REAL Liquid Glass (in our
+/// own capsule — the item's shared glass is hidden so it never double-wraps); the 15 floor gets
+/// the dark capsule. The magic is the EDGE FLOW: a slow current of the brand spectrum circling
+/// the rim. ⌘⇧G fires whichever door is currently mounted.
+struct SkyDoor: View {
+    let icon: String
+    let label: String
+    let action: () -> Void
+    @State private var hover = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                Image(systemName: icon).font(.system(size: 11, weight: .medium))
+                MonoCaps(label, size: 9.5, tracking: 2.5, color: .white.opacity(hover ? 0.95 : 0.8))
+            }
+            .foregroundStyle(.white.opacity(hover ? 0.95 : 0.8))
+            .padding(.horizontal, 14)
+            .frame(height: 33)                    // match the native glass toolbar buttons' height
+            .modifier(SkyDoorChrome())
+            .overlay(edgeFlow)
+            .shadow(color: Color(red: 1.0, green: 0.68, blue: 0.42).opacity(hover ? 0.30 : 0.10),
+                    radius: hover ? 14 : 8)
+            .contentShape(Capsule())
+        }
+        .buttonStyle(PressScaleStyle())
+        .keyboardShortcut("g", modifiers: [.command, .shift])
+        .onHover { hover = $0 }
+        .animation(.easeOut(duration: 0.18), value: hover)
+    }
+
+    /// The door's own warm spectrum — the Knowledge amber family (gold → orange → ember) with one
+    /// violet streak lapping through it. First == last, so the angular seam never shows.
+    private static let flow: [Color] = [
+        Color(red: 1.00, green: 0.78, blue: 0.45),   // gold
+        Color(red: 1.00, green: 0.66, blue: 0.38),   // amber (the sidebar's accent family)
+        Color(red: 0.99, green: 0.52, blue: 0.40),   // ember
+        Color(red: 0.80, green: 0.42, blue: 0.88),   // the violet streak
+        Color(red: 0.58, green: 0.44, blue: 0.98),   // purple
+        Color(red: 1.00, green: 0.70, blue: 0.42),   // back through amber
+        Color(red: 1.00, green: 0.78, blue: 0.45),   // wrap = gold
+    ]
+
+    /// The current riding the capsule's edge — one slow lap every 15s, brighter under the cursor.
+    private var edgeFlow: some View {
+        TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { tl in
+            Capsule().strokeBorder(
+                AngularGradient(colors: Self.flow, center: .center,
+                                angle: .degrees(tl.date.timeIntervalSinceReferenceDate * 24)),
+                lineWidth: 1)
+        }
+        .opacity(hover ? 0.85 : 0.45)
+        .allowsHitTesting(false)
+    }
+}
+
+/// Liquid Glass where it exists, quiet dark glass where it doesn't (the macOS 15 floor).
+private struct SkyDoorChrome: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(macOS 26.0, *) {
+            content.glassEffect(.regular.interactive(), in: Capsule())
+        } else {
+            content.background(Theme.Ink.cardBG.opacity(0.85), in: Capsule())
+        }
+    }
+}
+
+/// The door's toolbar seat. On macOS 26 the toolbar would wrap the door in ANOTHER glass capsule
+/// (glass-on-glass — the "lol" screenshot); hiding the item's shared background lets the door
+/// carry its own.
+struct SkyDoorToolbarItem: ToolbarContent {
+    let icon: String
+    let label: String
+    let help: String
+    var placement: ToolbarItemPlacement = .principal   // sky: top-center · reader: .navigation (top-left)
+    let action: () -> Void
+
+    var body: some ToolbarContent {
+        if #available(macOS 26.0, *) {
+            ToolbarItem(placement: placement) { door }
+                .sharedBackgroundVisibility(.hidden)
+        } else {
+            ToolbarItem(placement: placement) { door }
+        }
+    }
+
+    private var door: some View {
+        SkyDoor(icon: icon, label: label, action: action).help(help)
+    }
+}
+
+// MARK: - The hover card
+
+private struct SkyHoverCard: View {
+    let info: SkyHoverInfo
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            MonoCaps(info.domainName, size: 8.5, tracking: 2, color: Theme.Ink.label)
+            Text(info.title)
+                .font(.system(size: 14, design: .serif))
+                .foregroundStyle(Theme.Ink.statusInk)
+                .lineLimit(2)
+            if !info.preview.isEmpty {
+                Text(info.preview)
+                    .font(.system(size: 11))
+                    .foregroundStyle(Theme.Ink.body)
+                    .lineLimit(2)
+            }
+            if info.recentlyChanged {
+                MonoCaps("Changed last night", size: 7.5, tracking: 1.5, color: Theme.Ink.amber)
+            }
+        }
+        .padding(12)
+        .frame(width: 250, alignment: .leading)
+        .background(Theme.Ink.cardBG.opacity(0.94), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: 12, style: .continuous).strokeBorder(Theme.stroke, lineWidth: 1))
+        .allowsHitTesting(false)
+    }
+}
+
+// MARK: - Event catcher (real AppKit events: scroll, pinch, drag, hover, click, Esc)
+
+private struct SkyEventCatcher: NSViewRepresentable {
+    let model: NightSkyModel
+    let onOpen: (URL) -> Void
+    let onExit: () -> Void
+
+    func makeNSView(context: Context) -> SkyEventNSView { SkyEventNSView() }
+
+    func updateNSView(_ v: SkyEventNSView, context: Context) {
+        v.model = model
+        v.onOpen = onOpen
+        v.onExit = onExit
+    }
+}
+
+private final class SkyEventNSView: NSView {
+    weak var model: NightSkyModel?
+    var onOpen: ((URL) -> Void)?
+    var onExit: (() -> Void)?
+
+    private enum DragMode { case none, star(Int), pan }
+    private var dragMode: DragMode = .none
+    private var downPoint: CGPoint = .zero
+    private var lastDragPoint: CGPoint = .zero
+    private var moved = false
+
+    override var acceptsFirstResponder: Bool { true }
+    override var isFlipped: Bool { true }           // match SwiftUI/Canvas coordinates
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        guard window != nil else { return }
+        DispatchQueue.main.async { [weak self] in
+            guard let self, let w = self.window else { return }
+            w.makeFirstResponder(self)
+        }
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        trackingAreas.forEach(removeTrackingArea)
+        addTrackingArea(NSTrackingArea(rect: .zero,
+                                       options: [.mouseMoved, .mouseEnteredAndExited,
+                                                 .activeInKeyWindow, .inVisibleRect],
+                                       owner: self))
+    }
+
+    // MARK: Hover
+
+    override func mouseMoved(with event: NSEvent) {
+        let p = convert(event.locationInWindow, from: nil)
+        model?.updateHover(p, size: bounds.size)
+        (model?.hoverIndex != nil ? NSCursor.pointingHand : NSCursor.arrow).set()
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        model?.clearHover()
+        NSCursor.arrow.set()
+    }
+
+    // MARK: Click / drag (a still click opens the note; a drag moves a star or pans the sky)
+
+    override func mouseDown(with event: NSEvent) {
+        let p = convert(event.locationInWindow, from: nil)
+        downPoint = p
+        lastDragPoint = p
+        moved = false
+        if let i = model?.hitTest(p, size: bounds.size) {
+            dragMode = .star(i)
+            model?.beginDrag(i)
+        } else {
+            dragMode = .pan
+        }
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        let p = convert(event.locationInWindow, from: nil)
+        if (p - downPoint).length > 3 { moved = true }
+        switch dragMode {
+        case .star:
+            model?.dragStar(to: p, size: bounds.size)
+        case .pan:
+            model?.panBy(dx: p.x - lastDragPoint.x, dy: p.y - lastDragPoint.y)
+        case .none:
+            break
+        }
+        lastDragPoint = p
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        if case .star(let i) = dragMode {
+            model?.endDrag()
+            if !moved, let url = model?.nodeURL(i) { onOpen?(url) }
+        }
+        dragMode = .none
+    }
+
+    // MARK: Scroll + pinch (trackpad pans, wheel/⌘-scroll/pinch zoom — Figma manners)
+
+    override func scrollWheel(with event: NSEvent) {
+        let p = convert(event.locationInWindow, from: nil)
+        if event.hasPreciseScrollingDeltas && !event.modifierFlags.contains(.command) {
+            model?.panBy(dx: event.scrollingDeltaX, dy: event.scrollingDeltaY)
+        } else {
+            let scale = event.hasPreciseScrollingDeltas ? 0.01 : 0.05
+            model?.zoom(by: exp(event.scrollingDeltaY * scale), at: p, size: bounds.size)
+        }
+    }
+
+    override func magnify(with event: NSEvent) {
+        let p = convert(event.locationInWindow, from: nil)
+        model?.zoom(by: 1 + event.magnification, at: p, size: bounds.size)
+    }
+
+    // MARK: Keys (Esc returns to the reader; everything else is quietly ignored — no beeps)
+
+    override func keyDown(with event: NSEvent) {
+        if event.keyCode == 53 { onExit?() }
+    }
+}
+
+// MARK: - Previews (SkyRenderer's eyes — the mock galaxy is seeded, so renders are stable)
+
+#Preview("Night Sky — settled") {
+    NightSkyView(vault: nil, model: .preview(), onOpen: { _ in }, onExit: {})
+        .frame(width: 1280, height: 800)
+        .preferredColorScheme(.dark)
+}
+
+#Preview("Night Sky — ignited (hover)") {
+    NightSkyView(vault: nil, model: .preview(hovering: 22), onOpen: { _ in }, onExit: {})
+        .frame(width: 1280, height: 800)
+        .preferredColorScheme(.dark)
+}
+
+#Preview("Night Sky — hover card") {
+    ZStack {
+        Color.black
+        SkyHoverCard(info: SkyHoverInfo(url: URL(fileURLWithPath: "/mock/a.md"),
+                                        title: "Sentient OS – Launch Timeline",
+                                        domainName: "Sentient OS",
+                                        preview: "Beta invite waves, the Reddit playbook, and what has to be true before strangers see it.",
+                                        recentlyChanged: true,
+                                        anchor: .zero))
+    }
+    .frame(width: 400, height: 240)
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Night Sky — real vault") {
+    NightSkyView(vault: KnowledgeVault.load(), model: NightSkyModel(), onOpen: { _ in }, onExit: {})
+        .frame(width: 1280, height: 800)
+        .preferredColorScheme(.dark)
+}

--- a/Sentient OS macOS/Views/Knowledge/Graph/SkyGraph.swift
+++ b/Sentient OS macOS/Views/Knowledge/Graph/SkyGraph.swift
@@ -1,0 +1,226 @@
+//
+//  SkyGraph.swift
+//  Sentient OS macOS
+//
+//  Data for the Knowledge window's Night Sky (the graph view): every vault note becomes a star,
+//  every resolved [[wikilink]] a thread. One pass over the on-disk vault reads each body once,
+//  extracting links (resolved through KnowledgeVault.titleIndex), a clean hover-card preview
+//  line, and a "changed last night" flag. Top-level folders become constellations (domains),
+//  ordered biggest-first for palette assignment; the root README is the sun.
+//
+//  Key types: SkyNode · SkyEdge · SkyGraph (.build(from:) / .mock() for previews).
+//  Physics: SkySimulation.swift · drawing: SkyRenderer.swift · view: NightSkyView.swift.
+//  Doc: Documentation/Knowledge Viewer.md
+//
+
+import Foundation
+
+/// One star: a vault note plus everything the sky needs to draw it.
+struct SkyNode: Identifiable {
+    let url: URL
+    let title: String            // filename stem — the same name the sidebar shows
+    let domain: Int              // index into SkyGraph.domains · -1 = the root README (the sun)
+    var degree: Int              // resolved wikilink connections (deduped, undirected)
+    let isRoot: Bool
+    let recentlyChanged: Bool    // modified in the last 36h → the amber shimmer
+    let preview: String          // first readable body line (cleaned) — the hover card's one-liner
+    let twinklePhase: Double     // stable per-note personality (hashed from the path, so a star
+    let twinkleSpeed: Double     //  twinkles the same way every night)
+
+    var id: URL { url }
+}
+
+/// One thread: an undirected, deduplicated wikilink between two stars (node indices).
+struct SkyEdge {
+    let a: Int
+    let b: Int
+    let sameDomain: Bool
+}
+
+struct SkyGraph {
+    let nodes: [SkyNode]
+    let edges: [SkyEdge]
+    let adjacency: [[Int]]       // node index → neighbor node indices
+    let domains: [String]        // constellation names, biggest first
+    let rootIndex: Int?          // the README's node index, if the vault has one
+    let maxDegree: Int           // for star-brightness normalization (≥ 1)
+
+    // MARK: Build from the real vault
+
+    static func build(from vault: KnowledgeVault) -> SkyGraph {
+        let notes = vault.allNotes                       // includes the README
+        let rootPath = vault.root.standardizedFileURL.path
+
+        // Constellations = top-level folders, biggest first (ties alphabetical, so palette
+        // assignment is stable run to run).
+        var noteDomainNames: [String?] = []
+        var domainCounts: [String: Int] = [:]
+        for n in notes {
+            let d = (n.url == vault.readme) ? nil : topFolder(of: n.url, rootPath: rootPath)
+            noteDomainNames.append(d)
+            if let d { domainCounts[d, default: 0] += 1 }
+        }
+        let domains = domainCounts.sorted { $0.value != $1.value ? $0.value > $1.value : $0.key < $1.key }
+            .map(\.key)
+        let domainIndex = Dictionary(uniqueKeysWithValues: domains.enumerated().map { ($1, $0) })
+        let urlIndex = Dictionary(uniqueKeysWithValues: notes.enumerated().map { ($1.url, $0) })
+
+        // One pass over the bodies: wikilink edges + the hover preview + recency.
+        var pairs = Set<EdgePair>()
+        var previews = [String](repeating: "", count: notes.count)
+        var recent = [Bool](repeating: false, count: notes.count)
+        let recencyFloor = Date().addingTimeInterval(-36 * 3600)
+        for (i, n) in notes.enumerated() {
+            let body = KnowledgeVault.read(n.url).markdown
+            previews[i] = previewLine(from: body)
+            for m in body.matches(of: #/\[\[([^\]]+)\]\]/#) {
+                var target = String(m.output.1)
+                if let bar = target.firstIndex(of: "|") { target = String(target[..<bar]) }    // [[X|alias]]
+                if let hash = target.firstIndex(of: "#") { target = String(target[..<hash]) }  // [[X#heading]]
+                guard let dest = vault.resolve(target), let j = urlIndex[dest], j != i else { continue }
+                pairs.insert(EdgePair(a: min(i, j), b: max(i, j)))
+            }
+            if let mtime = try? n.url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate {
+                recent[i] = mtime > recencyFloor
+            }
+        }
+        // Bulk-change guard: a first build (or a stage-then-swap that touched every mtime) would
+        // make the WHOLE sky shimmer amber — which says nothing. Shimmer only when "recent" is
+        // actually selective.
+        if recent.filter({ $0 }).count > max(4, notes.count * 35 / 100) {
+            recent = [Bool](repeating: false, count: notes.count)
+        }
+
+        let nodes: [SkyNode] = notes.enumerated().map { i, n in
+            let isRoot = n.url == vault.readme
+            let h = stableHash(n.url.path)
+            return SkyNode(url: n.url,
+                           title: isRoot ? "Overview" : n.name,
+                           domain: noteDomainNames[i].flatMap { domainIndex[$0] } ?? -1,
+                           degree: 0,
+                           isRoot: isRoot,
+                           recentlyChanged: recent[i],
+                           preview: previews[i],
+                           twinklePhase: Double(h % 6283) / 1000.0,
+                           twinkleSpeed: 1.1 + Double((h >> 16) % 1000) / 1000.0 * 2.1)
+        }
+        return finish(nodes: nodes, pairs: pairs, domains: domains)
+    }
+
+    /// The first path component under the vault root, if the note lives inside a folder.
+    private static func topFolder(of url: URL, rootPath: String) -> String? {
+        let p = url.standardizedFileURL.path
+        guard p.hasPrefix(rootPath) else { return nil }
+        let rel = p.dropFirst(rootPath.count).trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let comps = rel.components(separatedBy: "/")
+        return comps.count >= 2 ? comps.first : nil
+    }
+
+    /// First readable line of a body, cleaned into plain prose for the hover card.
+    private static func previewLine(from body: String) -> String {
+        for raw in body.components(separatedBy: "\n") {
+            var line = raw.trimmingCharacters(in: .whitespaces)
+            if line.isEmpty { continue }
+            if line.hasPrefix("#") || line.hasPrefix("---") || line.hasPrefix("|") || line.hasPrefix(">") { continue }
+            if line.hasPrefix("- ") { line = String(line.dropFirst(2)) }
+            line = line.replacing(#/\[\[([^\]|]+)\|([^\]]+)\]\]/#) { String($0.output.2) }   // alias wins
+            line = line.replacing(#/\[\[([^\]]+)\]\]/#) { String($0.output.1) }
+            line = line.replacingOccurrences(of: "**", with: "").replacingOccurrences(of: "`", with: "")
+            if line.count > 150 { line = String(line.prefix(150)) + "…" }
+            return line
+        }
+        return ""
+    }
+
+    /// FNV-1a — stable across launches (String.hashValue is not), so twinkle personality sticks.
+    private static func stableHash(_ s: String) -> UInt64 {
+        var h: UInt64 = 0xcbf29ce484222325
+        for b in s.utf8 { h = (h ^ UInt64(b)) &* 0x100000001b3 }
+        return h
+    }
+
+    // MARK: Shared assembly (degrees, adjacency, sameDomain)
+
+    fileprivate struct EdgePair: Hashable { let a: Int; let b: Int }
+
+    private static func finish(nodes: [SkyNode], pairs: Set<EdgePair>, domains: [String]) -> SkyGraph {
+        var nodes = nodes
+        var adjacency = [[Int]](repeating: [], count: nodes.count)
+        let edges = pairs.sorted { ($0.a, $0.b) < ($1.a, $1.b) }.map { p in
+            nodes[p.a].degree += 1
+            nodes[p.b].degree += 1
+            adjacency[p.a].append(p.b)
+            adjacency[p.b].append(p.a)
+            return SkyEdge(a: p.a, b: p.b,
+                           sameDomain: nodes[p.a].domain == nodes[p.b].domain && nodes[p.a].domain >= 0)
+        }
+        return SkyGraph(nodes: nodes,
+                        edges: edges,
+                        adjacency: adjacency,
+                        domains: domains,
+                        rootIndex: nodes.firstIndex(where: \.isRoot),
+                        maxDegree: max(nodes.map(\.degree).max() ?? 1, 1))
+    }
+
+    // MARK: Mock (previews only — seeded, deterministic)
+
+    static func mock() -> SkyGraph {
+        var rng = SplitMix64(seed: 7)
+        let spec: [(name: String, size: Int)] = [
+            ("Sentient OS", 20), ("Career & Network", 17), ("AI Research", 15), ("Health", 13),
+            ("University", 12), ("Life Admin", 10), ("Relationships", 9), ("Identity", 7),
+        ]
+        let bank = ["Launch Timeline", "Investor Outreach", "Pitch Notes", "Quantization Runs",
+                    "Housing Search", "Visa Admin", "Gym Protocol", "Reading List", "Meeting Prep",
+                    "Weekly Review", "Flight Options", "Course Plan", "Demo Script", "Press Kit",
+                    "Sleep Log", "Budget", "Networking Events", "Research Ideas", "Beta Waitlist",
+                    "Product Thesis", "Roadmap", "Old Friends", "Side Quests", "Archive"]
+
+        var nodes: [SkyNode] = []
+        var pairs = Set<EdgePair>()
+        func addNode(_ title: String, domain: Int, isRoot: Bool = false, recent: Bool = false) -> Int {
+            let h = stableHash("\(domain)/\(title)/\(nodes.count)")
+            nodes.append(SkyNode(url: URL(fileURLWithPath: "/mock/\(domain)/\(nodes.count) \(title).md"),
+                                 title: title, domain: domain, degree: 0, isRoot: isRoot,
+                                 recentlyChanged: recent,
+                                 preview: "A short line of what this note remembers about your life.",
+                                 twinklePhase: Double(h % 6283) / 1000.0,
+                                 twinkleSpeed: 1.1 + Double((h >> 16) % 1000) / 1000.0 * 2.1))
+            return nodes.count - 1
+        }
+
+        let root = addNode("Overview", domain: -1, isRoot: true)
+        var titleCursor = 0
+        var hubs: [Int] = []
+        var recentBudget = 4
+        for (d, s) in spec.enumerated() {
+            let hub = addNode("\(s.name) Map", domain: d)
+            hubs.append(hub)
+            pairs.insert(EdgePair(a: root, b: hub))
+            var members: [Int] = []
+            for _ in 0..<s.size {
+                let title = bank[titleCursor % bank.count] + (titleCursor >= bank.count ? " \(titleCursor / bank.count + 1)" : "")
+                titleCursor += 1
+                let recent = recentBudget > 0 && UInt64.random(in: 0..<10, using: &rng) == 0
+                if recent { recentBudget -= 1 }
+                members.append(addNode(title, domain: d, recent: recent))
+            }
+            for m in members {
+                if UInt64.random(in: 0..<4, using: &rng) != 0 {                       // hub → ~75%
+                    pairs.insert(EdgePair(a: min(hub, m), b: max(hub, m)))
+                }
+                if UInt64.random(in: 0..<3, using: &rng) == 0, let other = members.randomElement(using: &rng), other != m {
+                    pairs.insert(EdgePair(a: min(m, other), b: max(m, other)))        // intra sprinkle
+                }
+            }
+        }
+        for _ in 0..<20 {                                                             // cross-domain bridges
+            let a = Int.random(in: 1..<nodes.count, using: &rng)
+            let b = Int.random(in: 1..<nodes.count, using: &rng)
+            if a != b, nodes[a].domain != nodes[b].domain {
+                pairs.insert(EdgePair(a: min(a, b), b: max(a, b)))
+            }
+        }
+        return finish(nodes: nodes, pairs: pairs, domains: spec.map(\.name))
+    }
+}

--- a/Sentient OS macOS/Views/Knowledge/Graph/SkyRenderer.swift
+++ b/Sentient OS macOS/Views/Knowledge/Graph/SkyRenderer.swift
@@ -1,0 +1,405 @@
+//
+//  SkyRenderer.swift
+//  Sentient OS macOS
+//
+//  All Canvas drawing for the Night Sky, painter's order: parallax stardust → constellation
+//  watermark labels → the center breath → threads (resting, then ignited) → photon pulses →
+//  stars (halo/core/ring; the root sun wears the one rotating magic-gradient ring on screen) →
+//  note titles (semantic zoom). Stateless: reads NightSkyModel each frame.
+//
+//  Performance rules inherited from Orb.swift: no per-frame blur filters — every glow here is a
+//  layered radial gradient; resting threads batch into two stroked Paths.
+//
+
+import SwiftUI
+
+struct SkyRenderer {
+
+    /// Ten desaturated constellation hues (assigned biggest-domain-first, wrapping if needed).
+    /// Kept as components so cores can be mixed toward white without Color introspection.
+    private static let palette: [(r: Double, g: Double, b: Double)] = [
+        (1.00, 0.80, 0.55),  // gold
+        (0.45, 0.85, 0.78),  // teal
+        (0.72, 0.62, 1.00),  // violet
+        (1.00, 0.62, 0.70),  // rose
+        (0.55, 0.75, 1.00),  // sky
+        (0.68, 0.88, 0.62),  // sage
+        (1.00, 0.72, 0.55),  // peach
+        (0.60, 0.62, 0.98),  // indigo
+        (0.55, 0.92, 0.80),  // mint
+        (0.82, 0.70, 0.98),  // lavender
+    ]
+    private static let amber = (r: 1.0, g: 0.682, b: 0.42)   // Theme.knowledgeAccent's components
+
+    static func domainColor(_ d: Int, alpha: Double = 1) -> Color {
+        guard d >= 0 else { return Color(red: 1, green: 0.93, blue: 0.85, opacity: alpha) }   // the sun: warm white
+        let c = palette[d % palette.count]
+        return Color(red: c.r, green: c.g, blue: c.b, opacity: alpha)
+    }
+
+    /// A star's core: mostly white, kissed by its constellation hue.
+    private static func coreColor(_ d: Int, alpha: Double) -> Color {
+        guard d >= 0 else { return Color(red: 1, green: 0.96, blue: 0.9, opacity: alpha) }
+        let c = palette[d % palette.count]
+        return Color(red: 0.78 + 0.22 * c.r, green: 0.78 + 0.22 * c.g, blue: 0.78 + 0.22 * c.b, opacity: alpha)
+    }
+
+    // MARK: The frame
+
+    static func draw(_ ctx: GraphicsContext, size: CGSize, model: NightSkyModel, t: TimeInterval) {
+        guard let graph = model.graph, let sim = model.sim else { return }
+        let cam = model.camera
+        let zf = CGFloat(pow(Double(cam.zoom), 0.62))          // star sizes scale sub-linearly
+
+        // Assembly reveal: stars ignite as they fly in; threads fade in last, once things settle.
+        let heat = sim.alpha
+        let starReveal = min(1, (1 - heat) * 3 + 0.15)
+        let threadReveal = max(0, min(1, (0.55 - heat) / 0.45))
+
+        let focusSet: Set<Int> = {
+            guard let f = model.focusIndex else { return [] }
+            return model.focusNeighbors.union([f])
+        }()
+
+        drawDust(ctx, size: size, model: model, t: t)
+        drawConstellationLabels(ctx, size: size, model: model, graph: graph, sim: sim,
+                                reveal: threadReveal, dim: 1 - 0.5 * model.focusBlend)
+        drawBreath(ctx, size: size, model: model, t: t, reveal: threadReveal)
+        drawThreads(ctx, size: size, model: model, graph: graph, sim: sim,
+                    reveal: threadReveal, focusSet: focusSet, zf: zf)
+        drawPulses(ctx, size: size, model: model, graph: graph, sim: sim, t: t, reveal: threadReveal)
+        drawSunOcclusion(ctx, size: size, model: model, graph: graph, sim: sim, zf: zf)
+        drawStars(ctx, size: size, model: model, graph: graph, sim: sim, t: t, zf: zf,
+                  starReveal: starReveal, focusSet: focusSet)
+        drawTitles(ctx, size: size, model: model, graph: graph, sim: sim, zf: zf,
+                   reveal: starReveal, focusSet: focusSet)
+    }
+
+    /// How far (screen px) threads must keep clear of the sun's center — just past the
+    /// SpinningLogo's ring + bloom, so nothing ever crosses the mark's face.
+    private static func sunClearance(_ zf: CGFloat) -> CGFloat { 22 * zf }
+
+    /// Move `p` toward `q` by `d` screen px (stops root-incident threads at the sun's rim).
+    private static func pulledIn(_ p: CGPoint, toward q: CGPoint, by d: CGFloat) -> CGPoint {
+        let dx = q.x - p.x, dy = q.y - p.y
+        let len = sqrt(dx * dx + dy * dy)
+        guard len > d else { return q }
+        return CGPoint(x: p.x + dx / len * d, y: p.y + dy / len * d)
+    }
+
+    /// A soft black disc under the SpinningLogo: threads merely PASSING the center (they belong
+    /// to other stars, so they can't be trimmed) fade out under the logo instead of showing
+    /// through its transparent gaps.
+    private static func drawSunOcclusion(_ ctx: GraphicsContext, size: CGSize, model: NightSkyModel,
+                                         graph: SkyGraph, sim: SkySimulation, zf: CGFloat) {
+        guard let root = graph.rootIndex else { return }
+        let p = model.toScreen(sim.pos[root], size: size)
+        let r = sunClearance(zf)
+        ctx.fill(Path(ellipseIn: CGRect(x: p.x - r, y: p.y - r, width: r * 2, height: r * 2)),
+                 with: .radialGradient(Gradient(stops: [.init(color: .black, location: 0),
+                                                        .init(color: .black, location: 0.72),
+                                                        .init(color: .black.opacity(0), location: 1)]),
+                                       center: p, startRadius: 0, endRadius: r))
+    }
+
+    // MARK: Stardust (two parallax depth layers, drifting, faintly twinkling)
+
+    struct Speck {
+        let base: CGPoint          // in a unit tile
+        let size: CGFloat
+        let alpha: Double
+        let parallax: CGFloat
+        let drift: CGPoint         // px per second
+        let phase: Double
+    }
+
+    static func makeDust() -> [Speck] {
+        var rng = SplitMix64(seed: 0xD057)
+        func layer(count: Int, parallax: CGFloat, sizes: ClosedRange<CGFloat>, alpha: ClosedRange<Double>) -> [Speck] {
+            (0..<count).map { _ in
+                Speck(base: CGPoint(x: CGFloat.random(in: 0...1, using: &rng),
+                                    y: CGFloat.random(in: 0...1, using: &rng)),
+                      size: CGFloat.random(in: sizes, using: &rng),
+                      alpha: Double.random(in: alpha, using: &rng),
+                      parallax: parallax,
+                      drift: CGPoint(x: CGFloat.random(in: -2.2...2.2, using: &rng),
+                                     y: CGFloat.random(in: -1.6...1.6, using: &rng)),
+                      phase: Double.random(in: 0...6.28, using: &rng))
+            }
+        }
+        return layer(count: 150, parallax: 0.22, sizes: 0.7...1.4, alpha: 0.03...0.07)
+             + layer(count: 90, parallax: 0.45, sizes: 1.1...2.1, alpha: 0.05...0.10)
+    }
+
+    private static func drawDust(_ ctx: GraphicsContext, size: CGSize, model: NightSkyModel, t: TimeInterval) {
+        let margin: CGFloat = 80
+        let tileW = size.width + margin * 2
+        let tileH = size.height + margin * 2
+        guard tileW > 0, tileH > 0 else { return }
+        for s in model.dust {
+            var x = (s.base.x * tileW + s.drift.x * t + model.camera.pan.x * s.parallax)
+                .truncatingRemainder(dividingBy: tileW)
+            var y = (s.base.y * tileH + s.drift.y * t + model.camera.pan.y * s.parallax)
+                .truncatingRemainder(dividingBy: tileH)
+            if x < 0 { x += tileW }
+            if y < 0 { y += tileH }
+            let a = s.alpha * (0.75 + 0.25 * sin(t * 0.7 + s.phase))
+            ctx.fill(Path(ellipseIn: CGRect(x: x - margin, y: y - margin, width: s.size, height: s.size)),
+                     with: .color(.white.opacity(a)))
+        }
+    }
+
+    // MARK: The center breath (a barely-there luminance wave every ~11s — the heartbeat)
+
+    private static func drawBreath(_ ctx: GraphicsContext, size: CGSize, model: NightSkyModel,
+                                   t: TimeInterval, reveal: Double) {
+        guard reveal > 0.3 else { return }
+        let period = 11.0
+        let phase = t.truncatingRemainder(dividingBy: period) / period
+        guard phase < 0.5 else { return }
+        let p = phase / 0.5
+        let ease = 1 - pow(1 - p, 2)
+        let center = model.toScreen(.zero, size: size)
+        let r = (40 + 560 * ease) * model.camera.zoom
+        ctx.fill(Path(ellipseIn: CGRect(x: center.x - r, y: center.y - r, width: r * 2, height: r * 2)),
+                 with: .radialGradient(Gradient(colors: [.white.opacity(0.030 * (1 - p) * reveal), .clear]),
+                                       center: center, startRadius: 0, endRadius: r))
+    }
+
+    // MARK: Threads
+
+    private static func drawThreads(_ ctx: GraphicsContext, size: CGSize, model: NightSkyModel,
+                                    graph: SkyGraph, sim: SkySimulation,
+                                    reveal: Double, focusSet: Set<Int>, zf: CGFloat) {
+        guard reveal > 0.01 else { return }
+        let dim = 1 - 0.55 * model.focusBlend
+        let root = graph.rootIndex
+        let clear = sunClearance(zf)
+
+        /// Endpoints with the root's end pulled back to the sun's rim (never through the logo).
+        func endpoints(_ e: SkyEdge) -> (CGPoint, CGPoint)? {
+            var a = model.toScreen(sim.pos[e.a], size: size)
+            var b = model.toScreen(sim.pos[e.b], size: size)
+            if e.a == root { a = pulledIn(a, toward: b, by: clear) }
+            if e.b == root { b = pulledIn(b, toward: a, by: clear) }
+            return (b - a).length > 2 ? (a, b) : nil
+        }
+
+        // Resting threads batch into two paths (one stroke call each).
+        var same = Path()
+        var cross = Path()
+        for e in graph.edges {
+            guard let (a, b) = endpoints(e) else { continue }
+            if e.sameDomain { same.move(to: a); same.addLine(to: b) }
+            else { cross.move(to: a); cross.addLine(to: b) }
+        }
+        ctx.stroke(same, with: .color(.white.opacity(0.075 * reveal * dim)), lineWidth: 0.8)
+        ctx.stroke(cross, with: .color(.white.opacity(0.05 * reveal * dim)), lineWidth: 0.8)
+
+        // Ignited threads: the focused star's edges light up as domain→domain gradients.
+        func ignite(_ center: Int, intensity: Double) {
+            guard intensity > 0.02 else { return }
+            for e in graph.edges where e.a == center || e.b == center {
+                guard let (pa, pb) = endpoints(e) else { continue }
+                var p = Path()
+                p.move(to: pa)
+                p.addLine(to: pb)
+                let shading = GraphicsContext.Shading.linearGradient(
+                    Gradient(colors: [domainColor(graph.nodes[e.a].domain, alpha: 0.9 * intensity),
+                                      domainColor(graph.nodes[e.b].domain, alpha: 0.9 * intensity)]),
+                    startPoint: pa, endPoint: pb)
+                var wide = ctx
+                wide.opacity = 0.28 * intensity
+                wide.stroke(p, with: shading, lineWidth: 4.5)
+                ctx.stroke(p, with: shading, lineWidth: 1.3)
+            }
+        }
+        if let f = model.focusIndex { ignite(f, intensity: model.focusBlend * reveal) }
+        if let h = model.highlightIndex, h != model.focusIndex,
+           model.glow.indices.contains(h) {
+            ignite(h, intensity: model.glow[h] * 0.7 * reveal)
+        }
+    }
+
+    // MARK: Photon pulses (one synapse firing at a time)
+
+    private static func drawPulses(_ ctx: GraphicsContext, size: CGSize, model: NightSkyModel,
+                                   graph: SkyGraph, sim: SkySimulation, t: TimeInterval, reveal: Double) {
+        for pulse in model.pulses {
+            guard graph.edges.indices.contains(pulse.edge) else { continue }
+            let e = graph.edges[pulse.edge]
+            let progress = max(0, min(1, (t - pulse.start) / pulse.duration))
+            let envelope = sin(.pi * progress) * reveal
+            guard envelope > 0.01 else { continue }
+            let a = model.toScreen(sim.pos[e.a], size: size)
+            let b = model.toScreen(sim.pos[e.b], size: size)
+            let head = CGPoint(x: a.x + (b.x - a.x) * progress, y: a.y + (b.y - a.y) * progress)
+            let tailP = max(0, progress - 0.13)
+            let tail = CGPoint(x: a.x + (b.x - a.x) * tailP, y: a.y + (b.y - a.y) * tailP)
+            var trail = Path()
+            trail.move(to: tail)
+            trail.addLine(to: head)
+            ctx.stroke(trail,
+                       with: .linearGradient(Gradient(colors: [.clear, .white.opacity(0.55 * envelope)]),
+                                             startPoint: tail, endPoint: head),
+                       lineWidth: 1.2)
+            let r = 4.5 * max(model.camera.zoom, 0.6)
+            ctx.fill(Path(ellipseIn: CGRect(x: head.x - r, y: head.y - r, width: r * 2, height: r * 2)),
+                     with: .radialGradient(Gradient(colors: [.white.opacity(0.9 * envelope), .clear]),
+                                           center: head, startRadius: 0, endRadius: r))
+        }
+    }
+
+    // MARK: Stars
+
+    static func starRadius(_ n: SkyNode, maxDegree: Int, zf: CGFloat) -> CGFloat {
+        let degN = sqrt(Double(n.degree) / Double(max(maxDegree, 1)))
+        let world: CGFloat = n.isRoot ? 9 : (2.3 + 3.3 * CGFloat(degN))
+        return world * zf
+    }
+
+    private static func drawStars(_ ctx: GraphicsContext, size: CGSize, model: NightSkyModel,
+                                  graph: SkyGraph, sim: SkySimulation, t: TimeInterval, zf: CGFloat,
+                                  starReveal: Double, focusSet: Set<Int>) {
+        let margin: CGFloat = 80
+        for (i, n) in graph.nodes.enumerated() {
+            let p = model.toScreen(sim.pos[i], size: size)
+            guard p.x > -margin, p.x < size.width + margin, p.y > -margin, p.y < size.height + margin
+            else { continue }
+
+            let g = model.glow.indices.contains(i) ? model.glow[i] : 0
+            let dim = (focusSet.isEmpty || focusSet.contains(i)) ? 1.0 : 1.0 - 0.62 * model.focusBlend
+            let twinkle = 0.86 + 0.14 * sin(t * n.twinkleSpeed + n.twinklePhase)
+            let bright = twinkle * dim * starReveal
+            let r = starRadius(n, maxDegree: graph.maxDegree, zf: zf)
+
+            if n.isRoot {
+                drawSunBed(ctx, at: p, r: r, bright: bright * (1 + 0.6 * g))
+                continue
+            }
+
+            let degN = sqrt(Double(n.degree) / Double(max(graph.maxDegree, 1)))
+
+            // Halo (constellation hue), blooming when ignited.
+            let haloR = r * 3.6 * (1 + 0.8 * g)
+            ctx.fill(Path(ellipseIn: CGRect(x: p.x - haloR, y: p.y - haloR, width: haloR * 2, height: haloR * 2)),
+                     with: .radialGradient(
+                        Gradient(colors: [domainColor(n.domain, alpha: (0.16 + 0.10 * degN) * bright * (1 + 1.7 * g)),
+                                          .clear]),
+                        center: p, startRadius: 0, endRadius: haloR))
+
+            // "Changed last night" — a slow amber breath around the star.
+            if n.recentlyChanged {
+                let aR = r * 5
+                let aA = (0.10 + 0.07 * sin(t * 1.5 + n.twinklePhase)) * dim * starReveal
+                ctx.fill(Path(ellipseIn: CGRect(x: p.x - aR, y: p.y - aR, width: aR * 2, height: aR * 2)),
+                         with: .radialGradient(
+                            Gradient(colors: [Color(red: amber.r, green: amber.g, blue: amber.b, opacity: aA), .clear]),
+                            center: p, startRadius: 0, endRadius: aR))
+            }
+
+            // Core.
+            let coreR = r * (1 + 0.30 * g)
+            ctx.fill(Path(ellipseIn: CGRect(x: p.x - coreR, y: p.y - coreR, width: coreR * 2, height: coreR * 2)),
+                     with: .color(coreColor(n.domain, alpha: min(1, 0.10 + 0.9 * bright + 0.25 * g))))
+
+            // Ignite ring.
+            if g > 0.02 {
+                let ringR = r * 2.15 + 1.5
+                ctx.stroke(Path(ellipseIn: CGRect(x: p.x - ringR, y: p.y - ringR, width: ringR * 2, height: ringR * 2)),
+                           with: .color(domainColor(n.domain, alpha: 0.55 * g)),
+                           lineWidth: 1)
+            }
+        }
+    }
+
+    /// The root README's light bed — a soft warm halo under the sun. The sun itself is the REAL
+    /// brand mark: NightSkyView floats a slow SpinningLogo (the notch spinner) over the canvas at
+    /// this exact spot, so the center of your life wears the actual logo.
+    private static func drawSunBed(_ ctx: GraphicsContext, at p: CGPoint, r: CGFloat, bright: Double) {
+        let halo = r * 7
+        ctx.fill(Path(ellipseIn: CGRect(x: p.x - halo, y: p.y - halo, width: halo * 2, height: halo * 2)),
+                 with: .radialGradient(Gradient(colors: [.white.opacity(0.10 * bright), .clear]),
+                                       center: p, startRadius: 0, endRadius: halo))
+    }
+
+    // MARK: Labels
+
+    /// Constellation names as star-atlas watermarks under the graph (fade out as you zoom in).
+    private static func drawConstellationLabels(_ ctx: GraphicsContext, size: CGSize, model: NightSkyModel,
+                                                graph: SkyGraph, sim: SkySimulation,
+                                                reveal: Double, dim: Double) {
+        let zoom = model.camera.zoom
+        let labelA = max(0, min(1, (1.9 - Double(zoom)) / 0.9)) * reveal * dim
+        guard labelA > 0.02, !graph.domains.isEmpty else { return }
+
+        var sums = [CGPoint](repeating: .zero, count: graph.domains.count)
+        var counts = [Int](repeating: 0, count: graph.domains.count)
+        for (i, n) in graph.nodes.enumerated() where n.domain >= 0 {
+            sums[n.domain] += sim.pos[i]
+            counts[n.domain] += 1
+        }
+        for (d, name) in graph.domains.enumerated() where counts[d] > 0 {
+            let centroid = model.toScreen(sums[d] * (1 / CGFloat(counts[d])), size: size)
+            var txt = ctx.resolve(Text(name.uppercased())
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .tracking(3.5))
+            txt.shading = .color(.white.opacity(0.20 * labelA))
+            ctx.draw(txt, at: centroid, anchor: .center)
+        }
+    }
+
+    /// Note titles under their stars — zoom-gated at rest (conservative: the resting sky stays
+    /// clean), but on hover the whole ignited neighborhood becomes candidates. Placement is
+    /// COLLISION-AWARE (map-app style): labels are placed greedily by priority (hovered star →
+    /// highlight → busiest neighbors) and any label whose measured rect would overlap an already
+    /// placed one — or the hover card — simply isn't drawn. As many names as fit, zero clutter.
+    private static func drawTitles(_ ctx: GraphicsContext, size: CGSize, model: NightSkyModel,
+                                   graph: SkyGraph, sim: SkySimulation, zf: CGFloat,
+                                   reveal: Double, focusSet: Set<Int>) {
+        let zoom = Double(model.camera.zoom)
+        guard zoom > 1.0 || model.focusIndex != nil || model.highlightIndex != nil else { return }
+        let margin: CGFloat = 40
+
+        struct Candidate {
+            let i: Int
+            let anchor: CGPoint
+            let alpha: Double
+            let priority: Double     // static per hover session, so placement never flickers
+        }
+        var candidates: [Candidate] = []
+        for (i, n) in graph.nodes.enumerated() {
+            let degN = sqrt(Double(n.degree) / Double(max(graph.maxDegree, 1)))
+            let threshold = n.isRoot ? 1.2 : 2.0 - 0.55 * degN
+            let g = model.glow.indices.contains(i) ? model.glow[i] : 0
+            var a = max(0, min(1, (zoom - threshold) / 0.4))
+            if i == model.focusIndex || i == model.highlightIndex || focusSet.contains(i) {
+                a = max(a, g * 0.92)                       // the ignited neighborhood gets named too
+            }
+            if !focusSet.isEmpty && !focusSet.contains(i) { a *= 1 - 0.62 * model.focusBlend }
+            guard a > 0.03 else { continue }
+            let p = model.toScreen(sim.pos[i], size: size)
+            guard p.x > -margin, p.x < size.width + margin, p.y > -margin, p.y < size.height + margin
+            else { continue }
+            // The root's label clears the SpinningLogo's ring, not just its (smaller) hit radius.
+            let r = n.isRoot ? sunClearance(zf) : starRadius(n, maxDegree: graph.maxDegree, zf: zf)
+            let priority: Double = i == model.focusIndex ? 3 : (i == model.highlightIndex ? 2 : degN)
+            candidates.append(Candidate(i: i, anchor: CGPoint(x: p.x, y: p.y + r + 12),
+                                        alpha: a, priority: priority))
+        }
+
+        candidates.sort { $0.priority != $1.priority ? $0.priority > $1.priority : $0.i < $1.i }
+        var placed: [CGRect] = []
+        if let card = model.hoverCardRect(in: size) { placed.append(card) }
+        for c in candidates {
+            var txt = ctx.resolve(Text(graph.nodes[c.i].title).font(.system(size: 10.5, design: .serif)))
+            txt.shading = .color(.white.opacity(0.62 * c.alpha * reveal))
+            let sz = txt.measure(in: CGSize(width: 360, height: 60))
+            let rect = CGRect(x: c.anchor.x - sz.width / 2, y: c.anchor.y - sz.height / 2,
+                              width: sz.width, height: sz.height).insetBy(dx: -6, dy: -3)
+            guard !placed.contains(where: { $0.intersects(rect) }) else { continue }
+            placed.append(rect)
+            ctx.draw(txt, at: c.anchor, anchor: .center)
+        }
+    }
+}

--- a/Sentient OS macOS/Views/Knowledge/Graph/SkySimulation.swift
+++ b/Sentient OS macOS/Views/Knowledge/Graph/SkySimulation.swift
@@ -1,0 +1,199 @@
+//
+//  SkySimulation.swift
+//  Sentient OS macOS
+//
+//  The Night Sky's physics: a small force-directed simulation — spring threads, pairwise star
+//  repulsion, per-constellation ring anchors, a root sun pinned at the origin — with a cooling
+//  "alpha" that starts hot (the assembly entrance: stars fly in from beyond the rim and settle)
+//  and goes to sleep once still. Dragging a star reheats its neighborhood. Positions are world
+//  space; NightSkyModel owns the camera. ~130 stars → the O(n²) pass is microseconds per frame.
+//
+//  Key methods: init(graph:) · step(elapsed:) · settle() · restore(positions:) ·
+//  beginDrag/drag/endDrag. All knobs live in SkyTuning.
+//
+
+import Foundation
+import CoreGraphics
+
+/// Every physics/feel knob in one place, so taste-tuning never means spelunking.
+/// ⚠️ The force constants are a BALANCED SET: they were scaled down uniformly (~×0.65 from the
+/// first draft) to calm the motion WITHOUT moving the equilibrium — the settled layout only
+/// depends on their ratios. Scale them together or the composition changes.
+enum SkyTuning {
+    static let ringRadius: CGFloat = 300       // where the constellation anchors sit (world units)
+    static let repulsion: CGFloat = 1700       // pairwise star push (÷ distance²)
+    static let repulsionCutoff: CGFloat = 300  // beyond this, stars ignore each other
+    static let springSameRest: CGFloat = 62    // thread rest lengths + stiffness
+    static let springSameK: CGFloat = 0.036
+    static let springCrossRest: CGFloat = 185  // cross-constellation threads are long and loose,
+    static let springCrossK: CGFloat = 0.0065  //  so bridges don't yank clusters together
+    static let anchorPull: CGFloat = 0.020     // gravity toward the constellation's ring anchor
+    static let centerPull: CGFloat = 0.0010    // faint pull keeping strays in the frame
+    static let damping: CGFloat = 0.80         // heavy friction — overshoot dies, no boing
+    static let maxSpeed: CGFloat = 14          // terminal velocity: stars GLIDE in, never slingshot
+    static let alphaDecay: Double = 0.986      // per substep — the entrance settles in ~3–4s
+    static let sleepAlpha: Double = 0.012
+    static let dragAlpha: Double = 0.35        // heat held while a star is being dragged
+}
+
+final class SkySimulation {
+    private(set) var pos: [CGPoint]
+    private var vel: [CGPoint]                 // CGPoint doubling as a vector
+    private(set) var alpha: Double = 1         // 1 = assembly heat → 0 = asleep
+    let anchors: [CGPoint]                     // per domain index
+    private let graph: SkyGraph
+    private var dragIndex: Int?
+    private var dragTarget: CGPoint = .zero
+
+    var isAwake: Bool { alpha > 0 || dragIndex != nil }
+
+    /// `entrance: true` starts hot with stars scattered beyond the rim (the assembly moment);
+    /// `false` runs the same physics to rest immediately (previews, refreshes).
+    init(graph: SkyGraph, entrance: Bool) {
+        self.graph = graph
+        let d = max(graph.domains.count, 1)
+        let anchors = (0..<graph.domains.count).map { i -> CGPoint in
+            let ang = -CGFloat.pi / 2 + 2 * .pi * CGFloat(i) / CGFloat(d)
+            return CGPoint(x: cos(ang) * SkyTuning.ringRadius, y: sin(ang) * SkyTuning.ringRadius)
+        }
+        self.anchors = anchors
+
+        var rng = SplitMix64(seed: 0xC0FFEE ^ UInt64(graph.nodes.count))
+        pos = graph.nodes.map { n in
+            if n.isRoot { return .zero }
+            let anchor = (n.domain >= 0 && n.domain < anchors.count) ? anchors[n.domain] : .zero
+            let toward = anchor == .zero ? CGFloat.random(in: -.pi ... .pi, using: &rng)
+                                         : atan2(anchor.y, anchor.x)
+            let ang = toward + CGFloat.random(in: -0.55...0.55, using: &rng)
+            let r = SkyTuning.ringRadius * CGFloat.random(in: 1.95...2.8, using: &rng)
+            return CGPoint(x: cos(ang) * r, y: sin(ang) * r)
+        }
+        vel = [CGPoint](repeating: .zero, count: graph.nodes.count)
+        if !entrance { settle() }
+    }
+
+    private func anchorPoint(_ domain: Int) -> CGPoint {
+        domain >= 0 && domain < anchors.count ? anchors[domain] : .zero
+    }
+
+    // MARK: Stepping
+
+    /// Advance by wall-clock `elapsed` (1–3 unit substeps — frame-rate independent enough).
+    func step(elapsed: TimeInterval) {
+        guard isAwake else { return }
+        let n = max(1, min(3, Int((elapsed * 60).rounded())))
+        for _ in 0..<n { substep() }
+    }
+
+    /// Run the physics to rest without animating (caps at ~1500 steps just in case).
+    func settle() {
+        for _ in 0..<1500 {
+            substep()
+            if alpha == 0 { break }
+        }
+    }
+
+    /// Reuse positions from a previous session of the sky (matched by note URL) so a refresh
+    /// never replays the entrance: matched stars stay put, new ones fade in near their anchor,
+    /// and a little heat absorbs the difference.
+    func restore(positions: [URL: CGPoint]) {
+        var rng = SplitMix64(seed: 42)
+        for (i, n) in graph.nodes.enumerated() {
+            if n.isRoot { pos[i] = .zero }
+            else if let p = positions[n.url] { pos[i] = p }
+            else {
+                let a = anchorPoint(n.domain)
+                pos[i] = CGPoint(x: a.x + CGFloat.random(in: -34...34, using: &rng),
+                                 y: a.y + CGFloat.random(in: -34...34, using: &rng))
+            }
+            vel[i] = .zero
+        }
+        alpha = 0.2
+    }
+
+    private func substep() {
+        let count = graph.nodes.count
+        guard count > 0 else { return }
+        var force = [CGPoint](repeating: .zero, count: count)
+        let cutoff2 = SkyTuning.repulsionCutoff * SkyTuning.repulsionCutoff
+
+        // Pairwise repulsion — O(n²), measured trivial at this scale.
+        for i in 0..<count {
+            for j in (i + 1)..<count {
+                var d = pos[i] - pos[j]
+                var dist2 = d.x * d.x + d.y * d.y
+                if dist2 > cutoff2 { continue }
+                if dist2 < 0.01 {                                   // coincident guard (no NaNs)
+                    d = CGPoint(x: 0.017 * CGFloat(i - j), y: 0.013)
+                    dist2 = d.x * d.x + d.y * d.y
+                }
+                let dist = sqrt(max(dist2, 25))
+                let f = SkyTuning.repulsion / max(dist2, 25)
+                let dir = d * (1 / dist)
+                force[i] += dir * f
+                force[j] -= dir * f
+            }
+        }
+        // Threads as springs.
+        for e in graph.edges {
+            let rest = e.sameDomain ? SkyTuning.springSameRest : SkyTuning.springCrossRest
+            let k = e.sameDomain ? SkyTuning.springSameK : SkyTuning.springCrossK
+            let d = pos[e.b] - pos[e.a]
+            let dist = max(d.length, 0.01)
+            let f = (dist - rest) * k
+            let dir = d * (1 / dist)
+            force[e.a] += dir * f
+            force[e.b] -= dir * f
+        }
+        // Constellation anchors + the faint center keep.
+        for i in 0..<count {
+            let n = graph.nodes[i]
+            let pull = SkyTuning.anchorPull * (n.domain >= 0 ? 1 : 0.5)
+            force[i] += (anchorPoint(n.domain) - pos[i]) * pull
+            force[i] += pos[i] * -SkyTuning.centerPull
+        }
+        // Integrate. The root sun is pinned; a dragged star obeys the cursor.
+        let heat = CGFloat(0.2 + 0.8 * alpha)
+        for i in 0..<count {
+            if graph.nodes[i].isRoot { pos[i] = .zero; vel[i] = .zero; continue }
+            if i == dragIndex { pos[i] = dragTarget; vel[i] = .zero; continue }
+            vel[i] = (vel[i] + force[i] * heat) * SkyTuning.damping
+            let speed = vel[i].length
+            if speed > SkyTuning.maxSpeed { vel[i] = vel[i] * (SkyTuning.maxSpeed / speed) }
+            pos[i] = pos[i] + vel[i]
+        }
+        if dragIndex == nil {
+            alpha *= SkyTuning.alphaDecay
+            if alpha < SkyTuning.sleepAlpha { alpha = 0 }
+        } else {
+            alpha = max(alpha, SkyTuning.dragAlpha)
+        }
+    }
+
+    // MARK: Dragging (the fidget toy)
+
+    func beginDrag(_ i: Int) {
+        guard graph.nodes.indices.contains(i), !graph.nodes[i].isRoot else { return }
+        dragIndex = i
+        dragTarget = pos[i]
+        alpha = max(alpha, SkyTuning.dragAlpha)
+    }
+
+    func drag(to world: CGPoint) {
+        guard dragIndex != nil else { return }
+        dragTarget = world
+    }
+
+    func endDrag() { dragIndex = nil }
+}
+
+// MARK: - Vector helpers (world positions are CGPoints; the whole sky shares these)
+
+extension CGPoint {
+    static func + (l: CGPoint, r: CGPoint) -> CGPoint { CGPoint(x: l.x + r.x, y: l.y + r.y) }
+    static func - (l: CGPoint, r: CGPoint) -> CGPoint { CGPoint(x: l.x - r.x, y: l.y - r.y) }
+    static func * (l: CGPoint, r: CGFloat) -> CGPoint { CGPoint(x: l.x * r, y: l.y * r) }
+    static func += (l: inout CGPoint, r: CGPoint) { l = l + r }
+    static func -= (l: inout CGPoint, r: CGPoint) { l = l - r }
+    var length: CGFloat { sqrt(x * x + y * y) }
+}

--- a/Sentient OS macOS/Views/Knowledge/KnowledgeView.swift
+++ b/Sentient OS macOS/Views/Knowledge/KnowledgeView.swift
@@ -8,6 +8,9 @@
 //  right-click) and a rendered-markdown reader on the right. [[Wikilinks]] jump between notes (Back walks the trail);
 //  the titlebar carries Edit / Delete (→ Trash) / Reveal in Finder. Every edit/create/delete commits
 //  locally and DEBOUNCE-syncs to the cloud MCP (VaultActivity.markChanged → the sidebar status line).
+//  The window OPENS in the "Constellation View" graph (Graph/NightSkyView.swift — the default);
+//  glowing SkyDoor capsules swap between it and the reader (sky: top-center · reader: top-left;
+//  ⌘⇧G). Click a star to read that note; Back (or Esc) returns to the sky where you left it.
 //
 //  Replaced the old DatabaseView (a dev CycleStore-summaries inspector, still in Dev Tools via
 //  SummariesView). Data: VaultTree.swift · rendering: MarkdownView.swift.
@@ -54,26 +57,31 @@ struct KnowledgeView: View {
     @State private var createParent: URL?     // nil = the vault root
     @State private var createName = ""
 
+    // The Night Sky graph view — the window OPENS here (Constellation View is the default; the
+    // Reader door leads to the split view). The model outlives toggles, so the sky keeps its
+    // camera and star positions across reader trips; `cameFromSky` makes Back return to the sky
+    // after a star click.
+    @State private var mode: Mode = .sky
+    @StateObject private var skyModel = NightSkyModel()
+    @State private var cameFromSky = false
+
+    /// Reader (the split view) or the Night Sky (the full-window galaxy).
+    private enum Mode { case reader, sky }
+
     /// A navigation parked behind the unsaved-edits prompt.
-    private enum PendingNav { case open(URL), follow(URL), back }
+    private enum PendingNav { case open(URL), follow(URL), back, sky }
 
     var body: some View {
-        NavigationSplitView {
-            sidebar.navigationSplitViewColumnWidth(min: 280, ideal: 320, max: 430)
-        } detail: {
-            reader
+        Group {
+            if mode == .sky {
+                skyPane.transition(.opacity)
+            } else {
+                splitView.transition(.opacity)
+            }
         }
-        .navigationSplitViewStyle(.balanced)
         .frame(minWidth: 900, minHeight: 600)
         .background(Theme.bg)
         .background(WindowChrome())   // transparent titlebar from launch (no "grey until resize")
-        // Window-open focus lands in the search box, not the sidebar's "+" button. defaultFocus
-        // declares it; the delayed onAppear claim backs it up (AppKit assigns the initial key
-        // view a beat after SwiftUI's appear — same pattern as PromptBar's launch focus).
-        .defaultFocus($searchFocused, true)
-        .onAppear {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { searchFocused = true }
-        }
         .task { await loadVault() }
         .alert("You have unsaved edits", isPresented: $showDiscardPrompt) {
             Button("Save") { promptSave() }
@@ -87,6 +95,35 @@ struct KnowledgeView: View {
             Button("Create") { performCreate() }
             Button("Cancel", role: .cancel) {}
         }
+    }
+
+    /// The reader half: the familiar sidebar + rendered-markdown split.
+    private var splitView: some View {
+        NavigationSplitView {
+            sidebar.navigationSplitViewColumnWidth(min: 280, ideal: 320, max: 430)
+        } detail: {
+            reader
+        }
+        .navigationSplitViewStyle(.balanced)
+        // Window-open focus lands in the search box, not the sidebar's "+" button. defaultFocus
+        // declares it; the delayed onAppear claim backs it up (AppKit assigns the initial key
+        // view a beat after SwiftUI's appear — same pattern as PromptBar's launch focus).
+        .defaultFocus($searchFocused, true)
+        .onAppear {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { searchFocused = true }
+        }
+    }
+
+    /// The Constellation View takes the whole window (the planetarium moment). The top-left
+    /// "Reader" door, Esc, and ⌘⇧G all lead back.
+    private var skyPane: some View {
+        NightSkyView(vault: vault, vaultLoaded: loaded, model: skyModel,
+                     onOpen: { openFromSky($0) },
+                     onExit: { requestMode(.reader) })
+            .toolbar {
+                SkyDoorToolbarItem(icon: "doc.plaintext", label: "Reader View",
+                                   help: "Back to the reader (Esc or ⌘⇧G)") { requestMode(.reader) }
+            }
     }
 
     private func loadVault() async {
@@ -108,7 +145,34 @@ struct KnowledgeView: View {
     /// Open a note from the sidebar (or on first load): a clean start, so no Back button shows.
     private func open(_ url: URL) {
         history = [url]; historyIndex = 0
+        cameFromSky = false      // a fresh trail forgets the sky (openFromSky re-sets it)
         select(url)
+    }
+
+    // MARK: The Night Sky (mode switching + the star → reader → back-to-sky loop)
+
+    /// Switch reader ⟷ sky. Entering the sky funnels through the same unsaved-edits guard as
+    /// every other navigation.
+    private func requestMode(_ new: Mode) {
+        guard new != mode else { return }
+        if new == .sky {
+            if editing { if isDirty { pendingNav = .sky; showDiscardPrompt = true; return }; exitEdit() }
+            enterSky()
+        } else {
+            withAnimation(.easeInOut(duration: 0.3)) { mode = .reader }
+        }
+    }
+
+    private func enterSky() {
+        if cameFromSky, let sel = selection { skyModel.highlight(sel) }   // "you were just here"
+        withAnimation(.easeInOut(duration: 0.3)) { mode = .sky }
+    }
+
+    /// A star was clicked: land in the reader on that note, and let Back lead home to the sky.
+    private func openFromSky(_ url: URL) {
+        withAnimation(.easeInOut(duration: 0.3)) { mode = .reader }
+        open(url)
+        cameFromSky = true
     }
 
     /// Follow a wikilink: push onto the trail (truncating anything we'd gone back past), so Back
@@ -143,7 +207,13 @@ struct KnowledgeView: View {
     }
     private func requestBack() {
         if editing { if isDirty { pendingNav = .back; showDiscardPrompt = true; return }; exitEdit() }
-        goBack()
+        backAction()
+    }
+
+    /// Back walks the wikilink trail; with the trail exhausted, it returns to the Night Sky if
+    /// that's where this reading trip began.
+    private func backAction() {
+        if canGoBack { goBack() } else if cameFromSky { enterSky() }
     }
 
     // MARK: The markdown editor
@@ -201,7 +271,8 @@ struct KnowledgeView: View {
         switch p {
         case .open(let u):   open(u)
         case .follow(let u): follow(u)
-        case .back:          goBack()
+        case .back:          backAction()
+        case .sky:           enterSky()
         }
     }
 
@@ -211,8 +282,9 @@ struct KnowledgeView: View {
     /// (a now-missing selection is handled by the caller).
     private func reloadVault() { vault = KnowledgeVault.load() }
 
-    /// Move a note to the macOS Trash (recoverable). If it was the open note, land on Overview.
-    private func deleteNote(_ url: URL) {
+    /// Move a note OR a folder to the macOS Trash (recoverable). If the open note was the trashed
+    /// item — or lived anywhere inside a trashed folder — land back on Overview.
+    private func deleteItem(_ url: URL) {
         guard url != vault?.readme else { return }   // never trash the vault index
         do {
             try FileManager.default.trashItem(at: url, resultingItemURL: nil)
@@ -220,9 +292,9 @@ struct KnowledgeView: View {
             Log("Knowledge: delete failed — \(error.localizedDescription)")
             return
         }
-        let wasOpen = (url == selection)
+        let lostSelection = selection == url || (selection?.path.hasPrefix(url.path + "/") ?? false)
         reloadVault()
-        if wasOpen {
+        if lostSelection {
             if let r = vault?.readme { open(r) }
             else { selection = nil; note = nil; history = []; historyIndex = -1 }
         }
@@ -359,16 +431,17 @@ struct KnowledgeView: View {
     }
 
     /// The line under the count: "Saved locally on this Mac" (mirror off) or the live cloud-MCP sync
-    /// state — a glowing status dot (white at rest, warm accent while working; a spinner while pushing)
-    /// then the state with an inline, single-color "(🔒 E2E Encrypted)". @Observable → re-renders live.
-    /// (E2E Encrypted is surfaced now, implemented later.)
+    /// state — a calm white status dot (a spinner while pushing; deliberately NEVER colored — an
+    /// orange "will sync" read as a warning) then the state with an inline, single-color
+    /// "(🔒 E2E Encrypted)". @Observable → re-renders live. (E2E Encrypted is surfaced now,
+    /// implemented later.)
     @ViewBuilder
     private var statusLine: some View {
         if mirrorEnabled {
             switch VaultActivity.shared.syncState {
             case .synced:  cloudStatus("Synced to Cloud MCP", color: Theme.secondary, dot: .white, spinner: false)
-            case .pending: cloudStatus("Will sync soon", color: Theme.knowledgeAccent, dot: Theme.knowledgeAccent, spinner: false)
-            case .syncing: cloudStatus("Syncing to Cloud MCP", color: Theme.knowledgeAccent, dot: Theme.knowledgeAccent, spinner: true)
+            case .pending: cloudStatus("Will sync soon", color: Theme.secondary, dot: .white, spinner: false)
+            case .syncing: cloudStatus("Syncing to Cloud MCP", color: Theme.secondary, dot: .white, spinner: true)
             }
         } else {
             HStack(spacing: 7) {
@@ -430,7 +503,7 @@ struct KnowledgeView: View {
                     NodeRow(node: node, depth: 0, expanded: $expanded, selection: selection,
                             onSelect: { requestOpen($0) },
                             onCreate: { promptCreate(folder: $1, in: $0) },
-                            onDelete: { deleteNote($0) })
+                            onDelete: { deleteItem($0) })
                 }
             } else if searchResults.isEmpty {
                 Text("No matches").font(.system(size: 12)).foregroundStyle(Theme.faint)
@@ -438,7 +511,7 @@ struct KnowledgeView: View {
             } else {
                 ForEach(searchResults) { node in
                     NoteRow(url: node.url, title: node.name, depth: 0, selected: node.url == selection,
-                            onDelete: { deleteNote($0) }) {
+                            onDelete: { deleteItem($0) }) {
                         requestOpen(node.url)
                     }
                 }
@@ -454,14 +527,22 @@ struct KnowledgeView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(Theme.bg)
             .toolbar {
-                // The actions live in the window's titlebar (no extra row): Back rides in on the left
-                // only after a wikilink jump; Edit + Reveal in Finder sit TOGETHER at the top-right.
-                // (One ToolbarItemGroup, not two ToolbarItems — split-view detail toolbars left-align
-                // multiple separate .primaryAction items; a single group trails correctly.)
-                if canGoBack {
+                // The actions live in the window's titlebar (no extra row): the glowing
+                // "Constellation View" door leads top-left (mode switches funnel through
+                // requestMode, so unsaved edits are never dropped), Back rides in beside it
+                // after a wikilink jump (or a star click — then it returns to the sky); Edit +
+                // Reveal in Finder sit TOGETHER at the top-right. (One ToolbarItemGroup, not two
+                // ToolbarItems — split-view detail toolbars left-align multiple separate
+                // .primaryAction items; a single group trails correctly.)
+                if vault != nil {
+                    SkyDoorToolbarItem(icon: "sparkles", label: "Constellation View",
+                                       help: "See your knowledge as a galaxy (⌘⇧G)",
+                                       placement: .navigation) { requestMode(.sky) }
+                }
+                if canGoBack || cameFromSky {
                     ToolbarItem(placement: .navigation) {
                         Button(action: requestBack) { Label("Back", systemImage: "chevron.left") }
-                            .help("Back")
+                            .help(canGoBack ? "Back" : "Back to the Night Sky")
                     }
                 }
                 if selection != nil {
@@ -479,7 +560,7 @@ struct KnowledgeView: View {
     @ViewBuilder
     private var deleteToolbarButton: some View {
         if let url = selection, url != vault?.readme {
-            Button(role: .destructive) { deleteNote(url) } label: {
+            Button(role: .destructive) { deleteItem(url) } label: {
                 Label("Move to Trash", systemImage: "trash")
             }
             .labelStyle(.iconOnly)
@@ -622,6 +703,7 @@ private struct FolderRow: View {
     let depth: Int
     let isOpen: Bool
     let onCreate: (URL, Bool) -> Void
+    let onDelete: (URL) -> Void
     let toggle: () -> Void
     @State private var hover = false
 
@@ -672,6 +754,8 @@ private struct FolderRow: View {
             Button { onCreate(url, true) } label: { Label("New Folder", systemImage: "folder.badge.plus") }
             Divider()
             Button { NSWorkspace.shared.activateFileViewerSelecting([url]) } label: { Label("Reveal in Finder", systemImage: "folder") }
+            Divider()
+            Button(role: .destructive) { onDelete(url) } label: { Label("Move to Trash", systemImage: "trash") }
         }
     }
 }
@@ -730,7 +814,8 @@ private struct NodeRow: View {
     var body: some View {
         if node.isFolder {
             VStack(alignment: .leading, spacing: 1) {
-                FolderRow(url: node.url, name: node.name, depth: depth, isOpen: isOpen, onCreate: onCreate) {
+                FolderRow(url: node.url, name: node.name, depth: depth, isOpen: isOpen,
+                          onCreate: onCreate, onDelete: onDelete) {
                     withAnimation(.easeInOut(duration: 0.22)) {
                         if isOpen { expanded.remove(node.url) } else { expanded.insert(node.url) }
                     }

--- a/Sentient OS macOS/Views/Orb.swift
+++ b/Sentient OS macOS/Views/Orb.swift
@@ -390,7 +390,8 @@ struct OrbMark: View {
 }
 
 /// Tiny deterministic RNG so the ring's matter is identical every launch.
-private struct SplitMix64: RandomNumberGenerator {
+/// Internal (not private): the Night Sky graph view seeds its star field and mock graph with it too.
+struct SplitMix64: RandomNumberGenerator {
     var state: UInt64
     init(seed: UInt64) { state = seed }
     mutating func next() -> UInt64 {


### PR DESCRIPTION
## What

The Knowledge window now opens into the **Constellation View** — the knowledge base as a living night-sky graph. `Views/Knowledge/Graph/` (5 new files: data → physics → model → renderer → view), integrated into `KnowledgeView` behind glowing SkyDoor capsules (⌘⇧G / Esc).

- **Stars = notes** (sized by wikilink degree, per-note twinkle) · **threads = resolved `[[wikilinks]]`** · **constellations = top-level folders** (watermark labels) · **the sun = the root README**, wearing the notch's SpinningLogo (slow spin) over a pinned center.
- **Assembly entrance** on every window open (hot force-sim cooling to rest — heavy damping + terminal-velocity cap, so it glides, never boings). Camera + positions survive reader trips within a session.
- **Hover** ignites the neighborhood (domain→domain gradient threads, hover card) with **collision-aware labels** — only names that fit are drawn, nothing overlaps.
- **Click a star → reader**; Back walks the wikilink trail then returns to the sky with the star glowing amber. Mode switches funnel through the unsaved-edits guard.
- Pan/zoom/drag via a real AppKit event catcher (two-finger pan · pinch/wheel/⌘-scroll zoom-at-cursor · springy star drags). Photon pulses + an 11s center breath keep it alive at rest.
- SkyDoor: real Liquid Glass on macOS 26 (`sharedBackgroundVisibility(.hidden)` kills the double-wrap; dark capsule on the 15 floor) with a warm gold→ember→violet edge-flow rim.

## Also

- Folder right-click **Move to Trash** (folder-aware: trashing the open note's folder lands on Overview).
- Sync status line stays calm white in all states (amber 'Will sync soon' read as a warning).
- `Documentation/Knowledge Viewer.md` rewritten for both faces; `SplitMix64` promoted to internal (second use-case).

## Verified

Built green via Xcode MCP throughout; iterated on real hardware with Jesai (screenshots) — entrance feel, hover ignition, sun-logo occlusion, label collisions, glass chrome.