### PR TITLE
Keep the screen awake during the initial ingest

### DIFF
--- a/Sentient OS macOS/System/DisplayAwake.swift
+++ b/Sentient OS macOS/System/DisplayAwake.swift
@@ -1,0 +1,39 @@
+//
+//  DisplayAwake.swift
+//  Sentient OS macOS
+//
+//  Keeps the SCREEN powered on for the lifetime of a foreground processing run, so the long
+//  first ingest isn't cut short by macOS dimming the display and idle-sleeping the Mac while
+//  real work is happening. This is the polite, no-root, no-entitlement path a video player
+//  uses: `ProcessInfo.beginActivity(.idleDisplaySleepDisabled)` → hold the token → `endActivity`.
+//  Keeping the display on implicitly blocks system idle-sleep too, so this covers both.
+//
+//  NB: this is intentionally NOT the WakeHelper's `pmset disablesleep` (that needs root, only
+//  stops SYSTEM sleep, and exists for the headless 3am lid-shut case). This one is foreground-only.
+//
+//  begin()/end() are idempotent; `deinit` releases as a backstop.
+//
+
+import Foundation
+
+final class DisplayAwake {
+    private var token: NSObjectProtocol?
+
+    /// Keep the display powered on. Safe to call twice — the second call is a no-op.
+    func begin(reason: String) {
+        guard token == nil else { return }
+        token = ProcessInfo.processInfo.beginActivity(
+            options: [.userInitiated, .idleDisplaySleepDisabled], reason: reason)
+        Log("DisplayAwake: holding the screen awake — \(reason)")
+    }
+
+    /// Release the hold; the display resumes its normal idle timer. Idempotent.
+    func end() {
+        guard let token else { return }
+        ProcessInfo.processInfo.endActivity(token)
+        self.token = nil
+        Log("DisplayAwake: released — screen may sleep normally again")
+    }
+
+    deinit { end() }
+}

--- a/Sentient OS macOS/Views/ProcessingView.swift
+++ b/Sentient OS macOS/Views/ProcessingView.swift
@@ -77,6 +77,7 @@ struct ProcessingView: View {
     @State private var progress = RunProgress()
     @State private var started = false
     @State private var runTask: Task<RunProgress, Never>?
+    @State private var awake = DisplayAwake()   // keeps the screen on during the long first ingest
 
     var body: some View {
         ZStack {
@@ -365,6 +366,15 @@ struct ProcessingView: View {
     /// complete, internally-consistent snapshot, so dropping intermediate frames never desyncs the
     /// prompt pane from the card.
     private func run() async {
+        // Keep the display awake ONLY for the initial ingest — the long one. The home + 3am both run
+        // `.auto`, so the honest "is this the first-ever descent" signal is the flag the 18h auto-enable
+        // uses (nil until the first full cycle completes). `defer` releases on completion, failure, or
+        // cancellation; the 3am path never reaches here (it never presents this view).
+        if mode == .initial || OvernightScheduler.firstCycleCompletedAt == nil {
+            awake.begin(reason: "Initial ingestion — keeping the screen on")
+        }
+        defer { awake.end() }
+
         state = .loadingModel
         progress = RunProgress()
         let (stream, continuation) = AsyncStream.makeStream(


### PR DESCRIPTION
## What
Holds the display (and thus the Mac) awake for the duration of the **initial ingest** — the long first-ever descent — so macOS doesn't dim the screen and idle-sleep mid-run.

## How
- New `System/DisplayAwake.swift` — a small RAII wrapper around `ProcessInfo.beginActivity([.userInitiated, .idleDisplaySleepDisabled])`. No root, no entitlement (unlike the WakeHelper's `pmset disablesleep`, which is root + system-only and exists for the headless 3am lid-shut case). `begin`/`end` are idempotent; `deinit` releases as a backstop.
- `Views/ProcessingView.swift` — acquires in `run()`, releases via `defer` (covers completion, the failure early-return, and .task cancellation).

## Gate
```
mode == .initial || OvernightScheduler.firstCycleCompletedAt == nil
```
The home and the 3am scheduler both pass `.auto`, so `Mode` alone can't identify the first run — the honest signal is the first-cycle-completed flag the 18h auto-enable already uses (set once, survives interruption/resume).

- First-ever ingest (`.auto`, flag nil) → **held**
- Dev/forced INITIAL re-read (`.initial`) → held
- Returning user's short Analyze Now catch-up (flag set) → not held
- 3am overnight run → never reaches this path (it never presents ProcessingView; `pmset` still handles system-awake there)

Closes the "auto sleep disable during initial" to-do.

## Test plan
Fresh initial ingest from the Xcode GUI Debug build, walk away, confirm the screen stays lit; confirm it sleeps normally after completion. `/tmp/sentient-dev.log` shows the `DisplayAwake: holding…`/`released…` lines.