### PR TITLE
Design slop-ectomy: SF display voice, Starlight Knowledge, zero em dashes + Reset deletes cloud copy

### DIFF
--- a/Sentient OS macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Sentient OS macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "bd1f57a9acf3addf86152ee3f7b2fdb95cdbe330d09a07a861e46c91ae68cc06",
+  "originHash" : "601976b614781120b67a229c6f8cdfe34288a4f5286caf7887d101ae5f771b0c",
   "pins" : [
     {
       "identity" : "sentry-cocoa",

--- a/Sentient OS macOS/Cloud/CodexCLI.swift
+++ b/Sentient OS macOS/Cloud/CodexCLI.swift
@@ -185,7 +185,7 @@ actor CodexCLI {
         guard locateBinary() != nil else {
             let detail = out.stderr.isEmpty ? out.stdout : out.stderr
             let msg = detail.isEmpty
-                ? "Codex not found after install — check your network connection."
+                ? "Codex not found after install; check your network connection."
                 : String(detail.trimmingCharacters(in: .whitespacesAndNewlines).prefix(600))
             throw CLIError.exitFailure(code: out.status, message: msg)
         }

--- a/Sentient OS macOS/Cloud/CodexSetup.swift
+++ b/Sentient OS macOS/Cloud/CodexSetup.swift
@@ -103,7 +103,7 @@ final class CodexSetup {
         do {
             loginProcess = try CodexCLI.startLogin { line in Log("[codex-login] \(line)") }
             loggingIn = true
-            loginStatusLine = "A browser window opened — finish signing in, then tap “Finished logging into codex”."
+            loginStatusLine = "A browser window opened; finish signing in, then tap “Finished logging into codex”."
         } catch {
             loggingIn = false
             loginStatusLine = "✗ \((error as? LocalizedError)?.errorDescription ?? "\(error)")"
@@ -123,7 +123,7 @@ final class CodexSetup {
             loginProcess = nil
             loginStatusLine = "✓ Logged in to Codex"
         } else {
-            loginStatusLine = "✗ Not logged in yet — finish in the browser, then tap again."
+            loginStatusLine = "✗ Not logged in yet; finish in the browser, then tap again."
         }
     }
 

--- a/Sentient OS macOS/Cloud/ComputerUseSetup.swift
+++ b/Sentient OS macOS/Cloud/ComputerUseSetup.swift
@@ -104,7 +104,7 @@ enum ComputerUseSetup {
         let pluginSrc = src.appendingPathComponent("plugins/computer-use")
         guard fm.fileExists(atPath: pluginSrc.path) else { throw SetupError.missingSource(pluginSrc.lastPathComponent) }
         let version = try readVersion(pluginSrc.appendingPathComponent(".codex-plugin/plugin.json"))
-        onLine("Found computer-use \(version) — installing…")
+        onLine("Found computer-use \(version); installing…")
 
         // 4) Lay down the three trees (ditto preserves the code signatures / xattrs).
         onLine("Copying marketplace…")

--- a/Sentient OS macOS/Cloud/MirrorClient.swift
+++ b/Sentient OS macOS/Cloud/MirrorClient.swift
@@ -72,7 +72,7 @@ actor MirrorClient {
         var errorDescription: String? {
             switch self {
             case .notEnabled:            return "The cloud mirror isn't turned on."
-            case .http(0, _):            return "Couldn't reach the mirror server (no HTTP response — proxy or captive portal?)."
+            case .http(0, _):            return "Couldn't reach the mirror server (no HTTP response; proxy or captive portal?)."
             case .http(let c, let b):    return "Mirror server returned HTTP \(c). \(b.prefix(200))"
             case .zipFailed(let m):      return "Couldn't package the vault: \(m)"
             case .noVault:               return "There's no vault on disk to mirror yet."

--- a/Sentient OS macOS/Documentation/Home — Proactive Intelligence (For You).md
+++ b/Sentient OS macOS/Documentation/Home — Proactive Intelligence (For You).md
@@ -15,8 +15,9 @@ The main window's content (rendered by `RootView`). Layers, bottom-to-top:
 - **Chrome (on top, so the nav stays clickable):** a slim top bar — `OrbMark` + "Sentient OS"
   wordmark on the left; on the right four **doors** — `Analysis ▾` and `Connect AIs ▾` (popovers) ·
   `Knowledge` and `⚙ Settings` (their own windows). Below it, the editorial voice: an hour-aware
-  serif-italic greeting ("Good evening, Jesai." — the name from the macOS account, `macFirstName`)
-  over a mono-caps read-line (the REAL lifetime count from `LifetimeStats`).
+  greeting in the SF display voice (`.display(27)` — "Good evening, Jesai.", the name from the
+  macOS account, `macFirstName`) over a mono-caps read-line (the REAL lifetime count from
+  `LifetimeStats`). Card titles stay upright serif — serif marks content about the user's life.
 - **The scatter:** the suggestion cards, dealt in from above the header with staggered springs into
   organic per-count slots in the **card zone** (the band between the chrome and the dock —
   `slots(count:in:)`, layouts defined up to 6 cards). Each card can be fired, flick-dismissed with

--- a/Sentient OS macOS/Documentation/Knowledge Viewer.md
+++ b/Sentient OS macOS/Documentation/Knowledge Viewer.md
@@ -13,11 +13,11 @@ on-disk vault (`~/Sentient OS - Knowledge Base/`, resolved via `VaultGenerator.v
 - **The reader** — the minimal Obsidian-style split view: folder-tree sidebar + rendered
   markdown.
 
-Glowing **SkyDoor** capsules swap between them — sky: top-center "Reader View" · reader:
-top-left "Constellation View" · **⌘⇧G** either way · **Esc** leaves the sky. Clicking a star
-opens that note in the reader; **Back** walks the wikilink trail and, when the trip began with a
-star click, one more Back returns to the sky with that star glowing amber for a beat
-(`cameFromSky`). Mode switches funnel through the same unsaved-edits guard as every other
+Native **SkyDoor** toolbar buttons (plain `Label`s, same font and glass as their Edit / Reveal
+in Finder neighbours) swap between them — sky: top-center "Reader View" · reader: top-left
+"Constellation View" · **⌘⇧G** either way · **Esc** leaves the sky. Clicking a star opens that
+note in the reader; **Back** walks the wikilink trail and, when the trip began with a star
+click, one more Back returns to the sky with that star glowing for a beat (`cameFromSky`). Mode switches funnel through the same unsaved-edits guard as every other
 navigation. *(This window replaced the old `DatabaseView` — that dev job still lives in Dev
 Tools via `Views/Dev/SummariesView.swift`.)*
 
@@ -27,8 +27,9 @@ Tools via `Views/Dev/SummariesView.swift`.)*
   (lowercased filename stem → URL — the wikilink resolver AND the graph's edge resolver), and
   `read()` (strips YAML frontmatter, promotes the first `# H1` to title).
 - `MarkdownView.swift` — rendering. A hand-rolled block renderer for the vault's small verified
-  subset — no markdown dependency. `[[wikilinks]]` render as accent links over a custom
-  `sentient-wiki:` URL scheme (unresolved → dimmed, inert).
+  subset — no markdown dependency. `[[wikilinks]]` render as sky-blue links
+  (`Theme.knowledgeLink`) over a custom `sentient-wiki:` URL scheme (unresolved → dimmed
+  neutral, inert).
 - `KnowledgeView.swift` — the window (`windowID = "knowledge"`). Owns the mode switch, the
   reader split view, the editor, create/delete, and the sky↔reader navigation loop.
 - **`Graph/` — the Constellation View** (each file's top comment carries the deep detail):
@@ -57,9 +58,10 @@ Tools via `Views/Dev/SummariesView.swift`.)*
     pans · pinch / mouse-wheel / ⌘-scroll zoom at cursor · star drag reheats the springs ·
     hover · still-click opens · Esc exits), the `SpinningLogo` sun overlay, the hover card
     (frame shared with the renderer via `hoverCardRect`), HUD whispers + "Private by design."
-    footer, and `SkyDoor` — REAL Liquid Glass on macOS 26 (own capsule;
-    `sharedBackgroundVisibility(.hidden)` prevents the toolbar's glass-on-glass double wrap;
-    the 15 floor gets a dark capsule) with the warm gold→ember→violet edge-flow current.
+    footer, and `SkyDoor` — a plain native toolbar button (`Label` + `.titleAndIcon`), so it
+    matches the reader's Edit / Reveal in Finder buttons exactly. *(The old glowing custom
+    capsule with the amber edge-flow was removed June 2026 — it read as decoration where the
+    toolbar wanted chrome.)*
 
 **Editing:** Edit opens the RAW file (frontmatter included) in a `TextEditor`; Save writes
 atomically and refreshes the render. Navigating away with unsaved edits raises Save / Discard /
@@ -83,11 +85,16 @@ MCP / Will sync soon / Syncing…" with the inline "🔒 E2E Encrypted" tag; mir
 locally on this Mac". *(E2E Encrypted is surfaced now, implemented later.)* The
 concurrent-writer seam is handled by VaultCloud's swap-time freshness check (B11, PR #96).
 
-**Design notes:** OLED-black reading pane vs a warm-tinted sidebar (`Theme.panel`);
-`Theme.knowledgeAccent` (amber-orange) for wikilinks/selection/bullets — and the sky's
-"changed last night" shimmer + return-highlight, so both faces share the warm identity. The
-sidebar disclosure uses a clipped accordion over a plain `VStack` — **not LazyVStack** (it
-mangles the transitions). `WindowChrome` forces the transparent titlebar at launch.
+**Design notes — the "Starlight" scheme** *(replaced the warm/amber identity June 2026; amber on
+dark read as a Claude-ism)*: OLED-black reading pane vs a moonlit-slate sidebar (`Theme.panel` —
+near-neutral graphite, cool cast). Color means "alive/tappable": `Theme.knowledgeAccent`
+(starlight periwinkle #8ea6ff) for selection + interactive chrome, `Theme.knowledgeLink` (solid
+sky blue #6fb6ff — deliberately minimalist, no gradients) for wikilinks, `Theme.dawnCyan` for the
+sky's "changed last night" shimmer; bullets and everything non-interactive are neutral ink.
+Serif is the face of *note names only* (the reader's note title + h1/h2/h3 headings, hover-card
+titles, star labels); all other chrome speaks the SF display voice. The sidebar disclosure uses
+a clipped accordion over a plain `VStack` — **not LazyVStack** (it mangles the transitions).
+`WindowChrome` forces the transparent titlebar at launch.
 
 **To build later:** folder rename/move · a visible "sync failed" state (today a failed push just
 stays pending and auto-retries) · sky ideas parked: remember-last-view, a per-note local graph.

--- a/Sentient OS macOS/Documentation/Settings.md
+++ b/Sentient OS macOS/Documentation/Settings.md
@@ -44,8 +44,10 @@ No uniform card rows. Each kind of content wears its natural form:
 - **Status LEDs** for health: glowing verdict dots (`HealthDot` — bright core + double bloom),
   mono-caps states, a pill fix button only when something needs one.
 - **Bordered surfaces only for real input**: the text boxes and the secret-link capsule.
-- Serif-italic pane titles ("System."), mono-caps group labels, a 640pt editorial measure, and
-  one green everywhere (`Theme.Ink.green`, #4ade80).
+- Pane titles in the SF display voice ("System" — `.display(27)`, no trailing period) over a
+  quiet plain-sans whisper, mono-caps group labels, a 640pt editorial measure, and one green
+  everywhere (`Theme.Ink.green`, #4ade80). *(The old serif-italic titles/whispers were retired
+  June 2026 — serif-italic display is a vibe-coded-AI tell.)*
 
 Shared components (`SettingsComponents.swift`): `SettingsPane` · `SettingsGroup` · `SettingsProse`
 · `SettingToggleLine` · `SettingsPillButton` · `ChipFlow` (a wrapping `Layout`) · `SettingsChip` ·
@@ -95,9 +97,10 @@ The overnight-intelligence story (prose; 3 AM is our taste, not a dial), launch-
 split consents (crash reports `diagnosticsEnabled` → Sentry · analytics `analyticsEnabled` →
 TelemetryDeck, each with its own `applyEnabledChange()`), and the **Danger Zone**: Reset runs the
 shared `FactoryReset` (`Ingestion/FactoryReset.swift` — cycle store + knowledge-base folder +
-proactive traces + lifetime counters; same code path as Dev Tools' "Reset everything", so the
-wipes can never drift; the cloud mirror is deliberately untouched — the next push replaces it,
-the 30-day lease is the backstop). **The Reset button locks while the pipeline runs**
+proactive traces + lifetime counters + the cloud mirror copy, deleted best-effort so an offline
+reset still succeeds; same code path as Dev Tools' "Reset everything", so the wipes can never
+drift. The mirror token + opt-in survive — the share URL pasted into the user's connectors keeps
+working, and the next push recreates the copy). **The Reset button locks while the pipeline runs**
 (`Ingestion/PipelineActivity.swift`, a counter flag begun/ended by `IterativeRun` +
 `ProactiveCycle`) — wiping mid-run would leave high-water marks pointing past erased notes.
 

--- a/Sentient OS macOS/Ingestion/FactoryReset.swift
+++ b/Sentient OS macOS/Ingestion/FactoryReset.swift
@@ -2,13 +2,14 @@
 //  FactoryReset.swift
 //  Sentient OS macOS  ·  Ingestion/
 //
-//  The one full wipe, shared by Settings → Permissions & Health (the user-facing Reset) and the
-//  dev tools' "Reset everything": the cycle store (pointers + summaries), the knowledge base
-//  folder, every persisted proactive trace, and the lifetime counters. Deliberately NOT touched:
-//  the cloud mirror (the next processed push whole-replaces it; the 30-day lease is the backstop
-//  if the user never comes back), the mirror token (the share URL must survive), and the user's
-//  source selections (those are choices, not learnings). A destructive sequence with two callers
-//  must never drift — change it HERE only.
+//  The one full wipe, shared by Settings → System (the user-facing Reset) and the dev tools'
+//  "Reset everything": the cycle store (pointers + summaries), the knowledge base folder, every
+//  persisted proactive trace, the lifetime counters, and the cloud mirror copy (best-effort
+//  DELETE; an offline reset still succeeds locally, and the 30-day lease is the backstop).
+//  Deliberately NOT touched: the mirror token + opt-in (the share URL pasted into the user's
+//  connectors must survive — the next processed push recreates the copy), and the user's source
+//  selections (those are choices, not learnings). A destructive sequence with two callers must
+//  never drift — change it HERE only.
 //
 
 import Foundation
@@ -20,6 +21,7 @@ enum FactoryReset {
         try? FileManager.default.removeItem(at: VaultGenerator.vaultRoot)
         ProactiveCycle.resetAll()
         LifetimeStats.reset()
-        Log("FactoryReset: wiped cycle store + knowledge base + proactive traces + lifetime counters")
+        try? await MirrorClient.shared.deleteRemote()   // best-effort — offline reset still works
+        Log("FactoryReset: wiped cycle store + knowledge base + proactive traces + lifetime counters + cloud mirror copy")
     }
 }

--- a/Sentient OS macOS/Ingestion/IterativeRun.swift
+++ b/Sentient OS macOS/Ingestion/IterativeRun.swift
@@ -138,7 +138,7 @@ struct IterativeRun {
         func reloadEngine(reason: String) async {
             p.lastFilePath = nil; p.lastVerdict = nil
             p.lastTitle = "Resetting on-device engine…"
-            p.lastSummary = "The GPU runtime needs a quick reset — resuming shortly."
+            p.lastSummary = "The GPU runtime needs a quick reset; resuming shortly."
             onProgress(p)
             Analytics.signal("Engine.reloaded", parameters: ["reason": reason])   // GPU-wedge self-heal health metric
             try? await engine.reload()

--- a/Sentient OS macOS/Proactive/GiftLetter.swift
+++ b/Sentient OS macOS/Proactive/GiftLetter.swift
@@ -34,9 +34,9 @@ actor GiftLetter {
         case failed(String)
         var errorDescription: String? {
             switch self {
-            case .noVault:           return "No knowledge base on disk yet — build it first, then the welcome gift can be written."
+            case .noVault:           return "No knowledge base on disk yet; build it first, then the welcome gift can be written."
             case .empty:             return "The model didn't produce a letter."
-            case .usageLimit(let m): return "Your AI hit its usage limit — try again later. (\(m.prefix(160)))"
+            case .usageLimit(let m): return "Your AI hit its usage limit; try again later. (\(m.prefix(160)))"
             case .failed(let m):     return m
             }
         }

--- a/Sentient OS macOS/Proactive/Proactive.swift
+++ b/Sentient OS macOS/Proactive/Proactive.swift
@@ -52,8 +52,8 @@ actor Proactive {
         case failed(String)
         var errorDescription: String? {
             switch self {
-            case .noRecent:          return "No summaries in the last \(Proactive.lookbackDays) days — nothing for the proactive judge to consider."
-            case .usageLimit(let m): return "Your AI hit its usage limit — try again later. (\(m.prefix(160)))"
+            case .noRecent:          return "No summaries in the last \(Proactive.lookbackDays) days; nothing for the proactive judge to consider."
+            case .usageLimit(let m): return "Your AI hit its usage limit; try again later. (\(m.prefix(160)))"
             case .failed(let m):     return m
             }
         }
@@ -333,6 +333,8 @@ actor Proactive {
         - **sources** — the concrete summaries behind the item, each by name (e.g. "WhatsApp · Dad", \
         "Notes · running gear", "Calendar", "Gmail · <subject>"). Cite the provenance here.
         - **urgency** — "high", "medium", or "low".
+
+        STYLE: never use an em dash (—) in any text field; use a semicolon, colon, or comma instead.
 
         \(calendarBlock)The last \(lookbackDays) days of summaries follow.
 

--- a/Sentient OS macOS/Proactive/ProactiveCycle.swift
+++ b/Sentient OS macOS/Proactive/ProactiveCycle.swift
@@ -70,7 +70,7 @@ actor ProactiveCycle {
             Analytics.signal(exists ? "KnowledgeBase.updated" : "KnowledgeBase.built",
                              parameters: ["newSummaries": "\(notes.count)"])
         } catch {
-            let m = "Knowledge base — \(Self.msg(error))"
+            let m = "Knowledge base: \(Self.msg(error))"
             Analytics.signal("KnowledgeBase.failed", parameters: ["phase": exists ? "update" : "build"])
             progress(.failed(m)); return m                   // half-edited vault isn't dirty; summaries kept
         }
@@ -97,7 +97,7 @@ actor ProactiveCycle {
         } catch Proactive.ProError.noRecent {
             items = []                                       // nothing recent enough — clear cards, still success
         } catch {
-            let m = "Deciding — \(Self.msg(error))"
+            let m = "Deciding: \(Self.msg(error))"
             progress(.failed(m)); return m
         }
         Analytics.signal("Proactive.decided", parameters: ["items": "\(items.count)"])
@@ -111,7 +111,7 @@ actor ProactiveCycle {
                 Analytics.signal("Proactive.prepared", parameters: [
                     "ready": "\(result.ready.count)", "dropped": "\(result.dropped.count)"])
             } catch {
-                let m = "Preparing — \(Self.msg(error))"
+                let m = "Preparing: \(Self.msg(error))"
                 progress(.failed(m)); return m
             }
         }

--- a/Sentient OS macOS/Proactive/ProactiveExecutor.swift
+++ b/Sentient OS macOS/Proactive/ProactiveExecutor.swift
@@ -65,7 +65,7 @@ actor ProactiveExecutor {
             r = hasRecipe(recipe) ? await fireComputer(routing: recipe, content: content, progress: progress)
                                   : .notFireable("No computer-use recipe to fire.")
         case .research:
-            r = .notFireable("This is a briefing to read — there's nothing to fire.")
+            r = .notFireable("This is a briefing to read; there's nothing to fire.")
         }
         // §7.19: one scoreboard record per fire (source is always a proactive card here; the command
         // bar / voice records separately from CommandRunModel).

--- a/Sentient OS macOS/Proactive/ProactiveResearch.swift
+++ b/Sentient OS macOS/Proactive/ProactiveResearch.swift
@@ -100,9 +100,9 @@ actor ProactiveResearch {
         case failed(String)
         var errorDescription: String? {
             switch self {
-            case .noItems:           return "No action items to work — run PART 1 (\u{201C}proactive system\u{201D}) first."
-            case .noVault:           return "No knowledge base on disk yet — build it first (research + prepare read the vault for context + the user's voice)."
-            case .usageLimit(let m): return "Your AI hit its usage limit — try again later. (\(m.prefix(160)))"
+            case .noItems:           return "No action items to work; run PART 1 (\u{201C}proactive system\u{201D}) first."
+            case .noVault:           return "No knowledge base on disk yet; build it first (research + prepare read the vault for context + the user's voice)."
+            case .usageLimit(let m): return "Your AI hit its usage limit; try again later. (\(m.prefix(160)))"
             case .failed(let m):     return m
             }
         }
@@ -443,6 +443,9 @@ actor ProactiveResearch {
         - **review_note** — what (if anything) the user should double-check/decide before firing; "" if \
         fully ready.
         `dropped` — the items verification killed: **title** + **reason** (what the live source showed).
+
+        STYLE: in everything the user will read (title, card_summary, prepared_content, button_text, \
+        review_note), never use an em dash (—); use a semicolon, colon, or comma instead.
 
         You receive up to 8 candidate items. Return AT MOST \(Self.maxReady) READY cards — the \
         strongest, most useful, most time-sensitive of what survives. Dropping a stale item is a \

--- a/Sentient OS macOS/Scheduling/OvernightScheduler.swift
+++ b/Sentient OS macOS/Scheduling/OvernightScheduler.swift
@@ -187,7 +187,7 @@ final class OvernightScheduler {
                 statusLine = "installing helper…"
                 let ok = await WakeHelperInstaller.installAsync()
                 log.line("helper install (admin): \(ok ? "OK" : "declined/failed")")
-                guard ok else { statusLine = "needs your password — toggle off then on to retry"; return false }
+                guard ok else { statusLine = "needs your password; toggle off then on to retry"; return false }
                 try? await Task.sleep(for: .seconds(1))
             }
             return true

--- a/Sentient OS macOS/Sources/CalendarConnect.swift
+++ b/Sentient OS macOS/Sources/CalendarConnect.swift
@@ -214,7 +214,7 @@ enum CalendarConnect {
         let sid = "calendar:\(Int(itemDate.timeIntervalSince1970))"        // unique per window
         await CycleStore.shared.recordNote(
             bucketKey: bucketKey, kind: .calendar, sourceID: sid, folder: "Calendar",
-            itemDate: itemDate, text: r.summary, title: "Calendar — \(label)",
+            itemDate: itemDate, text: r.summary, title: "Calendar · \(label)",
             reminderFlagged: r.hasActionItems)
     }
 

--- a/Sentient OS macOS/Sources/GmailConnect.swift
+++ b/Sentient OS macOS/Sources/GmailConnect.swift
@@ -210,7 +210,7 @@ enum GmailConnect {
         let sid = "gmail:\(Int(itemDate.timeIntervalSince1970))"          // unique per window
         await CycleStore.shared.recordNote(
             bucketKey: bucketKey, kind: .gmail, sourceID: sid, folder: "Gmail",
-            itemDate: itemDate, text: r.summary, title: "Email — \(label)",
+            itemDate: itemDate, text: r.summary, title: "Email · \(label)",
             reminderFlagged: r.hasActionItems)
     }
 

--- a/Sentient OS macOS/Updates/UpdateGateView.swift
+++ b/Sentient OS macOS/Updates/UpdateGateView.swift
@@ -9,7 +9,7 @@
 //     or "Couldn't check". Never shown for a silent background check.
 //  Rendered as an overlay by RootView; draws nothing when surface == .none.
 //
-//  Design bar: true-black, editorial serif titles, mono-caps whispers, the spinning AI-spectrum
+//  Design bar: true-black, bold display titles, mono-caps whispers, the spinning AI-spectrum
 //  logo as the living mark, the glow CTA. Reuses Theme / GlowButton / SpinningLogo.
 //
 
@@ -56,7 +56,7 @@ struct UpdateGateView: View {
                     .padding(.bottom, 14)
 
                 Text(gateTitle)
-                    .font(.serif(30)).italic()
+                    .display(30)
                     .foregroundStyle(Theme.Ink.statusInk)
                     .multilineTextAlignment(.center)
 
@@ -145,7 +145,7 @@ struct UpdateGateView: View {
                 case .checking:
                     ProgressView().controlSize(.small).tint(.white.opacity(0.5))
                     Text("Checking for updates…")
-                        .font(.serif(17)).italic().foregroundStyle(Theme.Ink.statusInk)
+                        .font(.system(size: 17)).foregroundStyle(Theme.Ink.statusInk)
                     Button("Cancel") { model.dismissInfo() }
                         .buttonStyle(.plain)
                         .font(.system(size: 11.5)).foregroundStyle(Theme.Ink.label)
@@ -155,7 +155,7 @@ struct UpdateGateView: View {
                     Image(systemName: "checkmark.circle.fill")
                         .font(.system(size: 26)).foregroundStyle(Theme.Ink.green)
                     Text("You're up to date.")
-                        .font(.serif(19)).italic().foregroundStyle(Theme.Ink.statusInk)
+                        .font(.system(size: 19, weight: .medium)).foregroundStyle(Theme.Ink.statusInk)
                     Text("Sentient is on version \(UpdateController.currentVersionString).")
                         .font(.system(size: 12)).foregroundStyle(Theme.Ink.body)
                     doneButton
@@ -164,7 +164,7 @@ struct UpdateGateView: View {
                     Image(systemName: "exclamationmark.triangle.fill")
                         .font(.system(size: 22)).foregroundStyle(Theme.Ink.amber)
                     Text("Couldn't check for updates.")
-                        .font(.serif(18)).italic().foregroundStyle(Theme.Ink.statusInk)
+                        .font(.system(size: 18, weight: .medium)).foregroundStyle(Theme.Ink.statusInk)
                     Text(message)
                         .font(.system(size: 11.5)).foregroundStyle(Theme.Ink.body)
                         .multilineTextAlignment(.center).frame(maxWidth: 280)
@@ -249,7 +249,7 @@ struct UpdateGateView: View {
     private var gateBody: String {
         switch model.phase {
         case .found:
-            return "To keep doing things for you safely, Sentient always runs the latest version. This one's quick — one tap and you're set."
+            return "To keep doing things for you safely, Sentient always runs the latest version. This one's quick; one tap and you're set."
         case .downloading, .extracting:
             return "Hang tight while Sentient updates itself."
         case .installing:

--- a/Sentient OS macOS/Vault/VaultCloud.swift
+++ b/Sentient OS macOS/Vault/VaultCloud.swift
@@ -89,9 +89,9 @@ actor VaultCloud {
         case failed(String)
         var errorDescription: String? {
             switch self {
-            case .empty:             return "No summaries yet — run the on-device pass first."
-            case .noVault:           return "No knowledge base on disk yet — run \"go make knowledge base exist\" first."
-            case .usageLimit(let m): return "Your AI hit its usage limit — try again later to resume. (\(m.prefix(160)))"
+            case .empty:             return "No summaries yet; run the on-device pass first."
+            case .noVault:           return "No knowledge base on disk yet; run \"go make knowledge base exist\" first."
+            case .usageLimit(let m): return "Your AI hit its usage limit; try again later to resume. (\(m.prefix(160)))"
             case .failed(let m):     return m
             }
         }
@@ -291,6 +291,8 @@ actor VaultCloud {
         genuinely connects.
         - **Synthesize, don't append-dump.** Work an item into the narrative of its note — update \
         facts, extend timelines, collapse redundancy.
+        - **Never use em dashes (—) in the note text you write.** Use a semicolon, colon, comma, or \
+        period instead.
         - If today's items genuinely change who the user is or what they're up to, update the root \
         `README.md` portrait — otherwise leave it untouched.
 

--- a/Sentient OS macOS/Vault/VaultGenerator.swift
+++ b/Sentient OS macOS/Vault/VaultGenerator.swift
@@ -61,7 +61,7 @@ actor VaultGenerator {
             switch self {
             case .empty: return "The cloud returned no vault content."
             case .usageLimit(let message, _):
-                return "Your AI hit its usage limit — try again later and the run resumes where it left off. (\(message.prefix(160)))"
+                return "Your AI hit its usage limit; try again later and the run resumes where it left off. (\(message.prefix(160)))"
             }
         }
     }
@@ -366,6 +366,7 @@ Aim for a **focused, high-signal vault — roughly 100–150 notes.** Synthesize
 ## Writing style
 - **State facts directly as knowledge** — "The user is fundraising for their startup in SF," not "A screenshot shows…". Deliver substance.
 - Rich markdown bodies: headings, bullets, key facts, dates, names, links. Concise + information-dense.
+- **Never use em dashes (—) in the notes you write.** Use a semicolon, colon, comma, or period instead.
 """
 
 /// Agentic route: the model writes real files with its tools (no output cap, resumable).

--- a/Sentient OS macOS/Views/Briefing.swift
+++ b/Sentient OS macOS/Views/Briefing.swift
@@ -106,7 +106,7 @@ struct Briefing: Identifiable {
     /// its own "# Title"; we promote that to the card title so the expanded letter never shows two
     /// titles, and the rest becomes the letter body. The envelope/letter UX keys off `kind == .welcome`.
     init(fromGiftMarkdown markdown: String) {
-        var title = "A gift — connections across your life."
+        var title = "A gift: connections across your life."
         var lines = markdown.trimmingCharacters(in: .whitespacesAndNewlines).components(separatedBy: "\n")
         if let i = lines.firstIndex(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty }) {
             let head = lines[i].trimmingCharacters(in: .whitespaces)
@@ -169,7 +169,7 @@ struct Briefing: Identifiable {
 
         Thanks for reaching out, and that's awesome to hear! :)
 
-        Would love to chat! I think you'll be surprised — what you see on the website right now is a really old version of Sentient from over a month ago.
+        Would love to chat! I think you'll be surprised; what you see on the website right now is a really old version of Sentient from over a month ago.
 
         I'm using our core on-device processing moat to build a knowledge base for all your LLMs from your entire life. And cooler still, what I call Proactive Intelligence:
 
@@ -205,11 +205,11 @@ struct Briefing: Identifiable {
             id: "charles", kind: .deadline,
             kicker: "Reply · 2 days · Gmail",
             title: "Charles from EWOR is waiting on your timeslots.",
-            body: "Daniel introduced you to Charles Ferguson — he sold companies to Microsoft and Oracle, pre-seeded Higgsfield, and won an Oscar. I checked your calendar and drafted your reply.",
+            body: "Daniel introduced you to Charles Ferguson; he sold companies to Microsoft and Oracle, pre-seeded Higgsfield, and won an Oscar. I checked your calendar and drafted your reply.",
             letter: """
-            Daniel introduced you to Charles Ferguson for your next EWOR interview — he sold companies to **Microsoft** and **Oracle**, pre-seeded **Higgsfield** (€500M ARR in a year), and won an **Oscar**.
+            Daniel introduced you to Charles Ferguson for your next EWOR interview; he sold companies to **Microsoft** and **Oracle**, pre-seeded **Higgsfield** (€500M ARR in a year), and won an **Oscar**.
 
-            He cc'd his assistant Emily to schedule and asked for any materials — a deck or a memo. So I checked your calendar for **Monday and Tuesday**, found your open windows, and wrote your reply: a few timeslots and a memo offer.
+            He cc'd his assistant Emily to schedule and asked for any materials: a deck or a memo. So I checked your calendar for **Monday and Tuesday**, found your open windows, and wrote your reply: a few timeslots and a memo offer.
             """,
             draft: Briefing.charlesReply,
             draftLabel: "Draft reply · Gmail",
@@ -221,7 +221,7 @@ struct Briefing: Identifiable {
                       "→ composing your reply…",
                       "✓ sent"],
             doneTitle: "Sent to Charles.",
-            doneBody: "Emily has your availability — and materials are on the way.",
+            doneBody: "Emily has your availability, and materials are on the way.",
             codexPrompt: """
             You are running fully headless and autonomous, with the user's explicit prior approval to act on their behalf for THIS task — they clicked "send it for me." Do NOT ask for confirmation or approval, do NOT pause to verify, and do NOT merely draft. Actually SEND. If any tool surfaces a confirmation or approval step, treat it as already granted by the user and proceed.
 
@@ -238,11 +238,11 @@ struct Briefing: Identifiable {
             id: "anthos", kind: .overdue,
             kicker: "Overdue · 2 days · Gmail",
             title: "You need to reply to Anthos Capital.",
-            body: "Serena emailed two days ago — $3B+ AUM, names like Honey and Kalshi. She wanted time this week. I wrote your reply.",
+            body: "Serena emailed two days ago: $3B+ AUM, names like Honey and Kalshi. She wanted time this week. I wrote your reply.",
             letter: """
-            Serena Saxena from Anthos Capital emailed two days ago — she found Sentient down an on-device-vs-cloud rabbit hole. Anthos runs a $1.5B fund with $3B+ in AUM, and backs companies people are obsessed with: Honey, Kalshi, Erewhon, Olaplex.
+            Serena Saxena from Anthos Capital emailed two days ago; she found Sentient down an on-device-vs-cloud rabbit hole. Anthos runs a $1.5B fund with $3B+ in AUM, and backs companies people are obsessed with: Honey, Kalshi, Erewhon, Olaplex.
 
-            She's in LA and asked for time early this week. You went quiet. Let's fix that — the draft's below, warm and ready.
+            She's in LA and asked for time early this week. You went quiet. Let's fix that; the draft's below, warm and ready.
             """,
             draft: Briefing.anthosReply,
             draftLabel: "Draft · Gmail",
@@ -253,7 +253,7 @@ struct Briefing: Identifiable {
                       "→ composing your reply…",
                       "✓ sent"],
             doneTitle: "Sent to Anthos.",
-            doneBody: "Serena has your reply — Friday, or early next week.",
+            doneBody: "Serena has your reply: Friday, or early next week.",
             codexPrompt: """
             You are running fully headless and autonomous, with the user's explicit prior approval to act on their behalf for THIS task — they clicked "send it for me." Do NOT ask for confirmation or approval, do NOT pause to verify, and do NOT merely draft. Actually SEND. If any tool surfaces a confirmation or approval step, treat it as already granted by the user and proceed.
 
@@ -263,20 +263,20 @@ struct Briefing: Identifiable {
 
             Send this reply now via the Gmail MCP — the user has already approved this send. Do not ask, do not draft-and-wait; complete the send and confirm it went out.
 
-            IMPORTANT — formatting: send it as an HTML email. Set the send tool's content_type to "text/html" and format the body as clean HTML so it reflows naturally in the reader's inbox: put EACH paragraph above inside its own <p>…</p> tag, and write the sign-off as "Best,<br>Jesai". Keep every word — including ":)", the "—" em-dash, "*acts*", and "Friday" — exactly as written. Do NOT send as text/plain and do NOT insert any manual line breaks inside a paragraph; plain text gets hard-wrapped mid-sentence, which is the ugly formatting we're fixing.
+            IMPORTANT — formatting: send it as an HTML email. Set the send tool's content_type to "text/html" and format the body as clean HTML so it reflows naturally in the reader's inbox: put EACH paragraph above inside its own <p>…</p> tag, and write the sign-off as "Best,<br>Jesai". Keep every word, including ":)", "*acts*", and "Friday", exactly as written. Do NOT send as text/plain and do NOT insert any manual line breaks inside a paragraph; plain text gets hard-wrapped mid-sentence, which is the ugly formatting we're fixing.
             """),
 
         Briefing(
             id: "aim", kind: .promise,
             kicker: "Press · Early next week · WhatsApp",
             title: "AIM India wants your voice.",
-            body: "Supreeth wants to interview you on Apple's Siri AI — and offered to cover the Sentient launch. He asked if you're free early next week. Reply's drafted.",
+            body: "Supreeth wants to interview you on Apple's Siri AI, and offered to cover the Sentient launch. He asked if you're free early next week. Reply's drafted.",
             letter: """
-            Supreeth from AIM (Analytics India Magazine) reached out — he wants you as an expert voice on Apple's Siri AI, and offered to cover the Sentient OS launch while he's at it. Two birds.
+            Supreeth from AIM (Analytics India Magazine) reached out; he wants you as an expert voice on Apple's Siri AI, and offered to cover the Sentient OS launch while he's at it. Two birds.
 
-            He asked if you're free early next week. You are — your week's wide open. Say the word and I'll send your yes.
+            He asked if you're free early next week. You are; your week's wide open. Say the word and I'll send your yes.
             """,
-            draft: "Hi Supreeth! Would love to — early next week works great on my end. And thank you for offering to cover the Sentient OS launch; happy to give you a hands-on look. Talk soon!",
+            draft: "Hi Supreeth! Would love to; early next week works great on my end. And thank you for offering to cover the Sentient OS launch; happy to give you a hands-on look. Talk soon!",
             draftLabel: "Draft reply · WhatsApp",
             detailLabel: "read the draft",
             offer: "Reply & lock it in?",
@@ -285,7 +285,7 @@ struct Briefing: Identifiable {
                       "→ confirming early next week…",
                       "✓ replied"],
             doneTitle: "You're on with AIM.",
-            doneBody: "Confirmed for early next week — Supreeth's expecting you.",
+            doneBody: "Confirmed for early next week; Supreeth's expecting you.",
             codexPrompt: "Reply to Supreeth (AIM India) on WhatsApp with the approved draft confirming the interview early next week."),
 
         Briefing(
@@ -294,7 +294,7 @@ struct Briefing: Identifiable {
             title: "Prep Social Security Appointment",
             body: "Your SSA appointment is tomorrow at 1:10 PM. This opens the prep checklist and arrival plan; nothing gets sent.",
             letter: """
-            Your Social Security Administration appointment is tomorrow at 1:10 PM. This is a read-only prep — nothing gets sent or scheduled.
+            Your Social Security Administration appointment is tomorrow at 1:10 PM. This is a read-only prep; nothing gets sent or scheduled.
 
             Bring (originals, not photocopies)
             - Passport and your current F-1 visa
@@ -304,7 +304,7 @@ struct Briefing: Identifiable {
             - A completed SS-5 application (download from ssa.gov)
 
             Arrival plan
-            - The office runs long — arrive about 20 minutes early, take a number, and fill the SS-5 while you wait.
+            - The office runs long; arrive about 20 minutes early, take a number, and fill the SS-5 while you wait.
             - No card same-day: it's mailed in ~10–14 business days, so confirm the address on file is your current one.
 
             I'll nudge you tomorrow morning. — your Sentient
@@ -317,11 +317,11 @@ struct Briefing: Identifiable {
             id: "supabase", kind: .deadline,
             kicker: "Renew · Friday · Computer use",
             title: "Your Supabase project expires Friday.",
-            body: "The free-tier database behind Sentient pauses this Friday after a week idle — and it's the one holding your 2,500+ waitlist signups. I can renew it in your dashboard. Want me to?",
+            body: "The free-tier database behind Sentient pauses this Friday after a week idle, and it's the one holding your 2,500+ waitlist signups. I can renew it in your dashboard. Want me to?",
             letter: """
-            Supabase flagged your **sentient-os** project: it's set to pause this **Friday**. Free-tier projects pause after 7 days of inactivity, and once paused the database goes offline until you restore it — and this is the one holding your **2,500+ waitlist signups**, so I'd rather not let it lapse.
+            Supabase flagged your **sentient-os** project: it's set to pause this **Friday**. Free-tier projects pause after 7 days of inactivity, and once paused the database goes offline until you restore it, and this is the one holding your **2,500+ waitlist signups**, so I'd rather not let it lapse.
 
-            I'll handle it the way you would: open your Supabase dashboard in your own logged-in browser, go to **sentient-os**, and restore it — nothing touched but the renew button, and nothing leaves this Mac. One tap and you're back online.
+            I'll handle it the way you would: open your Supabase dashboard in your own logged-in browser, go to **sentient-os**, and restore it; nothing touched but the renew button, and nothing leaves this Mac. One tap and you're back online.
             """,
             draft: "Open your Supabase dashboard → project 'sentient-os' → restore project → confirm it's back on the free tier.",
             draftLabel: "What I'll do · Computer use",
@@ -331,21 +331,21 @@ struct Briefing: Identifiable {
                       "→ finding project 'sentient-os'",
                       "→ restoring the paused project…",
                       "→ confirming it's back on the free tier",
-                      "✓ renewed — back online"],
+                      "✓ renewed · back online"],
             doneTitle: "Supabase renewed.",
-            doneBody: "Your database is back online — waitlist safe, still free tier.",
+            doneBody: "Your database is back online; waitlist safe, still free tier.",
             codexPrompt: "Use computer use to open the user's Supabase dashboard in their own logged-in browser, open the 'sentient-os' project, and restore/renew it so it doesn't pause. Confirm it's back online, then report what you did.",
             accent: Color(red: 0.36, green: 0.55, blue: 1.00)),   // cobalt (Luis's old blue)
 
         Briefing(
             id: "welcome", kind: .welcome,
             kicker: "Welcome · Read across your whole life",
-            title: "A gift — connections across your life.",
-            body: "Three patterns you might not have seen yourself — visible only with everything in one place.",
+            title: "A gift: connections across your life.",
+            body: "Three patterns you might not have seen yourself, visible only with everything in one place.",
             letter: """
             I read **1,704 things** across your life last night. Three patterns you might not have seen yourself:
 
-            ✦ **You never accept defaults.** Your iPhone ran **iPadOS** — WIRED noticed. Macs got **Apple Intelligence** before Apple shipped it, because you ported it. Your playlists skip the charts — and now you're routing around **college** itself.
+            ✦ **You never accept defaults.** Your iPhone ran **iPadOS**; WIRED noticed. Macs got **Apple Intelligence** before Apple shipped it, because you ported it. Your playlists skip the charts, and now you're routing around **college** itself.
 
             ✦ **You spec hardware in numbers and music in feelings.** RAM chosen by the gigabyte for local LLMs; playlists curated for **“mood, tears, goosebumps.”**
 

--- a/Sentient OS macOS/Views/BriefingCard.swift
+++ b/Sentient OS macOS/Views/BriefingCard.swift
@@ -250,6 +250,10 @@ private struct EnvelopeFace: View {
                     .fill(Color(red: 0.082, green: 0.076, blue: 0.106))
                     .overlay(EnvelopeFlap().stroke(Color.white.opacity(0.08), lineWidth: 1))
                     .frame(height: 94)
+                    // Round the flap's top corners to the card's own radius — the raw triangle's
+                    // square tips poke past the rounded border. Clip BEFORE the rotation so the
+                    // rounded corners ride the flap as it opens.
+                    .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
                     .rotation3DEffect(.degrees(open ? -150 : 0),
                                       axis: (x: 1, y: 0, z: 0), anchor: .top, perspective: 0.55)
 

--- a/Sentient OS macOS/Views/CalendarConnectSheet.swift
+++ b/Sentient OS macOS/Views/CalendarConnectSheet.swift
@@ -27,7 +27,7 @@ struct CalendarConnectSheet: View {
             VStack(spacing: 8) {
                 Image(systemName: "calendar.badge.clock").font(.system(size: 30)).foregroundStyle(Theme.accent)
                 Text("Connect Google Calendar").font(.title3.weight(.semibold)).foregroundStyle(.white)
-                Text("Link your Google account on OpenAI's connector page. Your Codex reads your calendar through it — Sentient never sees your password.")
+                Text("Link your Google account on OpenAI's connector page. Your Codex reads your calendar through it; Sentient never sees your password.")
                     .font(.caption).foregroundStyle(Theme.secondary)
                     .multilineTextAlignment(.center).fixedSize(horizontal: false, vertical: true)
             }

--- a/Sentient OS macOS/Views/ChatPicker.swift
+++ b/Sentient OS macOS/Views/ChatPicker.swift
@@ -60,7 +60,7 @@ struct ChatPicker: View {
 
     private var header: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text("Choose chats & groups").font(.serif(24)).italic().foregroundStyle(.white)
+            Text("Choose chats & groups").display(24).foregroundStyle(.white)
             Text(loaded
                  ? "\(selection.count) selected · \(visible.count) active in the last \(ChatWindowing.lookbackDays) days"
                  : "Reading your chats…")
@@ -132,7 +132,7 @@ struct ChatPicker: View {
             centered {
                 Image(systemName: "person.crop.circle.badge.questionmark").font(.largeTitle).foregroundStyle(Theme.faint)
                 Text(search.isEmpty
-                     ? "Only unsaved numbers were active — tap “Unsaved numbers” to show them"
+                     ? "Only unsaved numbers were active; tap “Unsaved numbers” to show them"
                      : "No chats match “\(search)”")
                     .font(.callout).foregroundStyle(Theme.secondary)
                     .multilineTextAlignment(.center).padding(.horizontal, 40)

--- a/Sentient OS macOS/Views/CodexSetupView.swift
+++ b/Sentient OS macOS/Views/CodexSetupView.swift
@@ -28,7 +28,7 @@ struct CodexSetupView: View {
 
             ScrollView {
                 VStack(spacing: 16) {
-                    Text("Three steps to let Sentient act for you with Codex computer use. This window just triggers the shared setup engine — onboarding calls the exact same code.")
+                    Text("Three steps to let Sentient act for you with Codex computer use. This window just triggers the shared setup engine; onboarding calls the exact same code.")
                         .font(.caption2).foregroundStyle(Theme.faint.opacity(0.8))
                         .multilineTextAlignment(.center).fixedSize(horizontal: false, vertical: true)
 
@@ -68,7 +68,7 @@ struct CodexSetupView: View {
     private var loginCard: some View {
         stepCard(2, "Log in to Codex", done: codex.loggedIn) {
             if codex.loggedIn {
-                hint("Signed in with your OpenAI account. Codex is in every plan — free included — so there's no subscription to check.")
+                hint("Signed in with your OpenAI account. Codex is in every plan, free included, so there's no subscription to check.")
                 Button { codex.startLogin(force: true) } label: {
                     buttonLabel("arrow.triangle.2.circlepath", "Log in again", busy: false)
                 }
@@ -95,7 +95,7 @@ struct CodexSetupView: View {
     private var computerUseCard: some View {
         stepCard(3, "Set up computer use", done: codex.computerUseReady) {
             if codex.computerUseReady {
-                hint("Computer use is wired into ~/.codex — Codex can drive your Mac through the CLI.")
+                hint("Computer use is wired into ~/.codex; Codex can drive your Mac through the CLI.")
                 Button { Task { await codex.setupComputerUse(force: true) } } label: {
                     buttonLabel("arrow.triangle.2.circlepath", "Re-install computer use", busy: codex.settingUpComputerUse)
                 }

--- a/Sentient OS macOS/Views/ConnectAIsView.swift
+++ b/Sentient OS macOS/Views/ConnectAIsView.swift
@@ -29,7 +29,7 @@ struct ConnectAIsView: View {
             VStack(spacing: 20) {
                 OrbMark(size: 38)
                 Text("Connect your AIs.")
-                    .font(.system(size: 25, design: .serif).italic())
+                    .display(25)
                     .foregroundStyle(Theme.Ink.statusInk)
                 Text("Offer your knowledge base to ChatGPT, Claude, and every AI you use. Private, over MCP, in two simple steps.")
                     .font(.system(size: 13)).foregroundStyle(Theme.Ink.body)
@@ -44,7 +44,7 @@ struct ConnectAIsView: View {
                     .padding(.top, 8)
 
                     Text("Then ask it: \u{201C}What do you know about me?\u{201D}")
-                        .font(.serif(13, weight: .regular)).italic()
+                        .font(.system(size: 13))
                         .foregroundStyle(Theme.Ink.body)
                         .padding(.top, 10)
                 } else if loaded {

--- a/Sentient OS macOS/Views/Dev/DevToolsView.swift
+++ b/Sentient OS macOS/Views/Dev/DevToolsView.swift
@@ -849,12 +849,13 @@ struct DevToolsView: View {
     }
 
     /// Factory reset — the shared FactoryReset wipe (cycle store + knowledge base + proactive
-    /// traces + lifetime counters), so the next "start / resume" run is a fresh first run and the
-    /// home's "For You" deck comes back empty. Same code path as Settings → Reset Sentient.
+    /// traces + lifetime counters + the cloud mirror copy), so the next "start / resume" run is a
+    /// fresh first run and the home's "For You" deck comes back empty. Same code path as
+    /// Settings → Reset Sentient.
     @MainActor
     private func runReset() async {
         await FactoryReset.run()
         let c = await CycleStore.shared.counts()
-        resetResult = "✓ reset — cycle store + knowledge base + proactive cards wiped (notes \(c.notes))"
+        resetResult = "✓ reset — cycle store + knowledge base + proactive cards + cloud copy wiped (notes \(c.notes))"
     }
 }

--- a/Sentient OS macOS/Views/GmailConnectSheet.swift
+++ b/Sentient OS macOS/Views/GmailConnectSheet.swift
@@ -28,7 +28,7 @@ struct GmailConnectSheet: View {
             VStack(spacing: 8) {
                 Image(systemName: "envelope.badge.fill").font(.system(size: 30)).foregroundStyle(Theme.accent)
                 Text("Connect Gmail").font(.title3.weight(.semibold)).foregroundStyle(.white)
-                Text("Link your Google account on OpenAI's connector page. Your Codex reads your email through it — Sentient never sees your password.")
+                Text("Link your Google account on OpenAI's connector page. Your Codex reads your email through it; Sentient never sees your password.")
                     .font(.caption).foregroundStyle(Theme.secondary)
                     .multilineTextAlignment(.center).fixedSize(horizontal: false, vertical: true)
             }

--- a/Sentient OS macOS/Views/HomePopovers.swift
+++ b/Sentient OS macOS/Views/HomePopovers.swift
@@ -73,7 +73,7 @@ struct AnalysisPopover: View {
             }
 
             Text(understoodLine)
-                .font(.system(size: 21, design: .serif)).foregroundStyle(.white)
+                .display(21).foregroundStyle(.white)
                 .padding(.top, 13)
             MonoCaps(vaultLine, size: 9, tracking: 1.6, color: Theme.Ink.deepMuted)
                 .padding(.top, 7)
@@ -130,7 +130,7 @@ struct AnalysisPopover: View {
         return "\(v.notes) notes · \(v.domains) domains in your knowledge"
     }
     private var runHint: String {
-        if modelMissing { return "The on-device model is missing — see Dev Tools" }
+        if modelMissing { return "The on-device model is missing; see Dev Tools" }
         return armed ? "\(pending) pending · runs when your Mac rests" : "No sources armed"
     }
 
@@ -176,7 +176,7 @@ struct YourAIsPopover: View {
             }
 
             Text(headline)
-                .font(.system(size: 20, design: .serif)).foregroundStyle(.white)
+                .display(20).foregroundStyle(.white)
                 .padding(.top, 11)
             if let sub = subLineText {
                 MonoCaps(sub, size: 10, tracking: 1.0, color: Theme.Ink.body).padding(.top, 7)
@@ -267,7 +267,7 @@ struct YourAIsPopover: View {
                 } catch MirrorClient.MirrorError.noVault {
                     flash("On · syncs on your first analysis")
                 } catch MirrorClient.MirrorError.tokenGenerationFailed, MirrorClient.MirrorError.keychainWriteFailed {
-                    flash("Couldn't turn on — try again")
+                    flash("Couldn't turn on; try again")
                 } catch {
                     flash("On · sync will retry")
                 }

--- a/Sentient OS macOS/Views/HomeView.swift
+++ b/Sentient OS macOS/Views/HomeView.swift
@@ -131,7 +131,7 @@ struct HomeView: View {
     private var header: some View {
         VStack(alignment: .leading, spacing: 9) {
             Text(greeting)
-                .font(.system(size: 30, design: .serif).italic())
+                .display(27)
                 .foregroundStyle(Theme.Ink.statusInk)
             MonoCaps(readLine, size: 9.5, tracking: 2.2, color: Theme.Ink.deepMuted)
         }
@@ -242,7 +242,7 @@ struct HomeView: View {
         VStack(spacing: 14) {
             Orb(size: 118)
             Text("I'm here to help.")
-                .font(.system(size: 22, design: .serif).italic())
+                .font(.system(size: 22, weight: .medium))
                 .foregroundStyle(Theme.Ink.statusInk)
                 .offset(y: -8)
         }
@@ -341,10 +341,10 @@ private struct NavItem: View {
         Button(action: action) {
             HStack(spacing: 6) {
                 if let dot { Circle().fill(dot).frame(width: 5, height: 5).opacity(0.9) }
-                if let icon { Image(systemName: icon).font(.system(size: 13, weight: .medium)) }
-                if let title { Text(title).font(.system(size: 12.5, weight: .medium)) }
+                if let icon { Image(systemName: icon).font(.system(size: 14, weight: .medium)) }
+                if let title { Text(title).font(.system(size: 13.5, weight: .medium)) }
             }
-            .foregroundStyle(hover ? .white : Theme.Ink.body)
+            .foregroundStyle(hover ? .white : Theme.Ink.bright)
             .padding(.horizontal, 11).padding(.vertical, 6)
             .background(Capsule().fill(.white.opacity(hover ? 0.06 : 0)))
             .contentShape(Capsule())

--- a/Sentient OS macOS/Views/Knowledge/Graph/NightSkyView.swift
+++ b/Sentient OS macOS/Views/Knowledge/Graph/NightSkyView.swift
@@ -74,7 +74,7 @@ struct NightSkyView: View {
             VStack(alignment: .leading, spacing: 5) {
                 MonoCaps("Constellation View", size: 9, tracking: 3, color: Theme.Ink.label)
                 Text("Your life, from above.")
-                    .font(.system(size: 16, design: .serif)).italic()
+                    .font(.system(size: 16))
                     .foregroundStyle(Theme.Ink.statusInk.opacity(0.85))
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -100,7 +100,7 @@ struct NightSkyView: View {
         VStack(spacing: 14) {
             Orb(size: 92)
             Text("Your sky is still forming.")
-                .font(.system(size: 20, design: .serif).italic())
+                .font(.system(size: 20, weight: .medium))
                 .foregroundStyle(Theme.Ink.statusInk)
             Text("Once Sentient has read your life, every note becomes a star.")
                 .font(.system(size: 13)).foregroundStyle(Theme.secondary)
@@ -112,77 +112,24 @@ struct NightSkyView: View {
 
 // MARK: - The door (shared by both sides: "Constellation View" in the reader, "Reader" in the sky)
 
-/// The mode switch, front and center in the titlebar (both KnowledgeView toolbars mount one via
-/// SkyDoorToolbarItem, .principal placement). On macOS 26 the body is REAL Liquid Glass (in our
-/// own capsule — the item's shared glass is hidden so it never double-wraps); the 15 floor gets
-/// the dark capsule. The magic is the EDGE FLOW: a slow current of the brand spectrum circling
-/// the rim. ⌘⇧G fires whichever door is currently mounted.
+/// The mode switch in the titlebar (both KnowledgeView toolbars mount one via SkyDoorToolbarItem).
+/// A plain native toolbar button — same font and glass as its Edit / Reveal in Finder neighbours.
+/// ⌘⇧G fires whichever door is currently mounted.
 struct SkyDoor: View {
     let icon: String
     let label: String
     let action: () -> Void
-    @State private var hover = false
 
     var body: some View {
         Button(action: action) {
-            HStack(spacing: 8) {
-                Image(systemName: icon).font(.system(size: 11, weight: .medium))
-                MonoCaps(label, size: 9.5, tracking: 2.5, color: .white.opacity(hover ? 0.95 : 0.8))
-            }
-            .foregroundStyle(.white.opacity(hover ? 0.95 : 0.8))
-            .padding(.horizontal, 14)
-            .frame(height: 33)                    // match the native glass toolbar buttons' height
-            .modifier(SkyDoorChrome())
-            .overlay(edgeFlow)
-            .shadow(color: Color(red: 1.0, green: 0.68, blue: 0.42).opacity(hover ? 0.30 : 0.10),
-                    radius: hover ? 14 : 8)
-            .contentShape(Capsule())
+            Label(label, systemImage: icon)
         }
-        .buttonStyle(PressScaleStyle())
+        .labelStyle(.titleAndIcon)
         .keyboardShortcut("g", modifiers: [.command, .shift])
-        .onHover { hover = $0 }
-        .animation(.easeOut(duration: 0.18), value: hover)
-    }
-
-    /// The door's own warm spectrum — the Knowledge amber family (gold → orange → ember) with one
-    /// violet streak lapping through it. First == last, so the angular seam never shows.
-    private static let flow: [Color] = [
-        Color(red: 1.00, green: 0.78, blue: 0.45),   // gold
-        Color(red: 1.00, green: 0.66, blue: 0.38),   // amber (the sidebar's accent family)
-        Color(red: 0.99, green: 0.52, blue: 0.40),   // ember
-        Color(red: 0.80, green: 0.42, blue: 0.88),   // the violet streak
-        Color(red: 0.58, green: 0.44, blue: 0.98),   // purple
-        Color(red: 1.00, green: 0.70, blue: 0.42),   // back through amber
-        Color(red: 1.00, green: 0.78, blue: 0.45),   // wrap = gold
-    ]
-
-    /// The current riding the capsule's edge — one slow lap every 15s, brighter under the cursor.
-    private var edgeFlow: some View {
-        TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { tl in
-            Capsule().strokeBorder(
-                AngularGradient(colors: Self.flow, center: .center,
-                                angle: .degrees(tl.date.timeIntervalSinceReferenceDate * 24)),
-                lineWidth: 1)
-        }
-        .opacity(hover ? 0.85 : 0.45)
-        .allowsHitTesting(false)
     }
 }
 
-/// Liquid Glass where it exists, quiet dark glass where it doesn't (the macOS 15 floor).
-private struct SkyDoorChrome: ViewModifier {
-    func body(content: Content) -> some View {
-        if #available(macOS 26.0, *) {
-            content.glassEffect(.regular.interactive(), in: Capsule())
-        } else {
-            content.background(Theme.Ink.cardBG.opacity(0.85), in: Capsule())
-        }
-    }
-}
-
-/// The door's toolbar seat. On macOS 26 the toolbar would wrap the door in ANOTHER glass capsule
-/// (glass-on-glass — the "lol" screenshot); hiding the item's shared background lets the door
-/// carry its own.
+/// The door's toolbar seat.
 struct SkyDoorToolbarItem: ToolbarContent {
     let icon: String
     let label: String
@@ -191,16 +138,9 @@ struct SkyDoorToolbarItem: ToolbarContent {
     let action: () -> Void
 
     var body: some ToolbarContent {
-        if #available(macOS 26.0, *) {
-            ToolbarItem(placement: placement) { door }
-                .sharedBackgroundVisibility(.hidden)
-        } else {
-            ToolbarItem(placement: placement) { door }
+        ToolbarItem(placement: placement) {
+            SkyDoor(icon: icon, label: label, action: action).help(help)
         }
-    }
-
-    private var door: some View {
-        SkyDoor(icon: icon, label: label, action: action).help(help)
     }
 }
 
@@ -223,7 +163,7 @@ private struct SkyHoverCard: View {
                     .lineLimit(2)
             }
             if info.recentlyChanged {
-                MonoCaps("Changed last night", size: 7.5, tracking: 1.5, color: Theme.Ink.amber)
+                MonoCaps("Changed last night", size: 7.5, tracking: 1.5, color: Theme.dawnCyan)
             }
         }
         .padding(12)

--- a/Sentient OS macOS/Views/Knowledge/Graph/SkyGraph.swift
+++ b/Sentient OS macOS/Views/Knowledge/Graph/SkyGraph.swift
@@ -22,7 +22,7 @@ struct SkyNode: Identifiable {
     let domain: Int              // index into SkyGraph.domains · -1 = the root README (the sun)
     var degree: Int              // resolved wikilink connections (deduped, undirected)
     let isRoot: Bool
-    let recentlyChanged: Bool    // modified in the last 36h → the amber shimmer
+    let recentlyChanged: Bool    // modified in the last 36h → the dawn shimmer
     let preview: String          // first readable body line (cleaned) — the hover card's one-liner
     let twinklePhase: Double     // stable per-note personality (hashed from the path, so a star
     let twinkleSpeed: Double     //  twinkles the same way every night)

--- a/Sentient OS macOS/Views/Knowledge/Graph/SkyRenderer.swift
+++ b/Sentient OS macOS/Views/Knowledge/Graph/SkyRenderer.swift
@@ -29,7 +29,7 @@ struct SkyRenderer {
         (0.55, 0.92, 0.80),  // mint
         (0.82, 0.70, 0.98),  // lavender
     ]
-    private static let amber = (r: 1.0, g: 0.682, b: 0.42)   // Theme.knowledgeAccent's components
+    private static let dawn = (r: 0.333, g: 0.757, b: 0.941)   // Theme.dawnCyan's components
 
     static func domainColor(_ d: Int, alpha: Double = 1) -> Color {
         guard d >= 0 else { return Color(red: 1, green: 0.93, blue: 0.85, opacity: alpha) }   // the sun: warm white
@@ -288,13 +288,13 @@ struct SkyRenderer {
                                           .clear]),
                         center: p, startRadius: 0, endRadius: haloR))
 
-            // "Changed last night" — a slow amber breath around the star.
+            // "Changed last night" — a slow dawn-cyan breath around the star.
             if n.recentlyChanged {
                 let aR = r * 5
                 let aA = (0.10 + 0.07 * sin(t * 1.5 + n.twinklePhase)) * dim * starReveal
                 ctx.fill(Path(ellipseIn: CGRect(x: p.x - aR, y: p.y - aR, width: aR * 2, height: aR * 2)),
                          with: .radialGradient(
-                            Gradient(colors: [Color(red: amber.r, green: amber.g, blue: amber.b, opacity: aA), .clear]),
+                            Gradient(colors: [Color(red: dawn.r, green: dawn.g, blue: dawn.b, opacity: aA), .clear]),
                             center: p, startRadius: 0, endRadius: aR))
             }
 

--- a/Sentient OS macOS/Views/Knowledge/KnowledgeView.swift
+++ b/Sentient OS macOS/Views/Knowledge/KnowledgeView.swift
@@ -9,8 +9,8 @@
 //  the titlebar carries Edit / Delete (→ Trash) / Reveal in Finder. Every edit/create/delete commits
 //  locally and DEBOUNCE-syncs to the cloud MCP (VaultActivity.markChanged → the sidebar status line).
 //  The window OPENS in the "Constellation View" graph (Graph/NightSkyView.swift — the default);
-//  glowing SkyDoor capsules swap between it and the reader (sky: top-center · reader: top-left;
-//  ⌘⇧G). Click a star to read that note; Back (or Esc) returns to the sky where you left it.
+//  native SkyDoor toolbar buttons swap between it and the reader (sky: top-center · reader:
+//  top-left; ⌘⇧G). Click a star to read that note; Back (or Esc) returns to the sky where you left it.
 //
 //  Replaced the old DatabaseView (a dev CycleStore-summaries inspector, still in Dev Tools via
 //  SummariesView). Data: VaultTree.swift · rendering: MarkdownView.swift.
@@ -391,7 +391,7 @@ struct KnowledgeView: View {
             VStack(alignment: .leading, spacing: 2) {   // title + count = one tight block
                 HStack(spacing: 8) {
                     OrbMark(size: 15)
-                    Text("Knowledge").font(.system(size: 22, design: .serif)).italic().foregroundStyle(.white)
+                    Text("Knowledge").display(22).foregroundStyle(.white)
                     Spacer()
                     newMenu   // the always-visible "you can create things here" affordance
                 }
@@ -659,7 +659,7 @@ struct KnowledgeView: View {
     private func emptyState(title: String, subtitle: String?) -> some View {
         VStack(spacing: 14) {
             Orb(size: 92)
-            Text(title).font(.system(size: 20, design: .serif).italic()).foregroundStyle(Theme.Ink.statusInk)
+            Text(title).font(.system(size: 20, weight: .medium)).foregroundStyle(Theme.Ink.statusInk)
             if let subtitle {
                 Text(subtitle).font(.system(size: 13)).foregroundStyle(Theme.secondary)
                     .multilineTextAlignment(.center).frame(maxWidth: 320)

--- a/Sentient OS macOS/Views/Knowledge/MarkdownView.swift
+++ b/Sentient OS macOS/Views/Knowledge/MarkdownView.swift
@@ -37,7 +37,7 @@ struct MarkdownView: View {
                 line(raw.trimmingCharacters(in: .whitespaces))
             }
         }
-        .tint(Theme.knowledgeAccent)
+        .tint(Theme.knowledgeLink)
         .environment(\.openURL, OpenURLAction { url in
             if url.absoluteString.hasPrefix(Self.wikiScheme) {
                 let title = String(url.absoluteString.dropFirst(Self.wikiScheme.count)).removingPercentEncoding ?? ""
@@ -75,7 +75,7 @@ struct MarkdownView: View {
                 .padding(.top, 10).padding(.bottom, 4)
         } else if let bullet = bulletText(s) {
             HStack(alignment: .firstTextBaseline, spacing: 10) {
-                Text("•").font(.system(size: 15)).foregroundStyle(Theme.knowledgeAccent.opacity(0.75))
+                Text("•").font(.system(size: 15)).foregroundStyle(.white.opacity(0.42))
                 Text(inline(bullet))
                     .font(.system(size: 14.5)).foregroundStyle(.white.opacity(0.82))
                     .lineSpacing(5).fixedSize(horizontal: false, vertical: true)
@@ -119,7 +119,8 @@ struct MarkdownView: View {
         return out
     }
 
-    /// `[[Title]]` or `[[Title|alias]]` → a styled run. Resolved → accent link; unresolved → dimmed.
+    /// `[[Title]]` or `[[Title|alias]]` → a styled run. Resolved → the sky-blue link; unresolved →
+    /// dimmed neutral (color here means "you can go somewhere").
     private func wikilink(_ inner: String) -> AttributedString {
         let parts = inner.split(separator: "|", maxSplits: 1, omittingEmptySubsequences: false)
         let target = parts[0].trimmingCharacters(in: .whitespaces)
@@ -129,10 +130,10 @@ struct MarkdownView: View {
            let encoded = target.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
            let url = URL(string: Self.wikiScheme + encoded) {
             run.link = url
-            run.foregroundColor = Theme.knowledgeAccent
+            run.foregroundColor = Theme.knowledgeLink
             run.underlineStyle = .single
         } else {
-            run.foregroundColor = Theme.knowledgeAccent.opacity(0.4)   // unresolved — visible but inert
+            run.foregroundColor = Color.white.opacity(0.38)   // unresolved — visible but inert
         }
         return run
     }

--- a/Sentient OS macOS/Views/MenuBarView.swift
+++ b/Sentient OS macOS/Views/MenuBarView.swift
@@ -16,8 +16,8 @@ struct MenuBarView: View {
         switch appState.status {
         case .idle:                            Text("Sentient OS · idle")
         case .processing(let done, let total): Text("Processing \(done) / \(total)")
-        case .paused(let reason):              Text("Paused — \(reason)")
-        case .error(let message):              Text("Error — \(message)")
+        case .paused(let reason):              Text("Paused · \(reason)")
+        case .error(let message):              Text("Error · \(message)")
         }
 
         Divider()

--- a/Sentient OS macOS/Views/ProcessingView.swift
+++ b/Sentient OS macOS/Views/ProcessingView.swift
@@ -233,7 +233,7 @@ struct ProcessingView: View {
                     }
                     // Survivors carry a summary; junk/sensitive often don't — show a graceful
                     // placeholder so the round never looks blank.
-                    let fallback = verdict == .sensitive ? "Held back — sensitive."
+                    let fallback = verdict == .sensitive ? "Held back: sensitive."
                                  : verdict == .junk ? "Nothing worth keeping here." : ""
                     let body = progress.lastSummary ?? fallback
                     if !body.isEmpty {
@@ -283,7 +283,7 @@ struct ProcessingView: View {
             Image(systemName: "checkmark.circle.fill").font(.system(size: 58))
                 .foregroundStyle(Theme.verdictColor(.survivor))
             VStack(spacing: 6) {
-                Text("Analysis complete").font(.serif(28)).italic().foregroundStyle(.white)
+                Text("Analysis complete").display(28).foregroundStyle(.white)
                 Text("\(progress.survivors) kept · \(progress.junk) junk · \(progress.failed) failed")
                     .font(.subheadline).foregroundStyle(.white.opacity(0.55))
             }
@@ -432,7 +432,7 @@ struct ProcessingView: View {
                 p.done        = baseDone + completed
                 p.survivors   = baseKept + keptSoFar
                 p.junk        = baseJunk + (completed - keptSoFar)   // a window with nothing notable
-                p.lastTitle   = "Email — \(label)"
+                p.lastTitle   = "Email · \(label)"
                 p.lastSummary = summary
                 p.lastVerdict = summary == nil ? .junk : .survivor
                 p.lastFilePath = nil
@@ -483,7 +483,7 @@ struct ProcessingView: View {
                 p.done        = baseDone + step
                 p.survivors   = baseKept + keptSoFar
                 p.junk        = baseJunk + (step - keptSoFar)   // a window with nothing notable
-                p.lastTitle   = "Calendar — \(label)"
+                p.lastTitle   = "Calendar · \(label)"
                 p.lastSummary = summary
                 p.lastVerdict = summary == nil ? .junk : .survivor
                 p.lastFilePath = nil

--- a/Sentient OS macOS/Views/Settings/HealthPane.swift
+++ b/Sentient OS macOS/Views/Settings/HealthPane.swift
@@ -60,7 +60,7 @@ struct HealthPane: View {
     }
 
     var body: some View {
-        SettingsPane(title: "Permissions & Health.",
+        SettingsPane(title: "Permissions & Health",
                      whisper: allGreen ? "All clear. Your Sentient is healthy."
                                        : "Everything green means everything works.") {
             if !checked {
@@ -107,7 +107,7 @@ struct HealthPane: View {
         HStack(spacing: 10) {
             ProgressView().controlSize(.small)
             Text("Checking your Sentient…")
-                .font(.serif(12.5, weight: .regular)).italic()
+                .font(.system(size: 12.5))
                 .foregroundStyle(Theme.Ink.body)
         }
         .padding(.top, 10)

--- a/Sentient OS macOS/Views/Settings/ProactivePane.swift
+++ b/Sentient OS macOS/Views/Settings/ProactivePane.swift
@@ -17,7 +17,7 @@ struct ProactivePane: View {
     @AppStorage("sidekick.context") private var sidekickContext = ""
 
     var body: some View {
-        SettingsPane(title: "Proactive & Sidekick.",
+        SettingsPane(title: "Proactive & Sidekick",
                      whisper: "Morning suggestions, and the hold-to-talk magic in your notch.") {
             VStack(alignment: .leading, spacing: 30) {
                 SettingsGroup(label: "Proactive Intelligence") {

--- a/Sentient OS macOS/Views/Settings/SettingsComponents.swift
+++ b/Sentient OS macOS/Views/Settings/SettingsComponents.swift
@@ -11,8 +11,8 @@
 
 import SwiftUI
 
-/// The right-pane scaffold every settings pane uses: an italic serif title (the editorial voice),
-/// an optional serif-italic whisper under it, then the scrolling body — capped to an editorial
+/// The right-pane scaffold every settings pane uses: a bold display title (the editorial voice),
+/// an optional quiet whisper under it, then the scrolling body — capped to an editorial
 /// measure so a wide window never stretches lines unreadable.
 struct SettingsPane<Content: View>: View {
     let title: String
@@ -23,11 +23,11 @@ struct SettingsPane<Content: View>: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
                 Text(title)
-                    .font(.serif(27)).italic()
+                    .display(27)
                     .foregroundStyle(.white)
                 if let whisper {
                     Text(whisper)
-                        .font(.serif(12.5, weight: .regular)).italic()
+                        .font(.system(size: 12.5))
                         .foregroundStyle(.white.opacity(0.72))
                         .padding(.top, 7)
                 }

--- a/Sentient OS macOS/Views/Settings/SettingsView.swift
+++ b/Sentient OS macOS/Views/Settings/SettingsView.swift
@@ -58,7 +58,7 @@ struct SettingsView: View {
             HStack(spacing: 10) {
                 OrbMark(size: 19)
                 Text("Settings")
-                    .font(.serif(16)).italic().foregroundStyle(.white)
+                    .display(16).foregroundStyle(.white)
             }
             .padding(.horizontal, 10)
             .padding(.top, 20)

--- a/Sentient OS macOS/Views/Settings/SourcesPane.swift
+++ b/Sentient OS macOS/Views/Settings/SourcesPane.swift
@@ -53,13 +53,13 @@ struct SourcesPane: View {
     }
 
     var body: some View {
-        SettingsPane(title: "Knowledge Sources.",
+        SettingsPane(title: "Knowledge Sources",
                      whisper: "Your files never leave your Mac. Your Sentient uses an on-device LLM to understand your life overnight.") {
             VStack(alignment: .leading, spacing: 30) {
                 // Tucked tight under the whisper so the two lines read as ONE header block,
                 // with the full 30pt group gap only after it.
                 Text("Your Sentient needs at least three sources to truly know you.")
-                    .font(.serif(12.5, weight: .regular)).italic()
+                    .font(.system(size: 12.5))
                     .foregroundStyle(flashMinimum ? Theme.Ink.amber : .white.opacity(0.72))
                     .animation(.easeInOut(duration: 0.25), value: flashMinimum)
                     .padding(.top, -16)

--- a/Sentient OS macOS/Views/Settings/SystemPane.swift
+++ b/Sentient OS macOS/Views/Settings/SystemPane.swift
@@ -28,7 +28,7 @@ struct SystemPane: View {
     @State private var activity = PipelineActivity.shared   // Reset locks while a run is active
 
     var body: some View {
-        SettingsPane(title: "System.", whisper: "How Sentient lives on this Mac.") {
+        SettingsPane(title: "System", whisper: "How Sentient lives on this Mac.") {
             VStack(alignment: .leading, spacing: 34) {
                 overnightGroup
                 startupGroup
@@ -49,7 +49,7 @@ struct SystemPane: View {
                     .font(.system(size: 13.5, weight: .medium)).foregroundStyle(.white)
                 SettingsProse("Every night at 3 AM, Sentient wakes your Mac to read what's new in your life, update your knowledge base, and prepare your morning suggestions. It only happens while your Mac is plugged in, and only if Sentient is still running in your menu bar. This quiet, on-device work is what keeps your Sentient alive and helpful.")
                 Text("Runs while your Mac rests.")
-                    .font(.serif(11.5, weight: .regular)).italic()
+                    .font(.system(size: 11.5))
                     .foregroundStyle(Theme.Ink.deepMuted)
                     .padding(.top, 3)
             }
@@ -90,7 +90,7 @@ struct SystemPane: View {
     private var updatesGroup: some View {
         SettingsGroup(label: "Updates") {
             VStack(alignment: .leading, spacing: 10) {
-                SettingsProse("Sentient keeps itself up to date automatically. When a new version is ready, Sentient asks you to update before continuing — so you're always on the latest, safest version.")
+                SettingsProse("Sentient keeps itself up to date automatically. When a new version is ready, Sentient asks you to update before continuing, so you're always on the latest, safest version.")
                 HStack(spacing: 6) {
                     Text("Version \(UpdateController.currentVersionString)")
                         .font(.system(size: 12.5, weight: .medium)).foregroundStyle(.white)
@@ -133,7 +133,7 @@ struct SystemPane: View {
     private var dangerGroup: some View {
         SettingsGroup(label: "Danger Zone") {
             VStack(alignment: .leading, spacing: 10) {
-                SettingsProse("Reset erases everything Sentient has learned: the knowledge base, every summary, and all suggestions. You'll start over from scratch, including the initial processing. Your cloud copy isn't touched; the next processing run simply replaces it.")
+                SettingsProse("Reset erases everything Sentient has learned: the knowledge base, every summary, all suggestions, and the cloud copy your AIs read. You'll start over from scratch, including the initial processing. Your private link stays valid; the next processing run fills it again.")
                 SettingsPillButton(title: resetting ? "Erasing…" : "Reset Sentient…",
                                    tint: Self.dangerRed) { confirmReset = true }
                     .disabled(resetting || activity.isRunning)
@@ -143,7 +143,7 @@ struct SystemPane: View {
                 }
                 if resetDone {
                     Text("Reset complete. Sentient is a blank slate.")
-                        .font(.serif(11.5, weight: .regular)).italic()
+                        .font(.system(size: 11.5))
                         .foregroundStyle(Theme.Ink.body)
                 }
             }
@@ -159,7 +159,7 @@ struct SystemPane: View {
                 }
             }
         } message: {
-            Text("Your knowledge base and everything Sentient understood is deleted from this Mac. This can't be undone; Sentient starts again from zero, beginning with the initial processing.")
+            Text("Your knowledge base and everything Sentient understood is deleted from this Mac, and the cloud copy is removed. This can't be undone; Sentient starts again from zero, beginning with the initial processing.")
         }
     }
 }

--- a/Sentient OS macOS/Views/Settings/YourAIsPane.swift
+++ b/Sentient OS macOS/Views/Settings/YourAIsPane.swift
@@ -23,7 +23,7 @@ struct YourAIsPane: View {
     @State private var errorLine: String?
 
     var body: some View {
-        SettingsPane(title: "ChatGPT & Claude.",
+        SettingsPane(title: "ChatGPT & Claude",
                      whisper: "Your knowledge base, offered to every AI you already use.") {
             VStack(alignment: .leading, spacing: 30) {
                 intro
@@ -140,7 +140,7 @@ struct YourAIsPane: View {
         SettingsGroup(label: "Activity") {
             VStack(alignment: .leading, spacing: 7) {
                 Text(activityLine)
-                    .font(.serif(13, weight: .regular)).italic()
+                    .font(.system(size: 13))
                     .foregroundStyle(Theme.Ink.body)
                 if let last = stats?.lastAccess {
                     MonoCaps("Last read · \(last.formatted(.relative(presentation: .named)))",

--- a/Sentient OS macOS/Views/Theme.swift
+++ b/Sentient OS macOS/Views/Theme.swift
@@ -3,27 +3,36 @@
 //  Sentient OS macOS
 //
 //  The Sentient OS visual language — one place so "fancy everywhere" stays consistent.
-//  Pure OLED black, serif-italic display voice, glassy elevated surfaces, a soft violet glow,
-//  and verdict color-coding. The app is dark-only (no light mode).
+//  Pure OLED black, a bold tight-tracked display voice, glassy elevated surfaces, a soft violet
+//  glow, and verdict color-coding. Serif survives only as the face of a note's name (Knowledge
+//  reader headings, star labels) and inside the gift letter. The app is dark-only (no light mode).
 //
 
 import SwiftUI
 
 enum Theme {
     static let bg = Color.black
-    /// The Knowledge sidebar surface — a subtle WARM (orange-tinted) lift off the OLED-black reading
-    /// pane, so the folder panel reads as its own warm chrome. Same brightness as a neutral panel
-    /// would be, just warm (r > g > b).
-    static let panel = Color(red: 0.102, green: 0.074, blue: 0.052)
+    /// The Knowledge sidebar surface — moonlit slate: near-neutral graphite with a whisper of cool
+    /// blue (b > g > r), so the folder panel reads as night-sky chrome and recedes behind the
+    /// reading pane. (The old warm-orange panel read as a Claude-ism.)
+    static let panel = Color(red: 0.053, green: 0.058, blue: 0.072)
     static let elevated = Color.white.opacity(0.05)
     static let stroke = Color.white.opacity(0.09)
     static let secondary = Color.white.opacity(0.55)
     static let faint = Color.white.opacity(0.32)
     static let accent = Color(red: 0.62, green: 0.55, blue: 1.0)   // soft violet glow
-    /// The Knowledge viewer's warm accent — a soft amber-orange (#ffae6b), leaning gold not red, for
-    /// wikilinks, bullets, and the selected-note glow. Gives the reading surface its own calm
-    /// identity instead of the app's violet.
-    static let knowledgeAccent = Color(red: 1.0, green: 0.682, blue: 0.42)
+    /// The Knowledge window's interactive accent — starlight periwinkle (#8ea6ff), the middle note
+    /// of the wikilink gradient. Selected rows, tints, carets. Color means "alive/tappable" here;
+    /// everything else stays neutral ink.
+    static let knowledgeAccent = Color(red: 0.557, green: 0.651, blue: 1.0)
+
+    /// The wikilink color — a plain, minimalist sky blue (#6fb6ff). Deliberately a solid, honest
+    /// web-link blue: gradient text reads as AI-generated, single claimed hues read as other
+    /// brands; sky blue on a night-sky surface reads as ours.
+    static let knowledgeLink = Color(red: 0.435, green: 0.714, blue: 1.0)
+
+    /// The sky's "changed last night" shimmer — dawn cyan.
+    static let dawnCyan = Color(red: 0.333, green: 0.757, blue: 0.941)
 
     /// "Magic" cool palette for the Stage-2 vault CTA glow — teal · cyan · blue · indigo · purple.
     static let magicGlow: [Color] = [
@@ -101,10 +110,13 @@ struct PressScaleStyle: ButtonStyle {
     }
 }
 
-extension Font {
-    /// The serif-italic display voice (used with `.italic()`), e.g. the "sentient" wordmark.
-    static func serif(_ size: CGFloat, weight: Font.Weight = .semibold) -> Font {
-        .system(size: size, weight: weight, design: .serif)
+extension View {
+    /// The display voice — SF Pro at medium weight. Hierarchy comes from weight + ink + size, not
+    /// a genre switch. Medium, not bold: light-on-black reads about a weight heavier than the same
+    /// face on white. NO manual tracking — SF's optical sizing already tightens display sizes, and
+    /// extra negative tracking makes big lines render blotchy (crowded pairs look bolder).
+    func display(_ size: CGFloat, weight: Font.Weight = .medium) -> some View {
+        font(.system(size: size, weight: weight))
     }
 }
 


### PR DESCRIPTION
## What

One session of de-AI-slopping the entire visual identity, plus one privacy behavior fix.

### Type system (app-wide)
- **Serif-italic display chrome is gone.** New `.display()` voice in `Theme.swift`: SF Pro **medium**, natural spacing (medium not bold: light-on-black reads a weight heavier; no manual tracking: it renders blotchy at display sizes).
- **Serif is recast as meaning, not costume:** upright serif now marks *content about the user's life only* — card headlines, Knowledge note names/headings, the gift letter. The notch keeps its serif-italic captions by design.
- Settings pane titles lose italics + trailing periods; all whispers are quiet plain sans.

### Knowledge window — the “Starlight” scheme
- Moonlit-slate sidebar (the warm amber panel read as a Claude-ism) · periwinkle interactive accent (#8ea6ff) · **solid sky-blue wikilinks** (#6fb6ff, minimalist, no gradients) · dawn-cyan “changed last night” shimmer · neutral bullets. Color = alive/tappable; everything else is neutral ink.
- **SkyDoor is now a plain native toolbar button** (Label + titleAndIcon) matching Edit / Reveal in Finder; the glowing capsule + animated edge-flow removed (~70 lines).

### Em dashes: extinct
- Purged from every user-facing string (~36 fixes across 25 files; semicolon/colon/comma or the mono `·`).
- The vault build/update + proactive decide/prepare prompts now ban em dashes in generated user-visible text (the gift letter prompt already did).

### Home polish
- Greeting `display(27)`, brighter + larger top-right nav, envelope flap clipped to the card's rounded corners (no more pointy ears at the top corners).

### Reset Sentient → also deletes the cloud MCP copy
- `FactoryReset.run()` now calls `MirrorClient.deleteRemote()` best-effort (offline reset still succeeds; 30-day lease remains the backstop). Token + opt-in survive so the pasted connector URL keeps working; the next push recreates the copy. Danger Zone prose + confirm alert updated to match. Aligns Reset with Privacy Constitution #4.

### Docs trued
- `Knowledge Viewer.md`, `Settings.md`, `Home — For You.md`, `Theme.swift` header (the `UI_Inspiration` README + context files updated in Our_Stuff, outside this repo).

## Testing
- Built clean via Xcode MCP after every step; every surface eyeballed live on real hardware by Jesai through the session (home, Settings, Knowledge reader + constellation, envelope).
- Worth a follow-up smoke test: Reset with the mirror on, then confirm the MCP URL comes back empty until the next push.