### PR TITLE
Honest analytics gating + the one disclosed anonymous install ping

### DIFF
--- a/Sentient OS macOS/App/main.swift
+++ b/Sentient OS macOS/App/main.swift
@@ -17,5 +17,6 @@ if CommandLine.arguments.contains(WakeHelperConfig.helperFlag) {
 } else {
     CrashReporting.start(.app)          // crash reporting for the GUI app
     Analytics.start()                   // product analytics (TelemetryDeck) — GUI app only
+    Analytics.countInstallOnce()        // the one anonymous install ping — fires even when opted out
     SentientOSApp.main()                // normal GUI app
 }

--- a/Sentient OS macOS/Diagnostics/Analytics.swift
+++ b/Sentient OS macOS/Diagnostics/Analytics.swift
@@ -16,15 +16,24 @@
 //  so this upholds the Privacy Constitution (no accounts, nothing personal leaves the Mac). Signals
 //  carry structure only (names + counts/enums/versions), never user content — clean at the source.
 //
+//  The ONE thing the opt-out switch does NOT silence: `countInstallOnce()`, a single, totally
+//  anonymous "an install exists" ping that fires at most once per install EVEN when analytics are
+//  off, so we can always count how many people use Sentient. It carries no identity (a throwaway
+//  random hash, never stored, uncorrelatable to the install id or the crash-report id), no device
+//  info, and no content — just a bare count. It is disclosed in the opt-out's own Settings copy, so
+//  the switch is never a lie. All richer product analytics remain fully behind the opt-out.
+//
 //  Key members:
 //   - start()                 → boot TelemetryDeck (Release-only, opt-out gated)
 //   - signal(_:parameters:)   → send one product event (no-op until started / when opted out)
+//   - countInstallOnce()      → the one-off anonymous install count (Release-only, opt-out-INDEPENDENT)
 //   - applyEnabledChange()    → react to a mid-session flip of the shared opt-out switch
 //
 //  Doc: Documentation/Product Analytics (TelemetryDeck).md · twin: Documentation/Crash Reporting (Sentry).md
 //
 
 import Foundation
+import CryptoKit
 import TelemetryDeck
 
 enum Analytics {
@@ -97,5 +106,71 @@ enum Analytics {
             started = false
             Log("Analytics: analytics turned off — TelemetryDeck silenced")
         }
+    }
+
+    // MARK: - The one-off anonymous install count (opt-out-INDEPENDENT)
+
+    private static let installCountedKey = "analytics.installCounted"
+    private static let installSignalType = "App.anonymousInstall"
+    private static let ingestURL = URL(string: "https://nom.telemetrydeck.com/v2/")!
+
+    /// Send the single anonymous install ping — see the file header. Fires at most once per install
+    /// (latched in UserDefaults once it lands), and — unlike everything else here — does so even when
+    /// analytics are OPTED OUT: it's the bare "an install exists" beacon that lets us count how many
+    /// people use Sentient, and it's disclosed in the opt-out's Settings copy so the switch stays
+    /// honest. Release-only (a dev's Debug launches never inflate the count). It goes NOT through the
+    /// SDK (which would spin up ongoing session tracking) but as one direct, minimal POST carrying no
+    /// identity, no device info, and no content. Fire-and-forget; called once from main.swift.
+    static func countInstallOnce() {
+        #if DEBUG
+        Log("Analytics: DEBUG build — anonymous install ping skipped (Release-only)")
+        #else
+        guard !appID.hasPrefix("PASTE_") else { return }
+        guard !UserDefaults.standard.bool(forKey: installCountedKey) else { return }   // one-off, forever
+        postAnonymousInstall { ok in
+            guard ok else { return }   // not latched → retried next launch until it lands exactly once
+            UserDefaults.standard.set(true, forKey: installCountedKey)
+            Log("Analytics: anonymous install counted (one-off)")
+        }
+        #endif
+    }
+
+    /// The direct one-shot ingest POST, matching TelemetryDeck's V2 signal body. `clientUser` is a
+    /// throwaway random hash (never stored, never reused — so it ties to nothing), the payload is
+    /// empty, and no version/device/content rides along: a truly bare count. TelemetryDeck stores no
+    /// IP and salts the hash again, so this stays anonymous end to end.
+    private static func postAnonymousInstall(_ done: @escaping @Sendable (Bool) -> Void) {
+        let body: [[String: Any]] = [[
+            "receivedAt": ingestDateFormatter.string(from: Date()),
+            "appID": appID,
+            "clientUser": sha256Hex(UUID().uuidString),
+            "sessionID": UUID().uuidString,
+            "type": installSignalType,
+            "payload": [String: String](),
+            "isTestMode": "false",
+        ]]
+        guard let data = try? JSONSerialization.data(withJSONObject: body) else { done(false); return }
+        var req = URLRequest(url: ingestURL)
+        req.httpMethod = "POST"
+        req.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.httpBody = data
+        URLSession.shared.dataTask(with: req) { _, resp, err in
+            let ok = err == nil && ((resp as? HTTPURLResponse).map { (200..<300).contains($0.statusCode) } ?? false)
+            done(ok)
+        }.resume()
+    }
+
+    /// TelemetryDeck's ingest date format (`yyyy-MM-dd'T'HH:mm:ssZ`, GMT) — mirrored so the raw POST
+    /// speaks the same wire format as the SDK.
+    private static let ingestDateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(secondsFromGMT: 0)
+        return f
+    }()
+
+    private static func sha256Hex(_ s: String) -> String {
+        SHA256.hash(data: Data(s.utf8)).map { String(format: "%02x", $0) }.joined()
     }
 }

