### PR TITLE
Onboarding v1: slides → perms → codex login → ready screen → first analysis

### DIFF
--- a/Sentient OS macOS/App/AppState.swift
+++ b/Sentient OS macOS/App/AppState.swift
@@ -54,5 +54,36 @@ final class AppState {
         commandCoordinator.start()   // arm right-⌘ hold-to-talk + warm the speech model
         notch.start()                // raise the notch overlay window
         update.start()               // start Sparkle + one silent launch check (gates a mandatory update)
+
+        // First launch (onboarding not yet completed): kick off the codex CLI install silently in
+        // the background, 1s after launch, while the user reads the intro slides. A USED codex
+        // setup on this Mac (~/.codex/auth.json or config.toml — codex writes those once it's
+        // actually run) means never auto-install over it. The bare ~/.codex folder is NOT proof:
+        // an install interrupted mid-download (the FDA relaunch) leaves one behind, and skipping
+        // on it would strand onboarding without codex. installCodex() additionally no-ops when
+        // the binary is found, so a quit-and-relaunch mid-onboarding just re-checks. Login +
+        // computer-use stay interactive, later in the flow.
+        if !hasCompletedOnboarding {
+            Task {
+                try? await Task.sleep(for: .seconds(1))
+                let fm = FileManager.default
+                let codexDir = fm.homeDirectoryForCurrentUser.appendingPathComponent(".codex")
+                if fm.fileExists(atPath: codexDir.appendingPathComponent("auth.json").path)
+                    || fm.fileExists(atPath: codexDir.appendingPathComponent("config.toml").path) {
+                    Log("Onboarding: ~/.codex is a real setup — skipping the background codex install")
+                    return
+                }
+                // OpenAI's installer fails transiently (its GitHub-JSON parsing flaps per
+                // request), so one attempt isn't enough: retry with a 10s gap while the user is
+                // still on the slides/perms. A retried flap usually succeeds on the next try.
+                for attempt in 1...4 {
+                    await CodexSetup.shared.installCodex()
+                    if CodexSetup.shared.installed { return }
+                    Log("Onboarding: codex install attempt \(attempt) failed — retrying in 10s")
+                    try? await Task.sleep(for: .seconds(10))
+                }
+                Log("Onboarding: codex install still failing after 4 attempts — the login screen's re-kick is the remaining net")
+            }
+        }
     }
 }

