### PR TITLE
Make Sentient's Screen Recording optional (amber, never blocking)

### DIFF
--- a/Sentient OS macOS/Views/Permissions/ComputerUseGate.swift
+++ b/Sentient OS macOS/Views/Permissions/ComputerUseGate.swift
@@ -4,13 +4,14 @@
 //
 //  The first-use permission gate for everything that acts on the Mac. Every computer-use surface
 //  (the home command bar, Sidekick's hotkey, a proactive card's fire) funnels through
-//  `intercept(_:)`: while any of the four action grants is missing — Sentient's own Microphone &
-//  Speech and Screen Recording, plus the Codex Computer Use helper's Accessibility and Screen
-//  Recording — it stashes the pending action, raises the one-time setup window
-//  (ComputerUseGateView), and fires the action when the user taps Continue. Closing the window
-//  instead cancels the pending action. Shown at most once per app session; all four green means
-//  it never appears at all. Status probes reuse Permissions/VoiceCapture (the helper's grants are
-//  system-TCC, read via our FDA).
+//  `intercept(_:)`: while any REQUIRED action grant is missing — Sentient's own Microphone &
+//  Speech, plus the Codex Computer Use helper's Accessibility and Screen Recording — it stashes
+//  the pending action, raises the one-time setup window (ComputerUseGateView), and fires the
+//  action when the user taps Continue. Sentient's own Screen Recording rides along as an
+//  OPTIONAL row (screen context for Sidekick; missing it never gates anything — no grant means
+//  commands simply run text-only). Closing the window instead cancels the pending action. Shown
+//  at most once per app session; all required grants green means it never appears at all. Status
+//  probes reuse Permissions/VoiceCapture (the helper's grants are system-TCC, read via our FDA).
 //
 //  Key methods: intercept(_:) · refresh() · continueNow()
 //