--- a/Sentient OS macOS/Diagnostics/CrashReporting.swift
+++ b/Sentient OS macOS/Diagnostics/CrashReporting.swift
@@ -112,8 +112,11 @@ enum CrashReporting {
                 $0.lifecycle = .trace
             }
 
-            // Sessions (release health) + app-hang ("beachball") detection.
-            options.enableAutoSessionTracking = true
+            // App-hang ("beachball") detection. Auto session tracking is deliberately OFF: release-
+            // health sessions are a "how many people use Sentient" signal, and ALL usage counting
+            // belongs to the ANALYTICS toggle (TelemetryDeck), never the crash toggle. So a user who
+            // keeps crash reports on but opts OUT of analytics is never counted here.
+            options.enableAutoSessionTracking = false
             options.enableAppHangTracking = true
 
             options.environment = "release"

--- a/Sentient OS macOS/Documentation/Crash Reporting (Sentry).md
+++ b/Sentient OS macOS/Documentation/Crash Reporting (Sentry).md
@@ -25,11 +25,19 @@ if CommandLine.arguments.contains(WakeHelperConfig.helperFlag) {
 Each role tags every event with `process: app` or `process: wakeHelper`, so a 3am overnight-run
 crash is told apart from a UI crash in the dashboard.
 
-`start(_:)` boots Sentry with everything on: native crash handler + attached stack traces,
-app-hang ("beachball") detection, release-health sessions, 100% trace sampling, and trace-lifecycle
-profiling. It's idempotent (guarded by `started`), a no-op if the DSN is blank, and — the two hard
-gates — a no-op in DEBUG and whenever the `diagnosticsEnabled` opt-out is off (the full gate story:
+`start(_:)` boots Sentry with the crash surface on: native crash handler + attached stack traces,
+app-hang ("beachball") detection, 100% trace sampling, and trace-lifecycle profiling. It's
+idempotent (guarded by `started`), a no-op if the DSN is blank, and — the two hard gates — a no-op
+in DEBUG and whenever the `diagnosticsEnabled` opt-out is off (the full gate story:
 `Diagnostics (Sentry).md`).
+
+⚠️ **Auto session tracking is deliberately OFF** (`enableAutoSessionTracking = false`). Release-
+health sessions are a "how many people use Sentient" signal, and **all** usage counting belongs to
+the *analytics* toggle (TelemetryDeck), never the *crash* toggle. If it were on, a user who keeps
+crash reports on but opts OUT of analytics would still be counted here — which would break the
+promise the analytics toggle makes. Sentry therefore reports crashes, errors, hangs, and traces
+only; user/session counting lives solely in `Analytics.swift`. (This costs us Sentry's crash-free-
+session % — TelemetryDeck's counts plus crash volume cover it.)
 
 ## The DSN — safe in the code
 

--- a/Sentient OS macOS/Documentation/Product Analytics (TelemetryDeck).md
+++ b/Sentient OS macOS/Documentation/Product Analytics (TelemetryDeck).md
@@ -70,6 +70,39 @@ existing B7 "length, not the command text" log — same discipline.
 
 Plus what the SDK sends automatically: app launches, sessions, new-install, and device/OS/version.
 
+**This is the SOLE owner of usage/session counting.** Sentry's auto session tracking is deliberately
+off (`CrashReporting.swift`), so "how many people use Sentient" lives entirely behind *this* toggle —
+with **one deliberate exception**: the anonymous install ping (below).
+
+## The one anonymous install ping (`countInstallOnce()` — opt-out-INDEPENDENT)
+
+`countInstallOnce()` sends a **single, totally anonymous** "an install exists" beacon that fires at
+most once per install and, unlike everything else here, fires **even when analytics are opted out**.
+It's how we always know how many people use Sentient, without making the opt-out a lie: it's
+**disclosed in the opt-out's own Settings copy** (a caption appears under the toggle the moment it's
+switched off).
+
+- **Anonymity.** It carries a throwaway random hash as `clientUser` (a fresh `UUID`, SHA-256'd, never
+  stored, never reused — so it ties to nothing: not the install id, not the crash-report id, not each
+  other), an empty payload, and no version / device / locale / content. Just a bare count.
+  TelemetryDeck stores no IP and salts the hash again server-side.
+- **Not via the SDK.** It's a single direct `POST` to TelemetryDeck's V2 ingest
+  (`https://nom.telemetrydeck.com/v2/`, matching the SDK's `SignalPostBody` wire shape), *not*
+  `TelemetryDeck.initialize` — because initializing the SDK would spin up ongoing session tracking,
+  which is exactly what an opted-out user must not get.
+- **Exactly once.** Latched by the `analytics.installCounted` UserDefaults flag, set **only after a
+  confirmed 2xx** — so an offline first launch simply retries next launch until the count lands once
+  (a reinstall clears the flag and counts again, same coarseness as `installID`).
+- **Release-only**, like everything else here (a dev's Debug launches never inflate the count).
+- **Fires for every install** (opted in or out), so the headline metric is clean and uniform: build a
+  TelemetryDeck Insight on **unique users of the `App.anonymousInstall` signal** = total installs.
+  Opted-in installs additionally send the rich signals in the table above; this ping is the one
+  number that's complete across everyone.
+
+Called once from `main.swift` (the `.app` branch), right after `Analytics.start()`. Opting out of
+analytics therefore silences *all* rich product signals and any correlatable identity; the only thing
+that still leaves the Mac is this one anonymous, uncountable-to-you tally.
+
 The knowledge-base and proactive-stage signals live centrally in `ProactiveCycle.run()` — the one
 place with all the counts and the create-vs-update decision — rather than scattered into
 `VaultCloud`/`Proactive`/`ProactiveResearch`, so they can't double-fire.
@@ -99,8 +132,8 @@ Because sends are Release-only, verify from a **Release build** (Debug sends not
 
 ## Files
 
-- `Diagnostics/Analytics.swift` — `start()`, `signal(_:parameters:)`, `applyEnabledChange()`, the `analyticsEnabled` opt-out, the App ID constant.
-- `App/main.swift` — `Analytics.start()` in the `.app` branch.
+- `Diagnostics/Analytics.swift` — `start()`, `signal(_:parameters:)`, `countInstallOnce()` (the opt-out-independent anonymous install ping), `applyEnabledChange()`, the `analyticsEnabled` opt-out, the App ID constant.
+- `App/main.swift` — `Analytics.start()` and `Analytics.countInstallOnce()` in the `.app` branch.
 - `Diagnostics/CrashReporting.swift` — the `installID` identity (shared) + Sentry's separate `diagnosticsEnabled` opt-out.
 - `Views/Settings/SystemPane.swift` — the two Privacy toggles; each `onChange` calls its own `applyEnabledChange()`.
 - The ~12 call sites in the table above.

--- a/Sentient OS macOS/Views/Settings/SystemPane.swift
+++ b/Sentient OS macOS/Views/Settings/SystemPane.swift
@@ -119,9 +119,18 @@ struct SystemPane: View {
                                   isOn: $crashReportsEnabled)
                 SettingsHairline()
                 SettingToggleLine(title: "Share anonymous analytics",
-                                  sub: "A privacy-friendly ping that tells us how many people use Sentient; nothing more.",
+                                  sub: "Anonymous usage signals through a privacy-first, open-source analytics framework; structure only, never any of your personal information.",
                                   isOn: $analyticsEnabled)
+                if !analyticsEnabled {
+                    Text("Even with this off, Sentient sends a single anonymous ping so we can count how many people use it. No identity, no device details, nothing else, ever.")
+                        .font(.system(size: 10.5))
+                        .foregroundStyle(Theme.Ink.deepMuted)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.top, 1)
+                        .transition(.opacity)
+                }
             }
+            .animation(.easeInOut(duration: 0.2), value: analyticsEnabled)
         }
         .onChange(of: crashReportsEnabled) { _, _ in CrashReporting.applyEnabledChange() }
         .onChange(of: analyticsEnabled) { _, _ in Analytics.applyEnabledChange() }


### PR DESCRIPTION
## What

Closes the todo: *"double check that the toggles for analytics & crash logs are turned off... basic analytics are still sent (how many users?)... also fix wording"*.

### The leak fix
Sentry's `enableAutoSessionTracking` was reporting user/session counts under the **crash** toggle — so a user who opted out of *analytics* but kept crash reports on was still being counted. It's now **off**: all usage/user counting lives behind the analytics toggle alone. Sentry is purely crashes / errors / hangs / traces.

### The disclosed always-on install count (decided with Aditya)
New `Analytics.countInstallOnce()` — a single, totally anonymous "an install exists" ping that fires once per install **even when analytics are opted out**, so we always know how many people use Sentient:
- Throwaway random hash as `clientUser` (never stored/reused — ties to nothing), empty payload, no device/version info.
- Direct one-shot POST to TelemetryDeck's v2 ingest — **not** the SDK, so opting out never spins up session tracking.
- Latched (`analytics.installCounted`) only after a confirmed 2xx → offline first launch retries next launch; lands exactly once. Release-only.
- **Disclosed in the UI**: flipping analytics off reveals a caption — *"Even with this off, Sentient sends a single anonymous ping so we can count how many people use it. No identity, no device details, nothing else, ever."* — so the switch is never a lie.

### Wording
Analytics toggle subtitle was *"A privacy-friendly ping… nothing more"* (untrue — it's a rich signal catalog). Now: *"Anonymous usage signals through a privacy-first, open-source analytics framework; structure only, never any of your personal information."*

## Verification
- Release build compiles (isolated DerivedData).
- Ping verified end-to-end on real hardware: Release log line + server 2xx ack (the latch only sets on confirmed 2xx). `App.anonymousInstall` event type pending dashboard aggregation.
- Docs updated: `Crash Reporting (Sentry).md`, `Product Analytics (TelemetryDeck).md`.

## Metric
Total installs = unique users of the `App.anonymousInstall` signal (fires for everyone, opted in or out).