--- a/Sentient OS macOS/Cloud/CodexCLI.swift
+++ b/Sentient OS macOS/Cloud/CodexCLI.swift
@@ -177,8 +177,16 @@ actor CodexCLI {
     /// exit code: a `curl | sh` pipeline reports the trailing `sh`'s status, so a failed download
     /// (no network) can still "exit 0" with nothing installed. Throws if codex isn't found after the
     /// run. (Installed ≠ logged in — auth is the next step; detection-first is the caller's job.)
+    ///
+    /// ⚠️ The sed stage is a working workaround for an UPSTREAM bug [MEASURED 2026-07-08]: GitHub's
+    /// API began serving MINIFIED JSON to requests without an explicit Accept header, and OpenAI's
+    /// installer parses the release JSON line-by-line — so every vanilla `curl … | sh` run now dies
+    /// with "Could not find Codex package or platform npm release assets". Injecting
+    /// `Accept: application/json` into the script's curl calls makes GitHub pretty-print again
+    /// (verified end-to-end); it's harmless on the script's binary downloads. Drop the sed once
+    /// OpenAI fixes install.sh.
     static func install(onLine: @escaping @Sendable (String) -> Void) async throws {
-        let pipeline = "curl -fsSL https://chatgpt.com/codex/install.sh | CODEX_NON_INTERACTIVE=1 sh"
+        let pipeline = #"curl -fsSL https://chatgpt.com/codex/install.sh | sed 's|curl -fsSL|curl -fsSL -H "Accept: application/json"|g' | CODEX_NON_INTERACTIVE=1 sh"#
         let out = try await executeStreaming(binary: "/bin/sh", args: ["-c", pipeline],
                                              timeout: 300, onLine: onLine)
         UserDefaults.standard.removeObject(forKey: pathCacheKey)   // force a fresh discovery scan
@@ -236,6 +244,17 @@ actor CodexCLI {
     /// Step 2 ground-truth check — `codex login status`. [MEASURED v0.142.3] exit 0 = logged in;
     /// exit 1 + "Not logged in" = not. Exit status is the primary signal, with an output scan as a
     /// backstop. Uses the bare-env `executeAsync` (status only reads `~/.codex/auth.json` via HOME).
+    /// Ground truth for "codex is installed": actually RUN `codex --help` and see it answer.
+    /// A pure path check can be fooled (e.g. a broken symlink left by a half-deleted install);
+    /// no binary found anywhere = the shell's "command not found" case. Onboarding's login
+    /// screen polls this to un-grey its button the moment the background install lands.
+    static func isRunnable() async -> Bool {
+        guard let bin = locateBinary() else { return false }
+        guard let out = try? await executeAsync(binary: bin, args: ["--help"],
+                                                stdinText: nil, cwd: nil, timeout: 10) else { return false }
+        return out.status == 0 && !out.stdout.isEmpty
+    }
+
     static func loginStatus() async -> Bool {
         guard let bin = locateBinary() else { return false }
         guard let out = try? await executeAsync(binary: bin, args: ["login", "status"],

--- a/Sentient OS macOS/Scheduling/LoginItem.swift
+++ b/Sentient OS macOS/Scheduling/LoginItem.swift
@@ -25,12 +25,25 @@ enum LoginItem {
     /// True when the app is registered to launch at login.
     static var isEnabled: Bool { service.status == .enabled }
 
+    /// True when macOS registered the item but demands the user's OK in System Settings — the
+    /// answer it gives once the user has manually disabled the item there; the app can never
+    /// silently re-enable past it.
+    static var needsApproval: Bool { service.status == .requiresApproval }
+
     /// Register the app as a login item. Idempotent; silent (no approval prompt). Returns success.
     @discardableResult
     static func enable() -> Bool {
         guard service.status != .enabled else { return true }
         do { try service.register(); Log("LoginItem: registered (status=\(service.status.rawValue))"); return true }
         catch { Log("LoginItem: register failed — \(error)"); return false }
+    }
+
+    /// The UI "Turn On" action: register, and when macOS answers .requiresApproval (the user
+    /// disabled the item in System Settings once), deep-link them there to flip it back on —
+    /// that's the only way past it. Both onboarding and Settings → Health call THIS.
+    static func enableOrRequestApproval() {
+        enable()
+        if needsApproval { SMAppService.openSystemSettingsLoginItems() }
     }
 
     /// Unregister the login item. Best-effort.

--- a/Sentient OS macOS/Views/Onboarding/OnboardingCodexSteps.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingCodexSteps.swift
@@ -1,0 +1,179 @@
+//
+//  OnboardingCodexSteps.swift
+//  Sentient OS macOS
+//
+//  Onboarding's codex step — a pure renderer over the SHARED CodexSetup engine (the same
+//  instance the dev tools' CodexSetupView drives; zero setup logic lives here).
+//
+//  OnboardingCodexLoginView is purely the browser login: one button that opens the OAuth page,
+//  then the screen NOTICES the finished sign-in on its own (a 2s `codex login status` poll while
+//  the browser is out + a re-check on app foreground) — no "I'm done" button. Continue gates on
+//  logged in. The CLI install happens in the BACKGROUND (AppState's launch kick); in the rare
+//  case it hasn't finished yet, the login button stays greyed and the screen polls `codex --help`
+//  (CodexCLI.isRunnable — the ground truth, not a path check) every 2s, un-greying the moment
+//  codex actually answers. A silent same-engine re-kick is the safety net, so a failed or
+//  skipped install can never dead-end the flow.
+//
+//  (Computer-use setup is deliberately NOT in onboarding — it happens later, elsewhere.)
+//
+
+import SwiftUI
+import AppKit
+
+// MARK: - Step: log in to codex
+
+struct OnboardingCodexLoginView: View {
+    let onContinue: () -> Void
+
+    @State private var codex = CodexSetup.shared
+    /// `codex --help` answered — the ground-truth install confirmation that un-greys the button.
+    @State private var codexConfirmed = false
+
+    var body: some View {
+        VStack(spacing: 40) {
+            Spacer()
+
+            OnboardingWhisper("CONNECT CODEX")
+
+            Text("Sign in with your ChatGPT account.\nSentient's cloud thinking runs through OpenAI's Codex, on your own plan.")
+                .font(.system(size: 15))
+                .foregroundStyle(Theme.secondary)
+                .multilineTextAlignment(.center)
+                .lineSpacing(4)
+
+            VStack(spacing: 16) {
+                if codex.loggedIn {
+                    OnboardingDoneLine("Logged in to Codex")
+                } else if codex.loggingIn {
+                    Text("Finish signing in in your browser. This screen notices on its own.")
+                        .font(.system(size: 12.5))
+                        .foregroundStyle(Theme.Ink.body)
+                    HStack(spacing: 8) {
+                        ProgressView().controlSize(.mini)
+                        Text("waiting for the browser sign-in…")
+                            .font(.system(size: 11, weight: .medium, design: .monospaced))
+                            .kerning(1.5)
+                            .foregroundStyle(Theme.faint)
+                    }
+                } else {
+                    // The login button — greyed until `codex --help` confirms the install landed.
+                    OnboardingNextButton(title: "Log in with ChatGPT", enabled: codexConfirmed) {
+                        codex.startLogin()
+                    }
+                    if !codexConfirmed {
+                        HStack(spacing: 8) {
+                            ProgressView().controlSize(.mini)
+                            Text("installing codex in the background…")
+                                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                                .kerning(1.5)
+                                .foregroundStyle(Theme.faint)
+                        }
+                    }
+                    OnboardingStatusText(codex.loginStatusLine)
+                }
+            }
+            .frame(maxWidth: 560)
+
+            OnboardingNextButton(title: "Continue", enabled: codex.loggedIn, action: onContinue)
+
+            Spacer()
+
+            OnboardingTrustFooter()
+        }
+        .padding(40)
+        .onAppear {
+            codex.refreshInstalled()
+            Task { await codex.refreshLoginStatus() }
+            // Safety net: no binary and no install in flight (it failed, or the launch kick
+            // skipped over a half-deleted setup) — quietly re-kick the same engine.
+            if !codex.installed && !codex.installing {
+                Task { await codex.installCodex() }
+            }
+        }
+        .task {
+            // The confirmation poll: run `codex --help` now, then every 2s until it answers —
+            // "command not found" (no binary) means the install is still going. On the normal
+            // path this succeeds on the first try and the button is never seen greyed.
+            while !Task.isCancelled {
+                if await CodexCLI.isRunnable() {
+                    codex.refreshInstalled()   // align the shared engine's flag
+                    withAnimation(.easeInOut(duration: 0.3)) { codexConfirmed = true }
+                    return
+                }
+                try? await Task.sleep(for: .seconds(2))
+            }
+        }
+        .task(id: codex.loggingIn) {
+            // The sign-in watcher (replaces the old "I've finished" button): while the browser
+            // flow is out, quietly re-check `codex login status` every 2s — the section flips to
+            // the green done line by itself the moment auth.json lands.
+            guard codex.loggingIn else { return }
+            while !Task.isCancelled, codex.loggingIn, !codex.loggedIn {
+                try? await Task.sleep(for: .seconds(2))
+                await codex.refreshLoginStatus()
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            Task { await codex.refreshLoginStatus() }   // back from the browser — often already done
+        }
+    }
+}
+
+// MARK: - Shared onboarding bits
+
+/// The monospace-caps whisper label every onboarding screen opens with.
+struct OnboardingWhisper: View {
+    let text: String
+    init(_ text: String) { self.text = text }
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 11, weight: .medium, design: .monospaced))
+            .kerning(2)
+            .foregroundStyle(Theme.faint)
+    }
+}
+
+/// A green-dot "this step is done" line.
+private struct OnboardingDoneLine: View {
+    let text: String
+    init(_ text: String) { self.text = text }
+
+    var body: some View {
+        HStack(spacing: 11) {
+            HealthDot(color: Theme.Ink.green)
+            Text(text)
+                .font(.system(size: 12.5))
+                .foregroundStyle(Theme.Ink.statusInk)
+        }
+    }
+}
+
+/// The engine's latest streamed/status line — monospaced, colored by its ✓/✗ prefix (the same
+/// convention the dev CodexSetupView renders).
+private struct OnboardingStatusText: View {
+    let status: String?
+    init(_ status: String?) { self.status = status }
+
+    var body: some View {
+        if let status {
+            Text(status)
+                .font(.system(.caption2, design: .monospaced))
+                .foregroundStyle(status.hasPrefix("✓") ? Theme.Ink.green
+                               : status.hasPrefix("✗") ? .red : Theme.secondary)
+                .multilineTextAlignment(.center)
+                .lineLimit(3)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}
+
+#Preview("Onboarding — codex login") {
+    ZStack {
+        Theme.bg.ignoresSafeArea()
+        OnboardingCodexLoginView(onContinue: {})
+    }
+    .frame(width: 1180, height: 880)
+    .preferredColorScheme(.dark)
+}
+

--- a/Sentient OS macOS/Views/Onboarding/OnboardingPermissionsView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingPermissionsView.swift
@@ -1,0 +1,148 @@
+//
+//  OnboardingPermissionsView.swift
+//  Sentient OS macOS
+//
+//  Onboarding's permissions step: Sentient's three core grants as the same StatusLine rows
+//  Settings → Health uses, with the same fix actions. The rows unlock SEQUENTIALLY (each greyed
+//  until the previous one is granted) and Full Disk Access is deliberately LAST: FDA is the one
+//  grant that forces an app relaunch, and putting it at the end means the relaunch restarts the
+//  background codex install as late as possible — so it's done before the user reaches the codex
+//  login step. Continue stays disabled until all three are green; the persisted onboarding step
+//  brings the user straight back here after the FDA relaunch. Statuses re-probe when the app
+//  foregrounds (returning from System Settings).
+//
+
+import SwiftUI
+import AppKit
+
+struct OnboardingPermissionsView: View {
+    let onContinue: () -> Void
+
+    @State private var fdaGranted = Permissions.hasFullDiskAccess()
+    @State private var daemon: DaemonState = .notSetUp
+    @State private var loginOn = LoginItem.isEnabled
+    @State private var loginNeedsApproval = LoginItem.needsApproval
+
+    private enum DaemonState { case ready, installing, notSetUp }
+
+    private var allGreen: Bool { fdaGranted && daemon == .ready && loginOn }
+
+    // Sequential unlock: each row stays greyed until the previous one is granted (a row that's
+    // already green never dims). FDA sits last on purpose — see the top-of-file comment.
+    private var loginUnlocked: Bool { daemon == .ready || loginOn }
+    private var fdaUnlocked: Bool { (daemon == .ready && loginOn) || fdaGranted }
+
+    /// Grey + inert until unlocked.
+    private func gated<V: View>(_ unlocked: Bool, _ row: V) -> some View {
+        row.opacity(unlocked ? 1 : 0.35)
+            .disabled(!unlocked)
+            .animation(.easeInOut(duration: 0.3), value: unlocked)
+    }
+
+    var body: some View {
+        VStack(spacing: 40) {
+            Spacer()
+
+            OnboardingWhisper("PERMISSIONS")
+
+            Text("Sentient needs a few permissions to read your life on this Mac.")
+                .font(.system(size: 15))
+                .foregroundStyle(Theme.secondary)
+                .multilineTextAlignment(.center)
+
+            VStack(alignment: .leading, spacing: 2) {
+                SettingsGroup(label: "On-device Intelligence") {
+                    VStack(alignment: .leading, spacing: 2) {
+                        StatusLine(title: "Overnight wake",
+                                   health: daemon == .ready ? .ok : .bad,
+                                   note: daemonNote,
+                                   tip: "A tiny system helper that wakes your Mac at 3 AM so Sentient's on-device intelligence can work while you sleep. It only runs while your Mac is plugged in and Sentient is open in your menu bar. Installed once with your password.",
+                                   fixTitle: "Set Up…") {
+                            fixDaemon()
+                        }
+                        gated(loginUnlocked,
+                              StatusLine(title: "Launch at login",
+                                         health: loginOn ? .ok : .warn,
+                                         note: loginOn ? "on" : (loginNeedsApproval ? "approve in system settings" : "off"),
+                                         tip: "Starts Sentient quietly in your menu bar when you log in, so the overnight run can happen and your Sentient can stay alive.",
+                                         fixTitle: loginNeedsApproval ? "Approve…" : "Turn On") {
+                            LoginItem.enableOrRequestApproval()
+                            refresh()
+                        })
+                        gated(fdaUnlocked,
+                              StatusLine(title: "Full Disk Access",
+                                         health: fdaGranted ? .ok : .bad,
+                                         note: fdaGranted ? "granted" : "not granted",
+                                         tip: "Lets Sentient's on-device LLM read your files & folders, and the databases WhatsApp, iMessage, and Notes keep on this Mac. Everything is read right here on your Mac; your data never leaves it.",
+                                         fixTitle: "Grant…") {
+                            Permissions.openFullDiskAccessSettings()
+                        })
+                        if fdaUnlocked && !fdaGranted {
+                            HStack(spacing: 6) {
+                                SettingsProse("Flip Sentient's switch in the list, then:")
+                                Button { Permissions.relaunch() } label: {
+                                    Text("Relaunch Sentient")
+                                        .font(.system(size: 11, weight: .medium))
+                                        .foregroundStyle(Theme.Ink.bright)
+                                        .underline(true, color: Theme.Ink.deepMuted)
+                                }
+                                .buttonStyle(.plain)
+                                SettingsProse("You'll come right back here.")
+                            }
+                            .padding(.bottom, 6)
+                        }
+                    }
+                }
+            }
+            .frame(maxWidth: 560)
+
+            OnboardingNextButton(title: "Continue", enabled: allGreen, action: onContinue)
+
+            Spacer()
+
+            OnboardingTrustFooter()
+        }
+        .padding(40)
+        .onAppear { refresh() }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            refresh()   // the user may just have flipped a switch in System Settings
+        }
+    }
+
+    // MARK: Overnight wake daemon (same pattern as Settings → Health)
+
+    private var daemonNote: String {
+        switch daemon {
+        case .ready:      return "ready"
+        case .installing: return "installing…"
+        case .notSetUp:   return "not set up"
+        }
+    }
+
+    private func fixDaemon() {
+        guard daemon == .notSetUp else { return }
+        daemon = .installing
+        Task {
+            _ = await WakeHelperInstaller.installAsync()
+            daemon = WakeHelperInstaller.isInstalledAndCurrent() ? .ready : .notSetUp
+        }
+    }
+
+    private func refresh() {
+        fdaGranted = Permissions.hasFullDiskAccess()
+        loginOn = LoginItem.isEnabled
+        loginNeedsApproval = LoginItem.needsApproval
+        if daemon != .installing {
+            daemon = WakeHelperInstaller.isInstalledAndCurrent() ? .ready : .notSetUp
+        }
+    }
+}
+
+#Preview("Onboarding — permissions") {
+    ZStack {
+        Theme.bg.ignoresSafeArea()
+        OnboardingPermissionsView(onContinue: {})
+    }
+    .frame(width: 1180, height: 880)
+    .preferredColorScheme(.dark)
+}

--- a/Sentient OS macOS/Views/Onboarding/OnboardingReadyView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingReadyView.swift
@@ -1,0 +1,126 @@
+//
+//  OnboardingReadyView.swift
+//  Sentient OS macOS
+//
+//  Onboarding's final step — "ready to process". The source chips write the SAME dbg.run.* keys
+//  and open the SAME picker/connect sheets the Analysis popover uses, so this IS the real
+//  selection (it persists and feeds the 3am run too). Desktop, Documents, and Downloads ship
+//  armed; at least 3 FOLDERS must stay armed (apps are extra on top). The big Start Analysis
+//  button fires the exact run the home's Analyze Now fires, but wears the full-brightness glow
+//  (the popover's copy is deliberately subdued).
+//
+
+import SwiftUI
+import AppKit
+
+struct OnboardingReadyView: View {
+    let modelMissing: Bool
+    let onStart: () -> Void
+
+    // The live selection — the same keys SourceSelection / the popover / Settings / 3am all share.
+    @AppStorage("dbg.run.downloads")      private var runDownloads = true
+    @AppStorage("dbg.run.desktop")        private var runDesktop = true
+    @AppStorage("dbg.run.documents")      private var runDocuments = true
+    @AppStorage("dbg.run.notes")          private var runNotes = false
+    @AppStorage("dbg.run.whatsapp")       private var runWhatsApp = false
+    @AppStorage("dbg.run.imessage")       private var runIMessage = false
+    @AppStorage("dbg.whatsapp.chats")     private var whatsappCSV = ""
+    @AppStorage("dbg.imessage.chats")     private var imessageCSV = ""
+    @AppStorage("dbg.gmail.connected")    private var gmailConnected = false
+    @AppStorage("dbg.run.gmail")          private var runGmail = false
+    @AppStorage("dbg.calendar.connected") private var calendarConnected = false
+    @AppStorage("dbg.run.calendar")       private var runCalendar = false
+    @AppStorage(CustomRoots.key)          private var customRootsRaw = ""
+
+    @State private var showWhatsAppPicker = false
+    @State private var showIMessagePicker = false
+    @State private var showGmailConnect = false
+    @State private var showCalendarConnect = false
+
+    private var customRoots: [URL] { CustomRoots.decode(customRootsRaw) }
+
+    /// The min-3 rule counts FOLDERS only (defaults + custom); apps are extra on top.
+    private var folderCount: Int {
+        [runDownloads, runDesktop, runDocuments].count(where: { $0 }) + customRoots.count
+    }
+    private var canStart: Bool { folderCount >= 3 && !modelMissing }
+
+    var body: some View {
+        VStack(spacing: 40) {
+            Spacer()
+
+            OnboardingWhisper("READY")
+
+            Text("Sentient is ready to understand your life.\nPick what it can read. Everything stays on this Mac.")
+                .font(.system(size: 15))
+                .foregroundStyle(Theme.secondary)
+                .multilineTextAlignment(.center)
+                .lineSpacing(4)
+
+            VStack(alignment: .leading, spacing: 10) {
+                MonoCaps("Sources", size: 9, tracking: 2.2, color: Theme.Ink.label)
+                HStack(spacing: 8) {
+                    SourceChip("Desktop",   on: runDesktop)   { runDesktop.toggle() }
+                    SourceChip("Documents", on: runDocuments) { runDocuments.toggle() }
+                    SourceChip("Downloads", on: runDownloads) { runDownloads.toggle() }
+                    ForEach(customRoots, id: \.self) { url in
+                        SourceChip(url.lastPathComponent, on: true) { CustomRoots.remove(url) }
+                    }
+                    SourceChip("+ Add Folder", on: false, action: addFolder)
+                }
+                HStack(spacing: 8) {
+                    if WhatsAppSource.isInstalled {
+                        SourceChip("WhatsApp", on: runWhatsApp && !whatsappCSV.isEmpty) { showWhatsAppPicker = true }
+                    }
+                    SourceChip("iMessage", on: runIMessage && !imessageCSV.isEmpty) { showIMessagePicker = true }
+                    SourceChip("Notes",    on: runNotes) { runNotes.toggle() }
+                    SourceChip("Gmail",    on: gmailConnected && runGmail)       { showGmailConnect = true }
+                    SourceChip("Calendar", on: calendarConnected && runCalendar) { showCalendarConnect = true }
+                }
+                if folderCount < 3 {
+                    MonoCaps("keep at least 3 folders on", size: 8.5, tracking: 1.6, color: Theme.Ink.amber)
+                        .padding(.top, 2)
+                }
+            }
+
+            GlowButton(title: "Start Analysis", active: canStart, action: onStart)
+                .frame(maxWidth: 380)
+
+            Spacer()
+
+            OnboardingTrustFooter()
+        }
+        .padding(40)
+        .sheet(isPresented: $showWhatsAppPicker) {
+            ChatPicker(sourceName: "WhatsApp", loadChats: { try WhatsAppSource().listChats() },
+                       initialSelection: Set(whatsappCSV.split(separator: ",").map(String.init))) { sel in
+                whatsappCSV = sel.sorted().joined(separator: ","); runWhatsApp = !sel.isEmpty
+            }
+        }
+        .sheet(isPresented: $showIMessagePicker) {
+            ChatPicker(sourceName: "iMessage", loadChats: { try iMessageSource().listChats() },
+                       initialSelection: Set(imessageCSV.split(separator: ",").map(String.init))) { sel in
+                imessageCSV = sel.sorted().joined(separator: ","); runIMessage = !sel.isEmpty
+            }
+        }
+        .sheet(isPresented: $showGmailConnect) { GmailConnectSheet() }
+        .sheet(isPresented: $showCalendarConnect) { CalendarConnectSheet() }
+    }
+
+    private func addFolder() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        if panel.runModal() == .OK, let url = panel.url { CustomRoots.add(url) }
+    }
+}
+
+#Preview("Onboarding — ready to process") {
+    ZStack {
+        Theme.bg.ignoresSafeArea()
+        OnboardingReadyView(modelMissing: false, onStart: {})
+    }
+    .frame(width: 1180, height: 880)
+    .preferredColorScheme(.dark)
+}

--- a/Sentient OS macOS/Views/Onboarding/OnboardingView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingView.swift
@@ -1,0 +1,143 @@
+//
+//  OnboardingView.swift
+//  Sentient OS macOS
+//
+//  First-launch onboarding: three intro slides (placeholder boxes for now — real design comes
+//  later), then permissions (OnboardingPermissionsView), then codex login (OnboardingCodexSteps),
+//  then the ready-to-process screen (OnboardingReadyView) whose Start Analysis presents the REAL
+//  ProcessingView takeover (pausable) — and only a finished run calls `onFinished` and reveals
+//  the home. The current step persists (UserDefaults "onboarding.step") so a quit-and-relaunch
+//  mid-onboarding — which granting Full Disk Access requires — resumes exactly where the user
+//  left. The background codex install is NOT here: AppState kicks it off 1s after launch while
+//  the user reads the slides.
+//
+
+import SwiftUI
+
+struct OnboardingView: View {
+    let onFinished: () -> Void
+
+    /// Persisted so a relaunch mid-onboarding (the FDA grant needs one) resumes at the same step.
+    @AppStorage("onboarding.step") private var step = 0
+    private static let slideCount = 3
+
+    /// Start Analysis pressed — the ProcessingView takeover is up. Not persisted: a quit
+    /// mid-run relaunches to the ready screen, and the durable marks resume the analysis.
+    @State private var analyzing = false
+
+    // The same run flags the home's Analyze Now reads (RootView).
+    @AppStorage("dev.proactive.realCards") private var realCards = true
+    @AppStorage("dbg.gmail.connected")     private var gmailConnected = false
+    @AppStorage("dbg.run.gmail")           private var runGmail = false
+    @AppStorage("dbg.calendar.connected")  private var calendarConnected = false
+    @AppStorage("dbg.run.calendar")        private var runCalendar = false
+
+    // Resolved at launch (env → bundle → App Support → repo root); nil = model not on this Mac.
+    private static let modelPath = ModelLocator.resolve()
+
+    var body: some View {
+        ZStack {
+            Theme.bg.ignoresSafeArea()
+
+            switch step {
+            case ..<Self.slideCount:
+                slides.transition(.opacity)
+            case Self.slideCount:
+                OnboardingPermissionsView(onContinue: advance).transition(.opacity)
+            case Self.slideCount + 1:
+                OnboardingCodexLoginView(onContinue: advance).transition(.opacity)
+            default:
+                if analyzing, let modelPath = Self.modelPath {
+                    // The REAL first analysis — the same engine + takeover as the home's Analyze
+                    // Now, in pausable onboarding dress. Home appears only when this finishes.
+                    ProcessingView(modelPath: modelPath,
+                                   connectors: RunSource.connectors(from:
+                                       SourceSelection.current(fdaGranted: Permissions.hasFullDiskAccess())),
+                                   mode: .auto,
+                                   runGmail: gmailConnected && runGmail,
+                                   runCalendar: calendarConnected && runCalendar,
+                                   fullCycle: realCards,
+                                   pausable: true,
+                                   onExitEarly: { withAnimation(.easeInOut(duration: 0.3)) { analyzing = false } },
+                                   onDone: onFinished)
+                        .transition(.opacity)
+                } else {
+                    OnboardingReadyView(modelMissing: Self.modelPath == nil) {
+                        withAnimation(.easeInOut(duration: 0.3)) { analyzing = true }
+                    }
+                    .transition(.opacity)
+                }
+            }
+        }
+    }
+
+    private func advance() {
+        withAnimation(.easeInOut(duration: 0.25)) { step += 1 }
+    }
+
+    // MARK: The three intro slides (placeholders)
+
+    private var slides: some View {
+        VStack(spacing: 40) {
+            Spacer()
+
+            OnboardingWhisper("STEP \(step + 1) OF \(Self.slideCount)")
+
+            // Placeholder for the real slide design.
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .fill(Theme.panel)
+                .overlay(RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .stroke(Theme.stroke, lineWidth: 1))
+                .overlay(
+                    Text("Intro slide \(step + 1)")
+                        .font(.system(size: 15))
+                        .foregroundStyle(Theme.secondary))
+                .frame(maxWidth: 560, maxHeight: 360)
+
+            OnboardingNextButton(title: "Next", action: advance)
+
+            Spacer()
+
+            OnboardingTrustFooter()
+        }
+        .padding(40)
+    }
+}
+
+/// The onboarding CTA — a quiet white capsule, shared by the slides and the permissions screen.
+struct OnboardingNextButton: View {
+    let title: String
+    var enabled: Bool = true
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(enabled ? .black : .white.opacity(0.35))
+                .padding(.horizontal, 36)
+                .padding(.vertical, 12)
+                .background(Capsule(style: .continuous)
+                    .fill(enabled ? Color.white : Color.white.opacity(0.08)))
+        }
+        .buttonStyle(.plain)
+        .disabled(!enabled)
+        .animation(.easeInOut(duration: 0.3), value: enabled)
+    }
+}
+
+/// The trust footer — on every onboarding surface, like everywhere else in the app.
+struct OnboardingTrustFooter: View {
+    var body: some View {
+        Text("Private by design. Your files never leave this Mac.")
+            .font(.system(size: 12))
+            .foregroundStyle(Theme.faint)
+            .padding(.bottom, 28)
+    }
+}
+
+#Preview("Onboarding — intro slides") {
+    OnboardingView(onFinished: {})
+        .frame(width: 1180, height: 880)
+        .preferredColorScheme(.dark)
+}

