### PR TITLE
Morning-after caution banner (codex logged out · no internet · usage limit)

### DIFF
--- a/Sentient OS macOS/Proactive/ProactiveCycle.swift
+++ b/Sentient OS macOS/Proactive/ProactiveCycle.swift
@@ -51,8 +51,12 @@ actor ProactiveCycle {
     /// Run the post-read tail (knowledge base → mirror → proactive → wipe). Returns nil on a fully
     /// successful cycle (summaries wiped), or the failure message if a step errored (summaries kept).
     /// Never throws — every failure is ALSO reported through `progress(.failed(…))` for the live UI.
+    /// `scheduled` marks the UNATTENDED 3am run: its failures additionally classify into the
+    /// morning-after caution (OvernightCaution → the home's banner); a watched Analyze Now doesn't
+    /// (the takeover UI already shows those live).
     @discardableResult
-    func run(progress: @escaping @Sendable (ProactiveCyclePhase) -> Void) async -> String? {
+    func run(scheduled: Bool = false,
+             progress: @escaping @Sendable (ProactiveCyclePhase) -> Void) async -> String? {
         PipelineActivity.begin()                 // Settings' Reset is disabled while the tail runs
         defer { PipelineActivity.end() }
         let notes = await CycleStore.shared.notes().map(CloudNote.init)
@@ -74,6 +78,7 @@ actor ProactiveCycle {
         } catch {
             let m = "Knowledge base: \(Self.msg(error))"
             Analytics.signal("KnowledgeBase.failed", parameters: ["phase": exists ? "update" : "build"])
+            if scheduled { await OvernightCaution.note(error) }   // the morning-after banner
             progress(.failed(m)); return m                   // half-edited vault isn't dirty; summaries kept
         }
         await VaultCloud.pushIfDirty()                       // no-op if the mirror is off
@@ -105,6 +110,7 @@ actor ProactiveCycle {
                 items = []                                   // nothing recent enough — clear cards, still success
             } catch {
                 let m = "Deciding: \(Self.msg(error))"
+                if scheduled { await OvernightCaution.note(error) }
                 progress(.failed(m)); return m
             }
             Analytics.signal("Proactive.decided", parameters: ["items": "\(items.count)"])
@@ -119,6 +125,7 @@ actor ProactiveCycle {
                         "ready": "\(result.ready.count)", "dropped": "\(result.dropped.count)"])
                 } catch {
                     let m = "Preparing: \(Self.msg(error))"
+                    if scheduled { await OvernightCaution.note(error) }
                     progress(.failed(m)); return m
                 }
             }
