### PR TITLE
Wire up the Sidekick right-⌥ hotkey option

### DIFF
--- a/Sentient OS macOS/Notch Magic/CommandCoordinator.swift
+++ b/Sentient OS macOS/Notch Magic/CommandCoordinator.swift
@@ -3,8 +3,9 @@
 //  Sentient OS macOS
 //
 //  The app-lifetime brain behind "do this for me." Owns the ONE shared codex run (CommandRunModel),
-//  the right-⌘ hotkey (RightCommandMonitor), and voice capture (VoiceCapture) — so whether the user
-//  holds right-⌘ and speaks, or types in the home command bar, both reach the SAME backend and the
+//  the Sidekick hotkey (SidekickHotkeyMonitor — right ⌘ or right ⌥, the user's choice), and voice
+//  capture (VoiceCapture) — so whether the user holds the hotkey and speaks, or types in the home
+//  command bar, both reach the SAME backend and the
 //  SAME notch status (NotchPhase). The notch RENDERING is built later; this owns + drives `phase` and
 //  logs every transition, so the whole voice path is testable headlessly today.
 //
@@ -43,8 +44,9 @@ final class CommandCoordinator {
     /// `readBack ?? run.statusLine` while running.
     private(set) var readBack: String?
 
-    private let hotkey = RightCommandMonitor()
+    private let hotkey = SidekickHotkeyMonitor()
     private let voice = VoiceCapture()
+    private var hotkeyChangeObserver: NSObjectProtocol?
 
     private var listening = false           // a voice session is live (start → finalize / cancel)
     private var voiceStartTask: Task<Void, Never>?
@@ -58,17 +60,23 @@ final class CommandCoordinator {
     /// backend is testable immediately.)
     func start() {
         hotkey.maxHold = VoiceCapture.maxCaptureDuration   // cap the hold at the active engine's limit
+        hotkey.setKey(.current)                            // honor the user's Settings choice (right ⌘ / right ⌥)
         hotkey.onPress = { [weak self] in self?.voicePressBegan() }
         hotkey.onHoldConfirmed = { [weak self] in self?.voiceHoldConfirmed() }
         hotkey.onRelease = { [weak self] held in self?.voiceReleased(held: held) }
         // No global Esc: a keyDown tap is exactly what Input Monitoring gates, so the monitor
         // listens to modifiers only. Esc still cancels via the window's LOCAL monitor whenever
-        // Sentient itself is frontmost; over other apps, a fresh right-⌘ press is the cancel
+        // Sentient itself is frontmost; over other apps, a fresh hotkey press is the cancel
         // (see voicePressBegan).
         hotkey.start()
+        // Live re-key when the user flips the choice in Settings — no restart needed.
+        hotkeyChangeObserver = NotificationCenter.default.addObserver(
+            forName: .sidekickHotkeyChanged, object: nil, queue: .main) { [weak self] _ in
+            MainActor.assumeIsolated { self?.hotkey.setKey(.current) }
+        }
         voice.prewarm()
         run.onFinished = { [weak self] outcome in self?.runFinished(outcome) }
-        Log("CommandCoordinator armed (right-⌘ hold-to-talk · voice available: \(VoiceCapture.isAvailable))")
+        Log("CommandCoordinator armed (\(hotkey.key.label) hold-to-talk · voice available: \(VoiceCapture.isAvailable))")
     }
 
     // MARK: The one entry point — hotkey-voice AND the prompt bar both call this
@@ -130,16 +138,16 @@ final class CommandCoordinator {
 
     private func voicePressBegan() {
         guard VoiceCapture.isAvailable else { return }
-        // A right-⌘ tap while the type field is open toggles it closed (no action) — a quick way to back out.
+        // A hotkey tap while the type field is open toggles it closed (no action) — a quick way to back out.
         if phase == .typing { dismissTyping(); return }
-        // Right-⌘ doubles as the GLOBAL cancel (there is no global Esc — keyDown taps are what
+        // The hotkey doubles as the GLOBAL cancel (there is no global Esc — keyDown taps are what
         // Input Monitoring gates): a press while a stuck finalize is spinning, or while the
         // just-fired transcript is still shown ("you misheard me"), backs out — the beats the
         // global Esc used to cover.
         if phase == .transcribing { cancelCurrent(); return }
         if phase == .running, readBack != nil, run.remembering == nil {
             stop()                        // transcript shown → instant dismiss, run cancelled
-            Log("notch transcript cancelled (right-⌘)")
+            Log("notch transcript cancelled (\(hotkey.key.label))")
             return
         }
         guard !run.isRunning, !isInteracting else { Log("hotkey ignored — busy"); return }
@@ -175,7 +183,7 @@ final class CommandCoordinator {
     private func voiceReleased(held: TimeInterval) {
         switch phase {
         case .opening, .listening:
-            if held >= RightCommandMonitor.holdThreshold { finalizeVoice() } else { beginTyping() }
+            if held >= SidekickHotkeyMonitor.holdThreshold { finalizeVoice() } else { beginTyping() }
         default:
             break
         }

--- a/Sentient OS macOS/Notch Magic/SidekickHotkeyMonitor.swift
+++ b/Sentient OS macOS/Notch Magic/SidekickHotkeyMonitor.swift
@@ -1,20 +1,22 @@
 //
-//  RightCommandMonitor.swift
+//  SidekickHotkeyMonitor.swift
 //  Sentient OS macOS
 //
 //  The global notch trigger via a SINGLE listen-only CGEventTap — ZERO permissions: hold / tap the
-//  RIGHT ⌘ (push-to-talk · tap-to-type), read from the device-dependent flag bit (0x10) on every
-//  `flagsChanged`, so press/release self-heals even if an event is dropped.
+//  user's chosen Sidekick key (right ⌘ or right ⌥ — push-to-talk · tap-to-type), read from the
+//  device-dependent flag bit on every `flagsChanged`, so press/release self-heals even if an event
+//  is dropped. The key is configurable at runtime (`setKey`) — both choices are MODIFIERS, the half
+//  macOS does not gate, so switching between them never changes the (permission-free) tap mask.
 //
 //  ⚠️ The mask is `flagsChanged` ONLY — modifiers are the half macOS does not gate. NEVER add
 //  keyDown/keyUp: keyboard taps are exactly what Input Monitoring gates, and the one time we
 //  carried keyDown (for a global Esc) the system kept disabling the tap and surfaced a stray
 //  Input Monitoring request. Esc still cancels whenever Sentient is frontmost (the notch window's
-//  LOCAL monitor — no permission); over other apps, a right-⌘ press is the cancel
+//  LOCAL monitor — no permission); over other apps, a fresh hotkey press is the cancel
 //  (CommandCoordinator.voicePressBegan).
 //
-//  Emits: onPress (right ⌘ down) · onHoldConfirmed (still down at the hold threshold) ·
-//  onRelease(held:) (right ⌘ up, with duration). Reliability: re-enables a system-disabled tap,
+//  Emits: onPress (key down) · onHoldConfirmed (still down at the hold threshold) ·
+//  onRelease(held:) (key up, with duration). Reliability: re-enables a system-disabled tap,
 //  re-arms on wake, and a periodic health check reconciles a missed release + rebuilds a dead tap.
 //  Doc: Documentation/Notch Magic/Notch Magic.md.
 //
@@ -22,15 +24,60 @@
 import AppKit
 import CoreGraphics
 
+/// The Sidekick trigger key — the single source of truth mapping the persisted `sidekick.hotkey`
+/// choice to the flag bits we read and a label for logs / UI. Both are RIGHT-side modifiers, so
+/// holding/tapping either one alone types nothing — a safe push-to-talk trigger.
+enum SidekickHotkey: String {
+    case rightCommand
+    case rightOption
+
+    /// Device-dependent bit (NX_DEVICER*KEYMASK) — the TRUE right-key state on every `flagsChanged`
+    /// (distinguishes the right key from its left twin, which the generic modifier bit can't).
+    var deviceBit: UInt64 {
+        switch self {
+        case .rightCommand: return 0x10   // NX_DEVICERCMDKEYMASK
+        case .rightOption:  return 0x40   // NX_DEVICERALTKEYMASK
+        }
+    }
+
+    /// The generic modifier bit — used ONLY for the conservative "missed release" reconcile
+    /// (there we can only tell "some ⌘/⌥ is down", not which side).
+    var genericBit: UInt64 {
+        switch self {
+        case .rightCommand: return CGEventFlags.maskCommand.rawValue
+        case .rightOption:  return CGEventFlags.maskAlternate.rawValue
+        }
+    }
+
+    /// Short label for logs and copy.
+    var label: String {
+        switch self {
+        case .rightCommand: return "right ⌘"
+        case .rightOption:  return "right ⌥"
+        }
+    }
+
+    /// The user's current choice, read from the persisted setting (falls back to right ⌘).
+    static var current: SidekickHotkey {
+        SidekickHotkey(rawValue: UserDefaults.standard.string(forKey: "sidekick.hotkey") ?? "") ?? .rightCommand
+    }
+}
+
+/// Posted when the user changes the Sidekick hotkey in Settings, so the live monitor can re-key
+/// without a restart. (ProactivePane posts it on toggle; CommandCoordinator observes it.)
+extension Notification.Name {
+    static let sidekickHotkeyChanged = Notification.Name("sidekick.hotkey.changed")
+}
+
 // MARK: - C trampoline (captures nothing → bridges to a C function pointer; hops onto the main actor)
 //
 // `nonisolated` is load-bearing: the project builds with default MainActor isolation, and an
 // actor-isolated function can't be formed into a @convention(c) function pointer.
 
-private nonisolated func rightCommandTapCallback(_ proxy: CGEventTapProxy, _ type: CGEventType,
-                                                 _ event: CGEvent, _ refcon: UnsafeMutableRawPointer?) -> Unmanaged<CGEvent>? {
+private nonisolated func sidekickHotkeyTapCallback(_ proxy: CGEventTapProxy, _ type: CGEventType,
+                                                   _ event: CGEvent, _ refcon: UnsafeMutableRawPointer?) -> Unmanaged<CGEvent>? {
     guard let refcon else { return Unmanaged.passUnretained(event) }
-    let monitor = Unmanaged<RightCommandMonitor>.fromOpaque(refcon).takeUnretainedValue()
+    let monitor = Unmanaged<SidekickHotkeyMonitor>.fromOpaque(refcon).takeUnretainedValue()
     let flags = event.flags.rawValue
     let t = type
     Task { @MainActor in monitor.handle(type: t, flags: flags) }
@@ -38,14 +85,13 @@ private nonisolated func rightCommandTapCallback(_ proxy: CGEventTapProxy, _ typ
 }
 
 @MainActor
-final class RightCommandMonitor {
-    /// Held ≥ this long = a HOLD (push-to-talk). Below = a TAP (future: type mode; today a no-op).
+final class SidekickHotkeyMonitor {
+    /// Held ≥ this long = a HOLD (push-to-talk). Below = a TAP (type mode).
     static let holdThreshold: TimeInterval = 0.25
 
-    /// Device-dependent right-⌘ bit (NX_DEVICERCMDKEYMASK) — the true right-⌘ state on every event.
-    private static let rightCommandBit: UInt64 = 0x10
-    /// The generic ⌘ bit — used only for the conservative "missed release" reconcile.
-    private static let commandBit: UInt64 = CGEventFlags.maskCommand.rawValue
+    /// The key we currently watch. Swap it at runtime with `setKey` — no tap rebuild needed (the
+    /// mask stays `flagsChanged`); we just read a different device bit.
+    private(set) var key: SidekickHotkey = .rightCommand
 
     /// Force-release a hold after this long — set from the active speech engine's transcription limit
     /// (SpeechAnalyzer 3 min · SFSpeechRecognizer 59s), which doubles as the stuck-key safety net.
@@ -57,7 +103,7 @@ final class RightCommandMonitor {
 
     private var port: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
-    private var rightCmdDown = false
+    private var keyIsDown = false
     private var downAt: Date?
     private var holdConfirmTask: Task<Void, Never>?
     private var maxHoldTask: Task<Void, Never>?
@@ -66,6 +112,21 @@ final class RightCommandMonitor {
     private var running = false
 
     // MARK: Lifecycle
+
+    /// Point the monitor at a different key. If a press is somehow in flight (the user can't really
+    /// change Settings mid-hold, but be safe), abandon it cleanly so we never strand a "down" belief
+    /// on the old bit. Idempotent — a no-op when the key is unchanged.
+    func setKey(_ newKey: SidekickHotkey) {
+        guard newKey != key else { return }
+        if keyIsDown {
+            keyIsDown = false
+            holdConfirmTask?.cancel(); holdConfirmTask = nil
+            maxHoldTask?.cancel(); maxHoldTask = nil
+            downAt = nil
+        }
+        key = newKey
+        Log("hotkey: now watching \(newKey.label)")
+    }
 
     func start() {
         guard !running else { return }
@@ -90,7 +151,7 @@ final class RightCommandMonitor {
         healthTimer?.invalidate(); healthTimer = nil
         if let wakeObserver { NSWorkspace.shared.notificationCenter.removeObserver(wakeObserver) }
         wakeObserver = nil
-        rightCmdDown = false
+        keyIsDown = false
         downAt = nil
     }
 
@@ -98,14 +159,14 @@ final class RightCommandMonitor {
 
     private func installTap(quiet: Bool = false) {
         teardownTap()
-        // flagsChanged ONLY (right-⌘ is a modifier — the ungated half). NEVER add keyDown/keyUp:
+        // flagsChanged ONLY (the hotkey is a modifier — the ungated half). NEVER add keyDown/keyUp:
         // that's what Input Monitoring gates (see the top-of-file warning).
         let mask = CGEventMask(1) << UInt64(CGEventType.flagsChanged.rawValue)
         guard let port = CGEvent.tapCreate(tap: .cgSessionEventTap, place: .headInsertEventTap,
                                            options: .listenOnly, eventsOfInterest: mask,
-                                           callback: rightCommandTapCallback,
+                                           callback: sidekickHotkeyTapCallback,
                                            userInfo: Unmanaged.passUnretained(self).toOpaque()) else {
-            Log("⌘mon: tapCreate failed (a modifier-only tap shouldn't need anything) — will retry on the health tick")
+            Log("hotkey: tapCreate failed (a modifier-only tap shouldn't need anything) — will retry on the health tick")
             return
         }
         let src = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, port, 0)
@@ -113,7 +174,7 @@ final class RightCommandMonitor {
         CGEvent.tapEnable(tap: port, enable: true)
         self.port = port
         self.runLoopSource = src
-        if !quiet { Log("⌘mon: listening (flagsChanged-only, zero-permission)") }
+        if !quiet { Log("hotkey: listening for \(key.label) (flagsChanged-only, zero-permission)") }
     }
 
     private func teardownTap() {
@@ -134,7 +195,7 @@ final class RightCommandMonitor {
         if !enabled {
             reinstalls += 1
             if reinstalls == 1 || reinstalls % 200 == 0 {
-                Log("⌘mon: tap was disabled — re-armed (×\(reinstalls) this session)")
+                Log("hotkey: tap was disabled — re-armed (×\(reinstalls) this session)")
             }
             installTap(quiet: true)
         }
@@ -147,9 +208,9 @@ final class RightCommandMonitor {
         case .tapDisabledByTimeout, .tapDisabledByUserInput:
             if let port { CGEvent.tapEnable(tap: port, enable: true) }   // the system throttled us — re-arm
         case .flagsChanged:
-            let nowDown = (flags & Self.rightCommandBit) != 0
-            guard nowDown != rightCmdDown else { return }   // not a right-⌘ transition
-            rightCmdDown = nowDown
+            let nowDown = (flags & key.deviceBit) != 0
+            guard nowDown != keyIsDown else { return }   // not a transition on our key
+            keyIsDown = nowDown
             if nowDown { beginPress() } else { endPress() }
         default:
             break
@@ -162,16 +223,16 @@ final class RightCommandMonitor {
         holdConfirmTask?.cancel()
         holdConfirmTask = Task { [weak self] in
             try? await Task.sleep(for: .seconds(Self.holdThreshold))
-            guard let self, !Task.isCancelled, self.rightCmdDown else { return }
+            guard let self, !Task.isCancelled, self.keyIsDown else { return }
             self.onHoldConfirmed?()
         }
         let cap = maxHold
         maxHoldTask?.cancel()
         maxHoldTask = Task { [weak self] in
             try? await Task.sleep(for: .seconds(cap))
-            guard let self, !Task.isCancelled, self.rightCmdDown else { return }
-            Log("⌘mon: max-hold cap (\(Int(cap))s) — forcing release")
-            self.rightCmdDown = false
+            guard let self, !Task.isCancelled, self.keyIsDown else { return }
+            Log("hotkey: max-hold cap (\(Int(cap))s) — forcing release")
+            self.keyIsDown = false
             self.endPress()
         }
     }
@@ -189,14 +250,15 @@ final class RightCommandMonitor {
     private func healthCheck() {
         guard running else { return }
         reinstallIfNeeded()
-        // Reconcile a missed release: if we think right-⌘ is down but NO ⌘ is physically down now, we
-        // missed the up event → release. (Conservative: if some ⌘ is down we can't tell left vs right
-        // here, so we leave it — better a late release than a false one.)
-        if rightCmdDown {
+        // Reconcile a missed release: if we think the key is down but NO matching modifier is
+        // physically down now, we missed the up event → release. (Conservative: if the modifier is
+        // down we can't tell left vs right here, so we leave it — better a late release than a false
+        // one.)
+        if keyIsDown {
             let live = CGEventSource.flagsState(.combinedSessionState).rawValue
-            if (live & Self.commandBit) == 0 {
-                Log("⌘mon: reconciled a missed release")
-                rightCmdDown = false
+            if (live & key.genericBit) == 0 {
+                Log("hotkey: reconciled a missed release")
+                keyIsDown = false
                 endPress()
             }
         }

--- a/Sentient OS macOS/Views/Settings/ProactivePane.swift
+++ b/Sentient OS macOS/Views/Settings/ProactivePane.swift
@@ -4,9 +4,10 @@
 //
 //  Settings → Proactive & Sidekick: the user's standing instructions for the proactive
 //  suggestion writer, and Sidekick's shortcut key + standing context. The strings persist and
-//  autosave (keys: proactive.instructions · sidekick.hotkey · sidekick.context) — the backends
-//  consume them when the prompt wiring lands (the "prompt refinement" todo); the Right ⌥ choice
-//  additionally awaits RightCommandMonitor support for that key.
+//  autosave (keys: proactive.instructions · sidekick.hotkey · sidekick.context). The hotkey choice
+//  (right ⌘ / right ⌥) is LIVE — toggling it posts `.sidekickHotkeyChanged`, which re-keys the
+//  running SidekickHotkeyMonitor with no restart. The two text fields are consumed when the prompt
+//  wiring lands (the "prompt refinement" todo).
 //
 
 import SwiftUI
@@ -37,6 +38,10 @@ struct ProactivePane: View {
                             SettingsChip(label: "Right ⌥", on: sidekickHotkey == "rightOption") {
                                 sidekickHotkey = "rightOption"
                             }
+                        }
+                        .onChange(of: sidekickHotkey) {
+                            // Re-key the live monitor immediately — no restart.
+                            NotificationCenter.default.post(name: .sidekickHotkeyChanged, object: nil)
                         }
                         SettingsTextBox(placeholder: "e.g. When I say text someone, use WhatsApp. My main browser is Microsoft Edge.",
                                         text: $sidekickContext)


### PR DESCRIPTION
## What
Settings → Proactive & Sidekick let you pick **Right ⌘** or **Right ⌥**, but the choice was dead: `sidekick.hotkey` persisted and nothing read it, and the monitor only watched right-⌘. This wires it end to end.

## How
- **`RightCommandMonitor.swift` → `SidekickHotkeyMonitor.swift`** (renamed). New `SidekickHotkey` enum is the single source of truth: maps the persisted string → device bit (right ⌘ `0x10` / right ⌥ `0x40` = `NX_DEVICERALTKEYMASK`), the generic bit for the missed-release reconcile (`maskCommand` / `maskAlternate`), a label, and a `.current` reader.
- Monitor reads `key.deviceBit` and gains `setKey(_:)` — swaps the watched key with **no tap rebuild** (mask stays `flagsChanged`, so right-⌥ is just as permission-free as right-⌘); abandons any in-flight press on switch.
- **`CommandCoordinator`** keys off `.current` at `start()` and live-re-keys on `.sidekickHotkeyChanged` → **switching in Settings takes effect with no restart**.
- **`ProactivePane`** posts `.sidekickHotkeyChanged` on toggle; stale "awaits monitor support" caveat removed.

## Verification
- ✅ Isolated Debug build (`-derivedDataPath /tmp/sentient-verify`) — **BUILD SUCCEEDED**.
- ⏳ Real-hardware smoke test still pending (CGEventTap bit-reading can't be verified headlessly): hold right-⌥ → notch listens; flip back to right-⌘ without restart → confirms live re-key.

## Follow-ups (after test confirms)
- Docs: `Notch Magic/Notch Magic.md`, `Settings.md`, `README.md`, Sentry catalog, and the architecture [WIP] note "Right-⌥ also needs monitor support".

## Note
Right-⌥ is macOS's accent-composition modifier — inert when held alone (safe trigger), but flagging it. Right-⌘ remains the default.