### PR TITLE
First-use permission flow (gate + drag guide) + background computer-use bootstrap

### DIFF
--- a/Sentient OS macOS/Cloud/CodexSetup.swift
+++ b/Sentient OS macOS/Cloud/CodexSetup.swift
@@ -150,6 +150,7 @@ final class CodexSetup {
             computerUseStatus = "✓ Computer use already set up"
             return
         }
+        refreshInstalled()   // fresh probe, not the cached flag — the user may have installed codex themselves
         guard installed else { computerUseStatus = "✗ Install Codex first (step 1)"; return }
         settingUpComputerUse = true
         computerUseStatus = force ? "Re-installing…" : "Starting…"

--- a/Sentient OS macOS/Notch Magic/CommandCoordinator.swift
+++ b/Sentient OS macOS/Notch Magic/CommandCoordinator.swift
@@ -80,6 +80,18 @@ final class CommandCoordinator {
         guard !trimmed.isEmpty else { return }
         guard !run.isRunning else { Log("submit ignored — a task is already running"); return }
 
+        // First-use permission gate: while any of the four action grants is missing, the one-time
+        // setup window takes over and holds this command — Continue fires it, close drops it.
+        if ComputerUseGate.shared.intercept({ [weak self] in self?.launch(trimmed, mode: mode, source: source) }) {
+            setPhase(.hidden)   // the gate window owns the moment; the notch steps aside
+            return
+        }
+        launch(trimmed, mode: mode, source: source)
+    }
+
+    /// The actual fire — everything after the gate. Only submit() and the gate's Continue call this.
+    private func launch(_ trimmed: String, mode: AgentMode, source: TriggerSource) {
+        guard !run.isRunning else { Log("launch ignored — a task is already running"); return }
         if source == .voice { setReadBack(trimmed) } else { clearReadBack() }
         Analytics.signal("Command.submitted", parameters: ["source": source.rawValue, "mode": mode.label])   // count only, never the text
         run.start(trimmed, mode: mode, source: source.rawValue)
@@ -150,12 +162,32 @@ final class CommandCoordinator {
 
     private func finalizeVoice() {
         setPhase(.transcribing)
+        let token = phaseToken
+
+        // Watchdog: transcription must resolve promptly (the finalize itself is <2s; the trap is
+        // voice.start() still parked on the on-device speech model DOWNLOAD, which has no bound of
+        // its own — seen in the field as a notch spinning forever with every new press "busy").
+        // Still transcribing after 15s → cancel the capture, keep the model download moving for
+        // the next attempt, and say so honestly. The notch must never wedge.
+        Task { [weak self] in
+            try? await Task.sleep(for: .seconds(15))
+            guard let self, self.phaseToken == token, self.phase == .transcribing else { return }
+            Log("✗ transcription timed out — cancelling the capture (speech model likely still downloading)")
+            self.listening = false
+            self.voiceStartTask?.cancel(); self.voiceStartTask = nil
+            self.voice.cancel()
+            self.voice.prewarm()   // best-effort: resume/continue the model install in the background
+            self.flash("voice isn’t ready yet, try again in a moment")
+        }
+
         Task { [weak self] in
             guard let self else { return }
             await self.voiceStartTask?.value     // ensure capture actually started (or failed)
             guard self.listening else { return } // a start failure already set a notice/hidden phase
+            guard self.phaseToken == token else { return }   // timed out / Esc'd while waiting
             do {
                 let text = try await self.voice.stopAndTranscribe()
+                guard self.phaseToken == token else { return }   // timed out / Esc'd mid-finalize
                 self.listening = false
                 if text.isEmpty {
                     Log("🗣️ heard nothing")
@@ -168,6 +200,7 @@ final class CommandCoordinator {
                     self.submit(text, mode: .computer, source: .voice)
                 }
             } catch {
+                guard self.phaseToken == token else { return }   // the watchdog already spoke
                 self.listening = false
                 Log("✗ transcription failed — \(error.localizedDescription)")
                 self.flash("didn’t catch that")
@@ -205,7 +238,8 @@ final class CommandCoordinator {
     }
 
     /// Esc — back out of whatever the notch is doing, mirroring the obvious one-tap action for each state:
-    /// dismiss the type field · abandon an open/listening voice capture (so a later release fires nothing) ·
+    /// dismiss the type field · abandon an open/listening/transcribing voice capture (so a later release
+    /// fires nothing, and a stuck finalize can always be bailed) ·
     /// or, ONLY while the voice transcript is still on screen, cancel the just-fired run and dismiss INSTANTLY
     /// (no "Stopped" flourish — that's reserved for interrupting live computer use via STOP) so a misheard
     /// command can be killed and redone at a glance. The instant the transcript dissolves into the working /
@@ -218,7 +252,7 @@ final class CommandCoordinator {
         case .typing:
             dismissTyping()
             return true
-        case .opening, .listening:
+        case .opening, .listening, .transcribing:
             listening = false
             voiceStartTask?.cancel(); voiceStartTask = nil
             voice.cancel()

--- a/Sentient OS macOS/Notch Magic/RightCommandMonitor.swift
+++ b/Sentient OS macOS/Notch Magic/RightCommandMonitor.swift
@@ -108,7 +108,7 @@ final class RightCommandMonitor {
 
     // MARK: The tap
 
-    private func installTap() {
+    private func installTap(quiet: Bool = false) {
         teardownTap()
         // flagsChanged (right-⌘, a modifier) + keyDown (for Esc). Both flow through a listen-only tap with
         // no permission — measured on Tahoe (the keyDown half was the surprise; re-verify on macOS 15).
@@ -126,7 +126,7 @@ final class RightCommandMonitor {
         CGEvent.tapEnable(tap: port, enable: true)
         self.port = port
         self.runLoopSource = src
-        Log("⌘mon: listening (flagsChanged-only, zero-permission)")
+        if !quiet { Log("⌘mon: listening (flagsChanged-only, zero-permission)") }
     }
 
     private func teardownTap() {
@@ -136,10 +136,21 @@ final class RightCommandMonitor {
         port = nil
     }
 
+    /// Health-tick reinstalls of a dead tap run QUIET, with a periodic count instead — the system
+    /// can keep disabling a listen-only tap (seen after a full TCC reset), and per-reinstall logging
+    /// floods a session log at 1.5s intervals until it drowns everything else.
+    private var reinstalls = 0
+
     private func reinstallIfNeeded() {
         guard running else { return }
         let enabled = port.map { CGEvent.tapIsEnabled(tap: $0) } ?? false
-        if !enabled { installTap() }
+        if !enabled {
+            reinstalls += 1
+            if reinstalls == 1 || reinstalls % 200 == 0 {
+                Log("⌘mon: tap was disabled — re-armed (×\(reinstalls) this session)")
+            }
+            installTap(quiet: true)
+        }
     }
 
     // MARK: Event handling (on the main actor, via the trampoline)

--- a/Sentient OS macOS/System/Permissions.swift
+++ b/Sentient OS macOS/System/Permissions.swift
@@ -117,6 +117,24 @@ enum Permissions {
         return "granted \(bundleID) → Codex Computer Use (csreq \(csreq.count)B · target \(target.count)B)"
     }
 
+    /// Quiet self-heal for the Automation grant (Sentient → Codex Computer Use over Apple Events):
+    /// probe, and if it's missing while the prerequisites exist (FDA + the helper on disk), silently
+    /// re-grant in the background — idempotent, no UI, just a log line. The user has no job here.
+    /// Called from Settings → Health on open and from the computer-use gate before the first fire.
+    static func selfHealComputerUseAutomation(context: String) {
+        guard hasFullDiskAccess(), computerUseHelperURL() != nil else { return }
+        let bundleID = Bundle.main.bundleIdentifier ?? "jesai.Sentient-OS-macOS"
+        guard !isTCCGranted(service: "kTCCServiceAppleEvents", clientBundleID: bundleID) else { return }
+        Task.detached {
+            do {
+                let receipt = try grantComputerUseAutomation()
+                Log("\(context): automation self-heal — \(receipt)")
+            } catch {
+                Log("\(context): automation self-heal failed — \(error)")
+            }
+        }
+    }
+
     // MARK: - Codex helper: Accessibility + Screen Recording — READ-ONLY status (can't be granted by us)
     //
     // Computer use spawns `codex`, which launches Codex's bundled helper app ("Codex Computer Use.app",

--- a/Sentient OS macOS/Views/HomeView.swift
+++ b/Sentient OS macOS/Views/HomeView.swift
@@ -423,7 +423,11 @@ final class ForYouModel {
     /// STOP); a demo card plays the briefing's hard-coded `workLog` theater for visual feedback.
     func run(_ id: String) {
         guard let e = entry(id), e.phase == .offer, e.b.offer != nil else { return }
-        if let action = e.action { runReal(id, action); return }   // real card → fire for real
+        if let action = e.action {   // real card → fire for real (behind the first-use permission gate)
+            if ComputerUseGate.shared.intercept({ [weak self] in self?.runReal(id, action) }) { return }
+            runReal(id, action)
+            return
+        }
         let v = visit
 
         Task {

--- a/Sentient OS macOS/Views/Onboarding/OnboardingPermissionsView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingPermissionsView.swift
@@ -68,6 +68,10 @@ struct OnboardingPermissionsView: View {
                                          fixTitle: loginNeedsApproval ? "Approve…" : "Turn On") {
                             LoginItem.enableOrRequestApproval()
                             refresh()
+                            // macOS wants the switch flipped by hand → escort the user to it.
+                            if LoginItem.needsApproval {
+                                PermissionGuide.shared.guide(.loginItems, dragging: nil)
+                            }
                         })
                         gated(fdaUnlocked,
                               StatusLine(title: "Full Disk Access",
@@ -75,7 +79,9 @@ struct OnboardingPermissionsView: View {
                                          note: fdaGranted ? "granted" : "not granted",
                                          tip: "Lets Sentient's on-device LLM read your files & folders, and the databases WhatsApp, iMessage, and Notes keep on this Mac. Everything is read right here on your Mac; your data never leaves it.",
                                          fixTitle: "Grant…") {
-                            Permissions.openFullDiskAccessSettings()
+                            // The floating guide carries Sentient itself as the drag card — no
+                            // hunting through the "+" file picker.
+                            PermissionGuide.shared.guide(.fullDiskAccess, dragging: Bundle.main.bundleURL)
                         })
                         if fdaUnlocked && !fdaGranted {
                             HStack(spacing: 6) {

--- a/Sentient OS macOS/Views/Onboarding/OnboardingView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingView.swift
@@ -9,7 +9,8 @@
 //  the home. The current step persists (UserDefaults "onboarding.step") so a quit-and-relaunch
 //  mid-onboarding — which granting Full Disk Access requires — resumes exactly where the user
 //  left. The background codex install is NOT here: AppState kicks it off 1s after launch while
-//  the user reads the slides.
+//  the user reads the slides. Computer use (codex step 3) IS here: Start Analysis arms a silent
+//  one-shot that bootstraps it 2 minutes into the first analysis (armComputerUseSetup).
 //
 
 import SwiftUI
@@ -24,6 +25,10 @@ struct OnboardingView: View {
     /// Start Analysis pressed — the ProcessingView takeover is up. Not persisted: a quit
     /// mid-run relaunches to the ready screen, and the durable marks resume the analysis.
     @State private var analyzing = false
+
+    /// One-shot: the deferred background computer-use setup (codex step 3) has been armed this
+    /// launch, so a pause → resume never spawns a second timer.
+    @State private var computerUseArmed = false
 
     // The same run flags the home's Analyze Now reads (RootView).
     @AppStorage("dev.proactive.realCards") private var realCards = true
@@ -64,6 +69,7 @@ struct OnboardingView: View {
                 } else {
                     OnboardingReadyView(modelMissing: Self.modelPath == nil) {
                         withAnimation(.easeInOut(duration: 0.3)) { analyzing = true }
+                        armComputerUseSetup()
                     }
                     .transition(.opacity)
                 }
@@ -78,6 +84,22 @@ struct OnboardingView: View {
                     .padding(.leading, 24)
                     .transition(.opacity)
             }
+        }
+    }
+
+    /// Two minutes into the first analysis, bootstrap codex computer use (setup step 3) silently
+    /// in the background — so it's ready by the time the home's cards and Sidekick need it, with
+    /// no onboarding screen of its own. An unstructured Task on purpose: pausing or exiting the
+    /// analysis must NOT cancel a DMG download mid-flight. setupComputerUse() self-guards (no-op
+    /// when already bootstrapped, requires the codex binary), so a quit-and-relaunch that restarts
+    /// the analysis just re-arms harmlessly; failures land in the log + Sentry, never in the UI.
+    private func armComputerUseSetup() {
+        guard !computerUseArmed else { return }
+        computerUseArmed = true
+        Task {
+            try? await Task.sleep(for: .seconds(120))
+            Log("Onboarding: 2 min into first analysis — starting background computer-use setup")
+            await CodexSetup.shared.setupComputerUse()
         }
     }
 

--- a/Sentient OS macOS/Views/Permissions/ComputerUseGate.swift
+++ b/Sentient OS macOS/Views/Permissions/ComputerUseGate.swift
@@ -1,0 +1,148 @@
+//
+//  ComputerUseGate.swift
+//  Sentient OS macOS
+//
+//  The first-use permission gate for everything that acts on the Mac. Every computer-use surface
+//  (the home command bar, Sidekick's hotkey, a proactive card's fire) funnels through
+//  `intercept(_:)`: while any of the four action grants is missing — Sentient's own Microphone &
+//  Speech and Screen Recording, plus the Codex Computer Use helper's Accessibility and Screen
+//  Recording — it stashes the pending action, raises the one-time setup window
+//  (ComputerUseGateView), and fires the action when the user taps Continue. Closing the window
+//  instead cancels the pending action. Shown at most once per app session; all four green means
+//  it never appears at all. Status probes reuse Permissions/VoiceCapture (the helper's grants are
+//  system-TCC, read via our FDA).
+//
+//  Key methods: intercept(_:) · refresh() · continueNow()
+//
+
+import AppKit
+import AVFoundation
+import Speech
+import SwiftUI
+
+@MainActor
+@Observable
+final class ComputerUseGate {
+
+    static let shared = ComputerUseGate()
+    private init() {}
+
+    // MARK: Grant status (probed, not cached beyond the last refresh)
+
+    /// Sentient's mic + speech recognition — Sidekick's ears. Detail preserved for the fix action.
+    enum MicSpeechState { case granted, notAsked, denied }
+    private(set) var micSpeech: MicSpeechState = .notAsked
+
+    /// Sentient's own Screen Recording — the screen context snapshot. Compulsory, not optional.
+    private(set) var sentientScreen = false
+
+    /// The Codex Computer Use helper's presence + its two system-TCC grants (its hands and eyes).
+    private(set) var helperOnDisk = false
+    private(set) var helperAccessibility = false
+    private(set) var helperScreen = false
+
+    var allGranted: Bool {
+        micSpeech == .granted && sentientScreen && helperAccessibility && helperScreen
+    }
+
+    // MARK: The gate
+
+    private var shownThisSession = false
+    private var pending: (@MainActor () -> Void)?
+    private var window: NSWindow?
+    private var closeObserver: NSObjectProtocol?
+
+    /// The one entry point. Returns true when the action was intercepted (the setup window is up
+    /// and the action is stashed — fired by Continue, dropped by close). Returns false when the
+    /// caller should just proceed: everything granted, or the gate already had its one showing
+    /// this session.
+    func intercept(_ action: @escaping @MainActor () -> Void) -> Bool {
+        refresh()
+        guard !allGranted, !shownThisSession else { return false }
+        shownThisSession = true
+        pending = action
+        present()
+        Analytics.signal("PermissionGate.shown")
+        Log("ComputerUseGate: intercepted first computer-use action — setup window up")
+        return true
+    }
+
+    /// Re-probe all four grants (cheap; the TCC reads are two tiny indexed SELECTs).
+    func refresh() {
+        let mic = AVCaptureDevice.authorizationStatus(for: .audio)
+        let speech = SFSpeechRecognizer.authorizationStatus()
+        if mic == .authorized && speech == .authorized {
+            micSpeech = .granted
+        } else if mic == .denied || mic == .restricted || speech == .denied || speech == .restricted {
+            micSpeech = .denied
+        } else {
+            micSpeech = .notAsked
+        }
+        // Preflight is the running process's view — it stays false until a relaunch even after the
+        // user flips the switch. The TCC read (we hold FDA) is the LIVE truth, so the row can go
+        // green the moment they grant; the tip still says a restart is needed for capture.
+        sentientScreen = Permissions.hasScreenRecording()
+            || Permissions.isTCCGranted(service: "kTCCServiceScreenCapture",
+                                        clientBundleID: Bundle.main.bundleIdentifier ?? "jesai.Sentient-OS-macOS")
+        helperOnDisk = Permissions.computerUseHelperURL() != nil
+        helperAccessibility = Permissions.isTCCGranted(
+            service: "kTCCServiceAccessibility",
+            clientBundleID: Permissions.computerUseHelperBundleID)
+        helperScreen = Permissions.isTCCGranted(
+            service: "kTCCServiceScreenCapture",
+            clientBundleID: Permissions.computerUseHelperBundleID)
+    }
+
+    /// The window's main button — dismiss and fire the held action (granted or not; the user decides).
+    func continueNow() {
+        let action = pending
+        pending = nil
+        Analytics.signal("PermissionGate.continued", parameters: ["all_granted": String(allGranted)])
+        dismissWindow()
+        action?()
+    }
+
+    // MARK: Window lifecycle (AppKit-owned — it must be able to appear over OTHER apps, since
+    // Sidekick fires from anywhere; a SwiftUI Window scene can't be raised from the coordinator)
+
+    private func present() {
+        // The executor also needs the Automation grant (Sentient → the helper over Apple Events);
+        // it's user-invisible and FDA-writable, so heal it here — before the first fire.
+        Permissions.selfHealComputerUseAutomation(context: "ComputerUseGate")
+        if window == nil {
+            let hosting = NSHostingController(rootView: ComputerUseGateView(gate: self))
+            let w = NSWindow(contentViewController: hosting)
+            w.styleMask = [.titled, .closable, .fullSizeContentView]
+            w.titlebarAppearsTransparent = true
+            w.titleVisibility = .hidden
+            w.backgroundColor = .black
+            w.isReleasedWhenClosed = false
+            w.level = .floating
+            w.isMovableByWindowBackground = true
+            window = w
+            closeObserver = NotificationCenter.default.addObserver(
+                forName: NSWindow.willCloseNotification, object: w, queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor [weak self] in self?.windowClosed() }
+            }
+        }
+        window?.center()
+        window?.makeKeyAndOrderFront(nil)
+        window?.orderFrontRegardless()
+        NSApp.activate()
+    }
+
+    private func dismissWindow() {
+        PermissionGuide.shared.close()   // take any drag panel down with the gate
+        window?.close()                  // willClose → windowClosed(), which finds pending already nil on Continue
+    }
+
+    /// The red button / X — a held action the user didn't Continue is dropped, not fired blind.
+    private func windowClosed() {
+        if pending != nil {
+            pending = nil
+            Log("ComputerUseGate: setup window closed — held action dropped")
+        }
+        PermissionGuide.shared.close()
+    }
+}

--- a/Sentient OS macOS/Views/Permissions/ComputerUseGateView.swift
+++ b/Sentient OS macOS/Views/Permissions/ComputerUseGateView.swift
@@ -1,0 +1,165 @@
+//
+//  ComputerUseGateView.swift
+//  Sentient OS macOS
+//
+//  The one-time setup window's face (ComputerUseGate presents it): the four action grants as the
+//  same StatusLine rows Settings → Health uses, in two groups — SIDEKICK & PROACTIVE (Sentient's
+//  Microphone & Speech, Screen Recording) and CODEX PERMISSIONS (the helper's Accessibility,
+//  Screen Recording). Sentient's grants fix via the native system prompts; the helper's fix via
+//  PermissionGuide's floating drag panel (they're system-TCC — only the user can flip them).
+//  Continue fires the held action whether or not everything is green; the rows re-probe when the
+//  app foregrounds (returning from System Settings).
+//
+
+import SwiftUI
+import AppKit
+import AVFoundation
+
+struct ComputerUseGateView: View {
+    let gate: ComputerUseGate
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            OnboardingWhisper("ONE-TIME SETUP")
+                .frame(maxWidth: .infinity)
+
+            Text("Give Sentient its hands and eyes.")
+                .display(23)
+                .foregroundStyle(.white)
+                .frame(maxWidth: .infinity)
+                .padding(.top, 18)
+
+            Text("Acting on your Mac needs these four grants, once. You will not be asked again.")
+                .font(.system(size: 12.5))
+                .foregroundStyle(Theme.secondary)
+                .frame(maxWidth: .infinity)
+                .multilineTextAlignment(.center)
+                .padding(.top, 8)
+
+            VStack(alignment: .leading, spacing: 26) {
+                SettingsGroup(label: "Sidekick & Proactive") {
+                    VStack(alignment: .leading, spacing: 2) {
+                        StatusLine(title: "Microphone & Speech",
+                                   health: micSpeechHealth,
+                                   note: micSpeechNote,
+                                   tip: "Lets Sidekick hear you and turn your words into text when you hold the shortcut key. Your voice is heard and transcribed on this Mac, never in the cloud.",
+                                   fixTitle: gate.micSpeech == .notAsked ? "Allow…" : "Fix…") {
+                            fixMicSpeech()
+                        }
+                        StatusLine(title: "Screen Recording",
+                                   health: gate.sentientScreen ? .ok : .bad,
+                                   note: gate.sentientScreen ? "granted" : "not granted",
+                                   tip: "Lets Sentient snap a still of your screen the moment you fire a command, so it can see the thing you're asking about. Takes effect after you restart Sentient.",
+                                   fixTitle: "Allow…") {
+                            fixSentientScreen()
+                        }
+                    }
+                }
+
+                SettingsGroup(label: "Codex Permissions") {
+                    VStack(alignment: .leading, spacing: 2) {
+                        StatusLine(title: "Accessibility (move the mouse, type)",
+                                   health: gate.helperAccessibility ? .ok : (gate.helperOnDisk ? .bad : .warn),
+                                   note: helperNote(granted: gate.helperAccessibility),
+                                   tip: "Lets Codex's helper app move the mouse and type for you. Granted to OpenAI's helper, not to Sentient.",
+                                   fixTitle: "Grant…") {
+                            fixHelper(.accessibility)
+                        }
+                        StatusLine(title: "Screen Recording (see the screen)",
+                                   health: gate.helperScreen ? .ok : (gate.helperOnDisk ? .bad : .warn),
+                                   note: helperNote(granted: gate.helperScreen),
+                                   tip: "Lets Codex's helper app see the screen so it acts on the right thing. Granted to OpenAI's helper, not to Sentient.",
+                                   fixTitle: "Grant…") {
+                            fixHelper(.screenRecording)
+                        }
+                    }
+                }
+            }
+            .padding(.top, 30)
+
+            OnboardingNextButton(title: gate.allGranted ? "Continue" : "Continue anyway") {
+                gate.continueNow()
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.top, 32)
+
+            HStack(spacing: 8) {
+                Image(systemName: "shield").font(.system(size: 10)).foregroundStyle(Theme.Ink.label)
+                Text("Private by design. Your files never leave this Mac.")
+                    .font(.system(size: 11)).foregroundStyle(Theme.Ink.label)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.top, 18)
+        }
+        .padding(.horizontal, 44)
+        .padding(.top, 34)
+        .padding(.bottom, 24)
+        .frame(width: 560)
+        .background(Color.black)
+        .preferredColorScheme(.dark)
+        .onAppear { gate.refresh() }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            gate.refresh()   // the user may just have flipped a switch in System Settings
+        }
+    }
+
+    // MARK: Sentient's grants — native prompts first, the guide as the fallback
+
+    private var micSpeechHealth: StatusLine.Health {
+        switch gate.micSpeech {
+        case .granted:  return .ok
+        case .notAsked: return .bad   // compulsory here — this window exists to get them granted
+        case .denied:   return .bad
+        }
+    }
+
+    private var micSpeechNote: String {
+        switch gate.micSpeech {
+        case .granted:  return "granted"
+        case .notAsked: return "not asked yet"
+        case .denied:   return "denied"
+        }
+    }
+
+    private func fixMicSpeech() {
+        switch gate.micSpeech {
+        case .granted:
+            break
+        case .notAsked:
+            Task { _ = await VoiceCapture.requestPermissions(); gate.refresh() }
+        case .denied:
+            // Deep-link to whichever grant is actually the blocker (mic first — it gates speech).
+            if AVCaptureDevice.authorizationStatus(for: .audio) != .authorized {
+                Permissions.openMicrophoneSettings()
+            } else {
+                Permissions.openSpeechRecognitionSettings()
+            }
+        }
+    }
+
+    /// The Screen Recording list is drag-authorizable, and Sentient may not be IN the list at all
+    /// (on Tahoe, CGRequestScreenCaptureAccess doesn't reliably add it — field-verified) — so the
+    /// guide always carries Sentient itself as the drag card. Dragging when the row already exists
+    /// is harmless; the user just flips the existing switch.
+    private func fixSentientScreen() {
+        guard !gate.sentientScreen else { return }
+        PermissionGuide.shared.guide(.screenRecording, dragging: Bundle.main.bundleURL)
+    }
+
+    // MARK: The helper's grants — system TCC; the drag panel is the only honest path
+
+    private func helperNote(granted: Bool) -> String {
+        if granted { return "granted" }
+        return gate.helperOnDisk ? "not granted" : "computer use still setting up"
+    }
+
+    private func fixHelper(_ pane: PermissionGuide.Pane) {
+        guard let helper = Permissions.computerUseHelperURL() else { return }
+        PermissionGuide.shared.guide(pane, dragging: helper)
+    }
+}
+
+#Preview("Computer-use gate") {
+    ComputerUseGateView(gate: ComputerUseGate.shared)
+        .preferredColorScheme(.dark)
+}

--- a/Sentient OS macOS/Views/Permissions/PermissionDragPanel.swift
+++ b/Sentient OS macOS/Views/Permissions/PermissionDragPanel.swift
@@ -1,0 +1,505 @@
+//
+//  PermissionDragPanel.swift
+//  Sentient OS macOS
+//
+//  PermissionGuide's floating panel: a borderless, NON-ACTIVATING NSPanel (System Settings keeps
+//  visual focus) that flies from the pressed button to just below the Settings window's content
+//  area and follows it. In drag mode it carries the .app card (AppDragSourceView) whose drag
+//  payload is shaped to look Finder-originated — the exact pasteboard mix System Settings accepts
+//  into its privacy lists; while dragging, the panel goes mouse-transparent so the drop lands in
+//  Settings. The SwiftUI content (PermissionPanelView) speaks the app's design language.
+//
+//  ⚠️ hostingView.sizingOptions = [] is load-bearing: with the default .intrinsicContentSize the
+//  hosting view re-advertises its own size to the window every layout pass and every setFrame is
+//  reverted, stranding the panel off-screen (documented upstream).
+//  Mechanics adapted from PermissionFlow (github.com/jaywcjlove/PermissionFlow, MIT).
+//
+
+import AppKit
+import QuartzCore
+import SwiftUI
+
+// MARK: - The panel window
+
+@MainActor
+final class PermissionDragPanel: NSPanel {
+    private weak var guide: PermissionGuide?
+    private let hostingView: NSHostingView<PermissionPanelView>
+    private let sizingView: NSHostingView<PermissionPanelView>
+    private let initialPanelWidth: CGFloat = 420
+
+    /// System Settings' leading sidebar width — the panel aligns to the trailing content area.
+    private let sidebarWidth: CGFloat = 230
+    private let screenInset: CGFloat = 12
+    private let minimumPanelHeight: CGFloat = 96
+    private let sizingHeightLimit: CGFloat = 4096
+
+    // Launch animation, tuned upstream to settle without overshoot while the target window is moving.
+    private let animationDuration: TimeInterval = 0.72
+    private let animationResponse: Double = 0.72
+    private let initialAlpha: CGFloat = 0.9
+    private let minimumLaunchScale: CGFloat = 0.58
+    private var launchTimer: Timer?
+    private var launchStartTime: CFTimeInterval = 0
+    private var launchFromFrame = NSRect.zero
+    private var launchToFrame = NSRect.zero
+    private var isAnimatingLaunch = false
+
+    init(guide: PermissionGuide) {
+        self.guide = guide
+        hostingView = NSHostingView(rootView: PermissionPanelView(guide: guide))
+        sizingView = NSHostingView(rootView: PermissionPanelView(guide: guide))
+        super.init(
+            contentRect: CGRect(origin: .zero, size: CGSize(width: initialPanelWidth, height: minimumPanelHeight)),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+
+        level = .floating
+        isReleasedWhenClosed = false
+        isOpaque = false
+        backgroundColor = .clear
+        hasShadow = true
+        collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        isMovableByWindowBackground = false
+        hidesOnDeactivate = false
+        animationBehavior = .utilityWindow
+
+        hostingView.translatesAutoresizingMaskIntoConstraints = false
+        hostingView.sizingOptions = []   // see the top-of-file warning
+        contentView = hostingView
+        setContentSize(CGSize(width: initialPanelWidth, height: measuredPanelHeight(for: initialPanelWidth)))
+    }
+
+    /// Non-activating on purpose — System Settings must stay the visible focus owner.
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
+
+    override func sendEvent(_ event: NSEvent) {
+        if event.type == .leftMouseDown || event.type == .rightMouseDown {
+            guide?.keepSettingsVisible()
+        }
+        super.sendEvent(event)
+    }
+
+    /// Show at the launch source before the Settings frame is known.
+    func show(at sourceFrameInScreen: CGRect) {
+        stopLaunchAnimation()
+        isAnimatingLaunch = false
+        alphaValue = 1
+        setContentSize(CGSize(width: frame.width, height: measuredPanelHeight(for: frame.width)))
+        setFrame(launchSourceFrame(for: sourceFrameInScreen), display: false)
+        orderFrontRegardless()
+    }
+
+    /// Fly from the triggering UI element to the Settings window.
+    func present(from sourceFrameInScreen: CGRect, to settingsFrame: CGRect) {
+        stopLaunchAnimation()
+        let targetFrame = targetFrame(for: settingsFrame)
+
+        guard sourceFrameInScreen.isEmpty == false else {
+            isAnimatingLaunch = false
+            alphaValue = 1
+            setFrame(targetFrame, display: false)
+            orderFrontRegardless()
+            return
+        }
+
+        isAnimatingLaunch = true
+        launchFromFrame = launchSourceFrame(for: sourceFrameInScreen)
+        launchToFrame = targetFrame
+        launchStartTime = CACurrentMediaTime()
+        alphaValue = initialAlpha
+        setFrame(launchFromFrame, display: false)
+        orderFrontRegardless()
+        stepLaunchAnimation()
+
+        let timer = Timer(timeInterval: 1.0 / 60.0, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in self?.stepLaunchAnimation() }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        launchTimer = timer
+    }
+
+    /// While the app card is being dragged, mouse events pass through so Settings gets the drop.
+    func setDraggingPassthrough(_ isDragging: Bool) {
+        ignoresMouseEvents = isDragging
+        alphaValue = isDragging ? 0.72 : 1.0
+        if isDragging { orderBack(nil) } else { orderFrontRegardless() }
+    }
+
+    /// Follow the tracked Settings frame. Mid-launch, only the destination updates (continuous motion).
+    func snap(to settingsFrame: CGRect) {
+        let target = targetFrame(for: settingsFrame)
+        if isAnimatingLaunch {
+            launchToFrame = target
+            return
+        }
+        stopLaunchAnimation()
+        setFrame(target, display: false)
+        orderFrontRegardless()
+    }
+
+    /// Final frame: under the Settings window, aligned to its trailing content area (past the
+    /// sidebar), clamped to the visible screen. Visual-attachment tuning belongs HERE (upstream note).
+    private func targetFrame(for settingsFrame: CGRect) -> CGRect {
+        let screenFrame = NSScreen.screens
+            .first(where: { $0.frame.intersects(settingsFrame) })?
+            .visibleFrame ?? settingsFrame
+
+        let contentMinX = settingsFrame.minX + sidebarWidth
+        let availableContentWidth = max(240, settingsFrame.width - sidebarWidth)
+        let width = min(availableContentWidth, screenFrame.width - (screenInset * 2))
+        let height = measuredPanelHeight(for: width)
+
+        var origin = CGPoint(x: contentMinX, y: settingsFrame.minY - height)
+        origin.x = max(screenFrame.minX + screenInset, min(origin.x, screenFrame.maxX - width - screenInset))
+        origin.y = max(screenFrame.minY + screenInset, min(origin.y, screenFrame.maxY - height - screenInset))
+
+        return CGRect(origin: origin, size: CGSize(width: width, height: height))
+    }
+
+    private func launchSourceFrame(for sourceFrameInScreen: CGRect) -> CGRect {
+        let launchSize = CGSize(
+            width: max(sourceFrameInScreen.width, frame.width * minimumLaunchScale),
+            height: max(sourceFrameInScreen.height, frame.height * minimumLaunchScale)
+        )
+        let center = CGPoint(x: sourceFrameInScreen.midX, y: sourceFrameInScreen.midY)
+        return CGRect(
+            x: center.x - (launchSize.width * 0.5),
+            y: center.y - (launchSize.height * 0.5),
+            width: launchSize.width,
+            height: launchSize.height
+        )
+    }
+
+    /// Measure the SwiftUI content at a width so the panel height fits before positioning.
+    private func measuredPanelHeight(for width: CGFloat) -> CGFloat {
+        sizingView.setFrameSize(NSSize(width: width, height: sizingHeightLimit))
+        sizingView.layoutSubtreeIfNeeded()
+        return max(minimumPanelHeight, sizingView.fittingSize.height)
+    }
+
+    private func stepLaunchAnimation() {
+        let elapsed = max(0, CACurrentMediaTime() - launchStartTime)
+        if elapsed >= animationDuration {
+            isAnimatingLaunch = false
+            stopLaunchAnimation()
+            alphaValue = 1
+            setFrame(launchToFrame, display: true)
+            return
+        }
+        let progress = springProgress(at: elapsed)
+        alphaValue = initialAlpha + ((1 - initialAlpha) * progress)
+        setFrame(curvedFrame(from: launchFromFrame, to: launchToFrame, progress: progress), display: true)
+    }
+
+    private func stopLaunchAnimation() {
+        launchTimer?.invalidate()
+        launchTimer = nil
+    }
+
+    private func springProgress(at elapsed: TimeInterval) -> CGFloat {
+        let omega = (2 * Double.pi) / animationResponse
+        let progress = 1 - exp(-omega * elapsed) * (1 + (omega * elapsed))
+        return min(max(progress, 0), 1)
+    }
+
+    /// Quadratic-bezier interpolation — the soft "fly to target" arc.
+    private func curvedFrame(from: CGRect, to: CGRect, progress: CGFloat) -> CGRect {
+        let size = CGSize(
+            width: from.width + ((to.width - from.width) * progress),
+            height: from.height + ((to.height - from.height) * progress)
+        )
+        let startCenter = CGPoint(x: from.midX, y: from.midY)
+        let endCenter = CGPoint(x: to.midX, y: to.midY)
+        let midpoint = CGPoint(x: (startCenter.x + endCenter.x) * 0.5, y: max(startCenter.y, endCenter.y))
+        let distance = hypot(endCenter.x - startCenter.x, endCenter.y - startCenter.y)
+        let lift = min(140, max(44, distance * 0.18))
+        let controlPoint = CGPoint(x: midpoint.x, y: midpoint.y + lift)
+        let inverse = 1 - progress
+        let center = CGPoint(
+            x: (inverse * inverse * startCenter.x) + (2 * inverse * progress * controlPoint.x) + (progress * progress * endCenter.x),
+            y: (inverse * inverse * startCenter.y) + (2 * inverse * progress * controlPoint.y) + (progress * progress * endCenter.y)
+        )
+        return CGRect(
+            x: center.x - (size.width * 0.5),
+            y: center.y - (size.height * 0.5),
+            width: size.width,
+            height: size.height
+        )
+    }
+}
+
+// MARK: - The panel content (Sentient-voiced)
+
+/// The floating card's face: a mono-caps whisper, the one-line instruction, and (drag mode) the
+/// app card to drag. OLED black with a hairline ring — it should read as a piece of Sentient
+/// hovering beside System Settings.
+struct PermissionPanelView: View {
+    let guide: PermissionGuide
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            header
+            if let appURL = guide.job?.appURL {
+                AppDragItemView(url: appURL) { dragging in
+                    guide.setDragging(dragging)
+                }
+                .frame(maxWidth: .infinity)
+            }
+        }
+        .padding(.top, 10)
+        .padding(.bottom, 12)
+        .padding(.horizontal, 14)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .fixedSize(horizontal: false, vertical: true)
+        .background(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(Color.black)
+                .overlay(RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .stroke(Color.white.opacity(0.14), lineWidth: 1))
+        )
+        .preferredColorScheme(.dark)
+    }
+
+    private var header: some View {
+        HStack(alignment: .top, spacing: 8) {
+            GuideDirectionIcon(isDragging: guide.isDraggingApp, isDragMode: guide.job?.appURL != nil)
+            VStack(alignment: .leading, spacing: 3) {
+                MonoCaps(guide.job?.pane.title.uppercased() ?? "", size: 8.5, tracking: 2.0,
+                         color: Theme.Ink.label)
+                Text(guide.instruction)
+                    .font(.system(size: 13))
+                    .foregroundStyle(.white)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 8)
+            HStack(alignment: .top, spacing: 4) {
+                if guide.isSettingsFrontmost == false {
+                    Button { guide.reopenSettings() } label: {
+                        Image(systemName: "gear")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundStyle(Theme.Ink.label)
+                    }
+                    .buttonStyle(.plain)
+                }
+                Button { guide.close() } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 16, weight: .semibold))
+                        .symbolRenderingMode(.palette)
+                        .foregroundStyle(Theme.Ink.label, Color.white.opacity(0.12))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+}
+
+/// The little animated pointer — wiggles at rest, pulses while the card is being dragged.
+private struct GuideDirectionIcon: View {
+    let isDragging: Bool
+    let isDragMode: Bool
+
+    @State private var wigglePhase = false
+    @State private var scalePhase = false
+
+    var body: some View {
+        Image(systemName: isDragMode ? "arrowshape.up.fill" : "switch.2")
+            .font(.system(size: 14, weight: .bold))
+            .symbolRenderingMode(.hierarchical)
+            .foregroundStyle(Theme.Ink.green)
+            .rotationEffect(.degrees(isDragging || !isDragMode ? 0 : (wigglePhase ? 12 : -12)))
+            .offset(y: isDragging || !isDragMode ? 0 : (wigglePhase ? -2 : 1))
+            .scaleEffect(isDragging ? (scalePhase ? 1.18 : 0.88) : 1)
+            .animation(
+                isDragging
+                    ? .easeInOut(duration: 0.68).repeatForever(autoreverses: true)
+                    : .easeInOut(duration: 0.22).repeatForever(autoreverses: true),
+                value: isDragging ? scalePhase : wigglePhase
+            )
+            .onAppear { if isDragMode { wigglePhase = true } }
+            .onChange(of: isDragging) { _, dragging in
+                if dragging {
+                    scalePhase = true
+                    wigglePhase = false
+                } else {
+                    scalePhase = false
+                    wigglePhase = isDragMode
+                }
+            }
+            .padding(.top, 2)
+    }
+}
+
+// MARK: - The drag source (the actual magic)
+
+private struct AppDragItemView: NSViewRepresentable {
+    let url: URL
+    let onDragStateChange: (Bool) -> Void
+
+    func makeNSView(context: Context) -> AppDragSourceView {
+        let view = AppDragSourceView(url: url)
+        view.onDragStateChange = onDragStateChange
+        return view
+    }
+
+    func updateNSView(_ nsView: AppDragSourceView, context: Context) {
+        nsView.update(url: url)
+        nsView.onDragStateChange = onDragStateChange
+    }
+}
+
+/// An NSView drag source whose payload mimics a Finder file drag — the pasteboard-type mix
+/// System Settings' privacy lists actually accept (fileURL + NSFilenamesPboardType +
+/// promised-file-url + string, with the app icon as the drag image).
+final class AppDragSourceView: NSView, NSDraggingSource {
+    private var url: URL
+    private let hostingView: NSHostingView<AnyView>
+    private var mouseDownPoint: NSPoint?
+    private var hasBegunDragging = false
+
+    /// Tells the panel to become mouse-transparent for the drag's duration.
+    var onDragStateChange: ((Bool) -> Void)?
+
+    init(url: URL) {
+        self.url = url
+        self.hostingView = NSHostingView(rootView: AnyView(AppDragCardContent(url: url).allowsHitTesting(false)))
+        super.init(frame: .zero)
+
+        hostingView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(hostingView)
+        NSLayoutConstraint.activate([
+            hostingView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            hostingView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            hostingView.topAnchor.constraint(equalTo: topAnchor),
+            hostingView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    func update(url: URL) {
+        self.url = url
+        hostingView.rootView = AnyView(AppDragCardContent(url: url).allowsHitTesting(false))
+        invalidateIntrinsicContentSize()
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard bounds.contains(point) else { return nil }
+        return self
+    }
+
+    override var intrinsicContentSize: NSSize {
+        NSSize(width: NSView.noIntrinsicMetric, height: max(64, hostingView.fittingSize.height))
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        mouseDownPoint = convert(event.locationInWindow, from: nil)
+        hasBegunDragging = false
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard hasBegunDragging == false, let mouseDownPoint else { return }
+        let currentPoint = convert(event.locationInWindow, from: nil)
+        guard hypot(currentPoint.x - mouseDownPoint.x, currentPoint.y - mouseDownPoint.y) > 4 else { return }
+        hasBegunDragging = true
+        beginAppDrag(with: event)
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        mouseDownPoint = nil
+        hasBegunDragging = false
+    }
+
+    func draggingSession(_ session: NSDraggingSession, sourceOperationMaskFor context: NSDraggingContext) -> NSDragOperation {
+        .copy
+    }
+
+    func ignoreModifierKeys(for session: NSDraggingSession) -> Bool { true }
+
+    func draggingSession(_ session: NSDraggingSession, willBeginAt screenPoint: NSPoint) {
+        onDragStateChange?(true)
+    }
+
+    func draggingSession(_ session: NSDraggingSession, endedAt screenPoint: NSPoint, operation: NSDragOperation) {
+        onDragStateChange?(false)
+        mouseDownPoint = nil
+        hasBegunDragging = false
+    }
+
+    private func beginAppDrag(with event: NSEvent) {
+        let writer = AppBundlePasteboardWriter(url: url)
+        let draggingItem = NSDraggingItem(pasteboardWriter: writer)
+        let icon = NSWorkspace.shared.icon(forFile: url.path)
+        icon.size = NSSize(width: 56, height: 56)
+        let dragPoint = convert(event.locationInWindow, from: nil)
+        draggingItem.setDraggingFrame(
+            NSRect(x: dragPoint.x - 28, y: dragPoint.y - 28, width: 56, height: 56),
+            contents: icon
+        )
+        let session = beginDraggingSession(with: [draggingItem], event: event, source: self)
+        session.animatesToStartingPositionsOnCancelOrFail = true
+        session.draggingFormation = .none
+    }
+}
+
+private final class AppBundlePasteboardWriter: NSObject, NSPasteboardWriting {
+    private let url: URL
+
+    init(url: URL) { self.url = url }
+
+    func writableTypes(for pasteboard: NSPasteboard) -> [NSPasteboard.PasteboardType] {
+        [
+            .fileURL,
+            .URL,
+            NSPasteboard.PasteboardType("NSFilenamesPboardType"),
+            NSPasteboard.PasteboardType("com.apple.pasteboard.promised-file-url"),
+            .string
+        ]
+    }
+
+    func pasteboardPropertyList(forType type: NSPasteboard.PasteboardType) -> Any? {
+        switch type {
+        case .fileURL, .URL, NSPasteboard.PasteboardType("com.apple.pasteboard.promised-file-url"):
+            return url.absoluteString
+        case NSPasteboard.PasteboardType("NSFilenamesPboardType"):
+            return [url.path]
+        case .string:
+            return url.path
+        default:
+            return nil
+        }
+    }
+}
+
+/// The draggable app card — icon, name, and a quiet "drag" affordance on a dashed ring.
+private struct AppDragCardContent: View {
+    let url: URL
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(nsImage: NSWorkspace.shared.icon(forFile: url.path))
+                .resizable()
+                .frame(width: 32, height: 32)
+            Text(FileManager.default.displayName(atPath: url.path))
+                .font(.system(size: 14, weight: .medium))
+                .foregroundStyle(.white)
+            Spacer()
+            VStack(spacing: 1) {
+                Image(systemName: "hand.draw")
+                    .font(.system(size: 13))
+                MonoCaps("DRAG", size: 7, tracking: 1.6, color: Theme.Ink.label)
+            }
+            .foregroundStyle(Theme.Ink.label)
+            .padding(.trailing, 4)
+        }
+        .padding(8)
+        .background(Color.white.opacity(0.05), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .strokeBorder(Color.white.opacity(0.28), style: StrokeStyle(lineWidth: 1, dash: [4, 3]))
+        )
+    }
+}

--- a/Sentient OS macOS/Views/Permissions/PermissionGuide.swift
+++ b/Sentient OS macOS/Views/Permissions/PermissionGuide.swift
@@ -1,0 +1,172 @@
+//
+//  PermissionGuide.swift
+//  Sentient OS macOS
+//
+//  The floating System-Settings companion for grants Sentient can't prompt for. `guide(...)` opens
+//  the right Privacy pane AND raises a small OLED-black panel that flies to the Settings window and
+//  follows it (SettingsWindowTracker). Two modes: DRAG (the panel carries an .app card the user
+//  drags straight into the permission list — Sentient itself for Full Disk Access, OpenAI's Codex
+//  Computer Use helper for its Accessibility/Screen Recording) and INSTRUCTION (toggle lists with
+//  no drag target — "flip the switch": Sentient's own Screen Recording, Login Items approval).
+//  One shared instance, one active panel; closing Settings auto-dismisses.
+//
+//  Key methods: guide(_:dragging:) · close()
+//  Flow mechanics adapted from PermissionFlow (github.com/jaywcjlove/PermissionFlow, MIT).
+//
+
+import AppKit
+import ServiceManagement
+import SwiftUI
+
+@MainActor
+@Observable
+final class PermissionGuide {
+
+    static let shared = PermissionGuide()
+    private init() {}
+
+    /// The System Settings destinations the guide knows how to escort the user into.
+    enum Pane {
+        case fullDiskAccess
+        case accessibility
+        case screenRecording
+        case loginItems
+
+        /// The list's name, for the panel copy.
+        var title: String {
+            switch self {
+            case .fullDiskAccess:  return "Full Disk Access"
+            case .accessibility:   return "Accessibility"
+            case .screenRecording: return "Screen Recording"
+            case .loginItems:      return "Login Items"
+            }
+        }
+
+        /// Open the matching System Settings page (deep-links live in Permissions/SMAppService).
+        fileprivate func openSettings() {
+            switch self {
+            case .fullDiskAccess:  Permissions.openFullDiskAccessSettings()
+            case .accessibility:   Permissions.openAccessibilitySettings()
+            case .screenRecording: Permissions.openScreenRecordingSettings()
+            case .loginItems:      SMAppService.openSystemSettingsLoginItems()
+            }
+        }
+    }
+
+    /// What the panel is currently guiding (nil = no panel up). `appURL` nil = instruction mode.
+    struct Job {
+        let pane: Pane
+        let appURL: URL?
+    }
+
+    private(set) var job: Job?
+    /// Drives the header arrow animation while the app card is mid-drag.
+    private(set) var isDraggingApp = false
+    /// Shows the "reopen Settings" affordance when Settings slipped behind something.
+    private(set) var isSettingsFrontmost = false
+
+    private let tracker = SettingsWindowTracker()
+    private var panel: PermissionDragPanel?
+    private var pendingLaunchSourceFrame: CGRect?
+    private var frontmostObserver: NSObjectProtocol?
+
+    /// The panel's one-line instruction, mode-aware.
+    var instruction: AttributedString {
+        guard let job else { return AttributedString("") }
+        let appName = job.appURL.map { FileManager.default.displayName(atPath: $0.path) } ?? "Sentient OS"
+        let markdown: String
+        if job.appURL != nil {
+            markdown = "Drag **\(appName)** into the list, then flip its switch on."
+        } else if job.pane == .loginItems {
+            markdown = "Flip **Sentient OS** on under \"Allow in the Background\"."
+        } else {
+            markdown = "Flip **Sentient OS** on in the list."
+        }
+        return (try? AttributedString(markdown: markdown)) ?? AttributedString(markdown)
+    }
+
+    /// Open the pane in System Settings and raise the floating companion panel. The launch
+    /// animation flies from the current mouse location (the button the user just pressed).
+    func guide(_ pane: Pane, dragging appURL: URL?) {
+        close()
+        job = Job(pane: pane, appURL: appURL)
+        let mouse = NSEvent.mouseLocation
+        pendingLaunchSourceFrame = CGRect(x: mouse.x - 16, y: mouse.y - 16, width: 32, height: 32)
+        pane.openSettings()
+
+        let panel = PermissionDragPanel(guide: self)
+        self.panel = panel
+        if let sourceFrame = pendingLaunchSourceFrame {
+            panel.show(at: sourceFrame)
+        }
+
+        updateFrontmostState()
+        observeFrontmostApplication()
+        tracker.onFrameChange = { [weak self] frame in
+            Task { @MainActor [weak self] in self?.settingsFrameChanged(frame) }
+        }
+        tracker.onTrackingEnded = { [weak self] in
+            Task { @MainActor [weak self] in self?.close() }   // Settings quit → panel goes too
+        }
+        tracker.startTracking()
+        Log("PermissionGuide: guiding \(pane.title) (\(appURL == nil ? "instruction" : "drag"))")
+    }
+
+    /// Dismiss the panel and stop tracking. Safe to call when nothing is up.
+    func close() {
+        tracker.stopTracking()
+        panel?.close()
+        panel = nil
+        job = nil
+        pendingLaunchSourceFrame = nil
+        isDraggingApp = false
+        if let frontmostObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(frontmostObserver)
+            self.frontmostObserver = nil
+        }
+    }
+
+    /// The panel's gear — bring the (possibly buried) Settings pane back to front.
+    func reopenSettings() {
+        job?.pane.openSettings()
+        panel?.orderFrontRegardless()
+    }
+
+    /// The drag source reports drag begin/end; the panel goes mouse-transparent so System
+    /// Settings underneath can receive the drop.
+    func setDragging(_ dragging: Bool) {
+        isDraggingApp = dragging
+        panel?.setDraggingPassthrough(dragging)
+    }
+
+    /// Keep System Settings visually frontmost whenever the panel is poked (it's non-activating).
+    func keepSettingsVisible() {
+        NSRunningApplication.runningApplications(withBundleIdentifier: "com.apple.systempreferences")
+            .first?.activate()
+        panel?.orderFrontRegardless()
+    }
+
+    private func settingsFrameChanged(_ frame: CGRect) {
+        guard let panel else { return }
+        if let sourceFrame = pendingLaunchSourceFrame {
+            panel.present(from: sourceFrame, to: frame)
+            pendingLaunchSourceFrame = nil
+        } else {
+            panel.snap(to: frame)
+        }
+    }
+
+    private func observeFrontmostApplication() {
+        guard frontmostObserver == nil else { return }
+        frontmostObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didActivateApplicationNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in self?.updateFrontmostState() }
+        }
+    }
+
+    private func updateFrontmostState() {
+        isSettingsFrontmost =
+            NSWorkspace.shared.frontmostApplication?.bundleIdentifier == "com.apple.systempreferences"
+    }
+}

--- a/Sentient OS macOS/Views/Permissions/SettingsWindowTracker.swift
+++ b/Sentient OS macOS/Views/Permissions/SettingsWindowTracker.swift
@@ -1,0 +1,274 @@
+//
+//  SettingsWindowTracker.swift
+//  Sentient OS macOS
+//
+//  Follows the System Settings window so the floating permission panel (PermissionDragPanel) can
+//  fly to it and stay attached while the user drags an app into a privacy list. Two geometry
+//  sources: a 30Hz CGWindowList poll (needs ZERO permissions — the bootstrap and the fallback) and
+//  AX move/resize observers when Sentient happens to be AX-trusted (it usually isn't; the poll
+//  alone is fine). Repeated process misses (12 polls) mean System Settings closed → the panel
+//  auto-dismisses via onTrackingEnded.
+//
+//  Adapted from PermissionFlow by 小弟调调 (github.com/jaywcjlove/PermissionFlow, MIT license) —
+//  the window-server frame heuristics and CG→AppKit coordinate flip are hard-won; see upstream
+//  comments before "simplifying" anything here.
+//
+
+import AppKit
+@preconcurrency import ApplicationServices
+import CoreGraphics
+
+@MainActor
+final class SettingsWindowTracker {
+    /// Polling stays on even when AX is available: System Settings can appear before AX observers attach.
+    private let pollInterval: TimeInterval = 1.0 / 30.0
+
+    /// Lookup misses are common while System Settings opens or swaps panes; requiring several
+    /// avoids false "window closed" detection.
+    private let missingAppThreshold = 12
+
+    var onFrameChange: ((CGRect) -> Void)?
+    var onTrackingEnded: (() -> Void)?
+    private(set) var currentFrame: CGRect?
+
+    private let bundleIdentifier = "com.apple.systempreferences"
+    private var appObserver: AXObserver?
+    private var windowObserver: AXObserver?
+    private var observedWindow: AXUIElement?
+    private var pollTimer: Timer?
+    private var hasActiveTrackingTarget = false
+    private var missingAppPollCount = 0
+
+    /// Start locating the System Settings window and emitting frame updates.
+    func startTracking() {
+        stopTracking()
+        pollTimer = Timer.scheduledTimer(withTimeInterval: pollInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in self?.attachIfNeeded() }
+        }
+        pollTimer?.tolerance = pollInterval * 0.25
+        attachIfNeeded()
+    }
+
+    /// Tear down polling and AX observers so the next session starts clean.
+    func stopTracking() {
+        pollTimer?.invalidate()
+        pollTimer = nil
+        if let observer = appObserver {
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), AXObserverGetRunLoopSource(observer), .commonModes)
+        }
+        if let observer = windowObserver {
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), AXObserverGetRunLoopSource(observer), .commonModes)
+        }
+        appObserver = nil
+        windowObserver = nil
+        observedWindow = nil
+        currentFrame = nil
+        hasActiveTrackingTarget = false
+        missingAppPollCount = 0
+    }
+
+    /// Central loop: resolve the running System Settings app, emit a best-effort window-server
+    /// frame immediately, and attach AX observers when available.
+    private func attachIfNeeded() {
+        guard let app = runningSettingsApplication() else {
+            finishTrackingIfNeededBecauseAppExited()
+            return
+        }
+
+        hasActiveTrackingTarget = true
+        missingAppPollCount = 0
+
+        updateFrameFromWindowServer(for: app.processIdentifier)
+        guard AXIsProcessTrusted() else { return }
+
+        let appElement = AXUIElementCreateApplication(app.processIdentifier)
+
+        if appObserver == nil {
+            appObserver = makeObserver(for: app.processIdentifier)
+            if let appObserver {
+                addNotification(kAXMainWindowChangedNotification as CFString, element: appElement, observer: appObserver)
+                addNotification(kAXFocusedWindowChangedNotification as CFString, element: appElement, observer: appObserver)
+                CFRunLoopAddSource(CFRunLoopGetMain(), AXObserverGetRunLoopSource(appObserver), .commonModes)
+            }
+        }
+
+        guard let window = mainWindow(for: appElement) else { return }
+        guard isSameElement(window, observedWindow) == false else {
+            updateCurrentFrame()
+            return
+        }
+
+        observedWindow = window
+        updateWindowObserver(for: app.processIdentifier, window: window)
+        updateCurrentFrame()
+    }
+
+    /// Window-server geometry — needs no permission; the initial and fallback source.
+    private func updateFrameFromWindowServer(for pid: pid_t) {
+        guard let frame = windowServerFrame(for: pid) else { return }
+        guard currentFrame != frame else { return }
+        currentFrame = frame
+        onFrameChange?(frame)
+    }
+
+    /// Rebind the AX observer to the currently tracked window for move/resize notifications.
+    private func updateWindowObserver(for pid: pid_t, window: AXUIElement) {
+        if let windowObserver {
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), AXObserverGetRunLoopSource(windowObserver), .commonModes)
+        }
+        windowObserver = makeObserver(for: pid)
+        if let windowObserver {
+            addNotification(kAXMovedNotification as CFString, element: window, observer: windowObserver)
+            addNotification(kAXResizedNotification as CFString, element: window, observer: windowObserver)
+            CFRunLoopAddSource(CFRunLoopGetMain(), AXObserverGetRunLoopSource(windowObserver), .commonModes)
+        }
+    }
+
+    /// Publish the AX window's frame, converted to AppKit screen coordinates.
+    private func updateCurrentFrame() {
+        guard let window = observedWindow else { return }
+        guard
+            let position = pointValue(for: kAXPositionAttribute, element: window),
+            let size = sizeValue(for: kAXSizeAttribute, element: window)
+        else { return }
+
+        let frame = appKitFrame(fromGlobalTopLeftFrame: CGRect(origin: position, size: size))
+        guard currentFrame != frame else { return }
+        currentFrame = frame
+        onFrameChange?(frame)
+    }
+
+    /// Main window preferred, then focused, then the first listed window.
+    private func mainWindow(for appElement: AXUIElement) -> AXUIElement? {
+        if let window = elementValue(for: kAXMainWindowAttribute, element: appElement) { return window }
+        if let window = elementValue(for: kAXFocusedWindowAttribute, element: appElement) { return window }
+        return arrayValue(for: kAXWindowsAttribute, element: appElement)?.first
+    }
+
+    /// All AX notifications funnel back into attachIfNeeded() on the main actor.
+    private func makeObserver(for pid: pid_t) -> AXObserver? {
+        var observer: AXObserver?
+        let result = AXObserverCreate(pid, { _, _, _, refcon in
+            guard let refcon else { return }
+            let tracker = Unmanaged<SettingsWindowTracker>.fromOpaque(refcon).takeUnretainedValue()
+            Task { @MainActor in tracker.attachIfNeeded() }
+        }, &observer)
+        guard result == .success else { return nil }
+        return observer
+    }
+
+    private func addNotification(_ name: CFString, element: AXUIElement, observer: AXObserver) {
+        let refcon = Unmanaged.passUnretained(self).toOpaque()
+        _ = AXObserverAddNotification(observer, element, name, refcon)
+    }
+
+    private func elementValue(for key: String, element: AXUIElement) -> AXUIElement? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, key as CFString, &value) == .success else { return nil }
+        return (value as! AXUIElement)
+    }
+
+    private func arrayValue(for key: String, element: AXUIElement) -> [AXUIElement]? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, key as CFString, &value) == .success else { return nil }
+        return value as? [AXUIElement]
+    }
+
+    private func pointValue(for key: String, element: AXUIElement) -> CGPoint? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, key as CFString, &value) == .success, let axValue = value else { return nil }
+        let pointValue = axValue as! AXValue
+        guard AXValueGetType(pointValue) == .cgPoint else { return nil }
+        var point = CGPoint.zero
+        AXValueGetValue(pointValue, .cgPoint, &point)
+        return point
+    }
+
+    private func sizeValue(for key: String, element: AXUIElement) -> CGSize? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, key as CFString, &value) == .success, let axValue = value else { return nil }
+        let sizeValue = axValue as! AXValue
+        guard AXValueGetType(sizeValue) == .cgSize else { return nil }
+        var size = CGSize.zero
+        AXValueGetValue(sizeValue, .cgSize, &size)
+        return size
+    }
+
+    private func isSameElement(_ lhs: AXUIElement?, _ rhs: AXUIElement?) -> Bool {
+        guard let lhs, let rhs else { return false }
+        return CFEqual(lhs, rhs)
+    }
+
+    /// Prefer a UI-capable System Settings process over prohibited activation-policy helpers.
+    private func runningSettingsApplication() -> NSRunningApplication? {
+        NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier)
+            .max(by: { ($0.activationPolicy == .prohibited ? 0 : 1) < ($1.activationPolicy == .prohibited ? 0 : 1) })
+    }
+
+    /// Largest visible layer-0 window-server window for the System Settings process. Upstream note:
+    /// kCGWindowBounds can read visually taller than the useful content edge (outer framing), which
+    /// is why panel attachment is tuned in PermissionDragPanel.targetFrame, not here.
+    private func windowServerFrame(for pid: pid_t) -> CGRect? {
+        guard
+            let windows = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID)
+                as? [[String: Any]]
+        else { return nil }
+
+        return windows
+            .filter { window in
+                guard let ownerPID = window[kCGWindowOwnerPID as String] as? pid_t else { return false }
+                guard ownerPID == pid else { return false }
+                let layer = window[kCGWindowLayer as String] as? Int ?? 0
+                let alpha = window[kCGWindowAlpha as String] as? Double ?? 1
+                return layer == 0 && alpha > 0
+            }
+            .compactMap { window -> CGRect? in
+                guard let bounds = window[kCGWindowBounds as String] as? NSDictionary else { return nil }
+                guard let cgBounds = CGRect(dictionaryRepresentation: bounds) else { return nil }
+                let frame = appKitFrame(fromGlobalTopLeftFrame: cgBounds)
+                guard frame.width > 320, frame.height > 240 else { return nil }
+                return frame
+            }
+            .max(by: { $0.width * $0.height < $1.width * $1.height })
+    }
+
+    /// Convert a global top-left-origin rect from CG/AX space into AppKit screen coordinates by
+    /// matching the rect to its containing screen.
+    private func appKitFrame(fromGlobalTopLeftFrame frame: CGRect) -> CGRect {
+        let screens = NSScreen.screens.compactMap { screen -> (frame: CGRect, cgBounds: CGRect)? in
+            guard
+                let number = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber
+            else { return nil }
+            let displayID = CGDirectDisplayID(number.uint32Value)
+            return (frame: screen.frame, cgBounds: CGDisplayBounds(displayID))
+        }
+
+        let matchedScreen = screens
+            .filter { $0.cgBounds.intersects(frame) }
+            .max { lhs, rhs in
+                lhs.cgBounds.intersection(frame).width * lhs.cgBounds.intersection(frame).height
+                    < rhs.cgBounds.intersection(frame).width * rhs.cgBounds.intersection(frame).height
+            }
+
+        guard let matchedScreen else { return frame }
+
+        let localX = frame.minX - matchedScreen.cgBounds.minX
+        let localY = frame.minY - matchedScreen.cgBounds.minY
+
+        return CGRect(
+            x: matchedScreen.frame.minX + localX,
+            y: matchedScreen.frame.maxY - localY - frame.height - 3,
+            width: frame.width,
+            height: frame.height
+        )
+    }
+
+    /// Only stop after repeated misses, so a short-lived lookup failure never closes the panel.
+    private func finishTrackingIfNeededBecauseAppExited() {
+        guard hasActiveTrackingTarget || currentFrame != nil else { return }
+        missingAppPollCount += 1
+        guard missingAppPollCount >= missingAppThreshold else { return }
+        stopTracking()
+        onTrackingEnded?()
+    }
+}