@@ -33,7 +34,8 @@ final class ComputerUseGate {
     enum MicSpeechState { case granted, notAsked, denied }
     private(set) var micSpeech: MicSpeechState = .notAsked
 
-    /// Sentient's own Screen Recording — the screen context snapshot. Compulsory, not optional.
+    /// Sentient's own Screen Recording — the screen context snapshot. OPTIONAL: without it,
+    /// Sidekick runs text-only; it never gates an action.
     private(set) var sentientScreen = false
 
     /// The Codex Computer Use helper's presence + its two system-TCC grants (its hands and eyes).
@@ -41,8 +43,10 @@ final class ComputerUseGate {
     private(set) var helperAccessibility = false
     private(set) var helperScreen = false
 
-    var allGranted: Bool {
-        micSpeech == .granted && sentientScreen && helperAccessibility && helperScreen
+    /// The REQUIRED grants — what the gate holds actions for. Sentient's Screen Recording is
+    /// deliberately absent (optional row, shown but never blocking).
+    var allRequiredGranted: Bool {
+        micSpeech == .granted && helperAccessibility && helperScreen
     }
 
     // MARK: The gate
@@ -58,7 +62,7 @@ final class ComputerUseGate {
     /// this session.
     func intercept(_ action: @escaping @MainActor () -> Void) -> Bool {
         refresh()
-        guard !allGranted, !shownThisSession else { return false }
+        guard !allRequiredGranted, !shownThisSession else { return false }
         shownThisSession = true
         pending = action
         present()
@@ -97,7 +101,7 @@ final class ComputerUseGate {
     func continueNow() {
         let action = pending
         pending = nil
-        Analytics.signal("PermissionGate.continued", parameters: ["all_granted": String(allGranted)])
+        Analytics.signal("PermissionGate.continued", parameters: ["all_granted": String(allRequiredGranted)])
         dismissWindow()
         action?()
     }

--- a/Sentient OS macOS/Views/Permissions/ComputerUseGateView.swift
+++ b/Sentient OS macOS/Views/Permissions/ComputerUseGateView.swift
@@ -4,11 +4,12 @@
 //
 //  The one-time setup window's face (ComputerUseGate presents it): the four action grants as the
 //  same StatusLine rows Settings → Health uses, in two groups — SIDEKICK & PROACTIVE (Sentient's
-//  Microphone & Speech, Screen Recording) and CODEX PERMISSIONS (the helper's Accessibility,
-//  Screen Recording). Sentient's grants fix via the native system prompts; the helper's fix via
-//  PermissionGuide's floating drag panel (they're system-TCC — only the user can flip them).
-//  Continue fires the held action whether or not everything is green; the rows re-probe when the
-//  app foregrounds (returning from System Settings).
+//  Microphone & Speech, plus its OPTIONAL Screen Recording — amber, never blocking) and CODEX
+//  PERMISSIONS (the helper's Accessibility, Screen Recording). Mic & Speech fix via the native
+//  system prompts; the other three fix via PermissionGuide's floating drag panel (they're
+//  system-TCC lists — only the user can flip them). Continue fires the held action whether or
+//  not everything is green; the rows re-probe when the app foregrounds (returning from System
+//  Settings).
 //
 
 import SwiftUI
@@ -29,7 +30,7 @@ struct ComputerUseGateView: View {
                 .frame(maxWidth: .infinity)
                 .padding(.top, 18)
 
-            Text("Acting on your Mac needs these four grants, once. You will not be asked again.")
+            Text("Acting on your Mac needs these grants, once. You will not be asked again.")
                 .font(.system(size: 12.5))
                 .foregroundStyle(Theme.secondary)
                 .frame(maxWidth: .infinity)
@@ -47,9 +48,9 @@ struct ComputerUseGateView: View {
                             fixMicSpeech()
                         }
                         StatusLine(title: "Screen Recording",
-                                   health: gate.sentientScreen ? .ok : .bad,
-                                   note: gate.sentientScreen ? "granted" : "not granted",
-                                   tip: "Lets Sentient snap a still of your screen the moment you fire a command, so it can see the thing you're asking about. Takes effect after you restart Sentient.",
+                                   health: gate.sentientScreen ? .ok : .warn,   // optional — amber, never blocking
+                                   note: gate.sentientScreen ? "granted" : "optional",
+                                   tip: "Optional. Lets Sentient snap a still of your screen the moment you fire a command, so it can see the thing you're asking about. Without it, commands run without screen context. Takes effect after you restart Sentient.",
                                    fixTitle: "Allow…") {
                             fixSentientScreen()
                         }
@@ -77,7 +78,7 @@ struct ComputerUseGateView: View {
             }
             .padding(.top, 30)
 
-            OnboardingNextButton(title: gate.allGranted ? "Continue" : "Continue anyway") {
+            OnboardingNextButton(title: gate.allRequiredGranted ? "Continue" : "Continue anyway") {
                 gate.continueNow()
             }
             .frame(maxWidth: .infinity)

--- a/Sentient OS macOS/Views/Settings/HealthPane.swift
+++ b/Sentient OS macOS/Views/Settings/HealthPane.swift
@@ -175,9 +175,9 @@ struct HealthPane: View {
                 }
                 .rise(3, revealed: revealed)
                 StatusLine(title: "Screen Recording",
-                           health: screenRec ? .ok : .bad,   // compulsory — Sidekick is half-blind without it
-                           note: screenRec ? "granted" : "not granted",
-                           tip: "Lets Sidekick snap a still of your screen the moment you summon it, so it can see the thing you're asking about (\u{201C}finish this\u{201D}, \u{201C}reply to this\u{201D}). Without it, Sidekick may not know which open app to start controlling to help you. Takes effect after you restart Sentient.",
+                           health: screenRec ? .ok : .warn,   // optional — Sidekick runs text-only without it
+                           note: screenRec ? "granted" : "optional",
+                           tip: "Optional. Lets Sidekick snap a still of your screen the moment you summon it, so it can see the thing you're asking about (\u{201C}finish this\u{201D}, \u{201C}reply to this\u{201D}). Without it, Sidekick may not know which open app to start controlling to help you. Takes effect after you restart Sentient.",
                            fixTitle: "Allow…") {
                     fixScreenRecording()
                 }


### PR DESCRIPTION
## What

Sentient's own Screen Recording grant is now **optional** across the permission surfaces (follow-up to #126, per the to-do "make screen rec optional"):

- **First-use gate**: the popup now holds actions only while a *required* grant is missing (Mic & Speech + the Codex helper's Accessibility/Screen Recording). Sentient's Screen Recording shows as an amber row with an `optional` note — missing it never triggers the gate or blocks a fire; commands just run text-only (`ScreenCapture` already degrades gracefully).
- **Continue button** reads "Continue" (not "Continue anyway") when only the optional row is amber.
- **Settings → Health**: same amber treatment + "Optional." tip copy.
- The drag-guide Allow flow is unchanged for users who do grant it.

Isolated build green. No behavior change for the three required grants.

https://claude.ai/code/session_0161f95wN1oMXG2FPRhzQrtk