### PR TITLE
Wire the Proactive & Sidekick custom-instruction fields into the prompts

### DIFF
--- a/Sentient OS macOS/Documentation/Notch Magic/Notch Magic.md
+++ b/Sentient OS macOS/Documentation/Notch Magic/Notch Magic.md
@@ -164,6 +164,10 @@ So the agent can act on what you're *actually looking at*, every command attache
 - **Privacy note:** the frame goes to the user's OWN codex/OpenAI — the same trust boundary computer use already crosses (it reads the live screen anyway). It never touches Sentient servers, and only the file *size* is logged, never the pixels.
 - **Known rough edges (§13):** no downscale yet (~0.5–1.5 MB per frame) · our own notch overlay is *in* the shot (recordable window) · main-display only (multi-monitor grabs the wrong screen sometimes) · the **home command-bar path is weak** — Sentient is frontmost there, so the frame is often our own UI; the two *notch* doors (non-activating panel) are where the shot is genuinely useful.
 
+### 6b. Standing context — `sidekick.context`
+
+`CommandRunModel.commandPrompt` injects the user's free-text Sidekick context from Settings → Proactive & Sidekick (`sidekick.context`, read via `CustomInstructions.sidekick`) as a "standing preferences" line — e.g. *"when I say text someone, use WhatsApp; my main browser is Edge."* It's `""` by default (prompt unchanged), and because `commandPrompt` is the ONE builder both the hotkey and the home command bar drive, the context applies to voice and typed runs alike. Trusted (user-authored), so it's stated as a directive, not wrapped as DATA. (The other pane key, `sidekick.hotkey`, is unrelated — it re-keys `SidekickHotkeyMonitor`, §4.)
+
 ---
 
 ## 7. The notch window — `NotchWindowController` + `NotchSpace`

--- a/Sentient OS macOS/Documentation/Proactive Intelligence (Judge).md
+++ b/Sentient OS macOS/Documentation/Proactive Intelligence (Judge).md
@@ -79,6 +79,12 @@ Accuracy-first and deliberately detailed. Cross-source context is the moat, but 
   teaches the SHAPE, not specific facts.
 - Standard guardrails: never invent a date/fact; no raw private specifics; a confident wrong item is
   worse than a miss.
+- **The user's own standing instructions** — `Proactive.instructionsBlock` injects the free text from
+  Settings → Proactive & Sidekick (`proactive.instructions`, via `CustomInstructions`) as a
+  high-priority directive block near the top: honor what they say to surface / skip, but it never
+  overrides the accuracy or never-fire rules. The block is `""` when unset (prompt unchanged), and the
+  SAME block is reused in PART 2 (like `recent`/`summaryLines`) so exclusions and preferences hold
+  end-to-end.
 
 ### Invocation specifics
 
@@ -110,7 +116,9 @@ Research surfaces (all read-only): the **full last-week summary corpus** (the SA
 as background context), the **knowledge base** (`cwd` — identity anchor + the user's **voice** + the
 facts a draft/form needs), the **Gmail MCP** if connected (read the live thread; skip gracefully +
 mark `unverified` if absent), **web search** (external facts, identity-matched), and the
