### PR TITLE
ChatGPT plan gate: free/go detection, crossroads onboarding, knowledge-base-only mode

### DIFF
--- a/Sentient OS macOS/App/AppState.swift
+++ b/Sentient OS macOS/App/AppState.swift
@@ -71,7 +71,11 @@ final class AppState {
         if hasCompletedOnboarding {
             Task {
                 let center = UNUserNotificationCenter.current()
-                if await center.notificationSettings().authorizationStatus == .notDetermined {
+                let status = await center.notificationSettings().authorizationStatus
+                let names = ["notDetermined", "denied", "authorized", "provisional", "ephemeral"]
+                let label = names.indices.contains(status.rawValue) ? names[status.rawValue] : "\(status.rawValue)"
+                Log("Notifications: launch status = \(label)")
+                if status == .notDetermined {
                     _ = try? await center.requestAuthorization(options: [.provisional])
                     Log("Notifications: banked provisional (quiet) authorization")
                 }

--- a/Sentient OS macOS/App/AppState.swift
+++ b/Sentient OS macOS/App/AppState.swift
@@ -51,7 +51,13 @@ final class AppState {
         self.notch = NotchWindowController(coordinator: commandCoordinator)
         scheduler.reevaluate()   // arm if the dev setting was left on; otherwise a no-op
         scheduler.maybeAutoEnable()   // 18h after initial: flip the overnight scheduler on (or arm the timer)
-        commandCoordinator.start()   // arm right-⌘ hold-to-talk + warm the speech model
+        if CodexAuth.knowledgeBaseOnly {
+            // Free/go knowledge-base-only mode: Sidekick runs computer use through codex, and
+            // that quota doesn't exist on these plans — the hotkey never arms.
+            Log("Sidekick: knowledge-base-only plan — hotkey not armed")
+        } else {
+            commandCoordinator.start()   // arm right-⌘ hold-to-talk + warm the speech model
+        }
         notch.start()                // raise the notch overlay window
         update.start()               // start Sparkle + one silent launch check (gates a mandatory update)
 

--- a/Sentient OS macOS/App/AppState.swift
+++ b/Sentient OS macOS/App/AppState.swift
@@ -9,6 +9,7 @@
 
 import Foundation
 import SwiftUI
+import UserNotifications
 
 @MainActor
 @Observable
@@ -60,6 +61,22 @@ final class AppState {
         }
         notch.start()                // raise the notch overlay window
         update.start()               // start Sparkle + one silent launch check (gates a mandatory update)
+
+        // Notifications, banked silently: PROVISIONAL authorization shows NO prompt — macOS just
+        // grants quiet Notification Center delivery and lists us in Settings → Notifications (the
+        // user sees at most the passive "Sentient OS can send you notifications" notice). Asked
+        // lazily after onboarding so that notice never lands mid-flow; the explicit alerts
+        // upgrade stays in Settings → Health's "Allow…". Only fires while status is untouched —
+        // a real Allow/Deny is never overridden.
+        if hasCompletedOnboarding {
+            Task {
+                let center = UNUserNotificationCenter.current()
+                if await center.notificationSettings().authorizationStatus == .notDetermined {
+                    _ = try? await center.requestAuthorization(options: [.provisional])
+                    Log("Notifications: banked provisional (quiet) authorization")
+                }
+            }
+        }
 
         // First launch (onboarding not yet completed): kick off the codex CLI install silently in
         // the background, 1s after launch, while the user reads the intro slides. A USED codex

--- a/Sentient OS macOS/App/AppState.swift
+++ b/Sentient OS macOS/App/AppState.swift
@@ -39,7 +39,7 @@ final class AppState {
     /// whole object is), never the root wake-helper. Its `model` drives UpdateGateView. (Updates/)
     let update = UpdateController()
 
-    private static let onboardingKey = "hasCompletedOnboarding"
+    static let onboardingKey = "hasCompletedOnboarding"   // FactoryReset clears it (the rewind)
     var hasCompletedOnboarding: Bool {
         didSet {
             UserDefaults.standard.set(hasCompletedOnboarding, forKey: Self.onboardingKey)

--- a/Sentient OS macOS/Cloud/CodexAuth.swift
+++ b/Sentient OS macOS/Cloud/CodexAuth.swift
@@ -1,0 +1,234 @@
+//
+//  CodexAuth.swift
+//  Sentient OS macOS
+//
+//  ChatGPT plan identity, read from the user's own codex login (~/.codex/auth.json).
+//  The file's OAuth tokens are JWTs whose claims carry `chatgpt_plan_type` — so the app can
+//  tell a free/go account (tiny MONTHLY codex quota, no Gmail/Calendar connectors) from a
+//  plus/pro one without any network call. Codex itself only re-mints the token every 8 days,
+//  so `refreshPlan()` replays codex's own refresh POST on demand (same endpoint, same public
+//  client id, same faithful write-back — rotated refresh_token honored, `last_refresh` reset,
+//  every other key preserved, atomic replace). After our refresh, auth.json is indistinguishable
+//  from a codex-native one. Verified live end-to-end (refresh → login status → real exec) 2026-07-08.
+//
+//  Key methods:
+//   - currentPlan()          → decode the plan claim from auth.json (pure file read, no network)
+//   - refreshPlan()          → the on-demand refresh POST + write-back → the FRESH plan
+//   - knowledgeBaseOnly      → the persisted "free user chose to continue anyway" mode flag
+//
+//  Fail-open policy: no file / no tokens / unknown plan string → treated as full. Worst case a
+//  limited account hits codex usage-limit errors, which every caller already survives (typed
+//  errors + resume handles). Only a POSITIVE free/go read gates anything.
+//
+
+import Foundation
+
+enum CodexAuth {
+
+    // MARK: Plan
+
+    /// Plans that can't run Sentient fully: tiny MONTHLY codex quota (the initial knowledge-base
+    /// build alone eats ~70% of it) and no ChatGPT connectors (Gmail/Calendar). Everything else —
+    /// plus, pro, prolite, team, business, edu, enterprise, and any future string — is full.
+    enum Tier: Sendable, Equatable {
+        case full
+        case limited
+    }
+
+    struct Plan: Sendable, Equatable {
+        /// The raw `chatgpt_plan_type` claim ("plus", "free", "go", "pro", "prolite", …).
+        let raw: String
+
+        var tier: Tier { ["free", "go"].contains(raw.lowercased()) ? .limited : .full }
+
+        /// For UI ("Plus", "Free", "Go"…). Unknown strings just get capitalized.
+        var displayName: String { raw.prefix(1).uppercased() + raw.dropFirst() }
+    }
+
+    /// The ChatGPT pricing page — where the crossroads screen and every upsell surface send users.
+    static let upgradeURL = URL(string: "https://chatgpt.com/#pricing")!
+
+    /// The hover explanation on locked Gmail/Calendar chips (knowledge-base-only mode) — shared
+    /// by every surface that shows them, so the wording never drifts.
+    static let connectorLockedTip = "ChatGPT Free and Go don't support this connector. Sentient connects to Gmail and Calendar through your own ChatGPT, so this one needs Plus."
+
+    // MARK: Persisted state
+
+    /// The user is a free/go account who chose "continue with just the knowledge base" in
+    /// onboarding. THE gate every limited-mode surface checks (scheduler auto-enable, Sidekick
+    /// arming, proactive stages, connector chips, the home's preview state).
+    static let kbOnlyKey = "plan.kbOnly"
+    static var knowledgeBaseOnly: Bool {
+        get { UserDefaults.standard.bool(forKey: kbOnlyKey) }
+        set { UserDefaults.standard.set(newValue, forKey: kbOnlyKey) }
+    }
+
+    /// Server-supplied refresh throttle (the POST answers `earliest_refresh_at`) — respected so
+    /// focus-return re-checks can never hammer the endpoint.
+    private static let earliestRefreshKey = "plan.earliestRefresh"
+
+    // MARK: Read (no network)
+
+    private static var authURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".codex/auth.json")
+    }
+
+    /// Decode the plan from auth.json's JWT claims. Pure file read — safe to call every launch,
+    /// every cycle. Returns nil when it can't know (no file, API-key-only auth, undecodable) —
+    /// callers treat nil as full (fail open).
+    static func currentPlan() -> Plan? {
+        guard let data = try? Data(contentsOf: authURL),
+              let root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+              let tokens = root["tokens"] as? [String: Any] else { return nil }
+        // id_token first (the one codex itself parses for plan display), access_token as backstop.
+        for key in ["id_token", "access_token"] {
+            if let jwt = tokens[key] as? String,
+               let plan = planClaim(fromJWT: jwt) { return Plan(raw: plan) }
+        }
+        return nil
+    }
+
+    /// True only on a POSITIVE free/go read — the convenience most gates want.
+    static func isLimited() -> Bool { currentPlan()?.tier == .limited }
+
+    /// Extract `chatgpt_plan_type` from a JWT's payload segment (base64url, no signature check —
+    /// we're reading our own user's token off their own disk, not authenticating anyone).
+    private static func planClaim(fromJWT jwt: String) -> String? {
+        let segments = jwt.split(separator: ".")
+        guard segments.count >= 2 else { return nil }
+        var b64 = segments[1].replacingOccurrences(of: "-", with: "+")
+                             .replacingOccurrences(of: "_", with: "/")
+        b64 += String(repeating: "=", count: (4 - b64.count % 4) % 4)
+        guard let payload = Data(base64Encoded: b64),
+              let claims = (try? JSONSerialization.jsonObject(with: payload)) as? [String: Any],
+              let auth = claims["https://api.openai.com/auth"] as? [String: Any] else { return nil }
+        return auth["chatgpt_plan_type"] as? String
+    }
+
+    // MARK: Refresh (the on-demand plan re-check)
+
+    enum AuthError: Error, CustomStringConvertible {
+        case notLoggedIn                    // no auth.json / no refresh_token to present
+        case refreshRejected(String)        // the server said no (expired/reused/revoked token)
+        case network(String)
+
+        var description: String {
+            switch self {
+            case .notLoggedIn:              return "Not logged in to codex"
+            case .refreshRejected(let m):   return "Token refresh rejected: \(m.prefix(200))"
+            case .network(let m):           return "Token refresh failed: \(m.prefix(200))"
+            }
+        }
+    }
+
+    /// Codex's own public OAuth client id (codex-rs `login/src/auth/manager.rs`).
+    private static let clientID = "app_EMoamEEZ73f0CkXaXp7hrann"
+    private static let refreshEndpoint = URL(string: "https://auth.openai.com/oauth/token")!
+
+    /// One in-flight refresh at a time — a second concurrent POST would present an
+    /// already-rotated refresh token and brick the user's codex login.
+    @MainActor private static var inFlight: Task<Plan?, Error>?
+
+    /// Re-mint the tokens NOW (instead of codex's 8-day timer) and return the fresh plan —
+    /// how "I've upgraded" gets verified. Single-flight; honors the server's
+    /// `earliest_refresh_at` throttle by returning the current claim without a network call.
+    @MainActor
+    static func refreshPlan() async throws -> Plan? {
+        if let inFlight { return try await inFlight.value }
+        let task = Task<Plan?, Error> { try await performRefresh() }
+        inFlight = task
+        defer { inFlight = nil }
+        return try await task.value
+    }
+
+    private static func performRefresh() async throws -> Plan? {
+        // The server told us when the next refresh is allowed — before that, the claim on disk
+        // is as fresh as a POST would mint anyway.
+        let earliest = UserDefaults.standard.double(forKey: earliestRefreshKey)
+        if Date().timeIntervalSince1970 < earliest { return currentPlan() }
+
+        guard let data = try? Data(contentsOf: authURL),
+              let root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+              let tokens = root["tokens"] as? [String: Any],
+              let refreshToken = tokens["refresh_token"] as? String else {
+            throw AuthError.notLoggedIn
+        }
+
+        var request = URLRequest(url: refreshEndpoint, timeoutInterval: 30)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: [
+            "client_id": clientID,
+            "grant_type": "refresh_token",
+            "refresh_token": refreshToken,
+        ])
+
+        let body: Data, status: Int
+        do {
+            let (d, response) = try await URLSession.shared.data(for: request)
+            body = d
+            status = (response as? HTTPURLResponse)?.statusCode ?? 0
+        } catch {
+            throw AuthError.network("\(error)")
+        }
+        guard (200..<300).contains(status),
+              let fresh = (try? JSONSerialization.jsonObject(with: body)) as? [String: Any] else {
+            let detail = String(data: body, encoding: .utf8) ?? "HTTP \(status)"
+            emitRefreshFailed(status: status)
+            throw AuthError.refreshRejected(detail)
+        }
+
+        try writeBack(fresh, into: root)
+
+        if let next = earliestRefreshDate(from: fresh["earliest_refresh_at"]) {
+            UserDefaults.standard.set(next.timeIntervalSince1970, forKey: earliestRefreshKey)
+        }
+        return currentPlan()
+    }
+
+    /// The faithful write-back: only the fields the server returned, every other key preserved,
+    /// `last_refresh` reset (so codex's 8-day timer restarts, exactly like a native refresh),
+    /// 0600 permissions, atomic replace. Success-only — a failed POST never touches the file.
+    private static func writeBack(_ fresh: [String: Any], into root: [String: Any]) throws {
+        var updated = root
+        var tokens = (root["tokens"] as? [String: Any]) ?? [:]
+        for key in ["id_token", "access_token", "refresh_token"] {
+            if let value = fresh[key] as? String { tokens[key] = value }
+        }
+        updated["tokens"] = tokens
+
+        let stamp = ISO8601DateFormatter()
+        stamp.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        updated["last_refresh"] = stamp.string(from: Date())
+
+        let out = try JSONSerialization.data(withJSONObject: updated,
+                                             options: [.prettyPrinted, .withoutEscapingSlashes])
+        let tmp = authURL.deletingLastPathComponent()
+            .appendingPathComponent("auth.json.sentient-\(UUID().uuidString.prefix(8))")
+        try out.write(to: tmp)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: tmp.path)
+        _ = try FileManager.default.replaceItemAt(authURL, withItemAt: tmp)
+    }
+
+    /// `earliest_refresh_at` arrives as epoch seconds or an ISO string depending on the server's
+    /// mood — accept both, ignore anything else.
+    private static func earliestRefreshDate(from value: Any?) -> Date? {
+        switch value {
+        case let seconds as Double: return Date(timeIntervalSince1970: seconds)
+        case let seconds as Int:    return Date(timeIntervalSince1970: Double(seconds))
+        case let iso as String:
+            let f = ISO8601DateFormatter()
+            f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            return f.date(from: iso) ?? ISO8601DateFormatter().date(from: iso)
+        default: return nil
+        }
+    }
+
+    /// §7.9-style structured signal — status code only, never token material or response bodies.
+    private static func emitRefreshFailed(status: Int) {
+        CrashReporting.captureEvent("codex_auth.refresh_failed", level: .warning,
+            tags: ["status": String(status)],
+            extra: [:], fingerprint: ["codex_auth", "refresh_failed"])
+    }
+}

--- a/Sentient OS macOS/Cloud/CodexAuth.swift
+++ b/Sentient OS macOS/Cloud/CodexAuth.swift
@@ -48,9 +48,9 @@ enum CodexAuth {
     /// The ChatGPT pricing page — where the crossroads screen and every upsell surface send users.
     static let upgradeURL = URL(string: "https://chatgpt.com/#pricing")!
 
-    /// The hover explanation on locked Gmail/Calendar chips (knowledge-base-only mode) — shared
-    /// by every surface that shows them, so the wording never drifts.
-    static let connectorLockedTip = "ChatGPT Free and Go don't support this connector. Sentient connects to Gmail and Calendar through your own ChatGPT, so this one needs Plus."
+    /// The hover notice on locked Gmail/Calendar chips (knowledge-base-only mode) — shared by
+    /// every surface that shows them, so the wording never drifts.
+    static let connectorLockedTip = "Only supported on ChatGPT Plus"
 
     // MARK: Persisted state
 

--- a/Sentient OS macOS/Ingestion/FactoryReset.swift
+++ b/Sentient OS macOS/Ingestion/FactoryReset.swift
@@ -4,24 +4,34 @@
 //
 //  The one full wipe, shared by Settings → System (the user-facing Reset) and the dev tools'
 //  "Reset everything": the cycle store (pointers + summaries), the knowledge base folder, every
-//  persisted proactive trace, the lifetime counters, and the cloud mirror copy (best-effort
-//  DELETE; an offline reset still succeeds locally, and the 30-day lease is the backstop).
-//  Deliberately NOT touched: the mirror token + opt-in (the share URL pasted into the user's
-//  connectors must survive — the next processed push recreates the copy), and the user's source
-//  selections (those are choices, not learnings). A destructive sequence with two callers must
-//  never drift — change it HERE only.
+//  persisted proactive trace, the lifetime counters, the cloud mirror copy (best-effort DELETE;
+//  an offline reset still succeeds locally, and the 30-day lease is the backstop) — and the
+//  rewind to the START of onboarding (step, completion flag, the knowledge-base-only plan mode),
+//  because "start over from scratch" means the setup too, and the free→Plus upgrade path's
+//  "Reset & Rebuild" depends on re-running it. Deliberately NOT touched: the mirror token +
+//  opt-in (the share URL pasted into the user's connectors must survive — the next processed
+//  push recreates the copy), and the user's source selections (those are choices, not
+//  learnings). A destructive sequence with two callers must never drift — change it HERE only.
 //
 
 import Foundation
 
 enum FactoryReset {
+    /// `appState` (both callers have it) gets the live rewind — the main window flips back to
+    /// onboarding the moment the wipe finishes; the persisted flags below guarantee the same on
+    /// the next launch regardless.
     @MainActor
-    static func run() async {
+    static func run(appState: AppState? = nil) async {
         await CycleStore.shared.wipeEverything()
         try? FileManager.default.removeItem(at: VaultGenerator.vaultRoot)
         ProactiveCycle.resetAll()
         LifetimeStats.reset()
         try? await MirrorClient.shared.deleteRemote()   // best-effort — offline reset still works
-        Log("FactoryReset: wiped cycle store + knowledge base + proactive traces + lifetime counters + cloud mirror copy")
+        let d = UserDefaults.standard
+        d.removeObject(forKey: "onboarding.step")
+        d.removeObject(forKey: CodexAuth.kbOnlyKey)     // the crossroads re-detects the plan fresh
+        d.removeObject(forKey: AppState.onboardingKey)
+        appState?.hasCompletedOnboarding = false        // live flip (didSet re-persists false)
+        Log("FactoryReset: wiped cycle store + knowledge base + proactive traces + lifetime counters + cloud mirror copy · rewound to onboarding")
     }
 }

--- a/Sentient OS macOS/Proactive/ProactiveCycle.swift
+++ b/Sentient OS macOS/Proactive/ProactiveCycle.swift
@@ -64,7 +64,8 @@ actor ProactiveCycle {
 
         // 1) Knowledge base — create first time, else a surgical update. 2) Push the mirror.
         let exists = FileManager.default.fileExists(atPath: VaultGenerator.vaultRoot.path)
-        progress(.knowledgeBase(exists ? "Updating your knowledge…" : "Building your knowledge…"))
+        progress(.knowledgeBase(exists ? "Updating your knowledge…"
+                                       : "Creating your perfect knowledge base from everything we've analyzed…"))
         do {
             if exists { _ = try await VaultCloud.shared.update(notes: notes) }
             else      { _ = try await VaultCloud.shared.create(notes: notes) }

--- a/Sentient OS macOS/Proactive/ProactiveCycle.swift
+++ b/Sentient OS macOS/Proactive/ProactiveCycle.swift
@@ -10,6 +10,7 @@
 //    1. file the summaries into the knowledge base (VaultCloud: create first time, else update)
 //    2. push the MCP mirror (no-op if it's off)
 //    3. PROACTIVE — decide (Proactive) → research + prepare (ProactiveResearch) → persisted `latest`
+//       (skipped entirely in knowledge-base-only mode — free/go plans have no quota for it)
 //    4. WIPE the summaries (CycleStore) — the knowledge base is the durable memory now
 //
 //  The read leg itself stays with the caller (ProcessingView's takeover UI / the scheduler's keep-
@@ -85,34 +86,40 @@ actor ProactiveCycle {
         }
 
         // 3) Proactive — decide, then research + prepare. Inject the live calendar when connected.
-        var calCtx: String?
-        if UserDefaults.standard.bool(forKey: "dbg.calendar.connected") {
-            calCtx = await CalendarConnect.fetchProactiveContext()
-        }
-
-        progress(.deciding)
-        let items: [ActionItem]
-        do {
-            items = try await Proactive.shared.findActionItems(from: notes, calendarContext: calCtx)
-        } catch Proactive.ProError.noRecent {
-            items = []                                       // nothing recent enough — clear cards, still success
-        } catch {
-            let m = "Deciding: \(Self.msg(error))"
-            progress(.failed(m)); return m
-        }
-        Analytics.signal("Proactive.decided", parameters: ["items": "\(items.count)"])
-
-        if items.isEmpty {
-            ProactiveResearch.saveLatest(ReadyResult(ready: [], dropped: []))   // clear any stale cards
+        //    Knowledge-base-only mode (free/go plan) skips the whole stage: no quota for it, and
+        //    no Gmail/Calendar to ground it — the knowledge base + mirror + gift ARE the product.
+        if CodexAuth.knowledgeBaseOnly {
+            ProactiveResearch.saveLatest(ReadyResult(ready: [], dropped: []))   // never leave stale cards
         } else {
-            progress(.researching(items.count))
+            var calCtx: String?
+            if UserDefaults.standard.bool(forKey: "dbg.calendar.connected") {
+                calCtx = await CalendarConnect.fetchProactiveContext()
+            }
+
+            progress(.deciding)
+            let items: [ActionItem]
             do {
-                let result = try await ProactiveResearch.shared.researchAndPrepare(items: items, notes: notes, calendarContext: calCtx)
-                Analytics.signal("Proactive.prepared", parameters: [
-                    "ready": "\(result.ready.count)", "dropped": "\(result.dropped.count)"])
+                items = try await Proactive.shared.findActionItems(from: notes, calendarContext: calCtx)
+            } catch Proactive.ProError.noRecent {
+                items = []                                   // nothing recent enough — clear cards, still success
             } catch {
-                let m = "Preparing: \(Self.msg(error))"
+                let m = "Deciding: \(Self.msg(error))"
                 progress(.failed(m)); return m
+            }
+            Analytics.signal("Proactive.decided", parameters: ["items": "\(items.count)"])
+
+            if items.isEmpty {
+                ProactiveResearch.saveLatest(ReadyResult(ready: [], dropped: []))   // clear any stale cards
+            } else {
+                progress(.researching(items.count))
+                do {
+                    let result = try await ProactiveResearch.shared.researchAndPrepare(items: items, notes: notes, calendarContext: calCtx)
+                    Analytics.signal("Proactive.prepared", parameters: [
+                        "ready": "\(result.ready.count)", "dropped": "\(result.dropped.count)"])
+                } catch {
+                    let m = "Preparing: \(Self.msg(error))"
+                    progress(.failed(m)); return m
+                }
             }
         }
 

--- a/Sentient OS macOS/Scheduling/OvernightScheduler.swift
+++ b/Sentient OS macOS/Scheduling/OvernightScheduler.swift
@@ -119,6 +119,9 @@ final class OvernightScheduler {
     /// when the prerequisites (approved root helper + launch-at-login) are in place — otherwise it flags
     /// `needsSchedulerSetup` for the setup UX and retries on the next tick.
     func maybeAutoEnable() {
+        // Free/go knowledge-base-only mode: no quota for nightly runs — auto-enable never fires.
+        // Deliberately NOT latched, so an upgrade (+ reset) later starts the 18h clock fresh.
+        guard !CodexAuth.knowledgeBaseOnly else { return }
         let d = UserDefaults.standard
         guard !d.bool(forKey: Self.autoEnableFiredKey) else { return }      // already handled once
 

--- a/Sentient OS macOS/Sources/SourceSelection.swift
+++ b/Sentient OS macOS/Sources/SourceSelection.swift
@@ -59,6 +59,21 @@ enum SourceSelection {
             .split(separator: ",").map(String.init))
     }
 
+    /// How many CONNECTORS are armed (all folders together count as ONE) — the shared 3-minimum
+    /// rule Settings and onboarding's ready screen both enforce. Breadth of life coverage, not
+    /// folder count.
+    static var connectorCount: Int {
+        var n = 0
+        if bool("dbg.run.downloads", default: true) || bool("dbg.run.desktop", default: true)
+            || bool("dbg.run.documents", default: true) || !CustomRoots.urls.isEmpty { n += 1 }
+        if bool("dbg.run.whatsapp", default: false) && !chatJIDs.isEmpty { n += 1 }
+        if bool("dbg.run.imessage", default: false) && !imessageGUIDs.isEmpty { n += 1 }
+        if bool("dbg.run.notes", default: false) { n += 1 }
+        if bool("dbg.gmail.connected", default: false) && bool("dbg.run.gmail", default: false) { n += 1 }
+        if bool("dbg.calendar.connected", default: false) && bool("dbg.run.calendar", default: false) { n += 1 }
+        return n
+    }
+
     static func current(fdaGranted: Bool) -> [RunSource] {
         var s: [RunSource] = []
         if bool("dbg.run.downloads", default: true) { s.append(.files(.downloads)) }

--- a/Sentient OS macOS/Sources/SourceSelection.swift
+++ b/Sentient OS macOS/Sources/SourceSelection.swift
@@ -59,13 +59,17 @@ enum SourceSelection {
             .split(separator: ",").map(String.init))
     }
 
-    /// How many CONNECTORS are armed (all folders together count as ONE) — the shared 3-minimum
-    /// rule Settings and onboarding's ready screen both enforce. Breadth of life coverage, not
-    /// folder count.
-    static var connectorCount: Int {
+    /// How many SELECTIONS are armed — every folder (default or custom), each chat source with
+    /// chats picked, Notes, and each connected cloud source counts as ONE. The shared minimum
+    /// (at least 4) that onboarding's ready screen and Settings both enforce: the defaults alone
+    /// (three folders) deliberately don't pass, so starting always takes one deliberate connect.
+    static let minimumSelections = 4
+    static var selectionCount: Int {
         var n = 0
-        if bool("dbg.run.downloads", default: true) || bool("dbg.run.desktop", default: true)
-            || bool("dbg.run.documents", default: true) || !CustomRoots.urls.isEmpty { n += 1 }
+        if bool("dbg.run.downloads", default: true) { n += 1 }
+        if bool("dbg.run.desktop", default: true) { n += 1 }
+        if bool("dbg.run.documents", default: true) { n += 1 }
+        n += CustomRoots.urls.count
         if bool("dbg.run.whatsapp", default: false) && !chatJIDs.isEmpty { n += 1 }
         if bool("dbg.run.imessage", default: false) && !imessageGUIDs.isEmpty { n += 1 }
         if bool("dbg.run.notes", default: false) { n += 1 }

--- a/Sentient OS macOS/Vault/VaultGenerator.swift
+++ b/Sentient OS macOS/Vault/VaultGenerator.swift
@@ -210,7 +210,9 @@ actor VaultGenerator {
 
         var invocation = CodexCLI.Invocation(prompt: prompt)
         invocation.feature = "vault"
-        invocation.effort = .xhigh                           // KB build gets the deepest pass (gpt-5.5)
+        // KB build gets the deepest pass (gpt-5.5) — except in knowledge-base-only mode, where
+        // .high keeps the one build a free/go plan's tiny monthly quota can afford (~70% of it).
+        invocation.effort = CodexAuth.knowledgeBaseOnly ? .high : .xhigh
         invocation.sandbox = .workspaceWrite                 // writes confined to the staging dir
         invocation.cwd = staging.path
         invocation.resumeSessionID = resume?.sessionID

--- a/Sentient OS macOS/Views/BriefingCard.swift
+++ b/Sentient OS macOS/Views/BriefingCard.swift
@@ -239,7 +239,9 @@ private struct EnvelopeFace: View {
 
                 VStack(spacing: 7) {
                     MonoCaps("A letter from your Sentient", size: 9, tracking: 2.4, color: Theme.Ink.label)
-                    Text("For Jesai")   // demo: the recipient comes from the vault portrait later
+                    // The recipient: the Mac account's first name (same source as the home
+                    // greeting); a nameless account just gets "For you".
+                    Text(HomeView.macFirstName.isEmpty ? "For you" : "For \(HomeView.macFirstName)")
                         .font(.system(size: 22, design: .serif).italic())
                         .foregroundStyle(Theme.Ink.statusInk)
                 }

--- a/Sentient OS macOS/Views/Dev/DevToolsView.swift
+++ b/Sentient OS macOS/Views/Dev/DevToolsView.swift
@@ -849,13 +849,14 @@ struct DevToolsView: View {
     }
 
     /// Factory reset — the shared FactoryReset wipe (cycle store + knowledge base + proactive
-    /// traces + lifetime counters + the cloud mirror copy), so the next "start / resume" run is a
-    /// fresh first run and the home's "For You" deck comes back empty. Same code path as
-    /// Settings → Reset Sentient.
+    /// traces + lifetime counters + the cloud mirror copy + the rewind to onboarding), so the
+    /// next "start / resume" run is a fresh first run and the home's "For You" deck comes back
+    /// empty. Same code path as Settings → Reset Sentient; the DEBUG "skip to home" handle gets
+    /// you straight back if you only wanted the data wipe.
     @MainActor
     private func runReset() async {
-        await FactoryReset.run()
+        await FactoryReset.run(appState: appState)
         let c = await CycleStore.shared.counts()
-        resetResult = "✓ reset — cycle store + knowledge base + proactive cards + cloud copy wiped (notes \(c.notes))"
+        resetResult = "✓ reset — cycle store + knowledge base + proactive cards + cloud copy wiped, rewound to onboarding (notes \(c.notes))"
     }
 }

--- a/Sentient OS macOS/Views/GlowButton.swift
+++ b/Sentient OS macOS/Views/GlowButton.swift
@@ -38,6 +38,27 @@ struct GlowButton: View {
     }
 }
 
+/// The glow CTA's quiet sibling — a grey outlined capsule for the visible-but-subordinate
+/// choice beside it (the crossroads' "continue with just the knowledge base", the free home's
+/// "Reset Sentient…"). Present enough to read as a real button, never competing with the glow.
+struct QuietPillButton: View {
+    let title: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 13.5, weight: .medium))
+                .foregroundStyle(Theme.Ink.bright)
+                .padding(.horizontal, 22).padding(.vertical, 12)
+                .background(Capsule().fill(.white.opacity(0.07)))
+                .overlay(Capsule().strokeBorder(.white.opacity(0.16), lineWidth: 1))
+                .contentShape(Capsule())
+        }
+        .buttonStyle(PressScaleStyle())
+    }
+}
+
 /// Subtle scale-on-press, mirroring the website's hover/active scale.
 private struct GlowPressStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {

--- a/Sentient OS macOS/Views/HomePopovers.swift
+++ b/Sentient OS macOS/Views/HomePopovers.swift
@@ -106,8 +106,10 @@ struct AnalysisPopover: View {
                 }
                 HStack(spacing: 8) {
                     SourceChip("Notes",    on: runNotes) { runNotes.toggle() }
-                    SourceChip("Gmail",    on: gmailConnected && runGmail,       action: onPickGmail)
-                    SourceChip("Calendar", on: calendarConnected && runCalendar, action: onPickCalendar)
+                    SourceChip("Gmail",    on: gmailConnected && runGmail,
+                               locked: CodexAuth.knowledgeBaseOnly, action: onPickGmail)
+                    SourceChip("Calendar", on: calendarConnected && runCalendar,
+                               locked: CodexAuth.knowledgeBaseOnly, action: onPickCalendar)
                 }
             }
             .padding(.top, 11)
@@ -326,30 +328,40 @@ private struct CopyPill: View {
 // MARK: - Shared bits
 
 /// A source pill (✓ when armed). Tappable when an `action` is set (toggles a source / opens a
-/// chat or connect sheet). Harvested from the Constellation.
+/// chat or connect sheet). `locked` (knowledge-base-only mode's Gmail/Calendar) renders a dim
+/// lock chip that ignores its action and explains itself on hover. Harvested from the Constellation.
 struct SourceChip: View {
     let name: String
     let on: Bool
+    var locked: Bool = false
     var action: (() -> Void)? = nil    // tappable when set (toggles a source / opens the chat picker)
 
     @State private var hover = false
 
-    init(_ name: String, on: Bool, action: (() -> Void)? = nil) {
-        self.name = name; self.on = on; self.action = action
+    init(_ name: String, on: Bool, locked: Bool = false, action: (() -> Void)? = nil) {
+        self.name = name; self.on = on; self.locked = locked; self.action = action
     }
 
     var body: some View {
         let chip = HStack(spacing: 5) {
-            if on { Text("✓").foregroundStyle(Theme.Ink.green) }
-            Text(name).foregroundStyle(on ? Theme.Ink.chipInk : .white.opacity(0.28))
+            if locked {
+                Image(systemName: "lock.fill")
+                    .font(.system(size: 7))
+                    .foregroundStyle(.white.opacity(0.28))
+            } else if on {
+                Text("✓").foregroundStyle(Theme.Ink.green)
+            }
+            Text(name).foregroundStyle(on && !locked ? Theme.Ink.chipInk : .white.opacity(0.28))
         }
         .font(.system(size: 9, weight: .medium, design: .monospaced)).tracking(0.8)
         .padding(.horizontal, 9).padding(.vertical, 4)
-        .background(Capsule().fill(.white.opacity(hover && action != nil ? 0.06 : 0)))
+        .background(Capsule().fill(.white.opacity(hover && action != nil && !locked ? 0.06 : 0)))
         .overlay(Capsule().strokeBorder(Theme.Ink.chipBorder, lineWidth: 1))
         .contentShape(Capsule())
 
-        if let action {
+        if locked {
+            chip.help(CodexAuth.connectorLockedTip)
+        } else if let action {
             Button(action: action) { chip }
                 .buttonStyle(.plain)
                 .onHover { hover = $0 }

--- a/Sentient OS macOS/Views/HomePopovers.swift
+++ b/Sentient OS macOS/Views/HomePopovers.swift
@@ -360,7 +360,12 @@ struct SourceChip: View {
         .contentShape(Capsule())
 
         if locked {
-            chip.help(CodexAuth.connectorLockedTip)
+            chip
+                .onHover { hover = $0 }
+                .overlay(alignment: .top) {
+                    if hover { LockedChipTip().offset(y: -26) }
+                }
+                .animation(.easeInOut(duration: 0.15), value: hover)
         } else if let action {
             Button(action: action) { chip }
                 .buttonStyle(.plain)

--- a/Sentient OS macOS/Views/HomeView.swift
+++ b/Sentient OS macOS/Views/HomeView.swift
@@ -319,7 +319,7 @@ struct HomeView: View {
             GlowButton(title: "Get ChatGPT Plus", systemImage: "arrow.up.forward",
                        glowIntensity: 0.5, action: { NSWorkspace.shared.open(CodexAuth.upgradeURL) })
                 .frame(width: 250)
-            quietPill("Reset Sentient…", action: openSystemPane)
+            QuietPillButton(title: "Reset Sentient…", action: openSystemPane)
         }
         .padding(.top, compact ? 22 : 28)
         Text("Upgraded? Reset rebuilds your knowledge with Gmail, Calendar, and the full engine.")
@@ -349,19 +349,6 @@ struct HomeView: View {
     private func openSystemPane() {
         SettingsView.requestedPane = .system
         openWindow(id: SettingsView.windowID)
-    }
-
-    private func quietPill(_ title: String, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            Text(title)
-                .font(.system(size: 13.5, weight: .medium))
-                .foregroundStyle(Theme.Ink.bright)
-                .padding(.horizontal, 22).padding(.vertical, 12)
-                .background(Capsule().fill(.white.opacity(0.05)))
-                .overlay(Capsule().strokeBorder(.white.opacity(0.14), lineWidth: 1))
-                .contentShape(Capsule())
-        }
-        .buttonStyle(PressScaleStyle())
     }
 
     private func previewRow(_ icon: String, _ text: String) -> some View {

--- a/Sentient OS macOS/Views/HomeView.swift
+++ b/Sentient OS macOS/Views/HomeView.swift
@@ -301,7 +301,7 @@ struct HomeView: View {
             .display(24)
             .foregroundStyle(Theme.Ink.statusInk)
             .padding(.top, 16)
-        Text("Your knowledge base is built, private, and yours to explore.\nThe living Sentient runs on ChatGPT Plus:")
+        Text("Your knowledge base is built, private, and yours to explore.\nThe living Sentient uses your ChatGPT Plus:")
             .font(.system(size: 13.5))
             .foregroundStyle(Theme.secondary)
             .multilineTextAlignment(.center)

--- a/Sentient OS macOS/Views/HomeView.swift
+++ b/Sentient OS macOS/Views/HomeView.swift
@@ -177,7 +177,7 @@ struct HomeView: View {
     }
 
     /// The user's first name from their macOS account — full name's first word (e.g. "Jesai
-    /// Avadhani" → "Jesai"), falling back to the (capitalized) short login name, then to nothing
+    /// Tarun" → "Jesai"), falling back to the (capitalized) short login name, then to nothing
     /// (the greeting just drops the name). Resolved once per launch; no account, no network.
     static let macFirstName: String = {
         let full = NSFullUserName().trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sentient OS macOS/Views/HomeView.swift
+++ b/Sentient OS macOS/Views/HomeView.swift
@@ -18,9 +18,10 @@
 //  sources + AIs + vault stats into this surface and its popovers.)
 //
 //  KNOWLEDGE-BASE-ONLY MODE (free/go plans, CodexAuth.knowledgeBaseOnly): cards never come and
-//  the command bar hides — the empty state instead carries the preview note under the orb
-//  (upgrade CTA + Reset jump), flipping to the reset-and-rebuild celebration once the plan
-//  claim reads Plus.
+//  the command bar hides — the preview note under the orb (upgrade CTA + Reset jump) is ALWAYS
+//  on this home. The gift envelope (the only card the free home can hold) perches top-center
+//  above the compact note; flinging the letter blooms the note into the full center. Once the
+//  plan claim reads Plus it becomes the reset-and-rebuild celebration.
 //
 //  Doc: Documentation/Home — Proactive Intelligence (For You).md · cards + the CodexCLI seam:
 //  Briefing.swift.
@@ -78,9 +79,13 @@ struct HomeView: View {
 
                 Group {
                     scatter(geo)
-                    if model.entries.isEmpty {
-                        (kbOnly ? AnyView(previewState) : AnyView(emptyState))
-                            .transition(.scale(scale: 0.86).combined(with: .opacity))
+                    if kbOnly {
+                        // The preview note is ALWAYS on the free home — the gift envelope (the
+                        // only card this home can ever hold) perches above it, never in front:
+                        // the pitch must not hide behind a fling.
+                        previewState
+                    } else if model.entries.isEmpty {
+                        emptyState.transition(.scale(scale: 0.86).combined(with: .opacity))
                     }
                     bottomDock
                     chrome                     // on top → the nav stays clickable
@@ -212,7 +217,11 @@ struct HomeView: View {
     // MARK: The scatter (the suggestion cards)
 
     private func scatter(_ geo: GeometryProxy) -> some View {
-        let slots = Self.slots(count: model.entries.count, in: geo.size)
+        // kb-only: the lone gift envelope gets a fixed top-center perch (the preview note owns
+        // the center beneath it). Any other population falls back to the normal scatter.
+        let slots = (kbOnly && model.entries.count == 1)
+            ? [CGPoint(x: geo.size.width / 2, y: geo.size.height * 0.24)]
+            : Self.slots(count: model.entries.count, in: geo.size)
         return ZStack {
             ForEach(Array(model.entries.enumerated()), id: \.element.id) { item in
                 DealtCard(
@@ -270,21 +279,24 @@ struct HomeView: View {
 
     // MARK: The knowledge-base-only preview state (free/go plans)
 
-    /// The free-plan home: the orb rises a touch and, where the cards would live, an honest,
-    /// nicely-set note — the knowledge base is real and theirs; the LIVING Sentient needs Plus.
-    /// Not a card: quiet centered text under the orb. The upgrade CTA carries this screen's one
-    /// glow (the command bar is hidden here, so the jewelry budget is free). Once the claim
-    /// reads Plus (they upgraded), the note flips to the reset-and-rebuild celebration.
+    /// The free-plan home: the orb and, where the cards would live, an honest, nicely-set
+    /// note — the knowledge base is real and theirs; the LIVING Sentient needs Plus. Not a
+    /// card: quiet centered text under the orb. The upgrade CTA carries this screen's one glow
+    /// (the command bar is hidden here, so the jewelry budget is free). ALWAYS mounted on the
+    /// kb-only home: while the gift envelope perches top-center the block rides compact and
+    /// low (feature rows tucked away); once the letter is flung it blooms into the full,
+    /// centered note. Once the claim reads Plus, it becomes the reset-and-rebuild celebration.
     private var previewState: some View {
-        VStack(spacing: 0) {
-            Orb(size: 104)
-            if planUpgraded { upgradedNote } else { previewNote }
+        let envelopePresent = !model.entries.isEmpty
+        return VStack(spacing: 0) {
+            Orb(size: envelopePresent ? 84 : 104)
+            if planUpgraded { upgradedNote } else { previewNote(compact: envelopePresent) }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .offset(y: -18)   // the orb rides a touch higher to make room for the note
+        .offset(y: envelopePresent ? 128 : -18)   // envelope above → the block waits lower
     }
 
-    @ViewBuilder private var previewNote: some View {
+    @ViewBuilder private func previewNote(compact: Bool) -> some View {
         Text("This is a preview of Sentient.")
             .display(24)
             .foregroundStyle(Theme.Ink.statusInk)
@@ -295,19 +307,21 @@ struct HomeView: View {
             .multilineTextAlignment(.center)
             .lineSpacing(4)
             .padding(.top, 10)
-        VStack(alignment: .leading, spacing: 11) {
-            previewRow("sunrise", "Mornings where things worth doing arrive already done")
-            previewRow("command", "Sidekick anywhere: hold right \u{2318} and just say it")
-            previewRow("moon.stars", "A knowledge base that keeps learning, night after night")
+        if !compact {   // the feature rows return once the envelope is gone
+            VStack(alignment: .leading, spacing: 11) {
+                previewRow("sunrise", "Mornings where things worth doing arrive already done")
+                previewRow("command", "Sidekick anywhere: hold right \u{2318} and just say it")
+                previewRow("moon.stars", "A knowledge base that keeps learning, night after night")
+            }
+            .padding(.top, 20)
         }
-        .padding(.top, 20)
         HStack(spacing: 14) {
             GlowButton(title: "Get ChatGPT Plus", systemImage: "arrow.up.forward",
                        glowIntensity: 0.5, action: { NSWorkspace.shared.open(CodexAuth.upgradeURL) })
                 .frame(width: 250)
             quietPill("Reset Sentient…", action: openSystemPane)
         }
-        .padding(.top, 28)
+        .padding(.top, compact ? 22 : 28)
         Text("Upgraded? Reset rebuilds your knowledge with Gmail, Calendar, and the full engine.")
             .font(.system(size: 11.5))
             .foregroundStyle(Theme.faint)

--- a/Sentient OS macOS/Views/HomeView.swift
+++ b/Sentient OS macOS/Views/HomeView.swift
@@ -17,6 +17,11 @@
 //  that hands your eye straight to the command bar. (Retired ConstellationHome; harvested orb +
 //  sources + AIs + vault stats into this surface and its popovers.)
 //
+//  KNOWLEDGE-BASE-ONLY MODE (free/go plans, CodexAuth.knowledgeBaseOnly): cards never come and
+//  the command bar hides — the empty state instead carries the preview note under the orb
+//  (upgrade CTA + Reset jump), flipping to the reset-and-rebuild celebration once the plan
+//  claim reads Plus.
+//
 //  Doc: Documentation/Home — Proactive Intelligence (For You).md · cards + the CodexCLI seam:
 //  Briefing.swift.
 //
@@ -31,8 +36,18 @@ struct HomeView: View {
     var customRoots: [URL] = []        // session folders from RootView — shown in the Analysis popover, like Dev Tools
     var modelMissing: Bool = false
     var realCards: Bool = false        // true → show real proactive cards from latest(); false → the demo deck
+    var previewKBOnly = false          // preview-only: force the knowledge-base-only state
     var onAnalyze: () -> Void = {}
     var onShowDevTools: () -> Void = {}
+
+    /// Free/go knowledge-base-only mode: no cards ever come, the command bar hides (computer use
+    /// burns quota these plans don't have), and the empty state carries the preview message.
+    private var kbOnly: Bool { previewKBOnly || CodexAuth.knowledgeBaseOnly }
+    var previewUpgraded: Bool? = nil   // preview-only: force the upgraded/not-upgraded note
+    /// A kbOnly user whose claim now reads full — they upgraded (codex's own 8-day refresh, the
+    /// Health pane's Re-check, or the crossroads all re-mint it). Re-read every appearance, so
+    /// the preview note flips to the "reset & rebuild" celebration without any push machinery.
+    @State private var planUpgraded = false
 
     @Environment(\.openWindow) private var openWindow
     @Environment(AppState.self) private var appState
@@ -64,7 +79,8 @@ struct HomeView: View {
                 Group {
                     scatter(geo)
                     if model.entries.isEmpty {
-                        emptyState.transition(.scale(scale: 0.86).combined(with: .opacity))
+                        (kbOnly ? AnyView(previewState) : AnyView(emptyState))
+                            .transition(.scale(scale: 0.86).combined(with: .opacity))
                     }
                     bottomDock
                     chrome                     // on top → the nav stays clickable
@@ -82,6 +98,7 @@ struct HomeView: View {
             letter = nil
             letterShown = false
             model.beginVisit(realCards: realCards)
+            planUpgraded = previewUpgraded ?? (kbOnly && CodexAuth.currentPlan()?.tier == .full)
         }
         .onChange(of: realCards) { _, v in model.beginVisit(realCards: v) }   // toggle flip → re-deal
         .animation(.spring(response: 0.5, dampingFraction: 0.82), value: model.entries.isEmpty)
@@ -251,6 +268,100 @@ struct HomeView: View {
         .allowsHitTesting(false)
     }
 
+    // MARK: The knowledge-base-only preview state (free/go plans)
+
+    /// The free-plan home: the orb rises a touch and, where the cards would live, an honest,
+    /// nicely-set note — the knowledge base is real and theirs; the LIVING Sentient needs Plus.
+    /// Not a card: quiet centered text under the orb. The upgrade CTA carries this screen's one
+    /// glow (the command bar is hidden here, so the jewelry budget is free). Once the claim
+    /// reads Plus (they upgraded), the note flips to the reset-and-rebuild celebration.
+    private var previewState: some View {
+        VStack(spacing: 0) {
+            Orb(size: 104)
+            if planUpgraded { upgradedNote } else { previewNote }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .offset(y: -18)   // the orb rides a touch higher to make room for the note
+    }
+
+    @ViewBuilder private var previewNote: some View {
+        Text("This is a preview of Sentient.")
+            .display(24)
+            .foregroundStyle(Theme.Ink.statusInk)
+            .padding(.top, 16)
+        Text("Your knowledge base is built, private, and yours to explore.\nThe living Sentient runs on ChatGPT Plus:")
+            .font(.system(size: 13.5))
+            .foregroundStyle(Theme.secondary)
+            .multilineTextAlignment(.center)
+            .lineSpacing(4)
+            .padding(.top, 10)
+        VStack(alignment: .leading, spacing: 11) {
+            previewRow("sunrise", "Mornings where things worth doing arrive already done")
+            previewRow("command", "Sidekick anywhere: hold right \u{2318} and just say it")
+            previewRow("moon.stars", "A knowledge base that keeps learning, night after night")
+        }
+        .padding(.top, 20)
+        HStack(spacing: 14) {
+            GlowButton(title: "Get ChatGPT Plus", systemImage: "arrow.up.forward",
+                       glowIntensity: 0.5, action: { NSWorkspace.shared.open(CodexAuth.upgradeURL) })
+                .frame(width: 250)
+            quietPill("Reset Sentient…", action: openSystemPane)
+        }
+        .padding(.top, 28)
+        Text("Upgraded? Reset rebuilds your knowledge with Gmail, Calendar, and the full engine.")
+            .font(.system(size: 11.5))
+            .foregroundStyle(Theme.faint)
+            .padding(.top, 12)
+    }
+
+    /// The claim reads Plus now — the one job left is the reset, so it gets the glow.
+    @ViewBuilder private var upgradedNote: some View {
+        Text("You're on Plus. Time to go live.")
+            .display(24)
+            .foregroundStyle(Theme.Ink.statusInk)
+            .padding(.top, 16)
+        Text("Reset Sentient and it rebuilds your knowledge with Gmail and Calendar,\nthen keeps it alive: proactive mornings, Sidekick, learning night after night.")
+            .font(.system(size: 13.5))
+            .foregroundStyle(Theme.secondary)
+            .multilineTextAlignment(.center)
+            .lineSpacing(4)
+            .padding(.top, 10)
+        GlowButton(title: "Reset & Rebuild", systemImage: "arrow.clockwise",
+                   glowIntensity: 0.5, action: openSystemPane)
+            .frame(width: 250)
+            .padding(.top, 28)
+    }
+
+    private func openSystemPane() {
+        SettingsView.requestedPane = .system
+        openWindow(id: SettingsView.windowID)
+    }
+
+    private func quietPill(_ title: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 13.5, weight: .medium))
+                .foregroundStyle(Theme.Ink.bright)
+                .padding(.horizontal, 22).padding(.vertical, 12)
+                .background(Capsule().fill(.white.opacity(0.05)))
+                .overlay(Capsule().strokeBorder(.white.opacity(0.14), lineWidth: 1))
+                .contentShape(Capsule())
+        }
+        .buttonStyle(PressScaleStyle())
+    }
+
+    private func previewRow(_ icon: String, _ text: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 11) {
+            Image(systemName: icon)
+                .font(.system(size: 12))
+                .foregroundStyle(Theme.Ink.label)
+                .frame(width: 16)
+            Text(text)
+                .font(.system(size: 13.5))
+                .foregroundStyle(.white.opacity(0.78))
+        }
+    }
+
     /// A discreet DEV TOOLS handle pinned bottom-right (DX continuity from the old home; the
     /// Phase-6 Release strip re-hides it). Opens the DevToolsView sheet via RootView.
     private var devToolsOverlay: some View {
@@ -275,10 +386,12 @@ struct HomeView: View {
 
     private var bottomDock: some View {
         VStack(spacing: 16) {
-            PromptBar(onSend: { text, mode in appState.commandCoordinator.submit(text, mode: mode, source: .promptBar) },
-                      onStop: { appState.commandCoordinator.stop() },
-                      isRunning: appState.commandCoordinator.run.isRunning,
-                      statusLine: appState.commandCoordinator.run.statusLine)
+            if !kbOnly {   // knowledge-base-only mode: computer use has no quota — no command bar
+                PromptBar(onSend: { text, mode in appState.commandCoordinator.submit(text, mode: mode, source: .promptBar) },
+                          onStop: { appState.commandCoordinator.stop() },
+                          isRunning: appState.commandCoordinator.run.isRunning,
+                          statusLine: appState.commandCoordinator.run.statusLine)
+            }
             HStack(spacing: 8) {
                 Image(systemName: "shield").font(.system(size: 11)).foregroundStyle(Theme.Ink.label)
                 Text("Private by design. Your files never leave this Mac.")
@@ -823,6 +936,26 @@ private enum Demo {
     HomeView(thingsUnderstood: 3339,
              sources: .init(files: true, whatsapp: true, imessage: true, notes: true),
              modelMissing: false)
+        .frame(width: 1180, height: 880)
+}
+
+#Preview("Home — knowledge-base-only (free plan)") {
+    HomeView(thingsUnderstood: 1704,
+             sources: .init(files: true),
+             modelMissing: false,
+             realCards: true,
+             previewKBOnly: true,
+             previewUpgraded: false)
+        .frame(width: 1180, height: 880)
+}
+
+#Preview("Home — kb-only, upgrade detected") {
+    HomeView(thingsUnderstood: 1704,
+             sources: .init(files: true),
+             modelMissing: false,
+             realCards: true,
+             previewKBOnly: true,
+             previewUpgraded: true)
         .frame(width: 1180, height: 880)
 }
 

--- a/Sentient OS macOS/Views/Onboarding/OnboardingCodexSteps.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingCodexSteps.swift
@@ -134,8 +134,8 @@ struct OnboardingWhisper: View {
     }
 }
 
-/// A green-dot "this step is done" line.
-private struct OnboardingDoneLine: View {
+/// A green-dot "this step is done" line (shared: the login step and the plan crossroads).
+struct OnboardingDoneLine: View {
     let text: String
     init(_ text: String) { self.text = text }
 

--- a/Sentient OS macOS/Views/Onboarding/OnboardingPlanView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingPlanView.swift
@@ -1,0 +1,191 @@
+//
+//  OnboardingPlanView.swift
+//  Sentient OS macOS
+//
+//  The plan crossroads — the step between codex login and the ready screen, and ONLY free/go
+//  accounts ever see it: a full plan (plus/pro/team/…, or anything we can't read — fail open)
+//  auto-advances before a single pixel renders. Free/go users get an honest fork: upgrade to
+//  Plus (opens ChatGPT's pricing page, then this screen notices the upgrade on its own via
+//  CodexAuth.refreshPlan — the same on-demand token re-mint codex does every 8 days), or
+//  continue with just the knowledge base (sets CodexAuth.knowledgeBaseOnly, the app-wide
+//  limited-mode gate). This screen sets expectations; the real conversion surface is the home's
+//  post-reveal preview message, after they've seen the magic.
+//
+
+import SwiftUI
+import AppKit
+
+struct OnboardingPlanView: View {
+    let onContinue: () -> Void
+    /// Preview-only: skip the disk probe and render the crossroads for this plan.
+    var previewPlan: CodexAuth.Plan? = nil
+
+    private enum Phase { case checking, crossroads, waiting, unlocked }
+    @State private var phase: Phase = .checking
+    @State private var plan: CodexAuth.Plan?
+    @State private var checkingUpgrade = false
+    @State private var statusLine: String?
+
+    private var planName: String { plan?.displayName ?? "Free" }
+
+    var body: some View {
+        VStack(spacing: 40) {
+            Spacer()
+
+            switch phase {
+            case .checking:
+                Color.clear.frame(height: 1)   // invisible: full plans skip this screen entirely
+
+            case .crossroads:
+                OnboardingWhisper("YOUR CHATGPT PLAN · \(planName.uppercased())")
+
+                Text("\(planName) covers a taste.")
+                    .display(30)
+                    .foregroundStyle(Theme.Ink.bright)
+
+                Text("Your plan includes just enough Codex to build your knowledge base once, from what's on this Mac. The rest of Sentient, mornings where things are already done, Gmail and Calendar awareness, an assistant that keeps learning, runs on ChatGPT Plus.")
+                    .font(.system(size: 15))
+                    .foregroundStyle(Theme.secondary)
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(4)
+                    .frame(maxWidth: 560)
+
+                VStack(spacing: 18) {
+                    GlowButton(title: "Upgrade on ChatGPT",
+                               systemImage: "arrow.up.forward",
+                               action: openUpgrade)
+                        .frame(maxWidth: 380)
+                    continueFreeButton
+                }
+
+            case .waiting:
+                OnboardingWhisper("YOUR CHATGPT PLAN · \(planName.uppercased())")
+
+                Text("Finish upgrading in your browser.\nThis screen notices on its own.")
+                    .font(.system(size: 15))
+                    .foregroundStyle(Theme.secondary)
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(4)
+
+                VStack(spacing: 16) {
+                    HStack(spacing: 8) {
+                        ProgressView().controlSize(.mini)
+                        Text("waiting for your upgrade…")
+                            .font(.system(size: 11, weight: .medium, design: .monospaced))
+                            .kerning(1.5)
+                            .foregroundStyle(Theme.faint)
+                    }
+                    OnboardingNextButton(title: checkingUpgrade ? "Checking…" : "I've upgraded",
+                                         enabled: !checkingUpgrade) {
+                        check(manual: true)
+                    }
+                    if let statusLine {
+                        Text(statusLine)
+                            .font(.system(.caption2, design: .monospaced))
+                            .foregroundStyle(Theme.secondary)
+                            .multilineTextAlignment(.center)
+                            .frame(maxWidth: 480)
+                    }
+                    continueFreeButton
+                        .padding(.top, 8)
+                }
+
+            case .unlocked:
+                OnboardingWhisper("YOUR CHATGPT PLAN · \(planName.uppercased())")
+                OnboardingDoneLine("\(planName) unlocked. Welcome to the full Sentient.")
+            }
+
+            Spacer()
+
+            OnboardingTrustFooter()
+        }
+        .padding(40)
+        .task {
+            // The silent gate: read the claim off disk (no network). Anything but a positive
+            // free/go read means this screen isn't for them.
+            let current = previewPlan ?? CodexAuth.currentPlan()
+            plan = current
+            if current?.tier == .limited {
+                Analytics.signal("PlanGate.shown", parameters: ["plan": current?.raw ?? "unknown"])
+                withAnimation(.easeInOut(duration: 0.25)) { phase = .crossroads }
+            } else {
+                CodexAuth.knowledgeBaseOnly = false
+                onContinue()
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            // Back from the browser — quietly re-check. Silent when still free (they may just
+            // be reading the pricing page); only the manual button reports a "still free" result.
+            if phase == .waiting { check() }
+        }
+    }
+
+    // MARK: Actions
+
+    private func openUpgrade() {
+        NSWorkspace.shared.open(CodexAuth.upgradeURL)
+        statusLine = nil
+        withAnimation(.easeInOut(duration: 0.25)) { phase = .waiting }
+    }
+
+    /// The upgrade check — CodexAuth.refreshPlan re-mints the token so a just-paid upgrade shows
+    /// up immediately (the claim on disk would otherwise lag on codex's 8-day timer). Single
+    /// in-flight; focus-return calls stay quiet on failure, the manual button explains itself.
+    private func check(manual: Bool = false) {
+        guard !checkingUpgrade else { return }
+        checkingUpgrade = true
+        if manual { statusLine = nil }
+        Task {
+            defer { checkingUpgrade = false }
+            do {
+                let fresh = try await CodexAuth.refreshPlan()
+                if let fresh { plan = fresh }
+                if fresh?.tier != .limited {
+                    CodexAuth.knowledgeBaseOnly = false
+                    Analytics.signal("PlanGate.upgraded")
+                    withAnimation(.easeInOut(duration: 0.3)) { phase = .unlocked }
+                    try? await Task.sleep(for: .seconds(1.4))
+                    onContinue()
+                } else if manual {
+                    statusLine = "Still seeing \(fresh?.displayName ?? planName) on your account. It can take a minute after paying; try again shortly."
+                }
+            } catch {
+                if manual { statusLine = "Couldn't check right now; try again in a moment." }
+            }
+        }
+    }
+
+    /// The quiet escape hatch — free users still get the knowledge base, honestly framed.
+    private var continueFreeButton: some View {
+        Button {
+            CodexAuth.knowledgeBaseOnly = true
+            Analytics.signal("PlanGate.continuedFree")
+            onContinue()
+        } label: {
+            Text("Continue with just the knowledge base")
+                .font(.system(size: 13))
+                .foregroundStyle(Theme.faint)
+                .underline(true, color: Theme.stroke)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(PressScaleStyle())
+    }
+}
+
+#Preview("Onboarding — plan crossroads (Free)") {
+    ZStack {
+        Theme.bg.ignoresSafeArea()
+        OnboardingPlanView(onContinue: {}, previewPlan: CodexAuth.Plan(raw: "free"))
+    }
+    .frame(width: 1180, height: 880)
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Onboarding — plan crossroads (Go)") {
+    ZStack {
+        Theme.bg.ignoresSafeArea()
+        OnboardingPlanView(onContinue: {}, previewPlan: CodexAuth.Plan(raw: "go"))
+    }
+    .frame(width: 1180, height: 880)
+    .preferredColorScheme(.dark)
+}

--- a/Sentient OS macOS/Views/Onboarding/OnboardingPlanView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingPlanView.swift
@@ -43,12 +43,23 @@ struct OnboardingPlanView: View {
                     .display(26)
                     .foregroundStyle(Theme.Ink.bright)
 
-                Text("Sentient uses your ChatGPT plan's Codex frontier model for a small part of its compute. You can still build your private knowledge base from this Mac and offer it to your AIs. But to use all of Sentient, proactive mornings, Sidekick, Gmail and Calendar, a knowledge base that keeps learning, you'll need ChatGPT Plus.")
-                    .font(.system(size: 15))
-                    .foregroundStyle(Theme.secondary)
-                    .multilineTextAlignment(.center)
-                    .lineSpacing(4)
-                    .frame(maxWidth: 580)
+                VStack(spacing: 6) {
+                    Text("Sentient uses your ChatGPT plan's Codex frontier model for a small part of its compute.")
+                    Text("You can still build your private knowledge base from this Mac and offer it to your AIs.")
+                }
+                .font(.system(size: 14.5))
+                .foregroundStyle(Theme.secondary)
+                .multilineTextAlignment(.center)
+                .lineSpacing(4)
+                .frame(maxWidth: 620)
+
+                VStack(alignment: .leading, spacing: 11) {
+                    MonoCaps("With ChatGPT Plus", size: 9, tracking: 2.2, color: Theme.Ink.label)
+                        .padding(.bottom, 3)
+                    featureRow("sunrise", "Proactive mornings: things worth doing, already done")
+                    featureRow("command", "Sidekick anywhere: hold right \u{2318} and just say it")
+                    featureRow("moon.stars", "Gmail, Calendar, and a knowledge base that keeps learning")
+                }
 
                 VStack(spacing: 18) {
                     GlowButton(title: "Upgrade on ChatGPT",
@@ -155,20 +166,25 @@ struct OnboardingPlanView: View {
         }
     }
 
-    /// The quiet escape hatch — free users still get the knowledge base, honestly framed.
+    /// The escape hatch — a real (grey) button, visible without competing with the glow CTA.
     private var continueFreeButton: some View {
-        Button {
+        QuietPillButton(title: "Continue with just the knowledge base") {
             CodexAuth.knowledgeBaseOnly = true
             Analytics.signal("PlanGate.continuedFree")
             onContinue()
-        } label: {
-            Text("Continue with just the knowledge base")
-                .font(.system(size: 13))
-                .foregroundStyle(Theme.faint)
-                .underline(true, color: Theme.stroke)
-                .contentShape(Rectangle())
         }
-        .buttonStyle(PressScaleStyle())
+    }
+
+    private func featureRow(_ icon: String, _ text: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 11) {
+            Image(systemName: icon)
+                .font(.system(size: 12))
+                .foregroundStyle(Theme.Ink.label)
+                .frame(width: 16)
+            Text(text)
+                .font(.system(size: 13.5))
+                .foregroundStyle(.white.opacity(0.78))
+        }
     }
 }
 

--- a/Sentient OS macOS/Views/Onboarding/OnboardingPlanView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingPlanView.swift
@@ -39,16 +39,16 @@ struct OnboardingPlanView: View {
             case .crossroads:
                 OnboardingWhisper("YOUR CHATGPT PLAN · \(planName.uppercased())")
 
-                Text("\(planName) covers a taste.")
-                    .display(30)
+                Text("We noticed you're not on ChatGPT Plus.")
+                    .display(26)
                     .foregroundStyle(Theme.Ink.bright)
 
-                Text("Your plan includes just enough Codex to build your knowledge base once, from what's on this Mac. The rest of Sentient, mornings where things are already done, Gmail and Calendar awareness, an assistant that keeps learning, runs on ChatGPT Plus.")
+                Text("Sentient uses your ChatGPT plan's Codex frontier model for a small part of its compute. You can still build your private knowledge base from this Mac and offer it to your AIs. But to use all of Sentient, proactive mornings, Sidekick, Gmail and Calendar, a knowledge base that keeps learning, you'll need ChatGPT Plus.")
                     .font(.system(size: 15))
                     .foregroundStyle(Theme.secondary)
                     .multilineTextAlignment(.center)
                     .lineSpacing(4)
-                    .frame(maxWidth: 560)
+                    .frame(maxWidth: 580)
 
                 VStack(spacing: 18) {
                     GlowButton(title: "Upgrade on ChatGPT",

--- a/Sentient OS macOS/Views/Onboarding/OnboardingPlanView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingPlanView.swift
@@ -44,7 +44,7 @@ struct OnboardingPlanView: View {
                     .foregroundStyle(Theme.Ink.bright)
 
                 VStack(spacing: 6) {
-                    Text("Sentient uses your ChatGPT plan's Codex frontier model for a small part of its compute.")
+                    Text("Right now, Sentient uses your ChatGPT plan's Codex frontier model for a small part of its compute.")
                     Text("You can still build your private knowledge base from this Mac and offer it to your AIs.")
                 }
                 .font(.system(size: 14.5))

--- a/Sentient OS macOS/Views/Onboarding/OnboardingPlanView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingPlanView.swift
@@ -43,15 +43,16 @@ struct OnboardingPlanView: View {
                     .display(26)
                     .foregroundStyle(Theme.Ink.bright)
 
+                // Two balanced single lines (no width cap — each takes its natural width, so
+                // neither ever wraps into an orphan on a normal window).
                 VStack(spacing: 6) {
-                    Text("Right now, Sentient uses your ChatGPT plan's Codex frontier model for a small part of its compute.")
+                    Text("Right now, Sentient's cloud thinking runs through your ChatGPT plan's Codex frontier model.")
                     Text("You can still build your private knowledge base from this Mac and offer it to your AIs.")
                 }
                 .font(.system(size: 14.5))
                 .foregroundStyle(Theme.secondary)
                 .multilineTextAlignment(.center)
                 .lineSpacing(4)
-                .frame(maxWidth: 620)
 
                 VStack(alignment: .leading, spacing: 11) {
                     MonoCaps("With ChatGPT Plus", size: 9, tracking: 2.2, color: Theme.Ink.label)

--- a/Sentient OS macOS/Views/Onboarding/OnboardingPlanView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingPlanView.swift
@@ -46,7 +46,7 @@ struct OnboardingPlanView: View {
                 // Two balanced single lines (no width cap — each takes its natural width, so
                 // neither ever wraps into an orphan on a normal window).
                 VStack(spacing: 6) {
-                    Text("Right now, Sentient's cloud thinking runs through your ChatGPT plan's Codex frontier model.")
+                    Text("Right now, Sentient uses your ChatGPT plan's Codex frontier model for a small part of its compute.")
                     Text("You can still build your private knowledge base from this Mac and offer it to your AIs.")
                 }
                 .font(.system(size: 14.5))

--- a/Sentient OS macOS/Views/Onboarding/OnboardingReadyView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingReadyView.swift
@@ -74,8 +74,10 @@ struct OnboardingReadyView: View {
                     }
                     SourceChip("iMessage", on: runIMessage && !imessageCSV.isEmpty) { showIMessagePicker = true }
                     SourceChip("Notes",    on: runNotes) { runNotes.toggle() }
-                    SourceChip("Gmail",    on: gmailConnected && runGmail)       { showGmailConnect = true }
-                    SourceChip("Calendar", on: calendarConnected && runCalendar) { showCalendarConnect = true }
+                    SourceChip("Gmail",    on: gmailConnected && runGmail,
+                               locked: CodexAuth.knowledgeBaseOnly) { showGmailConnect = true }
+                    SourceChip("Calendar", on: calendarConnected && runCalendar,
+                               locked: CodexAuth.knowledgeBaseOnly) { showCalendarConnect = true }
                 }
                 if folderCount < 3 {
                     MonoCaps("keep at least 3 folders on", size: 8.5, tracking: 1.6, color: Theme.Ink.amber)

--- a/Sentient OS macOS/Views/Onboarding/OnboardingReadyView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingReadyView.swift
@@ -7,8 +7,9 @@
 //  keys and the SAME picker/connect sheets — so this IS the real selection (it persists and
 //  feeds the 3am run too), styled to make connecting sources feel like the main event: we WANT
 //  a bunch connected before the first analysis. Desktop, Documents, and Downloads ship armed;
-//  at least 3 CONNECTORS must be armed to start (SourceSelection.connectorCount — the same rule
-//  Settings enforces; all folders together count as one). The big Start Analysis button
+//  at least 4 SELECTIONS must be armed to start (SourceSelection.selectionCount — the same rule
+//  Settings enforces; every folder/chat/notes/connector counts as one), so the default three
+//  folders alone never light the button. The big Start Analysis button
 //  fires the exact run the home's Analyze Now fires, but wears the full-brightness glow (the
 //  popover's copy is deliberately subdued).
 //
@@ -44,9 +45,10 @@ struct OnboardingReadyView: View {
     private var whatsappChats: Set<String> { Set(whatsappCSV.split(separator: ",").map(String.init)) }
     private var imessageChats: Set<String> { Set(imessageCSV.split(separator: ",").map(String.init)) }
 
-    /// The min-3 rule counts CONNECTORS, exactly like Settings (all folders together = one).
-    private var connectorCount: Int { SourceSelection.connectorCount }
-    private var canStart: Bool { connectorCount >= 3 && !modelMissing }
+    /// The shared minimum: at least 4 SELECTIONS (each folder, chat source, Notes, or connector
+    /// counts as one) — the three default folders alone deliberately don't light the button.
+    private var selectionCount: Int { SourceSelection.selectionCount }
+    private var canStart: Bool { selectionCount >= SourceSelection.minimumSelections && !modelMissing }
 
     var body: some View {
         VStack(spacing: 40) {
@@ -100,8 +102,8 @@ struct OnboardingReadyView: View {
                         }
                     }
                 }
-                if connectorCount < 3 {
-                    MonoCaps("keep at least 3 connectors on", size: 8.5, tracking: 1.6, color: Theme.Ink.amber)
+                if selectionCount < SourceSelection.minimumSelections {
+                    MonoCaps("keep at least 4 sources on", size: 8.5, tracking: 1.6, color: Theme.Ink.amber)
                 }
             }
             .frame(width: 640)

--- a/Sentient OS macOS/Views/Onboarding/OnboardingReadyView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingReadyView.swift
@@ -2,12 +2,14 @@
 //  OnboardingReadyView.swift
 //  Sentient OS macOS
 //
-//  Onboarding's final step — "ready to process". The source chips write the SAME dbg.run.* keys
-//  and open the SAME picker/connect sheets the Analysis popover uses, so this IS the real
-//  selection (it persists and feeds the 3am run too). Desktop, Documents, and Downloads ship
-//  armed; at least 3 FOLDERS must stay armed (apps are extra on top). The big Start Analysis
-//  button fires the exact run the home's Analyze Now fires, but wears the full-brightness glow
-//  (the popover's copy is deliberately subdued).
+//  Onboarding's final step — "ready to process". The source tiles are the SAME Settings-grade
+//  groups (SettingsGroup + SettingsChip) the Knowledge Sources pane uses, on the SAME dbg.run.*
+//  keys and the SAME picker/connect sheets — so this IS the real selection (it persists and
+//  feeds the 3am run too), styled to make connecting sources feel like the main event: we WANT
+//  a bunch connected before the first analysis. Desktop, Documents, and Downloads ship armed;
+//  at least 3 FOLDERS must stay armed (apps are extra on top). The big Start Analysis button
+//  fires the exact run the home's Analyze Now fires, but wears the full-brightness glow (the
+//  popover's copy is deliberately subdued).
 //
 
 import SwiftUI
@@ -38,6 +40,8 @@ struct OnboardingReadyView: View {
     @State private var showCalendarConnect = false
 
     private var customRoots: [URL] { CustomRoots.decode(customRootsRaw) }
+    private var whatsappChats: Set<String> { Set(whatsappCSV.split(separator: ",").map(String.init)) }
+    private var imessageChats: Set<String> { Set(imessageCSV.split(separator: ",").map(String.init)) }
 
     /// The min-3 rule counts FOLDERS only (defaults + custom); apps are extra on top.
     private var folderCount: Int {
@@ -51,39 +55,57 @@ struct OnboardingReadyView: View {
 
             OnboardingWhisper("READY")
 
-            Text("Sentient is ready to understand your life.\nPick what it can read. Everything stays on this Mac.")
+            Text("Sentient is ready to understand your life.\nConnect as much as you can; everything stays on this Mac.")
                 .font(.system(size: 15))
                 .foregroundStyle(Theme.secondary)
                 .multilineTextAlignment(.center)
                 .lineSpacing(4)
 
-            VStack(alignment: .leading, spacing: 10) {
-                MonoCaps("Sources", size: 9, tracking: 2.2, color: Theme.Ink.label)
-                HStack(spacing: 8) {
-                    SourceChip("Desktop",   on: runDesktop)   { runDesktop.toggle() }
-                    SourceChip("Documents", on: runDocuments) { runDocuments.toggle() }
-                    SourceChip("Downloads", on: runDownloads) { runDownloads.toggle() }
-                    ForEach(customRoots, id: \.self) { url in
-                        SourceChip(url.lastPathComponent, on: true) { CustomRoots.remove(url) }
+            // The Settings-grade source groups (same components as the Knowledge Sources pane) —
+            // connecting sources IS this screen's main event, so the tiles get real presence.
+            VStack(alignment: .leading, spacing: 26) {
+                SettingsGroup(label: "Folders") {
+                    ChipFlow {
+                        SettingsChip(label: "Desktop", on: runDesktop) { runDesktop.toggle() }
+                        SettingsChip(label: "Documents", on: runDocuments) { runDocuments.toggle() }
+                        SettingsChip(label: "Downloads", on: runDownloads) { runDownloads.toggle() }
+                        ForEach(customRoots, id: \.self) { url in
+                            SettingsChip(label: url.lastPathComponent, detail: "✕", on: true) {
+                                CustomRoots.remove(url)
+                            }
+                        }
+                        SettingsChip(label: "+ Add Folder", on: false, isAction: true) { addFolder() }
                     }
-                    SourceChip("+ Add Folder", on: false, action: addFolder)
                 }
-                HStack(spacing: 8) {
-                    if WhatsAppSource.isInstalled {
-                        SourceChip("WhatsApp", on: runWhatsApp && !whatsappCSV.isEmpty) { showWhatsAppPicker = true }
+                SettingsGroup(label: "Chats & Notes") {
+                    ChipFlow {
+                        if WhatsAppSource.isInstalled {
+                            SettingsChip(label: "WhatsApp",
+                                         detail: whatsappChats.isEmpty ? nil : "\(whatsappChats.count) chats",
+                                         on: runWhatsApp && !whatsappChats.isEmpty) { showWhatsAppPicker = true }
+                        }
+                        SettingsChip(label: "iMessage",
+                                     detail: imessageChats.isEmpty ? nil : "\(imessageChats.count) chats",
+                                     on: runIMessage && !imessageChats.isEmpty) { showIMessagePicker = true }
+                        SettingsChip(label: "Apple Notes", on: runNotes) { runNotes.toggle() }
                     }
-                    SourceChip("iMessage", on: runIMessage && !imessageCSV.isEmpty) { showIMessagePicker = true }
-                    SourceChip("Notes",    on: runNotes) { runNotes.toggle() }
-                    SourceChip("Gmail",    on: gmailConnected && runGmail,
-                               locked: CodexAuth.knowledgeBaseOnly) { showGmailConnect = true }
-                    SourceChip("Calendar", on: calendarConnected && runCalendar,
-                               locked: CodexAuth.knowledgeBaseOnly) { showCalendarConnect = true }
+                }
+                SettingsGroup(label: "Through Your ChatGPT") {
+                    VStack(alignment: .leading, spacing: 12) {
+                        SettingsProse("Read through your own connectors, never our servers.")
+                        ChipFlow {
+                            SettingsChip(label: "Gmail", on: gmailConnected && runGmail,
+                                         locked: CodexAuth.knowledgeBaseOnly) { showGmailConnect = true }
+                            SettingsChip(label: "Google Calendar", on: calendarConnected && runCalendar,
+                                         locked: CodexAuth.knowledgeBaseOnly) { showCalendarConnect = true }
+                        }
+                    }
                 }
                 if folderCount < 3 {
                     MonoCaps("keep at least 3 folders on", size: 8.5, tracking: 1.6, color: Theme.Ink.amber)
-                        .padding(.top, 2)
                 }
             }
+            .frame(width: 640)
 
             GlowButton(title: "Start Analysis", active: canStart, action: onStart)
                 .frame(maxWidth: 380)

--- a/Sentient OS macOS/Views/Onboarding/OnboardingReadyView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingReadyView.swift
@@ -7,7 +7,8 @@
 //  keys and the SAME picker/connect sheets — so this IS the real selection (it persists and
 //  feeds the 3am run too), styled to make connecting sources feel like the main event: we WANT
 //  a bunch connected before the first analysis. Desktop, Documents, and Downloads ship armed;
-//  at least 3 FOLDERS must stay armed (apps are extra on top). The big Start Analysis button
+//  at least 3 CONNECTORS must be armed to start (SourceSelection.connectorCount — the same rule
+//  Settings enforces; all folders together count as one). The big Start Analysis button
 //  fires the exact run the home's Analyze Now fires, but wears the full-brightness glow (the
 //  popover's copy is deliberately subdued).
 //
@@ -43,11 +44,9 @@ struct OnboardingReadyView: View {
     private var whatsappChats: Set<String> { Set(whatsappCSV.split(separator: ",").map(String.init)) }
     private var imessageChats: Set<String> { Set(imessageCSV.split(separator: ",").map(String.init)) }
 
-    /// The min-3 rule counts FOLDERS only (defaults + custom); apps are extra on top.
-    private var folderCount: Int {
-        [runDownloads, runDesktop, runDocuments].count(where: { $0 }) + customRoots.count
-    }
-    private var canStart: Bool { folderCount >= 3 && !modelMissing }
+    /// The min-3 rule counts CONNECTORS, exactly like Settings (all folders together = one).
+    private var connectorCount: Int { SourceSelection.connectorCount }
+    private var canStart: Bool { connectorCount >= 3 && !modelMissing }
 
     var body: some View {
         VStack(spacing: 40) {
@@ -101,8 +100,8 @@ struct OnboardingReadyView: View {
                         }
                     }
                 }
-                if folderCount < 3 {
-                    MonoCaps("keep at least 3 folders on", size: 8.5, tracking: 1.6, color: Theme.Ink.amber)
+                if connectorCount < 3 {
+                    MonoCaps("keep at least 3 connectors on", size: 8.5, tracking: 1.6, color: Theme.Ink.amber)
                 }
             }
             .frame(width: 640)

--- a/Sentient OS macOS/Views/Onboarding/OnboardingView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingView.swift
@@ -4,6 +4,7 @@
 //
 //  First-launch onboarding: three intro slides (placeholder boxes for now — real design comes
 //  later), then permissions (OnboardingPermissionsView), then codex login (OnboardingCodexSteps),
+//  then the plan crossroads (OnboardingPlanView — free/go accounts only; full plans skip it),
 //  then the ready-to-process screen (OnboardingReadyView) whose Start Analysis presents the REAL
 //  ProcessingView takeover (pausable) — and only a finished run calls `onFinished` and reveals
 //  the home. The current step persists (UserDefaults "onboarding.step") so a quit-and-relaunch
@@ -46,6 +47,10 @@ struct OnboardingView: View {
                 OnboardingPermissionsView(onContinue: advance).transition(.opacity)
             case Self.slideCount + 1:
                 OnboardingCodexLoginView(onContinue: advance).transition(.opacity)
+            case Self.slideCount + 2:
+                // The plan crossroads — free/go accounts decide here; full plans skip it
+                // before it renders (OnboardingPlanView auto-advances).
+                OnboardingPlanView(onContinue: advance).transition(.opacity)
             default:
                 if analyzing, let modelPath = Self.modelPath {
                     // The REAL first analysis — the same engine + takeover as the home's Analyze
@@ -86,7 +91,11 @@ struct OnboardingView: View {
     }
 
     private func goBack() {
-        withAnimation(.easeInOut(duration: 0.25)) { step = max(0, step - 1) }
+        var target = step - 1
+        // The crossroads only exists for free/go accounts — never strand a full plan on an
+        // auto-advancing screen (back would visibly bounce forward again).
+        if target == Self.slideCount + 2 && !CodexAuth.isLimited() { target -= 1 }
+        withAnimation(.easeInOut(duration: 0.25)) { step = max(0, target) }
     }
 
     // MARK: The three intro slides (placeholders)

--- a/Sentient OS macOS/Views/Onboarding/OnboardingView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingView.swift
@@ -19,6 +19,9 @@ import SwiftUI
 struct OnboardingView: View {
     let onFinished: () -> Void
 
+    /// For the DEBUG skip handle only — the quiet flag flip, no finale.
+    @Environment(AppState.self) private var appState
+
     /// Persisted so a relaunch mid-onboarding (the FDA grant needs one) resumes at the same step.
     @AppStorage("onboarding.step") private var step = 0
     private static let slideCount = 3
@@ -90,6 +93,33 @@ struct OnboardingView: View {
                     .transition(.opacity)
             }
         }
+        // DEV-ONLY: skip straight to the home (testing relaunches land back in onboarding until
+        // a full first analysis flips the flag). Quietly marks onboarding complete — deliberately
+        // NOT onFinished, so the Constellation finale stays reserved for the real finish.
+        // Compile-gated out of Release entirely.
+        #if DEBUG
+        .overlay(alignment: .bottomTrailing) {
+            if !analyzing {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.3)) { appState.hasCompletedOnboarding = true }
+                } label: {
+                    HStack(spacing: 5) {
+                        Image(systemName: "forward.end").font(.system(size: 8.5))
+                        Text("SKIP TO HOME")
+                            .font(.system(size: 9, weight: .medium, design: .monospaced)).tracking(1.6)
+                    }
+                    .foregroundStyle(Theme.Ink.deepMuted)
+                    .padding(.horizontal, 10).padding(.vertical, 5)
+                    .overlay(Capsule().strokeBorder(Color.white.opacity(0.07), lineWidth: 1))
+                    .contentShape(Capsule())
+                }
+                .buttonStyle(.plain)
+                .opacity(0.6)
+                .padding(.trailing, 22).padding(.bottom, 13)
+                .transition(.opacity)
+            }
+        }
+        #endif
     }
 
     /// Two minutes into the first analysis, bootstrap codex computer use (setup step 3) silently

--- a/Sentient OS macOS/Views/ProcessingView.swift
+++ b/Sentient OS macOS/Views/ProcessingView.swift
@@ -85,6 +85,12 @@ struct ProcessingView: View {
     @State private var started = false
     @State private var paused = false           // pausable only: frozen at the last item, awaiting Resume
     @State private var runTask: Task<RunProgress, Never>?
+    /// Generation token — pause/stop/disappear bump it, making the (cancelled, still-draining)
+    /// run() invocation STALE: it may finish whenever it likes, but it can no longer touch the
+    /// UI or fall into the proactive tail. `paused` alone couldn't guarantee that: a quick
+    /// pause→resume flipped it back to false before the old run drained, and the stale run
+    /// then fired the knowledge-base build mid-read.
+    @State private var runGeneration = 0
     @State private var awake = DisplayAwake()   // keeps the screen on during the long first ingest
 
     var body: some View {
@@ -110,7 +116,7 @@ struct ProcessingView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .task { await startIfNeeded() }
-        .onDisappear { runTask?.cancel() }
+        .onDisappear { runGeneration += 1; runTask?.cancel() }   // stale: no tail after the view is gone
     }
 
     // MARK: States
@@ -354,24 +360,33 @@ struct ProcessingView: View {
         }
     }
 
-    /// Stop the run and return. Pointers advance per durable save, so re-running resumes.
+    /// Stop the run and return. Pointers advance per durable save, so re-running resumes. The
+    /// generation bump keeps the draining run from starting the proactive tail behind the home.
     private func stop() {
+        runGeneration += 1
         runTask?.cancel()
         onDone()
     }
 
     /// Pause (pausable/onboarding only): cancel the run and FREEZE in place — the card keeps
-    /// showing the item it stopped on. Every item commits atomically, so nothing is lost.
+    /// showing the item it stopped on. Every item commits atomically, so nothing is lost; the
+    /// generation bump makes the draining run stale (see `runGeneration`).
     private func pause() {
         paused = true
+        runGeneration += 1
         runTask?.cancel()
     }
 
     /// Resume from the durable marks — the same restart the crash-safe design gives a 3am run.
+    /// Waits for the cancelled run to finish draining FIRST, so two engines never overlap on
+    /// the GPU and the stopped item's atomic commit lands before the fresh run reads the marks.
     private func resume() {
         paused = false
         started = false
-        Task { await startIfNeeded() }
+        Task {
+            _ = await runTask?.value
+            await startIfNeeded()
+        }
     }
 
     private var percent: Int {
@@ -381,7 +396,8 @@ struct ProcessingView: View {
     // MARK: Run
 
     private func startIfNeeded() async {
-        guard !started else { return }
+        // !paused: the user re-paused while resume() was still draining the old run — they win.
+        guard !started, !paused else { return }
         started = true
         await run()
     }
@@ -391,6 +407,7 @@ struct ProcessingView: View {
     /// complete, internally-consistent snapshot, so dropping intermediate frames never desyncs the
     /// prompt pane from the card.
     private func run() async {
+        let generation = runGeneration   // this invocation's identity — stale once pause/stop bump it
         // Keep the display awake ONLY for the initial ingest — the long one. The home + 3am both run
         // `.auto`, so the honest "is this the first-ever descent" signal is the flag the 18h auto-enable
         // uses (nil until the first full cycle completes). `defer` releases on completion, failure, or
@@ -420,11 +437,14 @@ struct ProcessingView: View {
         }
         runTask = task
         for await p in stream {
+            guard generation == runGeneration else { continue }   // stale: drain silently, freeze the card
             if state == .loadingModel { withAnimation { state = .processing } }
-            if !paused { progress = p }   // paused → freeze the card at the item it stopped on
+            progress = p
         }
         let final = await task.value
-        if paused { return }              // wait for Resume; never fall through to the cycle/completed
+        // Paused, stopped, or superseded by a resume: this invocation is stale — the proactive
+        // tail (knowledge base + cycle) must ONLY ever run at the end of a live, complete read.
+        guard generation == runGeneration else { return }
         progress = final
 
         // Real-mode Analyze Now: after the read, file into the knowledge base + run all three proactive

--- a/Sentient OS macOS/Views/ProcessingView.swift
+++ b/Sentient OS macOS/Views/ProcessingView.swift
@@ -91,6 +91,12 @@ struct ProcessingView: View {
     /// pause→resume flipped it back to false before the old run drained, and the stale run
     /// then fired the knowledge-base build mid-read.
     @State private var runGeneration = 0
+    /// Counts carried across pause→resume WITHIN this takeover. The resumed engine correctly
+    /// plans only the REMAINING items (the marks are the truth), so its numbers restart — the
+    /// display composes carried + live instead, and the bar picks up where it froze (6 of 50,
+    /// never 1 of 45). In-session only: a relaunch shows the honest remaining count, exactly
+    /// like the crash-recovery resume always has.
+    @State private var carried = RunProgress()
     @State private var awake = DisplayAwake()   // keeps the screen on during the long first ingest
 
     var body: some View {
@@ -380,13 +386,42 @@ struct ProcessingView: View {
     /// Resume from the durable marks — the same restart the crash-safe design gives a 3am run.
     /// Waits for the cancelled run to finish draining FIRST, so two engines never overlap on
     /// the GPU and the stopped item's atomic commit lands before the fresh run reads the marks.
+    /// The drained run's REAL counts (it may have committed the item it was on mid-pause) fold
+    /// into `carried`, so the fresh run's numbers stack on top instead of restarting the bar.
     private func resume() {
         paused = false
         started = false
         Task {
-            _ = await runTask?.value
+            if let finished = await runTask?.value {
+                carried.done             += finished.done
+                carried.survivors        += finished.survivors
+                carried.junk             += finished.junk
+                carried.sensitive        += finished.sensitive
+                carried.failed           += finished.failed
+                carried.parseFailures    += finished.parseFailures
+                carried.extractionFailed += finished.extractionFailed
+                carried.totalSeconds     += finished.totalSeconds
+            }
             await startIfNeeded()
         }
+    }
+
+    /// Overlay a live run on the carried base: the counters add, and the total re-anchors to
+    /// carried.done + the live run's own total (which counts only what's LEFT) — so 5 done of
+    /// 50 resumes as 5 of 50, not 0 of 45. The just-processed card always shows the live item.
+    private static func composed(_ base: RunProgress, _ p: RunProgress) -> RunProgress {
+        guard base.done > 0 else { return p }
+        var c = p
+        c.done             = base.done + p.done
+        c.total            = base.done + p.total
+        c.survivors        = base.survivors + p.survivors
+        c.junk             = base.junk + p.junk
+        c.sensitive        = base.sensitive + p.sensitive
+        c.failed           = base.failed + p.failed
+        c.parseFailures    = base.parseFailures + p.parseFailures
+        c.extractionFailed = base.extractionFailed + p.extractionFailed
+        c.totalSeconds     = base.totalSeconds + p.totalSeconds
+        return c
     }
 
     private var percent: Int {
@@ -417,8 +452,12 @@ struct ProcessingView: View {
         }
         defer { awake.end() }
 
-        state = .loadingModel
-        progress = RunProgress()
+        // A resumed run keeps the frozen card + composed bar on screen while the engine reloads
+        // (the reload is real, but "Loading on-device model" + a 0% bar read as progress lost).
+        if carried.done == 0 {
+            state = .loadingModel
+            progress = RunProgress()
+        }
         let (stream, continuation) = AsyncStream.makeStream(
             of: RunProgress.self, bufferingPolicy: .bufferingNewest(1))
         let task = Task<RunProgress, Never> {
@@ -439,13 +478,13 @@ struct ProcessingView: View {
         for await p in stream {
             guard generation == runGeneration else { continue }   // stale: drain silently, freeze the card
             if state == .loadingModel { withAnimation { state = .processing } }
-            progress = p
+            progress = Self.composed(carried, p)
         }
         let final = await task.value
         // Paused, stopped, or superseded by a resume: this invocation is stale — the proactive
         // tail (knowledge base + cycle) must ONLY ever run at the end of a live, complete read.
         guard generation == runGeneration else { return }
-        progress = final
+        progress = Self.composed(carried, final)   // completion shows the whole session's counts
 
         // Real-mode Analyze Now: after the read, file into the knowledge base + run all three proactive
         // steps + wipe the summaries — surfacing each phase — then reveal the real cards on the home.

--- a/Sentient OS macOS/Views/ProcessingView.swift
+++ b/Sentient OS macOS/Views/ProcessingView.swift
@@ -78,6 +78,9 @@ struct ProcessingView: View {
     private enum UIState: Equatable { case loadingModel, processing, preparing, completed, failed(String) }
     @State private var state: UIState = .loadingModel
     @State private var prepStatus = "Preparing your suggestions…"
+    /// Phase-appropriate caption under the phase line (nil = none) — the proactive stages get
+    /// the "things worth doing" promise; the knowledge-base/welcome phases speak for themselves.
+    @State private var prepSubtext: String?
     @State private var progress = RunProgress()
     @State private var started = false
     @State private var paused = false           // pausable only: frozen at the last item, awaiting Resume
@@ -278,8 +281,10 @@ struct ProcessingView: View {
             Text(prepStatus)
                 .font(.title3.weight(.semibold)).foregroundStyle(.white)
                 .multilineTextAlignment(.center)
-            Text("Reading what's new, then preparing a few things worth doing.")
-                .font(.caption).foregroundStyle(.white.opacity(0.4))
+            if let prepSubtext {
+                Text(prepSubtext)
+                    .font(.caption).foregroundStyle(.white.opacity(0.4))
+            }
             ProgressView().tint(.white.opacity(0.4)).padding(.top, 2)
         }
     }
@@ -429,10 +434,16 @@ struct ProcessingView: View {
             let failure = await ProactiveCycle.shared.run { phase in
                 Task { @MainActor in
                     switch phase {
-                    case .knowledgeBase(let s): prepStatus = s
-                    case .deciding:             prepStatus = "Deciding what's worth doing…"
-                    case .researching(let n):   prepStatus = "Preparing \(n) suggestion\(n == 1 ? "" : "s")…"
-                    case .done, .failed:        break
+                    case .knowledgeBase(let s):
+                        prepStatus = s; prepSubtext = nil            // the phase line says it all
+                    case .deciding:
+                        prepStatus = "Deciding what's worth doing…"
+                        prepSubtext = "Reading what's new, then preparing a few things worth doing."
+                    case .researching(let n):
+                        prepStatus = "Preparing \(n) suggestion\(n == 1 ? "" : "s")…"
+                        prepSubtext = "Reading what's new, then preparing a few things worth doing."
+                    case .done, .failed:
+                        break
                     }
                 }
             }

--- a/Sentient OS macOS/Views/RootView.swift
+++ b/Sentient OS macOS/Views/RootView.swift
@@ -13,6 +13,7 @@ import SwiftUI
 
 struct RootView: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.openWindow) private var openWindow
     @State private var isProcessing = false
     @State private var showDevTools = false
     // Persistent custom folder roots (CustomRoots store) — added in Settings or Dev Tools,
@@ -40,10 +41,16 @@ struct RootView: View {
         ZStack {
             Theme.bg.ignoresSafeArea()
             if !appState.hasCompletedOnboarding {
-                // First launch → the intro slides. TEMPORARY wiring: the last slide's Next marks
-                // onboarding complete and drops into home (until the full ~10-step flow lands).
+                // First launch → onboarding, whose finished first analysis calls this closure.
+                // The finale (every plan): onboarding dissolves into the home, then the Knowledge
+                // window (the Constellation) assembles on top — the user's first sight of their
+                // knowledge base, before the cards (or the free-plan preview message) behind it.
                 OnboardingView {
                     withAnimation(.easeInOut(duration: 0.3)) { appState.hasCompletedOnboarding = true }
+                    Task {
+                        try? await Task.sleep(for: .seconds(0.6))   // let the home settle first
+                        openWindow(id: KnowledgeView.windowID)
+                    }
                 }
                 .transition(.opacity)
             } else if isProcessing, let modelPath = Self.modelPath {

--- a/Sentient OS macOS/Views/Settings/HealthPane.swift
+++ b/Sentient OS macOS/Views/Settings/HealthPane.swift
@@ -4,8 +4,9 @@
 //
 //  Settings → Permissions & Health: the health board. Live LED rows for every grant Sentient
 //  actually asks for, in severity order — SENTIENT (Full Disk Access · the overnight wake daemon ·
-//  launch-at-login · mic & speech · notifications), SET UP CODEX (CLI · account · computer use,
-//  via the shared CodexSetup engine), and CODEX PERMISSIONS (the helper's Accessibility + Screen
+//  launch-at-login · mic & speech · notifications), SET UP CODEX (CLI · account · ChatGPT plan
+//  via CodexAuth · computer use, via the shared CodexSetup engine), and CODEX PERMISSIONS (the
+//  helper's Accessibility + Screen
 //  Recording — system-TCC, status-only, shown once computer use exists). The Automation grant has
 //  NO row: it self-heals silently shortly after the pane opens (the user has no job there).
 //  Red = a core capability is broken · yellow = optional or fixable-later. When the whole codex
@@ -35,6 +36,10 @@ struct HealthPane: View {
     @State private var helperAccessibility = false
     @State private var helperScreenRecording = false
 
+    // ChatGPT plan (decoded from the user's own codex login — CodexAuth)
+    @State private var plan: CodexAuth.Plan?
+    @State private var planChecking = false
+
     @State private var showCodexSetup = false
     @State private var codexExpanded = false
     @State private var checked = false        // first full probe done (codex login check is seconds)
@@ -46,10 +51,12 @@ struct HealthPane: View {
     private var showCodexPermissions: Bool { fdaGranted && codex.computerUseReady }
 
     /// The whole codex stack, healthy — the CLI, the account, computer use, AND its two helper
-    /// grants (verifiable only with FDA; unverifiable never claims "all good").
+    /// grants (verifiable only with FDA; unverifiable never claims "all good"). A free/go plan
+    /// keeps the group expanded so its amber row stays visible.
     private var codexAllGreen: Bool {
         codex.installed && codex.loggedIn && codex.computerUseReady
             && fdaGranted && helperAccessibility && helperScreenRecording
+            && plan?.tier != .limited
     }
 
     private var allGreen: Bool {
@@ -348,6 +355,15 @@ struct HealthPane: View {
                            note: codex.loggedIn ? "logged in" : "not logged in",
                            tip: "Your own OpenAI login for Codex. The sign in happens in your browser; Sentient never sees your password.",
                            fixTitle: "Log in…") { showCodexSetup = true }
+                if codex.loggedIn, let plan {
+                    StatusLine(title: "ChatGPT plan",
+                               health: plan.tier == .limited ? .warn : .ok,
+                               note: planChecking ? "checking…"
+                                   : plan.tier == .limited ? "\(plan.displayName.lowercased()) · knowledge base only"
+                                                           : plan.displayName.lowercased(),
+                               tip: "Read from your own codex login. Free and Go plans carry a tiny monthly Codex quota and no Gmail or Calendar connectors, so Sentient runs in knowledge-base-only mode; Plus unlocks proactive mornings, Sidekick, and nightly updates. Upgraded? Re-check picks it up right away.",
+                               fixTitle: "Re-check") { recheckPlan() }
+                }
                 StatusLine(title: "Computer use",
                            health: codex.computerUseReady ? .ok : .bad,
                            note: codex.computerUseReady ? "ready" : "not set up",
@@ -401,6 +417,18 @@ struct HealthPane: View {
         }
     }
 
+    /// The "Re-check" pill on a free/go row — re-mints the token (CodexAuth.refreshPlan) so an
+    /// upgrade shows up immediately instead of on codex's 8-day timer. Failure just keeps the
+    /// current claim; the row never blocks anything.
+    private func recheckPlan() {
+        guard !planChecking else { return }
+        planChecking = true
+        Task {
+            if let fresh = try? await CodexAuth.refreshPlan() { plan = fresh }
+            planChecking = false
+        }
+    }
+
     // MARK: - Probes
 
     private func refresh() async {
@@ -412,6 +440,7 @@ struct HealthPane: View {
         notifStatus = await UNUserNotificationCenter.current().notificationSettings().authorizationStatus
         codex.refreshInstalled()
         codex.refreshComputerUse()
+        plan = CodexAuth.currentPlan()   // pure file read (the JWT claim on disk)
         if fdaGranted {
             helperAccessibility = Permissions.isTCCGranted(
                 service: "kTCCServiceAccessibility",

--- a/Sentient OS macOS/Views/Settings/HealthPane.swift
+++ b/Sentient OS macOS/Views/Settings/HealthPane.swift
@@ -295,9 +295,10 @@ struct HealthPane: View {
 
     private var notifNote: String {
         switch notifStatus {
-        case .authorized, .provisional: return "on"
-        case .notDetermined:            return "not asked yet"
-        default:                        return "off"
+        case .authorized:    return "on"
+        case .provisional:   return "quiet"   // the launch-banked provisional grant (no banners/sounds)
+        case .notDetermined: return "not asked yet"
+        default:             return "off"
         }
     }
 

--- a/Sentient OS macOS/Views/Settings/SettingsComponents.swift
+++ b/Sentient OS macOS/Views/Settings/SettingsComponents.swift
@@ -152,39 +152,51 @@ struct ChipFlow: Layout {
 /// visibly counts. The label ink is ALWAYS pure white — the dot/wash/ring carry the on/off
 /// state, never a dimmed label (dim gray on OLED black was unreadable). `detail` carries counts
 /// ("12 chats"). Pure action chips ("+ Add Folder") pass `isAction: true`: no dot, a bright
-/// dashed border — an invitation, not a source.
+/// dashed border — an invitation, not a source. `locked` (knowledge-base-only mode's
+/// Gmail/Calendar) is the one deliberate exception to the always-white rule: a lock in place of
+/// the dot, softened ink, no action — unavailable, with the hover tip explaining why.
 struct SettingsChip: View {
     let label: String
     var detail: String? = nil
     let on: Bool
     var isAction: Bool = false
+    var locked: Bool = false
     var action: (() -> Void)? = nil
 
-    var body: some View {
-        Button { action?() } label: {
+    @ViewBuilder var body: some View {
+        if locked { chip.help(CodexAuth.connectorLockedTip) } else { chip }
+    }
+
+    private var chip: some View {
+        Button { if !locked { action?() } } label: {
             HStack(spacing: 7) {
-                if !isAction {
+                if locked {
+                    Image(systemName: "lock.fill")
+                        .font(.system(size: 9))
+                        .foregroundStyle(.white.opacity(0.4))
+                } else if !isAction {
                     Circle()
                         .fill(on ? Theme.Ink.green : .white.opacity(0.4))
                         .frame(width: 5, height: 5)
                 }
                 Text(label)
                     .font(.system(size: 12, weight: on || isAction ? .medium : .regular))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(.white.opacity(locked ? 0.55 : 1))
                 if let detail {
                     Text(detail).font(.system(size: 10.5))
                         .foregroundStyle(on ? Theme.Ink.green.opacity(0.85) : .white.opacity(0.62))
                 }
             }
             .padding(.horizontal, 13).padding(.vertical, 7)
-            .background(isAction ? Color.white.opacity(0.05) : (on ? Theme.Ink.green.opacity(0.13) : Color.clear),
+            .background(isAction ? Color.white.opacity(0.05) : (on && !locked ? Theme.Ink.green.opacity(0.13) : Color.clear),
                         in: Capsule())
             .overlay {
                 if isAction {
                     Capsule().strokeBorder(Color.white.opacity(0.32),
                                            style: StrokeStyle(lineWidth: 1, dash: [4, 3]))
                 } else {
-                    Capsule().strokeBorder(on ? Theme.Ink.green.opacity(0.38) : Color.white.opacity(0.16),
+                    Capsule().strokeBorder(on && !locked ? Theme.Ink.green.opacity(0.38)
+                                                         : Color.white.opacity(locked ? 0.10 : 0.16),
                                            lineWidth: 1)
                 }
             }

--- a/Sentient OS macOS/Views/Settings/SettingsComponents.swift
+++ b/Sentient OS macOS/Views/Settings/SettingsComponents.swift
@@ -163,8 +163,19 @@ struct SettingsChip: View {
     var locked: Bool = false
     var action: (() -> Void)? = nil
 
+    @State private var lockHover = false
+
     @ViewBuilder var body: some View {
-        if locked { chip.help(CodexAuth.connectorLockedTip) } else { chip }
+        if locked {
+            chip
+                .onHover { lockHover = $0 }
+                .overlay(alignment: .top) {
+                    if lockHover { LockedChipTip().offset(y: -32) }
+                }
+                .animation(.easeInOut(duration: 0.15), value: lockHover)
+        } else {
+            chip
+        }
     }
 
     private var chip: some View {
@@ -203,6 +214,22 @@ struct SettingsChip: View {
             .contentShape(Capsule())
         }
         .buttonStyle(PressScaleStyle())
+    }
+}
+
+/// The instant hover notice on a locked (knowledge-base-only) connector chip — the system
+/// tooltip's delay made it look like there was none. Shared by SettingsChip and SourceChip.
+struct LockedChipTip: View {
+    var body: some View {
+        Text(CodexAuth.connectorLockedTip)
+            .font(.system(size: 10.5, weight: .medium))
+            .foregroundStyle(.white.opacity(0.88))
+            .padding(.horizontal, 10).padding(.vertical, 5)
+            .background(Color(white: 0.14), in: Capsule())
+            .overlay(Capsule().strokeBorder(.white.opacity(0.14), lineWidth: 1))
+            .fixedSize()
+            .allowsHitTesting(false)
+            .transition(.opacity)
     }
 }
 

--- a/Sentient OS macOS/Views/Settings/SettingsView.swift
+++ b/Sentient OS macOS/Views/Settings/SettingsView.swift
@@ -39,6 +39,11 @@ struct SettingsView: View {
         }
     }
 
+    /// One-shot deep link: set before `openWindow(id: windowID)` to land on a specific pane
+    /// (the free-plan home's "Reset Sentient…" → .system). Consumed on appear; if the window
+    /// is already open the focus just returns to it on its current pane.
+    static var requestedPane: Pane?
+
     @State private var selection: Pane = .sources
 
     var body: some View {
@@ -49,6 +54,9 @@ struct SettingsView: View {
         }
         .background(Theme.bg.ignoresSafeArea())
         .frame(minWidth: 880, minHeight: 600)
+        .onAppear {
+            if let pane = Self.requestedPane { selection = pane; Self.requestedPane = nil }
+        }
     }
 
     // MARK: - Sidebar

--- a/Sentient OS macOS/Views/Settings/SourcesPane.swift
+++ b/Sentient OS macOS/Views/Settings/SourcesPane.swift
@@ -142,8 +142,10 @@ struct SourcesPane: View {
             VStack(alignment: .leading, spacing: 12) {
                 SettingsProse("Read through your own connectors, never our servers.")
                 ChipFlow {
-                    SettingsChip(label: "Gmail", on: gmailConnected && runGmail) { showGmailConnect = true }
-                    SettingsChip(label: "Google Calendar", on: calendarConnected && runCalendar) { showCalendarConnect = true }
+                    SettingsChip(label: "Gmail", on: gmailConnected && runGmail,
+                                 locked: CodexAuth.knowledgeBaseOnly) { showGmailConnect = true }
+                    SettingsChip(label: "Google Calendar", on: calendarConnected && runCalendar,
+                                 locked: CodexAuth.knowledgeBaseOnly) { showCalendarConnect = true }
                 }
             }
         }

--- a/Sentient OS macOS/Views/Settings/SourcesPane.swift
+++ b/Sentient OS macOS/Views/Settings/SourcesPane.swift
@@ -39,18 +39,9 @@ struct SourcesPane: View {
     private var whatsappChats: Set<String> { Set(whatsappCSV.split(separator: ",").map(String.init)) }
     private var imessageChats: Set<String> { Set(imessageCSV.split(separator: ",").map(String.init)) }
 
-    /// How many CONNECTORS are on (all folders together count as one). The three-source minimum
-    /// is about breadth of life coverage, not folder count.
-    private var connectorCount: Int {
-        var n = 0
-        if runDownloads || runDesktop || runDocuments || !customRoots.isEmpty { n += 1 }
-        if runWhatsApp && !whatsappChats.isEmpty { n += 1 }
-        if runIMessage && !imessageChats.isEmpty { n += 1 }
-        if runNotes { n += 1 }
-        if gmailConnected && runGmail { n += 1 }
-        if calendarConnected && runCalendar { n += 1 }
-        return n
-    }
+    /// The shared 3-minimum rule (SourceSelection.connectorCount — onboarding's ready screen
+    /// enforces the same one). The @AppStorage copies above keep this body re-evaluating live.
+    private var connectorCount: Int { SourceSelection.connectorCount }
 
     var body: some View {
         SettingsPane(title: "Knowledge Sources",

--- a/Sentient OS macOS/Views/Settings/SourcesPane.swift
+++ b/Sentient OS macOS/Views/Settings/SourcesPane.swift
@@ -5,7 +5,7 @@
 //  Settings → Knowledge Sources: the real source picker, on the SAME keys as the Analysis
 //  popover / Dev Tools / the 3am run (SourceSelection + CustomRoots). Folder chips toggle,
 //  custom roots add/remove (persistent), WhatsApp & iMessage open the shared ChatPicker,
-//  Gmail & Calendar open their connect sheets. Enforces the three-connector minimum on direct
+//  Gmail & Calendar open their connect sheets. Enforces the four-selection minimum on direct
 //  toggles, and surfaces a fix-it line when Full Disk Access is missing.
 //
 
@@ -39,9 +39,9 @@ struct SourcesPane: View {
     private var whatsappChats: Set<String> { Set(whatsappCSV.split(separator: ",").map(String.init)) }
     private var imessageChats: Set<String> { Set(imessageCSV.split(separator: ",").map(String.init)) }
 
-    /// The shared 3-minimum rule (SourceSelection.connectorCount — onboarding's ready screen
+    /// The shared minimum rule (SourceSelection.selectionCount — onboarding's ready screen
     /// enforces the same one). The @AppStorage copies above keep this body re-evaluating live.
-    private var connectorCount: Int { SourceSelection.connectorCount }
+    private var selectionCount: Int { SourceSelection.selectionCount }
 
     var body: some View {
         SettingsPane(title: "Knowledge Sources",
@@ -49,7 +49,7 @@ struct SourcesPane: View {
             VStack(alignment: .leading, spacing: 30) {
                 // Tucked tight under the whisper so the two lines read as ONE header block,
                 // with the full 30pt group gap only after it.
-                Text("Your Sentient needs at least three sources to truly know you.")
+                Text("Your Sentient needs at least four sources to truly know you.")
                     .font(.system(size: 12.5))
                     .foregroundStyle(flashMinimum ? Theme.Ink.amber : .white.opacity(0.72))
                     .animation(.easeInOut(duration: 0.25), value: flashMinimum)
@@ -97,9 +97,9 @@ struct SourcesPane: View {
     private var foldersGroup: some View {
         SettingsGroup(label: "Folders") {
             ChipFlow {
-                SettingsChip(label: "Desktop", on: runDesktop) { toggleFolder($runDesktop) }
-                SettingsChip(label: "Downloads", on: runDownloads) { toggleFolder($runDownloads) }
-                SettingsChip(label: "Documents", on: runDocuments) { toggleFolder($runDocuments) }
+                SettingsChip(label: "Desktop", on: runDesktop) { toggleConnector($runDesktop) }
+                SettingsChip(label: "Downloads", on: runDownloads) { toggleConnector($runDownloads) }
+                SettingsChip(label: "Documents", on: runDocuments) { toggleConnector($runDocuments) }
                 ForEach(customRoots, id: \.self) { url in
                     SettingsChip(label: url.lastPathComponent, detail: "✕", on: true) {
                         CustomRoots.remove(url)
@@ -142,22 +142,13 @@ struct SourcesPane: View {
         }
     }
 
-    // MARK: - Toggle guards (the three-connector minimum)
+    // MARK: - Toggle guards (the four-selection minimum)
 
-    /// The guard fires only on the 3 → 2 drop: onboarding guarantees users start at three or
-    /// more, and a pre-onboarding dev state below three must never get trapped by the rule.
-    private var atMinimum: Bool { connectorCount == 3 }
+    /// The guard fires only on the 4 → 3 drop: onboarding guarantees users start at four or
+    /// more, and a pre-onboarding dev state below four must never get trapped by the rule.
+    private var atMinimum: Bool { selectionCount == SourceSelection.minimumSelections }
 
-    /// Toggling a folder off is guarded only when it would kill the whole FILES connector
-    /// (the last enabled folder) while at the minimum.
-    private func toggleFolder(_ flag: Binding<Bool>) {
-        if flag.wrappedValue {
-            let foldersLeft = [runDesktop, runDownloads, runDocuments].filter(\.self).count - 1
-            if foldersLeft == 0 && customRoots.isEmpty && atMinimum { return flash() }
-        }
-        flag.wrappedValue.toggle()
-    }
-
+    /// Every selection counts as one (folders included), so one guard covers every chip.
     private func toggleConnector(_ flag: Binding<Bool>) {
         if flag.wrappedValue && atMinimum { return flash() }
         flag.wrappedValue.toggle()

--- a/Sentient OS macOS/Views/Settings/SystemPane.swift
+++ b/Sentient OS macOS/Views/Settings/SystemPane.swift
@@ -20,11 +20,12 @@ struct SystemPane: View {
     @AppStorage("diagnosticsEnabled") private var crashReportsEnabled = true
     @AppStorage("analyticsEnabled") private var analyticsEnabled = true
 
+    @Environment(\.dismiss) private var dismiss   // Reset closes Settings to reveal onboarding
+
     @State private var launchAtLogin = LoginItem.isEnabled
     @State private var confirmLoginOff = false
     @State private var confirmReset = false
     @State private var resetting = false
-    @State private var resetDone = false
     @State private var activity = PipelineActivity.shared   // Reset locks while a run is active
 
     var body: some View {
@@ -133,18 +134,13 @@ struct SystemPane: View {
     private var dangerGroup: some View {
         SettingsGroup(label: "Danger Zone") {
             VStack(alignment: .leading, spacing: 10) {
-                SettingsProse("Reset erases everything Sentient has learned: the knowledge base, every summary, all suggestions, and the cloud copy your AIs read. You'll start over from scratch, including the initial processing. Your private link stays valid; the next processing run fills it again.")
+                SettingsProse("Reset erases everything Sentient has learned: the knowledge base, every summary, all suggestions, and the cloud copy your AIs read. Sentient takes you back through setup and starts over from scratch. Your private link stays valid; the next processing run fills it again.")
                 SettingsPillButton(title: resetting ? "Erasing…" : "Reset Sentient…",
                                    tint: Self.dangerRed) { confirmReset = true }
                     .disabled(resetting || activity.isRunning)
                 if activity.isRunning {
                     Text("A run is in progress. Reset unlocks when it finishes.")
                         .font(.system(size: 11)).foregroundStyle(Theme.Ink.amber)
-                }
-                if resetDone {
-                    Text("Reset complete. Sentient is a blank slate.")
-                        .font(.system(size: 11.5))
-                        .foregroundStyle(Theme.Ink.body)
                 }
             }
         }
@@ -153,13 +149,13 @@ struct SystemPane: View {
             Button("Erase Everything", role: .destructive) {
                 resetting = true
                 Task {
-                    await FactoryReset.run()
+                    await FactoryReset.run(appState: appState)
                     resetting = false
-                    resetDone = true
+                    dismiss()   // close Settings — the main window is now the start of onboarding
                 }
             }
         } message: {
-            Text("Your knowledge base and everything Sentient understood is deleted from this Mac, and the cloud copy is removed. This can't be undone; Sentient starts again from zero, beginning with the initial processing.")
+            Text("Your knowledge base and everything Sentient understood is deleted from this Mac, and the cloud copy is removed. This can't be undone; Sentient takes you back through setup, beginning with the initial processing.")
         }
     }
 }


### PR DESCRIPTION
## What

Sentient now knows the user's ChatGPT plan (decoded from their own codex login) and adapts: free/go accounts get an honest crossroads at onboarding and a scoped knowledge-base-only experience instead of a broken one.

### The plumbing
- **`Cloud/CodexAuth.swift`** — plan decode from `~/.codex/auth.json` JWT claims + on-demand token refresh (codex's own endpoint + public client id; single-flight, honors `earliest_refresh_at`, rotation-safe atomic write-back). **Verified live end-to-end**: refresh → `codex login status` → real `codex exec`, all green. Codex only re-mints tokens every 8 days on its own — this is how we notice an upgrade in seconds instead.
- Fail-open: unknown/missing plan = full experience; only a positive free/go read gates.

### Onboarding
- **`OnboardingPlanView`** (between codex login and ready): full plans auto-skip before a pixel renders; free/go see "We noticed you're not on ChatGPT Plus" + [Upgrade on ChatGPT] (browser-return auto-recheck) or the quiet "continue with just the knowledge base".
- **Ready screen**: Settings-grade source groups (Folders / Chats & Notes / Through Your ChatGPT), locked Gmail/Calendar chips with instant hover notice for free users.
- **Minimum rule**: 4 selections flat, shared home in `SourceSelection.selectionCount` (Settings unified to the same rule; `toggleFolder` special-case deleted).

### Knowledge-base-only mode (`plan.kbOnly`)
- Scheduler 18h auto-enable never fires · Sidekick never arms · `ProactiveCycle` skips decide/research (KB → mirror → gift → wipe still run) · vault build at `high` instead of `xhigh`
- Home: command bar hidden; preview note under the orb (upgrade CTA + Reset jump to Settings → System); gift envelope perches top-center above it; flips to "You're on Plus. Time to go live." once the claim reads Plus (re-checked every launch for free)

### Everyone
- Post-processing finale: onboarding → home → **Knowledge (Constellation) window opens on top**
- Health pane: "ChatGPT plan" row with Re-check (the refresh POST)
- `PlanGate.shown/upgraded/continuedFree` analytics signals

## Testing
- CodexAuth verified against a live auth.json (plus account) — decode, refresh, rotation, write-back, codex still healthy
- Full free-account onboarding walked on real hardware (Jesai, free login): crossroads → continue-free → locked chips → ready screen
- Docs update follows after final hardware sign-off