### PR TITLE
Menu bar icon: the OrbMark ring+dot as a template image

### DIFF
--- a/Sentient OS macOS/App/Sentient_OS_macOSApp.swift
+++ b/Sentient OS macOS/App/Sentient_OS_macOSApp.swift
@@ -81,10 +81,13 @@ struct SentientOSApp: App {
         .windowResizability(.contentMinSize)
         .defaultSize(width: 720, height: 780)
 
-        MenuBarExtra("Sentient OS", systemImage: "brain.head.profile") {
+        MenuBarExtra {
             MenuBarView()
                 .environment(appState)
                 .preferredColorScheme(.dark)
+        } label: {
+            Image(nsImage: OrbMark.menuBarIcon)   // the home's ring+dot mark, as a template
+                .accessibilityLabel("Sentient OS")
         }
     }
 }

--- a/Sentient OS macOS/Views/Orb.swift
+++ b/Sentient OS macOS/Views/Orb.swift
@@ -21,6 +21,7 @@
 //
 
 import SwiftUI
+import AppKit
 
 enum OrbMode { case idle, processing, attention }
 
@@ -387,6 +388,26 @@ struct OrbMark: View {
         .frame(width: size, height: size)
         .shadow(color: Color(red: 0.69, green: 0.42, blue: 0.70).opacity(0.55), radius: size * 0.3)
     }
+
+    /// The mark as a monochrome menu-bar TEMPLATE image — same ring + dot proportions as the
+    /// view. Template (not colored) on purpose: macOS tints it live for light/dark menu bars,
+    /// wallpaper tinting, and the pressed highlight; the gradient glow stays an in-app treatment.
+    static let menuBarIcon: NSImage = {
+        let side: CGFloat = 17
+        let image = NSImage(size: NSSize(width: side, height: side), flipped: false) { rect in
+            let line = max(1, side * 0.085)
+            NSColor.black.set()
+            let ring = NSBezierPath(ovalIn: rect.insetBy(dx: line / 2, dy: line / 2))
+            ring.lineWidth = line
+            ring.stroke()
+            let dot = side * 0.38
+            NSBezierPath(ovalIn: NSRect(x: rect.midX - dot / 2, y: rect.midY - dot / 2,
+                                        width: dot, height: dot)).fill()
+            return true
+        }
+        image.isTemplate = true
+        return image
+    }()
 }
 
 /// Tiny deterministic RNG so the ring's matter is identical every launch.


### PR DESCRIPTION
## What
Replaces the menu bar's placeholder SF Symbol (`brain.head.profile`) with the brand mark — the same ring+dot OrbMark that sits at the top-left of the home screen.

## How
- `Views/Orb.swift`: new `OrbMark.menuBarIcon` — an `NSImage` drawn with the view's exact proportions (8.5% stroke ring, 38% center dot), rendered as a **template image** so macOS tints it for light/dark menu bars, wallpaper tinting, and the pressed highlight. The gradient glow stays an in-app treatment.
- `App/Sentient_OS_macOSApp.swift`: `MenuBarExtra` now uses that image as its label (accessibility label "Sentient OS").

## Verified
Isolated CLI build (`-derivedDataPath /tmp/sentient-verify`) — BUILD SUCCEEDED.