-**live-calendar context** (the same `calendarContext:` block as PART 1).
+**live-calendar context** (the same `calendarContext:` block as PART 1). It also carries the user's
+**standing instructions** — the SAME `Proactive.instructionsBlock` PART 1 shows — so preferences that
+shape staging (a channel to prefer, a draft tone, a thing to skip) hold through the prune-to-5.
 
 `CodexCLI.Invocation`: `effort .high`, `sandbox .readOnly`, `cwd = vault`, `webSearch = true`,
 `includeUserConfig = true`, `bypassApprovals = false`, `outputSchema`, `timeout 1800s`, `feature
@@ -187,8 +195,6 @@ the code itself — `GiftLetter.prompt(vaultPath:)` is the source of truth (the 
 
 - **Retiring the demo deck** — real cards are the default now; deleting the hard-coded demo cards
   (they carry real investor names) is a pre-launch checklist item.
-- **Consuming `proactive.instructions`** — the Settings → Proactive & Sidekick standing instructions
-  are stored but not yet read by the judge/research prompts (the "prompt refinement" todo).
 - **Tier 1 reminders** — a scheduled macOS notification from a `reminder`/dated action
   (`System/Notify.swift` is the dormant hook).
 - **The ≤1/day taste cap** in code (today the cycle runs whenever triggered).

--- a/Sentient OS macOS/Documentation/Settings.md
+++ b/Sentient OS macOS/Documentation/Settings.md
@@ -9,26 +9,21 @@ pieces (`SettingsComponents.swift`).
 
 ## ⚠️ NOT wired up yet (read this first)
 
-1. **Proactive instructions + Sidekick context** (`ProactivePane`) — these two text fields work and
-   persist (`proactive.instructions` · `sidekick.context`), but **nothing consumes the values yet**.
-   The proactive/Sidekick prompts learn to read them with the prompt-refinement work.
-   *(The Sidekick **hotkey** chip — `sidekick.hotkey`, right ⌘ / right ⌥ — is fully wired: toggling
-   it live-re-keys `SidekickHotkeyMonitor` with no restart. See `Notch Magic/Notch Magic.md` §4.)*
-2. **The E2E encryption claim front-runs the code** — the Connect-AIs privacy blurb says the cloud
+1. **The E2E encryption claim front-runs the code** — the Connect-AIs privacy blurb says the cloud
    copy is end-to-end encrypted and unreadable even by Sentient's devs. That is LAUNCH truth,
    decided 2026-07-04: the mirror stores plaintext markdown today, and the "mcp encryption"
    backlog item (Aditya) MUST ship before launch or the copy must change. Do not soften the copy;
    ship the encryption.
-3. **The morning notification** — the Notifications permission row is real, and the permission ask
+2. **The morning notification** — the Notifications permission row is real, and the permission ask
    is now wired: onboarding's permissions screen fires `Notify.ask()` on appear, so the native
    macOS prompt happens once with no extra UI (`ask()` no-ops unless status is still
    `.notDetermined`). What's still dormant is the *sending* — `Notify.now()` has zero call sites;
    the "Proactive Intelligence is ready" morning note ships with the reminders/scheduler work.
-4. **The Updates group** (System pane) — doesn't exist until Sparkle lands; it brings its own
+3. **The Updates group** (System pane) — doesn't exist until Sparkle lands; it brings its own
    keep-it-on message.
-5. **Privacy toggles transmit only in RELEASE builds** — by design (Sentry/TelemetryDeck never
+4. **Privacy toggles transmit only in RELEASE builds** — by design (Sentry/TelemetryDeck never
    boot in DEBUG), so a Debug QA can verify persistence but not transmission.
-6. **Small known holes, accepted for now:** removing the LAST custom folder can bypass the
+5. **Small known holes, accepted for now:** removing the LAST custom folder can bypass the
    four-selection minimum (the guard covers chip toggle-offs only) · the reset-vs-run race has
    only the UI guard (see Reset below; the Layer-2 generation counter is deferred hardening) ·
    three Settings deep-link anchors (Speech Recognition, Accessibility, Screen Recording) are
@@ -79,8 +74,11 @@ sees custom folders. Verified by a headless selftest (7/7) on ship day.
 ### Proactive & Sidekick (`ProactivePane.swift`)
 Autosaving standing instructions + Sidekick's shortcut key and standing context. The **shortcut
 key** (right ⌘ / right ⌥) is live — toggling it posts `.sidekickHotkeyChanged`, which re-keys the
-running `SidekickHotkeyMonitor` with no restart. The two **text fields** are stored, not yet
-consumed — see the NOT-wired list above.
+running `SidekickHotkeyMonitor` with no restart. The two **text fields** are live too: the keys
+live in `CustomInstructions` (so producer and consumers can't drift), and `proactive.instructions`
+feeds both proactive prompts (`Proactive.instructionsBlock` — PART 1 + PART 2) while
+`sidekick.context` feeds the command/Sidekick prompt (`CommandRunModel.commandPrompt`, §6b of the
+Notch doc). Each is `""`-safe: no text → the prompt is unchanged.
 
 ### Connect AIs to Knowledge (`YourAIsPane.swift`)
 The story leads: a value blurb (your ChatGPT/Claude, phone apps included, read the knowledge

--- a/Sentient OS macOS/Notch Magic/CommandRunModel.swift
+++ b/Sentient OS macOS/Notch Magic/CommandRunModel.swift
@@ -214,11 +214,16 @@ final class CommandRunModel {
         let screenLine = hasScreenshot
             ? "\nAttached is a screenshot of my screen exactly as it looks right now. Use it to see what I'm currently looking at — resolve any \"this\", \"here\", \"that form\", etc. against what's on screen before you act.\n"
             : ""
+        // The user's standing Sidekick context (Settings → Proactive & Sidekick) — preferred apps,
+        // browser, norms. Empty string when they've set none, so the prompt is unchanged by default.
+        let context = CustomInstructions.sidekick
+        let contextLine = context.isEmpty ? ""
+            : "\nStanding preferences I've set for you (apply them wherever they're relevant to this task): \(context)\n"
         return """
         Using \(mode.promptPhrase), \(task)
         \(screenLine)
         Carry out the task itself with \(mode.promptPhrase) — drive the real apps and websites directly (open them, click, type, navigate). Do NOT fake it with AppleScript, osascript, or other GUI-scripting shortcuts.
-
+        \(contextLine)
         For context about me, my knowledge base is a folder of markdown files at '\(VaultGenerator.vaultRoot.path)'. When you need it, read it directly with your shell/file tools — `ls`, `cat`, and `grep` the .md files. Do NOT open it in Obsidian or any GUI app to read it.
         """
     }

--- a/Sentient OS macOS/Proactive/Proactive.swift
+++ b/Sentient OS macOS/Proactive/Proactive.swift
@@ -69,6 +69,27 @@ actor Proactive {
         return notes.filter { itemDate($0) >= cutoff }.sorted { itemDate($0) > itemDate($1) }
     }
 
+    /// The user's OWN standing proactive instructions (Settings → Proactive & Sidekick), rendered as a
+    /// prompt block — or "" when they've set none. Shared by PART 1 (decide) and PART 2 (research +
+    /// prepare), like `recent`/`summaryLines`, so both honor the user's wishes with one wording. It's a
+    /// high-priority directive but NEVER overrides the accuracy / never-fire rules.
+    static var instructionsBlock: String {
+        let t = CustomInstructions.proactive
+        guard !t.isEmpty else { return "" }
+        return """
+
+        ## THE USER'S OWN STANDING INSTRUCTIONS (they set these in Settings — honor them)
+        In their own words, the user has told you what they care about and what to skip in their \
+        proactive suggestions. Treat this as a high-priority directive and follow it wherever it \
+        applies: drop what they ask you to drop, favor what they say matters, and respect how they \
+        want things handled. It NEVER overrides the hard accuracy rules (never fabricate a date, fact, \
+        or source) or the never-fire rule; within those, the user's wishes win over your defaults.
+
+        \(t)
+
+        """
+    }
+
     /// Render summaries as the numbered prompt block both parts show:
     /// `#n · [source] location · date` then `title — summary`.
     static func summaryLines(_ notes: [CloudNote]) -> String {
@@ -229,7 +250,7 @@ actor Proactive {
         single time. When in doubt, leave it out.
 
         Today is \(today).
-
+        \(Self.instructionsBlock)
         ## YOUR EDGE IS BREADTH — you see every source at once
         Everyone else's AI is trapped inside one app. You are not. These summaries span the user's \
         ENTIRE digital life at once — files, WhatsApp, iMessage, Apple Notes, Calendar, and email. \

--- a/Sentient OS macOS/Proactive/ProactiveResearch.swift
+++ b/Sentient OS macOS/Proactive/ProactiveResearch.swift
@@ -314,7 +314,7 @@ actor ProactiveResearch {
         nothing left to decide or look up.
 
         Today is \(today).
-
+        \(Proactive.instructionsBlock)
         ## TWO INVIOLABLE RULES
         **1 — Total accuracy, ZERO fabrication.** The user will ACT on what you produce, so a confident \
         wrong answer is catastrophic, far worse than admitting uncertainty.

--- a/Sentient OS macOS/System/CustomInstructions.swift
+++ b/Sentient OS macOS/System/CustomInstructions.swift
@@ -1,0 +1,30 @@
+//
+//  CustomInstructions.swift
+//  Sentient OS macOS
+//
+//  The user's standing, free-text instructions set in Settings → Proactive & Sidekick: what to care
+//  about / skip in the morning suggestions, and standing context for Sidekick ("text via WhatsApp,
+//  my browser is Edge"). This is the ONE source of truth for those two UserDefaults keys — the pane
+//  (ProactivePane) writes them, the prompts read them here, so a rename can never silently unwire.
+//  (`sidekick.hotkey` is separate — it drives SidekickHotkeyMonitor, not a prompt.)
+//
+//  Consumers: Proactive.instructionsBlock (PART 1 + PART 2) · CommandRunModel.commandPrompt (Sidekick).
+//
+
+import Foundation
+
+enum CustomInstructions {
+    /// Standing instructions for the proactive suggestion writer (what to surface / skip).
+    static let proactiveKey = "proactive.instructions"
+    /// Standing context for Sidekick + the command bar (preferred apps, browser, norms).
+    static let sidekickKey = "sidekick.context"
+
+    /// The proactive instructions, trimmed ("" when the user has set none).
+    static var proactive: String { value(proactiveKey) }
+    /// The Sidekick context, trimmed ("" when the user has set none).
+    static var sidekick: String { value(sidekickKey) }
+
+    private static func value(_ key: String) -> String {
+        (UserDefaults.standard.string(forKey: key) ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Sentient OS macOS/Views/Settings/ProactivePane.swift
+++ b/Sentient OS macOS/Views/Settings/ProactivePane.swift
@@ -4,18 +4,19 @@
 //
 //  Settings → Proactive & Sidekick: the user's standing instructions for the proactive
 //  suggestion writer, and Sidekick's shortcut key + standing context. The strings persist and
-//  autosave (keys: proactive.instructions · sidekick.hotkey · sidekick.context). The hotkey choice
-//  (right ⌘ / right ⌥) is LIVE — toggling it posts `.sidekickHotkeyChanged`, which re-keys the
-//  running SidekickHotkeyMonitor with no restart. The two text fields are consumed when the prompt
-//  wiring lands (the "prompt refinement" todo).
+//  autosave. The hotkey choice (right ⌘ / right ⌥) is LIVE — toggling it posts `.sidekickHotkeyChanged`,
+//  which re-keys the running SidekickHotkeyMonitor with no restart. The two text fields are LIVE too:
+//  `proactive.instructions` feeds the proactive prompts (Proactive.instructionsBlock, PART 1 + 2) and
+//  `sidekick.context` feeds the command/Sidekick prompt (CommandRunModel.commandPrompt) — the two keys
+//  live in CustomInstructions so producer and consumers can't drift.
 //
 
 import SwiftUI
 
 struct ProactivePane: View {
-    @AppStorage("proactive.instructions") private var proactiveInstructions = ""
+    @AppStorage(CustomInstructions.proactiveKey) private var proactiveInstructions = ""
     @AppStorage("sidekick.hotkey") private var sidekickHotkey = "rightCommand"
-    @AppStorage("sidekick.context") private var sidekickContext = ""
+    @AppStorage(CustomInstructions.sidekickKey) private var sidekickContext = ""
 
     var body: some View {
         SettingsPane(title: "Proactive & Sidekick",


### PR DESCRIPTION
## What

The two custom-instruction text fields in **Settings → Proactive & Sidekick** persisted but nothing consumed them. This wires them into the prompts (the `sidekick.hotkey` chip was already live and is untouched).

- **`proactive.instructions` → both proactive prompts.** New `Proactive.instructionsBlock` (mirrors the existing shared `Proactive.recent` / `summaryLines` pattern) injects the user's standing instructions into **PART 1** (the judge/decider) *and* **PART 2** (research + prepare / prune-to-5), so exclusions ("skip Chase alerts") and preferences ("text via WhatsApp", draft tone) hold end-to-end. Framed as a high-priority directive that **never** overrides the accuracy (never-fabricate) or never-fire rules.
- **`sidekick.context` → `CommandRunModel.commandPrompt`**, the single builder both the notch hold-to-talk and the home command bar drive, so it applies to voice and typed runs alike.
- **New `System/CustomInstructions.swift`** — one source of truth for the two keys, shared with `ProactivePane`, so producer and consumers can't drift on a magic string.
- Empty-string safe: no text set → prompts unchanged.

Instructions are user-authored → treated as trusted directives (not third-party content), so no prompt-injection DATA-wrapping.

## Docs
Updated `Proactive Intelligence (Judge).md` (PART 1 + PART 2 sections, removed the stale "not wired" bullet), `Notch Magic/Notch Magic.md` (new §6b Standing context), and `Settings.md` (removed the resolved "NOT wired up yet" item, refreshed the ProactivePane description).

## Verification
- Isolated build (`-derivedDataPath /tmp/sentient-verify`) **SUCCEEDS**, including after rebasing onto current `main` (gpt-5.6-sol / NSEvent-monitor / #139 changes all present).
- ⚠️ Not yet exercised end-to-end at runtime — worth a live check (type an instruction, run Analyze Now + a Sidekick command, confirm it lands in the prompt via `/tmp/sentient-dev.log`).