@@ -126,6 +133,7 @@ actor ProactiveCycle {
 
         // 4) Wipe this cycle's summaries — the knowledge base is the durable memory now. Success only.
         await CycleStore.shared.wipeAllNotes()
+        OvernightCaution.clear()                             // a full success retires any morning-after banner
         UserDefaults.standard.set(Date(), forKey: Self.lastCycleKey)
         OvernightScheduler.noteFirstCycleCompleted()   // "initial processing ended" → start the 18h auto-enable clock (once)
         progress(.done(ready: ProactiveResearch.latest()?.ready.count ?? 0))

--- a/Sentient OS macOS/Scheduling/OvernightCaution.swift
+++ b/Sentient OS macOS/Scheduling/OvernightCaution.swift
@@ -1,0 +1,94 @@
+//
+//  OvernightCaution.swift
+//  Sentient OS macOS
+//
+//  The morning-after caution: when the UNATTENDED 3am cycle fails for one of the three reasons a
+//  user can actually act on or should simply know about — codex signed out · no internet · usage
+//  limit — the failure is classified here (at ProactiveCycle's catch sites, the one choke point
+//  every codex call already funnels typed errors through) and persisted, and the home renders it
+//  as a quiet amber capsule (HomeView.cautionBanner). Any later fully successful cycle clears it;
+//  so does the banner's ✕. Other failure kinds stay log/Sentry territory — no banner.
+//
+//  Key methods: note(_:) (classify + record) · latest() · clear()
+//
+
+import Foundation
+import Network
+import os
+
+enum OvernightCaution {
+
+    enum Kind: String, Codable {
+        case loggedOut    // codex had no working login when the night's cloud work started
+        case noInternet   // the Mac was offline, so the cloud legs couldn't run
+        case usageLimit   // the ChatGPT plan's window was exhausted mid-run
+
+        /// The banner line — quiet, first-person, honest about what happens next.
+        var message: String {
+            switch self {
+            case .loggedOut:  return "I couldn't work last night. Codex was signed out; log back in and I'll catch up tonight."
+            case .noInternet: return "No internet last night, so I couldn't do my overnight work. I'll try again tonight."
+            case .usageLimit: return "We hit ChatGPT's usage limit last night. I'll pick it up again tomorrow."
+            }
+        }
+    }
+
+    struct Record: Codable {
+        let kind: Kind
+        let date: Date
+    }
+
+    private static let key = "overnight.caution"
+
+    /// The caution the home should show, if any.
+    static func latest() -> Record? {
+        guard let data = UserDefaults.standard.data(forKey: key) else { return nil }
+        return try? JSONDecoder().decode(Record.self, from: data)
+    }
+
+    /// A later cycle succeeded, or the user dismissed the banner.
+    static func clear() {
+        UserDefaults.standard.removeObject(forKey: key)
+    }
+
+    /// Classify a scheduled-cycle failure into one of the three user-facing kinds and persist it.
+    /// Anything unclassifiable records nothing (the banner only ever states what we verified).
+    static func note(_ error: Error) async {
+        let kind: Kind?
+        if case CodexCLI.CLIError.usageLimit = error {
+            kind = .usageLimit                       // typed — certain, no probing needed
+        } else if await !CodexCLI.loginStatus() {    // local auth check — reliable even offline
+            kind = .loggedOut
+        } else if await !networkUp() {
+            kind = .noInternet
+        } else {
+            kind = nil
+        }
+        guard let kind else { return }
+        if let data = try? JSONEncoder().encode(Record(kind: kind, date: Date())) {
+            UserDefaults.standard.set(data, forKey: key)
+        }
+        Log("OvernightCaution: recorded .\(kind.rawValue)")
+        CrashReporting.captureEvent("overnight.caution", level: .info,
+            tags: ["kind": kind.rawValue], fingerprint: ["overnight", "caution", kind.rawValue])
+    }
+
+    /// One NWPathMonitor snapshot — the first path update arrives immediately; guarded so the
+    /// continuation can never resume twice.
+    private static func networkUp() async -> Bool {
+        await withCheckedContinuation { (cont: CheckedContinuation<Bool, Never>) in
+            let monitor = NWPathMonitor()
+            let resumed = OSAllocatedUnfairLock(initialState: false)
+            monitor.pathUpdateHandler = { path in
+                guard resumed.withLock({ done in
+                    if done { return false }
+                    done = true
+                    return true
+                }) else { return }
+                monitor.cancel()
+                cont.resume(returning: path.status == .satisfied)
+            }
+            monitor.start(queue: .global(qos: .utility))
+        }
+    }
+}

--- a/Sentient OS macOS/Scheduling/OvernightScheduler.swift
+++ b/Sentient OS macOS/Scheduling/OvernightScheduler.swift
@@ -289,7 +289,7 @@ final class OvernightScheduler {
         // Now runs (ProcessingView → ProactiveCycle), so a scheduled run produces the morning's
         // For-You cards too — there is no scheduler-specific knowledge-base path. Still held awake +
         // heartbeating throughout (proactive uses codex, same as the KB step already does).
-        if let failure = await ProactiveCycle.shared.run(progress: { phase in
+        if let failure = await ProactiveCycle.shared.run(scheduled: true, progress: { phase in
             Task { @MainActor in
                 switch phase {
                 case .knowledgeBase(let s): log.line("proactive: \(s)")

--- a/Sentient OS macOS/Views/HomeView.swift
+++ b/Sentient OS macOS/Views/HomeView.swift
@@ -65,6 +65,8 @@ struct HomeView: View {
     @State private var showIMessagePicker = false
     @State private var showGmailConnect = false
     @State private var showCalendarConnect = false
+    /// The morning-after caution (last night's scheduled run hit a known snag) — nil = no banner.
+    @State private var caution: OvernightCaution.Record?
 
     // Chat selections the Analysis popover's WhatsApp/iMessage chips pick into (same keys as SourceSelection).
     @AppStorage("dbg.whatsapp.chats") private var whatsappCSV = ""
@@ -89,6 +91,7 @@ struct HomeView: View {
                     }
                     bottomDock
                     chrome                     // on top → the nav stays clickable
+                    cautionBanner              // the morning-after caution, in the blank top-right
                     devToolsOverlay
                 }
                 .blur(radius: letterShown ? 7 : 0)
@@ -104,6 +107,7 @@ struct HomeView: View {
             letterShown = false
             model.beginVisit(realCards: realCards)
             planUpgraded = previewUpgraded ?? (kbOnly && CodexAuth.currentPlan()?.tier == .full)
+            caution = OvernightCaution.latest()
         }
         .onChange(of: realCards) { _, v in model.beginVisit(realCards: v) }   // toggle flip → re-deal
         .animation(.spring(response: 0.5, dampingFraction: 0.82), value: model.entries.isEmpty)
@@ -158,6 +162,30 @@ struct HomeView: View {
             MonoCaps(readLine, size: 9.5, tracking: 2.2, color: Theme.Ink.deepMuted)
         }
         .padding(.leading, 30)
+    }
+
+    // MARK: The morning-after caution banner
+    //
+    // Last night's UNATTENDED run hit one of the three knowable snags (codex signed out · no
+    // internet · usage limit) — OvernightCaution recorded it at ProactiveCycle's choke point, and
+    // this quiet amber capsule surfaces it in the blank space beside the greeting. ✕ dismisses;
+    // the next fully successful cycle clears it on its own. Amber on purpose: a caution, never an
+    // alarm — the app still works, only the overnight magic was missed.
+
+    private var cautionBanner: some View {
+        Group {
+            if let caution {
+                CautionCapsule(kind: caution.kind,
+                               onOpenSettings: { openWindow(id: SettingsView.windowID) },
+                               onDismiss: {
+                                   OvernightCaution.clear()
+                                   withAnimation(.easeInOut(duration: 0.25)) { self.caution = nil }
+                               })
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
+        .padding(.trailing, 30).padding(.top, 64)
     }
 
     private var greeting: String {
@@ -440,6 +468,55 @@ struct HomeView: View {
     private func closeLetter() {
         withAnimation(.easeInOut(duration: 0.26)) { letterShown = false }
     }
+}
+
+// MARK: - The morning-after caution capsule (rendered by cautionBanner)
+
+private struct CautionCapsule: View {
+    let kind: OvernightCaution.Kind
+    let onOpenSettings: () -> Void
+    let onDismiss: () -> Void
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 10) {
+            HealthDot(color: Theme.Ink.amber)
+            Text(kind.message)
+                .font(.system(size: 12.5))
+                .foregroundStyle(Theme.Ink.statusInk)
+                .lineSpacing(3)
+                .fixedSize(horizontal: false, vertical: true)
+            if kind == .loggedOut {
+                SettingsPillButton(title: "Open Settings", action: onOpenSettings)
+            }
+            Button(action: onDismiss) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(Theme.Ink.label)
+                    .padding(4)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 16).padding(.vertical, 11)
+        .frame(maxWidth: 480, alignment: .leading)
+        .background(Color.white.opacity(0.04), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: 14, style: .continuous)
+            .strokeBorder(Theme.Ink.amber.opacity(0.28), lineWidth: 1))
+    }
+}
+
+#Preview("Caution capsules") {
+    ZStack {
+        Color.black.ignoresSafeArea()
+        VStack(alignment: .trailing, spacing: 14) {
+            CautionCapsule(kind: .loggedOut, onOpenSettings: {}, onDismiss: {})
+            CautionCapsule(kind: .noInternet, onOpenSettings: {}, onDismiss: {})
+            CautionCapsule(kind: .usageLimit, onOpenSettings: {}, onDismiss: {})
+        }
+        .padding(40)
+    }
+    .frame(width: 620, height: 320)
+    .preferredColorScheme(.dark)
 }
 
 // MARK: - Top-bar nav item


### PR DESCRIPTION
## What

When last night's unattended 3am run failed for one of the three reasons a user should actually hear about, the home now says so — a quiet amber capsule in the blank space beside the greeting:

- "I couldn't work last night. Codex was signed out; log back in and I'll catch up tonight." (+ Open Settings)
- "No internet last night, so I couldn't do my overnight work. I'll try again tonight."
- "We hit ChatGPT's usage limit last night. I'll pick it up again tomorrow."

## How

- **One choke point:** every codex call already funnels typed `CLIError`s through `ProactiveCycle.run`'s catch sites, so classification lives there — gated on a new `scheduled: Bool` that only the OvernightScheduler passes (a watched Analyze Now shows failures live in the takeover UI and records nothing).
- **Classification** (`Scheduling/OvernightCaution.swift`): typed `usageLimit` first → local `codex login status` probe (works offline) → one-shot `NWPathMonitor` snapshot → anything else records nothing (the banner never guesses).
- Record persists in UserDefaults; ✕ dismisses; the next fully successful cycle auto-clears. PII-free Sentry event per caution (kind tag only).
- `#Preview("Caution capsules")` renders all three states; capsule extracted to its own view (the inline version hit a type-checker timeout).

Isolated build green.

https://claude.ai/code/session_0161f95wN1oMXG2FPRhzQrtk