--- a/Sentient OS macOS/Views/Settings/HealthPane.swift
+++ b/Sentient OS macOS/Views/Settings/HealthPane.swift
@@ -89,7 +89,7 @@ struct HealthPane: View {
         .task {
             await refresh()
             try? await Task.sleep(for: .seconds(0.5))
-            selfHealAutomation()
+            Permissions.selfHealComputerUseAutomation(context: "HealthPane")
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             Task { await refresh() }   // the user may just have fixed something in System Settings
@@ -122,7 +122,7 @@ struct HealthPane: View {
                                note: fdaGranted ? "granted" : "not granted",
                                tip: "Lets Sentient's on-device LLM read your files & folders, and the databases WhatsApp, iMessage, and Notes keep on this Mac. Everything is read right here on your Mac; your data never leaves it.",
                                fixTitle: "Grant…") {
-                        Permissions.openFullDiskAccessSettings()
+                        PermissionGuide.shared.guide(.fullDiskAccess, dragging: Bundle.main.bundleURL)
                     }
                     if !fdaGranted {
                         HStack(spacing: 6) {
@@ -154,6 +154,9 @@ struct HealthPane: View {
                            fixTitle: LoginItem.needsApproval ? "Approve…" : "Turn On") {
                     LoginItem.enableOrRequestApproval()
                     loginOn = LoginItem.isEnabled
+                    if LoginItem.needsApproval {
+                        PermissionGuide.shared.guide(.loginItems, dragging: nil)
+                    }
                 }
                 .rise(2, revealed: revealed)
             }
@@ -172,7 +175,7 @@ struct HealthPane: View {
                 }
                 .rise(3, revealed: revealed)
                 StatusLine(title: "Screen Recording",
-                           health: screenRec ? .ok : .warn,
+                           health: screenRec ? .ok : .bad,   // compulsory — Sidekick is half-blind without it
                            note: screenRec ? "granted" : "not granted",
                            tip: "Lets Sidekick snap a still of your screen the moment you summon it, so it can see the thing you're asking about (\u{201C}finish this\u{201D}, \u{201C}reply to this\u{201D}). Without it, Sidekick may not know which open app to start controlling to help you. Takes effect after you restart Sentient.",
                            fixTitle: "Allow…") {
@@ -253,15 +256,13 @@ struct HealthPane: View {
 
     // MARK: Screen Recording (Sentient's own grant — Sidekick's screen context)
 
-    /// `CGRequestScreenCaptureAccess` prompts only on the FIRST ever ask (and adds Sentient to the
-    /// list); once denied it returns false silently, so the fallback is the Settings deep-link.
-    /// There is no macOS API to tell "never asked" from "denied" (the preflight is a plain Bool).
+    /// The Screen Recording list is drag-authorizable, and Sentient may not be IN the list at all
+    /// (on Tahoe, CGRequestScreenCaptureAccess doesn't reliably add it — field-verified), so the
+    /// guide always carries Sentient itself as the drag card. Harmless when the row already
+    /// exists; the user just flips the existing switch.
     private func fixScreenRecording() {
         guard !screenRec else { return }
-        if !Permissions.requestScreenRecording() {
-            Permissions.openScreenRecordingSettings()
-        }
-        screenRec = Permissions.hasScreenRecording()
+        PermissionGuide.shared.guide(.screenRecording, dragging: Bundle.main.bundleURL)
     }
 
     private func refreshMicSpeech() {
@@ -366,15 +367,15 @@ struct HealthPane: View {
                            health: helperAccessibility ? .ok : .bad,
                            note: helperAccessibility ? "granted" : "not granted",
                            tip: "Lets Codex's helper app move the mouse and type for you. Granted to OpenAI's helper, not to Sentient.",
-                           fixTitle: "Open Settings…") {
-                    Permissions.openAccessibilitySettings()
+                           fixTitle: "Grant…") {
+                    guideHelper(.accessibility)
                 }
                 StatusLine(title: "Screen Recording (see the screen)",
                            health: helperScreenRecording ? .ok : .bad,
                            note: helperScreenRecording ? "granted" : "not granted",
                            tip: "Lets Codex's helper app see the screen so it acts on the right thing. Granted to OpenAI's helper, not to Sentient.",
-                           fixTitle: "Open Settings…") {
-                    Permissions.openScreenRecordingSettings()
+                           fixTitle: "Grant…") {
+                    guideHelper(.screenRecording)
                 }
                 SettingsProse("These belong to Codex's Computer Use helper, not Sentient. Flip its switch in each list; macOS may also prompt on the first computer-use run.")
                     .padding(.top, 6)
@@ -382,22 +383,15 @@ struct HealthPane: View {
         }
     }
 
-    // MARK: - Automation: no row, just a quiet self-heal (the user has no job here)
-
-    /// Sentient drives Codex's helper over Apple Events; that grant lives in the USER TCC db,
-    /// which we can write with the FDA we already hold. Probe, and if it's missing while the
-    /// prerequisites exist, silently re-grant (idempotent INSERT OR REPLACE) — no UI, just a log.
-    private func selfHealAutomation() {
-        guard fdaGranted, Permissions.computerUseHelperURL() != nil else { return }
-        let bundleID = Bundle.main.bundleIdentifier ?? "jesai.Sentient-OS-macOS"
-        guard !Permissions.isTCCGranted(service: "kTCCServiceAppleEvents", clientBundleID: bundleID) else { return }
-        Task.detached {
-            do {
-                let receipt = try Permissions.grantComputerUseAutomation()
-                Log("HealthPane: automation self-heal — \(receipt)")
-            } catch {
-                Log("HealthPane: automation self-heal failed — \(error)")
-            }
+    /// The helper's system-TCC grants: the floating drag panel with the helper app as the card
+    /// (drag it into the list). Helper somehow missing → the plain deep-link is the fallback.
+    private func guideHelper(_ pane: PermissionGuide.Pane) {
+        if let helper = Permissions.computerUseHelperURL() {
+            PermissionGuide.shared.guide(pane, dragging: helper)
+        } else if pane == .accessibility {
+            Permissions.openAccessibilitySettings()
+        } else {
+            Permissions.openScreenRecordingSettings()
         }
     }
 


### PR DESCRIPTION
## What

Two related pieces, field-tested together on Aditya's Mac tonight:

### 1. Computer use bootstraps itself during onboarding
Start Analysis arms a one-shot: 2 minutes into the first processing run, codex setup step 3 (download OpenAI's DMG → lay the payload into `~/.codex` → patch config.toml) runs fully in the background via the shared `CodexSetup` engine. Detection-first everywhere: users who already have codex or computer use (incl. via the real desktop app) are never reinstalled over; users with their own codex but no computer use get just computer use. Verified live: the log shows the full 505 MB bootstrap completing mid-analysis.

### 2. The first-use permission gate + floating Settings guide (`Views/Permissions/`)
- **`ComputerUseGate`** — command bar, Sidekick, notch typing, and proactive card fires all pass one gate. While any of the four action grants is missing (Sentient's Mic & Speech + Screen Recording, the Codex helper's Accessibility + Screen Recording) it holds the fired action, shows the one-time setup window, and fires it on Continue. Shown once per session; all-green means never.
- **`PermissionGuide` / `PermissionDragPanel` / `SettingsWindowTracker`** — a floating OLED-black panel that flies to System Settings, tracks the window (zero-permission CGWindowList poll + AX when available), and carries a draggable .app card the user drops straight into the privacy list — Sentient itself for FDA/Screen Recording, the Codex helper for its two grants. Mechanics adapted from [jaywcjlove/PermissionFlow](https://github.com/jaywcjlove/PermissionFlow) (MIT, attribution in headers); panel face rewritten in the Sentient voice.
- Onboarding (FDA, Login Items approval) and Settings → Health adopt the same guide; Sentient's Screen Recording is drag-mode everywhere (Tahoe's `CGRequestScreenCaptureAccess` doesn't reliably add the app to the list — field-verified) and is now honestly red when missing, not yellow.

### Bug fixes that fell out of field testing
- **Notch can no longer wedge**: the transcription finalize gets a 15s watchdog (the on-device speech-model download it can park on has no bound of its own), Esc now bails out of `transcribing`, and the `⌘mon` health-tick re-arms quietly instead of flooding the session log at 1.5s intervals.
- Automation self-heal extracted to `Permissions.selfHealComputerUseAutomation`; the gate runs it before the first fire.
- `setupComputerUse` re-probes the disk instead of trusting the cached `installed` flag.

## Testing
- Full reset simulation (defaults + TCC + codex uninstall) → onboarding → gate popup → drag grants, on real hardware; isolated `xcodebuild` green throughout.
- Known follow-ups: docs update after Jesai's pass; card-fire `codex exited 15` should resolve once helper grants are dragged in (re-test).

https://claude.ai/code/session_0161f95wN1oMXG2FPRhzQrtk