### PR TITLE
App Support: namespace all on-disk writes under SentientOS/

### DIFF
--- a/Sentient OS macOS/Engine/Engine.swift
+++ b/Sentient OS macOS/Engine/Engine.swift
@@ -145,9 +145,7 @@ actor Engine {
 
     /// Writable scratch dir for LiteRT-LM's shader/compilation cache.
     private static func cacheDirectory() -> String {
-        let dir = FileManager.default
-            .urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
-            .appendingPathComponent("SentientOS/ModelCache", isDirectory: true)
+        let dir = URL.sentientSupport.appendingPathComponent("ModelCache", isDirectory: true)
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         return dir.path
     }

--- a/Sentient OS macOS/Engine/ModelLocator.swift
+++ b/Sentient OS macOS/Engine/ModelLocator.swift
@@ -29,8 +29,7 @@ enum ModelLocator {
             return bundled
         }
 
-        let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
-            .appendingPathComponent("SentientOS/Models/\(fileName)").path
+        let appSupport = URL.sentientSupport.appendingPathComponent("Models/\(fileName)").path
         if fm.fileExists(atPath: appSupport) { return appSupport }
 
         #if DEBUG

--- a/Sentient OS macOS/Ingestion/CycleStore.swift
+++ b/Sentient OS macOS/Ingestion/CycleStore.swift
@@ -335,12 +335,12 @@ actor CycleStore {
 // MARK: - Shared instance (its own container)
 
 extension CycleStore {
-    /// The app-wide iterative store, backed by its OWN on-disk store ("IterativeCycle.store" in
-    /// Application Support) — isolated from the old `Store`. Wipe-and-retry-once on an incompatible
-    /// schema change (dev convenience).
+    /// The app-wide iterative store, backed by its OWN on-disk store ("IterativeCycle.store" under
+    /// the namespaced `SentientOS` root in Application Support). Wipe-and-retry-once on an
+    /// incompatible schema change (dev convenience).
     static let shared: CycleStore = {
         let schema = Schema([BucketPointer.self, CycleNote.self])
-        let url = URL.applicationSupportDirectory.appending(path: "IterativeCycle.store")
+        let url = URL.sentientSupport.appending(path: "IterativeCycle.store")
         let config = ModelConfiguration(schema: schema, url: url)
         if let container = try? ModelContainer(for: schema, configurations: config) {
             return CycleStore(modelContainer: container)

--- a/Sentient OS macOS/System/AppSupport.swift
+++ b/Sentient OS macOS/System/AppSupport.swift
@@ -1,0 +1,25 @@
+//
+//  AppSupport.swift
+//  Sentient OS macOS
+//
+//  The single owner of Sentient's on-disk home under Application Support. We're non-sandboxed (Full
+//  Disk Access requires it), so ~/Library/Application Support is SHARED with every other app on the
+//  Mac — nothing of ours may sit naked at its top level (that's how you collide with someone else's
+//  "default.store"). Everything Sentient writes lives under ONE namespaced "SentientOS" root, so
+//  "delete everything we wrote" is a single path. One accessor here means the path can never drift.
+//
+
+import Foundation
+
+extension URL {
+    /// `~/Library/Application Support/SentientOS/` — the root under which every Sentient on-disk
+    /// artifact lives (the model + its cache, the iterative store, summary backups). Created on
+    /// first access; idempotent.
+    static var sentientSupport: URL {
+        let dir = FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("SentientOS", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+}

--- a/Sentient OS macOS/Views/Briefing.swift
+++ b/Sentient OS macOS/Views/Briefing.swift
@@ -181,58 +181,26 @@ struct Briefing: Identifiable {
         Jesai
         """
 
-    /// The EXACT reply we send Charles — shared by the Charles card's draft PREVIEW and its
-    /// `codexPrompt` (the live reply-all into the real "EWOR | Introducing Jesai & Charles"
-    /// thread), so the preview and the sent email can never drift.
-    private static let charlesReply = """
-        Hey Charles,
-
-        Really excited to meet you! :)
-        Thanks so much for making the time.
-
-        I'm in SF (PDT), and I'm happy to work around your schedule. For reference:
-        - I can make any time Monday work, until 4:30 PM
-        - I can make any time Tuesday work
-
-        I'll also send some materials before the call.
-
-        Looking forward to it,
-        Jesai
-        """
-
     static let demo: [Briefing] = [
         Briefing(
-            id: "charles", kind: .deadline,
-            kicker: "Reply · 2 days · Gmail",
-            title: "Charles from EWOR is waiting on your timeslots.",
-            body: "Daniel introduced you to Charles Ferguson; he sold companies to Microsoft and Oracle, pre-seeded Higgsfield, and won an Oscar. I checked your calendar and drafted your reply.",
+            id: "charles", kind: .plan,
+            kicker: "Prep · 4 PM today · Researched",
+            title: "Prepare for your call with Charles from EWOR.",
+            body: "Your EWOR final interview with Charles Ferguson is at 4 PM. He sold Vermeer to Microsoft, writes first checks into AI, and directed the Oscar-winning Inside Job. I pulled together what'll get you ready.",
             letter: """
-            Daniel introduced you to Charles Ferguson for your next EWOR interview; he sold companies to **Microsoft** and **Oracle**, pre-seeded **Higgsfield** (€500M ARR in a year), and won an **Oscar**.
+            Your EWOR final-stage interview is today at 4 PM: 45 minutes with Charles Ferguson, the call Daniel set up. Worth knowing going in that EWOR invests in people, not decks, so this is really about you and what drives you, more than the product.
 
-            He cc'd his assistant Emily to schedule and asked for any materials: a deck or a memo. So I checked your calendar for **Monday and Tuesday**, found your open windows, and wrote your reply: a few timeslots and a memo offer.
+            ✦ **Know who's across the table.** He founded Vermeer Technologies and sold it to Microsoft for $133M, holds an MIT PhD and a Berkeley math degree, and now writes first checks into early AI startups. He also directed *Inside Job*, which won the Oscar for best documentary. He's as technical as he is strategic.
+
+            ✦ **You're on the same side.** *Inside Job* is about institutions that quietly stopped serving the people they were built for. Sentient is the structural opposite: an AI that runs on your own Mac, that you can read, delete, or even fork, with nothing ever leaving the device. That's real common ground with him, and it's the honest reason you're building this.
+
+            ✦ **He'll actually follow the architecture, and he's lived your hardest question.** He's an engineer at heart, so he can tell real building from a demo: go as deep on the on-device stack as he wants to. And Microsoft squeezed Vermeer before buying it, so "what happens when Apple or OpenAI ships this?" is his own scar tissue, not a gotcha. It's worth asking what he learned.
+
+            Go have a real conversation. — your Sentient
             """,
-            draft: Briefing.charlesReply,
-            draftLabel: "Draft reply · Gmail",
-            detailLabel: "read the draft",
-            offer: "Should I send it for you?",
-            workLog: ["→ reading Charles's note",
-                      "→ checking Monday & Tuesday for open slots",
-                      "→ opening Gmail",
-                      "→ composing your reply…",
-                      "✓ sent"],
-            doneTitle: "Sent to Charles.",
-            doneBody: "Emily has your availability, and materials are on the way.",
-            codexPrompt: """
-            You are running fully headless and autonomous, with the user's explicit prior approval to act on their behalf for THIS task — they clicked "send it for me." Do NOT ask for confirmation or approval, do NOT pause to verify, and do NOT merely draft. Actually SEND. If any tool surfaces a confirmation or approval step, treat it as already granted by the user and proceed.
-
-            Use the Gmail MCP to open the thread titled "EWOR | Introducing Jesai & Charles". In that thread, find the message from Charles Ferguson (chf@cferguson.com) whose body STARTS WITH "Thank you, Daniel, and moving you to bcc." REPLY-ALL to THAT message — include every recipient on it (all To and all Cc: Charles, his assistant Emily, and the EWOR "selection" address) so everyone Charles addressed receives the reply. Reply to CHARLES'S message specifically (NOT Daniel's earlier intro) so the reply respects that Charles moved Daniel to bcc — do not add Daniel. Send EXACTLY the message below, verbatim — do not change, rephrase, summarize, or add anything:
-
-            \(Briefing.charlesReply)
-
-            Send this reply-all now via the Gmail MCP — the user has already approved it. Do not ask, do not draft-and-wait; complete the send, then report exactly who it went to (the full To and Cc list).
-
-            FORMATTING: send it as an HTML email (set the send tool's content_type to "text/html"). Put each paragraph in its own <p>…</p> tag; render the two "I can make any time…" lines as a <ul><li>…</li></ul> list; write the sign-off as "Looking forward to it,<br>Jesai". Keep every word — including ":)" and "4:30 PM" — exactly as written. Do NOT send as text/plain and do NOT insert any manual line breaks inside a paragraph.
-            """),
+            detailLabel: "read the prep doc",
+            offer: nil,
+            doneTitle: "", doneBody: ""),
 
         Briefing(
             id: "anthos", kind: .overdue,

--- a/Sentient OS macOS/Views/Dev/SummariesView.swift
+++ b/Sentient OS macOS/Views/Dev/SummariesView.swift
@@ -172,11 +172,11 @@ struct SummariesView: View {
         status = "✓ imported \(exp.notes.count)" + (existing.isEmpty ? "" : " · backed up \(existing.count)")
     }
 
-    /// Dump the soon-to-be-replaced notes to Application Support/SummaryBackups so an accidental
-    /// import is always recoverable (re-import the backup to undo).
+    /// Dump the soon-to-be-replaced notes to SentientOS/SummaryBackups so an accidental import is
+    /// always recoverable (re-import the backup to undo).
     private func backup(_ items: [CycleNoteItem]) {
         guard !items.isEmpty else { return }
-        let dir = URL.applicationSupportDirectory.appending(path: "SummaryBackups", directoryHint: .isDirectory)
+        let dir = URL.sentientSupport.appending(path: "SummaryBackups", directoryHint: .isDirectory)
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         let url = dir.appending(path: "backup-\(Self.stamp()).json")
         if let data = try? Self.encoder.encode(SummaryExport(notes: items)) {


### PR DESCRIPTION
## What

Everything Sentient writes on disk now lives under one namespaced root — `~/Library/Application Support/SentientOS/` — through a single owner, `URL.sentientSupport` (`System/AppSupport.swift`).

**Why:** we're non-sandboxed (Full Disk Access requires it), so `~/Library/Application Support` is *shared* with every app on the Mac. Two of our writers were dumping files at its naked top level — `IterativeCycle.store` (the live CycleStore) and `SummaryBackups/` — which is poor hygiene and could even collide with another app's generically-named file. Meanwhile Engine's `ModelCache` and ModelLocator's `Models/` already lived under `SentientOS/` but hand-computed the path four separate times.

## Changes

- **New:** `System/AppSupport.swift` → `URL.sentientSupport` (creates + returns the `SentientOS/` root, idempotent).
- Repointed `CycleStore.shared` (`IterativeCycle.store`) and `SummariesView` (`SummaryBackups/`) into `SentientOS/`.
- Folded `Engine` (`ModelCache`) and `ModelLocator` (`Models/`) through the same owner — kills all four hand-rolled path computations, so the path can't drift again.

**No data migration** (agreed): the store rebuilds itself fresh under the new root on next run. Old root-level files (`IterativeCycle.store`, `SummaryBackups/`, plus the orphaned legacy `default.store` / `FileIngestion.store`) should be deleted locally — Jesai's already done; there's an Obsidian handoff note for Aditya.

## Also in this PR

- **Demo deck:** reframe the Charles card from a reply-nudge to call-prep (unrelated copy edit that was in the working tree).

## Verification

- ✅ Builds clean via Xcode (BuildProject).
- Runtime: next run re-descends every source into a fresh `SentientOS/IterativeCycle.store` — expected, counters start at 0.