### PR TITLE
Kill the stray Input Monitoring request (flagsChanged-only tap)

### DIFF
--- a/Sentient OS macOS/Notch Magic/CommandCoordinator.swift
+++ b/Sentient OS macOS/Notch Magic/CommandCoordinator.swift
@@ -61,12 +61,10 @@ final class CommandCoordinator {
         hotkey.onPress = { [weak self] in self?.voicePressBegan() }
         hotkey.onHoldConfirmed = { [weak self] in self?.voiceHoldConfirmed() }
         hotkey.onRelease = { [weak self] held in self?.voiceReleased(held: held) }
-        // Global Esc → cancel/dismiss the notch. Skips .typing: that's owned by the window's LOCAL key
-        // monitor, which can consume Esc before the text field (no beep) — here we'd only race it.
-        hotkey.onEscape = { [weak self] in
-            guard let self, self.phase != .typing else { return }
-            self.cancelCurrent()
-        }
+        // No global Esc: a keyDown tap is exactly what Input Monitoring gates, so the monitor
+        // listens to modifiers only. Esc still cancels via the window's LOCAL monitor whenever
+        // Sentient itself is frontmost; over other apps, a fresh right-⌘ press is the cancel
+        // (see voicePressBegan).
         hotkey.start()
         voice.prewarm()
         run.onFinished = { [weak self] outcome in self?.runFinished(outcome) }
@@ -134,6 +132,16 @@ final class CommandCoordinator {
         guard VoiceCapture.isAvailable else { return }
         // A right-⌘ tap while the type field is open toggles it closed (no action) — a quick way to back out.
         if phase == .typing { dismissTyping(); return }
+        // Right-⌘ doubles as the GLOBAL cancel (there is no global Esc — keyDown taps are what
+        // Input Monitoring gates): a press while a stuck finalize is spinning, or while the
+        // just-fired transcript is still shown ("you misheard me"), backs out — the beats the
+        // global Esc used to cover.
+        if phase == .transcribing { cancelCurrent(); return }
+        if phase == .running, readBack != nil, run.remembering == nil {
+            stop()                        // transcript shown → instant dismiss, run cancelled
+            Log("notch transcript cancelled (right-⌘)")
+            return
+        }
         guard !run.isRunning, !isInteracting else { Log("hotkey ignored — busy"); return }
         // Knowledge-base-only plan (free/go): the notch answers the press INSTANTLY with the
         // Plus aside — same immediate beat as the mic-perms notice — and never opens for
@@ -258,15 +266,16 @@ final class CommandCoordinator {
         Log("notch typing dismissed")
     }
 
-    /// Esc — back out of whatever the notch is doing, mirroring the obvious one-tap action for each state:
+    /// Cancel — back out of whatever the notch is doing, mirroring the obvious one-tap action for each state:
     /// dismiss the type field · abandon an open/listening/transcribing voice capture (so a later release
     /// fires nothing, and a stuck finalize can always be bailed) ·
     /// or, ONLY while the voice transcript is still on screen, cancel the just-fired run and dismiss INSTANTLY
     /// (no "Stopped" flourish — that's reserved for interrupting live computer use via STOP) so a misheard
     /// command can be killed and redone at a glance. The instant the transcript dissolves into the working /
-    /// "Remembering" line, Esc is left ALONE — computer use is now quietly running and the user needs Esc for
-    /// their own apps. Returns whether it consumed the Esc (so the key monitor swallows it). Caught GLOBALLY
-    /// via RightCommandMonitor.onEscape (typing is handled by the window's local consuming monitor instead).
+    /// "Remembering" line, cancel is left ALONE — computer use is now quietly running. Returns whether it
+    /// consumed the event (so the key monitor swallows it). Reached via the window's LOCAL Esc monitor
+    /// (works whenever Sentient is frontmost — no global keyDown tap, that's Input-Monitoring-gated) and
+    /// via a right-⌘ press for the transcribing beat (voicePressBegan).
     @discardableResult
     func cancelCurrent() -> Bool {
         switch phase {

--- a/Sentient OS macOS/Notch Magic/NotchWindowController.swift
+++ b/Sentient OS macOS/Notch Magic/NotchWindowController.swift
@@ -58,12 +58,13 @@ final class NotchWindowController {
         }
     }
 
-    /// Esc handling has two halves. THE GLOBAL half lives in `RightCommandMonitor.onEscape` (a listen-only
-    /// keyDown tap) and covers the states where we're NOT the key window — a voice capture / a running
-    /// transcript over another app. THIS local half exists for the ONE thing the global tap can't do: while
-    /// the TYPE FIELD is focused (our key panel), it consumes Esc *before* the text field so dismissing never
-    /// beeps. A LOCAL monitor needs no permission (it only sees events already routed to us); `cancelCurrent()`
-    /// returns true when it handled the Esc → we swallow it (nil) so the field doesn't also act on it.
+    /// Esc handling is LOCAL-ONLY (a global keyDown tap is exactly what Input Monitoring gates — never
+    /// add one): this monitor sees Esc whenever events route to Sentient — the focused type field (where
+    /// it consumes Esc *before* the text field so dismissing never beeps) and any notch state while a
+    /// Sentient window is frontmost. Over OTHER apps, a fresh right-⌘ press is the cancel instead
+    /// (CommandCoordinator.voicePressBegan). A LOCAL monitor needs no permission (it only sees events
+    /// already routed to us); `cancelCurrent()` returns true when it handled the Esc → we swallow it
+    /// (nil) so the field doesn't also act on it.
     private func installKeyMonitor() {
         guard keyMonitor == nil else { return }
         keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in

--- a/Sentient OS macOS/Notch Magic/RightCommandMonitor.swift
+++ b/Sentient OS macOS/Notch Magic/RightCommandMonitor.swift
@@ -2,19 +2,19 @@
 //  RightCommandMonitor.swift
 //  Sentient OS macOS
 //
-//  Global notch triggers via a SINGLE listen-only CGEventTap — ZERO permissions:
-//   • hold / tap the RIGHT ⌘ (push-to-talk · tap-to-type) — read from the device-dependent flag bit
-//     (0x10) on every `flagsChanged`, so press/release self-heals even if an event is dropped.
-//   • press ESC anywhere — to cancel / dismiss the notch globally (onEscape).
+//  The global notch trigger via a SINGLE listen-only CGEventTap — ZERO permissions: hold / tap the
+//  RIGHT ⌘ (push-to-talk · tap-to-type), read from the device-dependent flag bit (0x10) on every
+//  `flagsChanged`, so press/release self-heals even if an event is dropped.
 //
-//  Modifiers (⌘) ride `flagsChanged`, which macOS doesn't gate. Esc is a regular key (keyDown) — long
-//  ASSUMED to need Input Monitoring, but MEASURED (macOS Tahoe, Input Monitoring OFF, app unfocused) to
-//  flow through a LISTEN-ONLY tap with no permission, no prompt, no Settings entry. ⚠️ Re-verify on the
-//  macOS-15 floor before launch. We filter to Esc inside the C callback, so only Esc hops to the main
-//  actor (never every keystroke), and the tap stays listen-only so keys always pass through untouched.
+//  ⚠️ The mask is `flagsChanged` ONLY — modifiers are the half macOS does not gate. NEVER add
+//  keyDown/keyUp: keyboard taps are exactly what Input Monitoring gates, and the one time we
+//  carried keyDown (for a global Esc) the system kept disabling the tap and surfaced a stray
+//  Input Monitoring request. Esc still cancels whenever Sentient is frontmost (the notch window's
+//  LOCAL monitor — no permission); over other apps, a right-⌘ press is the cancel
+//  (CommandCoordinator.voicePressBegan).
 //
-//  Emits: onPress (right ⌘ down) · onHoldConfirmed (still down at the hold threshold) · onRelease(held:)
-//  (right ⌘ up, with duration) · onEscape (Esc pressed). Reliability: re-enables a system-disabled tap,
+//  Emits: onPress (right ⌘ down) · onHoldConfirmed (still down at the hold threshold) ·
+//  onRelease(held:) (right ⌘ up, with duration). Reliability: re-enables a system-disabled tap,
 //  re-arms on wake, and a periodic health check reconciles a missed release + rebuilds a dead tap.
 //  Doc: Documentation/Notch Magic/Notch Magic.md.
 //
@@ -31,17 +31,9 @@ private nonisolated func rightCommandTapCallback(_ proxy: CGEventTapProxy, _ typ
                                                  _ event: CGEvent, _ refcon: UnsafeMutableRawPointer?) -> Unmanaged<CGEvent>? {
     guard let refcon else { return Unmanaged.passUnretained(event) }
     let monitor = Unmanaged<RightCommandMonitor>.fromOpaque(refcon).takeUnretainedValue()
-    if type == .keyDown {
-        // Filter to Esc HERE (synchronously, cheaply) so a global keyDown mask never floods the main
-        // actor — we hop over only for the one key we care about.
-        if event.getIntegerValueField(.keyboardEventKeycode) == RightCommandMonitor.escKeyCode {
-            Task { @MainActor in monitor.handleEscape() }
-        }
-    } else {
-        let flags = event.flags.rawValue
-        let t = type
-        Task { @MainActor in monitor.handle(type: t, flags: flags) }
-    }
+    let flags = event.flags.rawValue
+    let t = type
+    Task { @MainActor in monitor.handle(type: t, flags: flags) }
     return Unmanaged.passUnretained(event)   // listen-only: return the event unchanged
 }
 
@@ -52,9 +44,6 @@ final class RightCommandMonitor {
 
     /// Device-dependent right-⌘ bit (NX_DEVICERCMDKEYMASK) — the true right-⌘ state on every event.
     private static let rightCommandBit: UInt64 = 0x10
-    /// Esc's virtual keycode (kVK_Escape) — a regular key, caught as keyDown to cancel the notch. `nonisolated`
-    /// so the C event-tap callback (which runs off the main actor) can read it to filter for Esc.
-    nonisolated static let escKeyCode: Int64 = 53
     /// The generic ⌘ bit — used only for the conservative "missed release" reconcile.
     private static let commandBit: UInt64 = CGEventFlags.maskCommand.rawValue
 
@@ -65,7 +54,6 @@ final class RightCommandMonitor {
     var onPress: (() -> Void)?
     var onHoldConfirmed: (() -> Void)?
     var onRelease: ((TimeInterval) -> Void)?
-    var onEscape: (() -> Void)?              // Esc pressed anywhere — used to cancel / dismiss the notch
 
     private var port: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
@@ -110,10 +98,9 @@ final class RightCommandMonitor {
 
     private func installTap(quiet: Bool = false) {
         teardownTap()
-        // flagsChanged (right-⌘, a modifier) + keyDown (for Esc). Both flow through a listen-only tap with
-        // no permission — measured on Tahoe (the keyDown half was the surprise; re-verify on macOS 15).
-        let mask = (CGEventMask(1) << UInt64(CGEventType.flagsChanged.rawValue))
-                 | (CGEventMask(1) << UInt64(CGEventType.keyDown.rawValue))
+        // flagsChanged ONLY (right-⌘ is a modifier — the ungated half). NEVER add keyDown/keyUp:
+        // that's what Input Monitoring gates (see the top-of-file warning).
+        let mask = CGEventMask(1) << UInt64(CGEventType.flagsChanged.rawValue)
         guard let port = CGEvent.tapCreate(tap: .cgSessionEventTap, place: .headInsertEventTap,
                                            options: .listenOnly, eventsOfInterest: mask,
                                            callback: rightCommandTapCallback,
@@ -168,9 +155,6 @@ final class RightCommandMonitor {
             break
         }
     }
-
-    /// Esc pressed anywhere (already filtered to keycode 53 in the C callback) → fire the cancel hook.
-    func handleEscape() { onEscape?() }
 
     private func beginPress() {
         downAt = Date()


### PR DESCRIPTION
## What

Sentient was appearing in **System Settings → Input Monitoring** with a stray permission request. Root cause: the global hotkey tap's mask included `keyDown` (for the global Esc cancel) — keyboard taps are exactly what macOS gates behind Input Monitoring (the original `HotkeyLabView` research even documents the rule: never add keyDown/keyUp to the global mask). It's also the likely reason the system kept disabling the tap every 1.5s after a TCC reset.

- The tap mask is now **`flagsChanged` only** — the genuinely ungated modifier half. keyDown branch, Esc filter, and `onEscape` are gone; loud never-again warnings added at both files.
- **Esc still cancels whenever Sentient is frontmost** — the window's local monitor (permission-free) covers every notch state there, not just the type field.
- **Over other apps, right-⌘ itself is the cancel** (zero-permission by construction): a press bails a spinning transcription, and kills a just-fired transcript instantly (the "you misheard me, redo" beat). Mid-hold you release, then cancel at the transcript.
- Docs note: architecture §7.5 + the pre-launch checklist still reference the retired "zero-permission global-Esc tap" — will fix in the docs pass.

Rebased over the plan-gate work; cancel beats sit before the knowledge-base-only check in `voicePressBegan` (cancel works regardless of plan). Isolated build green on the merged tree.

https://claude.ai/code/session_0161f95wN1oMXG2FPRhzQrtk