### PR TITLE
Sparkle: Chrome-style silent auto-update relaunch

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -27,30 +27,26 @@
 	<key>SUPublicEDKey</key>
 	<string>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</string>
 
-	<!-- Check automatically once a day. No second-launch permission prompt (updates are mandatory,
-	     so there's nothing to opt out of). -->
+	<!-- Check hourly (3600s is Sparkle's floor). Frequent releases are planned, and pairing fast
+	     discovery with the silent idle-relaunch below keeps users effortlessly current. No
+	     second-launch permission prompt — there's nothing to opt out of. -->
 	<key>SUEnableAutomaticChecks</key>
 	<true/>
 	<key>SUScheduledCheckInterval</key>
-	<integer>86400</integer>
+	<integer>3600</integer>
 
-	<!-- Auto-update with our OLED gate as the FALLBACK: Sparkle silently downloads and installs
-	     updates on its own (applied on quit/relaunch — you can't swap a running bundle underneath the
-	     user). Zero taps in the normal case. Our custom forced-update gate (SentientUpdateDriver /
-	     UpdateGateView — no skip, no remind) only appears when a silent install CAN'T happen: macOS
-	     needs an admin password (app in /Applications), an install error, or the impatient window
-	     below elapses without the app being quit. -->
+	<!-- Chrome-style silent auto-update. Sparkle silently downloads + stages new versions; then
+	     UpdateController's `willInstallUpdateOnQuit` hook installs + relaunches on its own the moment
+	     it's safe (no pipeline run in flight, user not actively using the app) — no "install on quit"
+	     wait, zero taps. Because Sentient is a long-running menu-bar app, we deliberately do NOT set
+	     SUScheduledImpatientCheckInterval: idle-relaunch replaces the old 2-day forced-gate nag.
+	     Our OLED forced-update gate (SentientUpdateDriver / UpdateGateView — no skip, no remind) now
+	     appears ONLY when a silent install is genuinely impossible: macOS needs an admin password
+	     (app in a non-user-writable dir) or an install error — plus user-initiated "Check for Updates". -->
 	<key>SUAllowsAutomaticUpdates</key>
 	<true/>
 	<key>SUAutomaticallyUpdate</key>
 	<true/>
-
-	<!-- Sentient lives in the menu bar and may run for days, so "install on quit" can be slow to fire.
-	     If a silently-downloaded update still hasn't installed after this window, Sparkle surfaces it —
-	     i.e. our gate shows as the fallback. 2 days: current enough without nagging. Must exceed
-	     SUScheduledCheckInterval. -->
-	<key>SUScheduledImpatientCheckInterval</key>
-	<integer>172800</integer>
 
 	<!-- Privacy Constitution: send no system profile, and never run JavaScript in release notes.
 	     The only network exposure is the appcast GET (IP + User-Agent) over HTTPS — no account. -->

--- a/Sentient OS macOS/Updates/UpdateController.swift
+++ b/Sentient OS macOS/Updates/UpdateController.swift
@@ -3,14 +3,21 @@
 //  Sentient OS macOS
 //
 //  Owns the Sparkle updater and wires it to our own UI. Creates one SPUUpdater targeting the app's
-//  main bundle, driven by SentientUpdateDriver (our OLED gate) with this object as the (optional)
-//  delegate for logging. AppState holds one of these and calls `start()` — GUI path only (never the
-//  root wake-helper). The menu bar and Settings call `checkForUpdatesNow()`.
+//  main bundle, driven by SentientUpdateDriver (our OLED gate) with this object as the SPUUpdaterDelegate.
+//  AppState holds one of these and calls `start()` — GUI path only (never the root wake-helper). The
+//  menu bar and Settings call `checkForUpdatesNow()`.
 //
-//  Config (feed URL, EdDSA key, daily interval, mandatory model) lives in Info.plist — see
-//  Documentation/Auto-Update (Sparkle).md. This file is just the runtime glue.
+//  Chrome-style silent relaunch: once Sparkle has silently downloaded + staged an update, it calls our
+//  `willInstallUpdateOnQuit` hook. We take over and, the moment it's SAFE (no pipeline run in flight and
+//  the user isn't actively using the app), install + relaunch with zero UI — so the user never has to
+//  quit. The OLED gate only surfaces for user-initiated checks or when a silent install is impossible
+//  (needs an admin password, or errors).
+//
+//  Config (feed URL, EdDSA key, check interval) lives in Info.plist — see
+//  Documentation/Auto-Update (Sparkle).md. This file is the runtime glue.
 //
 
+import AppKit
 import Foundation
 import Sparkle
 
@@ -22,6 +29,12 @@ final class UpdateController: NSObject, SPUUpdaterDelegate {
 
     private let driver: SentientUpdateDriver
     private var updater: SPUUpdater!
+
+    /// Sparkle's "install + relaunch now" trigger for a silently-staged update, stashed until the
+    /// moment is safe (see `isSafeToRelaunch`). Set from `willInstallUpdateOnQuit`; cleared once fired.
+    private var pendingInstallHandler: (() -> Void)?
+    /// Polls for an idle-safe moment while an install is pending. Invalidated the instant we install.
+    private var idleTimer: Timer?
 
     override init() {
         let model = self.model
@@ -68,7 +81,7 @@ final class UpdateController: NSObject, SPUUpdaterDelegate {
         return short
     }
 
-    // MARK: - SPUUpdaterDelegate (optional — logging only)
+    // MARK: - SPUUpdaterDelegate
 
     @objc(updater:didFinishUpdateCycleForUpdateCheck:error:)
     func updater(_ updater: SPUUpdater,
@@ -77,5 +90,57 @@ final class UpdateController: NSObject, SPUUpdaterDelegate {
         if let error {
             Log("Sparkle: update cycle finished with error — \((error as NSError).localizedDescription)")
         }
+    }
+
+    /// Silent path: Sparkle has downloaded + staged an update for install-on-quit. Returning `true`
+    /// makes US responsible for triggering the install — we MUST eventually call the handler, or
+    /// Sparkle's update cycle stays blocked for the session. We stash it and fire it the moment it's
+    /// idle-safe; if the user quits first, Sparkle installs the staged update on quit anyway.
+    @objc(updater:willInstallUpdateOnQuit:immediateInstallationBlock:)
+    func updater(_ updater: SPUUpdater,
+                 willInstallUpdateOnQuit item: SUAppcastItem,
+                 immediateInstallationBlock immediateInstallHandler: @escaping () -> Void) -> Bool {
+        pendingInstallHandler = immediateInstallHandler
+        scheduleInstallWhenIdle()
+        return true
+    }
+
+    /// Last breath before the silent relaunch. Pipeline state is already durable (crash-safe CycleStore
+    /// marks), so there's nothing extra to flush — this is just a breadcrumb.
+    @objc(updaterWillRelaunchApplication:)
+    func updaterWillRelaunchApplication(_ updater: SPUUpdater) {
+        Log("Sparkle: relaunching into the new version")
+    }
+
+    // MARK: - Idle-gated silent install
+
+    /// Start (re)trying to install the staged update. Retries every 30s so a heavy/active session is
+    /// caught the moment it goes quiet; also tries once immediately.
+    private func scheduleInstallWhenIdle() {
+        idleTimer?.invalidate()
+        idleTimer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.installIfSafe() }
+        }
+        installIfSafe()
+    }
+
+    private func installIfSafe() {
+        guard let install = pendingInstallHandler, isSafeToRelaunch else { return }
+        pendingInstallHandler = nil
+        idleTimer?.invalidate()
+        idleTimer = nil
+        Log("Sparkle: idle-safe — installing staged update and relaunching silently")
+        install()   // Sparkle terminates, installs, and relaunches us — zero UI.
+    }
+
+    /// Two invariants: never relaunch out from under an in-flight processing run, and never yank the
+    /// app away from a user who's actively using it. Frontmost with a key window counts as "in use"
+    /// unless they've been idle 5+ minutes; if we're not frontmost at all, the relaunch is invisible.
+    private var isSafeToRelaunch: Bool {
+        if PipelineActivity.shared.isRunning { return false }
+        let appIsFrontmost = NSApp.isActive && NSApp.keyWindow != nil
+        let anyInput = CGEventType(rawValue: ~0)!   // kCGAnyInputEventType — time since any keyboard/mouse event
+        let idleSeconds = CGEventSource.secondsSinceLastEventType(.combinedSessionState, eventType: anyInput)
+        return !appIsFrontmost || idleSeconds > 300
     }
 }


### PR DESCRIPTION
## What
Makes auto-update fully silent (Chrome-style): once Sparkle has silently downloaded + staged an update, we install + relaunch on our own the moment it's safe — no "install on quit" wait, no forced-update wall, zero taps.

## How
- `UpdateController.swift`: implement the `willInstallUpdateOnQuit` delegate hook (return `true`, stash Sparkle's install handler) + idle gating. We only fire when it's safe: **never** during an in-flight processing run (`PipelineActivity.shared.isRunning`), and **never** while the user is actively using the app (frontmost + a key window unless idle 5+ min). A 30s retry timer catches the first safe moment; if the user quits first, Sparkle installs on quit anyway, so we can never wedge Sparkle's cycle. The custom driver + OLED gate are untouched.
- `Info.plist`: remove `SUScheduledImpatientCheckInterval` (the 2-day forced-gate nag — idle relaunch replaces it) and move checks to hourly (Sparkle's floor). The OLED gate now only surfaces for user-initiated checks and genuine can't-install-silently cases (admin password / install error).

## Testing
Not yet run on a real build — see `Our_Stuff/sentient-silent-updates-handoff.md`. Cannot be tested with the current placeholder EdDSA key; needs the real key baked in (Jesai) or the local throwaway-key harness.