--- a/Sentient OS macOS/Views/ProcessingView.swift
+++ b/Sentient OS macOS/Views/ProcessingView.swift
@@ -61,14 +61,18 @@ struct ProcessingView: View {
     let runCalendar: Bool             // append the cloud Google Calendar leg (same takeover)
     let showPrompt: Bool              // dev: add the left-side prompt pane
     let fullCycle: Bool               // real-mode Analyze Now: after the read, run ProactiveCycle (KB + proactive + wipe)
+    let pausable: Bool                // onboarding: the footer button is Pause/Resume (freeze in place) instead of Stop (exit)
+    let onExitEarly: (() -> Void)?    // onboarding: where "Back" on a failure returns (nil = onDone, the home behavior)
     var onDone: () -> Void
 
     init(modelPath: String, connectors: [any Connector], mode: IterativeRun.Mode,
          runGmail: Bool = false, runCalendar: Bool = false, showPrompt: Bool = false,
-         fullCycle: Bool = false, onDone: @escaping () -> Void) {
+         fullCycle: Bool = false, pausable: Bool = false, onExitEarly: (() -> Void)? = nil,
+         onDone: @escaping () -> Void) {
         self.modelPath = modelPath; self.connectors = connectors; self.mode = mode
         self.runGmail = runGmail; self.runCalendar = runCalendar; self.showPrompt = showPrompt
-        self.fullCycle = fullCycle; self.onDone = onDone
+        self.fullCycle = fullCycle; self.pausable = pausable; self.onExitEarly = onExitEarly
+        self.onDone = onDone
     }
 
     private enum UIState: Equatable { case loadingModel, processing, preparing, completed, failed(String) }
@@ -76,6 +80,7 @@ struct ProcessingView: View {
     @State private var prepStatus = "Preparing your suggestions…"
     @State private var progress = RunProgress()
     @State private var started = false
+    @State private var paused = false           // pausable only: frozen at the last item, awaiting Resume
     @State private var runTask: Task<RunProgress, Never>?
     @State private var awake = DisplayAwake()   // keeps the screen on during the long first ingest
 
@@ -305,7 +310,7 @@ struct ProcessingView: View {
             Text(message).font(.caption).foregroundStyle(.white.opacity(0.5))
                 .multilineTextAlignment(.center).frame(maxWidth: 360)
             HStack(spacing: 12) {
-                Button("Back", action: onDone).buttonStyle(.bordered).tint(.white)
+                Button("Back", action: onExitEarly ?? onDone).buttonStyle(.bordered).tint(.white)
                 Button("Retry") { Task { started = false; await startIfNeeded() } }
                     .buttonStyle(.borderedProminent).tint(.white)
             }
@@ -315,15 +320,16 @@ struct ProcessingView: View {
     private var footer: some View {
         VStack(spacing: 18) {
             VStack(spacing: 6) {
-                Button(action: stop) {
-                    Text("Stop Analysis")
+                Button(action: pausable ? (paused ? resume : pause) : stop) {
+                    Text(pausable ? (paused ? "Resume Analysis" : "Pause Analysis") : "Stop Analysis")
                         .font(.subheadline.weight(.medium)).foregroundStyle(.white.opacity(0.9))
                         .padding(.horizontal, 24).padding(.vertical, 10)
                         .background(Capsule().fill(.white.opacity(0.08)))
                         .overlay(Capsule().strokeBorder(.white.opacity(0.18)))
                 }
                 .buttonStyle(.plain)
-                Text("Analysis can always resume later.")
+                Text(pausable ? (paused ? "Paused. It picks up exactly where it stopped." : "Pausing keeps your progress.")
+                              : "Analysis can always resume later.")
                     .font(.caption).foregroundStyle(.white.opacity(0.4))
             }
             if showPrompt {
@@ -347,6 +353,20 @@ struct ProcessingView: View {
     private func stop() {
         runTask?.cancel()
         onDone()
+    }
+
+    /// Pause (pausable/onboarding only): cancel the run and FREEZE in place — the card keeps
+    /// showing the item it stopped on. Every item commits atomically, so nothing is lost.
+    private func pause() {
+        paused = true
+        runTask?.cancel()
+    }
+
+    /// Resume from the durable marks — the same restart the crash-safe design gives a 3am run.
+    private func resume() {
+        paused = false
+        started = false
+        Task { await startIfNeeded() }
     }
 
     private var percent: Int {
@@ -396,9 +416,11 @@ struct ProcessingView: View {
         runTask = task
         for await p in stream {
             if state == .loadingModel { withAnimation { state = .processing } }
-            progress = p
+            if !paused { progress = p }   // paused → freeze the card at the item it stopped on
         }
-        progress = await task.value
+        let final = await task.value
+        if paused { return }              // wait for Resume; never fall through to the cycle/completed
+        progress = final
 
         // Real-mode Analyze Now: after the read, file into the knowledge base + run all three proactive
         // steps + wipe the summaries — surfacing each phase — then reveal the real cards on the home.

--- a/Sentient OS macOS/Views/RootView.swift
+++ b/Sentient OS macOS/Views/RootView.swift
@@ -39,7 +39,14 @@ struct RootView: View {
     var body: some View {
         ZStack {
             Theme.bg.ignoresSafeArea()
-            if isProcessing, let modelPath = Self.modelPath {
+            if !appState.hasCompletedOnboarding {
+                // First launch → the intro slides. TEMPORARY wiring: the last slide's Next marks
+                // onboarding complete and drops into home (until the full ~10-step flow lands).
+                OnboardingView {
+                    withAnimation(.easeInOut(duration: 0.3)) { appState.hasCompletedOnboarding = true }
+                }
+                .transition(.opacity)
+            } else if isProcessing, let modelPath = Self.modelPath {
                 // Same engine + UI as the dev "start on device" buttons; .auto = backfill new
                 // buckets, catch up the rest. (Gmail is a dev-tools leg; the home button is on-device.)
                 ProcessingView(modelPath: modelPath,

--- a/Sentient OS macOS/Views/Settings/HealthPane.swift
+++ b/Sentient OS macOS/Views/Settings/HealthPane.swift
@@ -149,10 +149,10 @@ struct HealthPane: View {
                 .rise(1, revealed: revealed)
                 StatusLine(title: "Launch at login",
                            health: loginOn ? .ok : .warn,
-                           note: loginOn ? "on" : "off",
+                           note: loginOn ? "on" : (LoginItem.needsApproval ? "approve in system settings" : "off"),
                            tip: "Starts Sentient quietly in your menu bar when you log in, so the overnight run can happen and your Sentient can stay alive.",
-                           fixTitle: "Turn On") {
-                    LoginItem.enable()
+                           fixTitle: LoginItem.needsApproval ? "Approve…" : "Turn On") {
+                    LoginItem.enableOrRequestApproval()
                     loginOn = LoginItem.isEnabled
                 }
                 .rise(2, revealed: revealed)


### PR DESCRIPTION
The first real onboarding flow, end to end:

- **Intro slides** (3 placeholder boxes, design later) with the codex CLI installing silently in the background from 1s after launch (skips machines with a real ~/.codex setup, retries 4x, and the install pipeline patches around OpenAI's installer being broken by GitHub's minified-JSON API change).
- **Permissions step** — Overnight wake → Launch at login → Full Disk Access, unlocking sequentially; FDA sits last so its relaunch restarts the install with maximum runway. The persisted step index resumes onboarding exactly where it left after the relaunch.
- **Codex login step** — pure login UX: the button greys until `codex --help` actually answers, the browser sign-in is auto-detected (no "I'm done" button). Computer use is deliberately not in onboarding (later).
- **Ready-to-process step** — the real source chips (same dbg.run.* keys + sheets as the Analysis popover; min 3 folders, Desktop/Documents/Downloads pre-armed) and a full-glow Start Analysis that fires the real full-cycle run. Home appears only after the run finishes.
- **ProcessingView pausable mode** (onboarding only): Pause freezes on the current item, Resume picks up from the durable marks. Home/dev keep Stop.
- **LoginItem**: the `.requiresApproval` dead-end (user once disabled it in System Settings) now deep-links to Login Items, in onboarding and Settings → Health.

Everything drives the existing shared engines (CodexSetup, Permissions, WakeHelperInstaller, LoginItem, SourceSelection, ProcessingView) — zero duplicated setup logic. Verified with isolated builds throughout; flow exercised on real hardware across multiple full resets tonight.