### PR TITLE
Add 'Open Sentient OS' to the menu bar

### DIFF
--- a/Sentient OS macOS/App/Sentient_OS_macOSApp.swift
+++ b/Sentient OS macOS/App/Sentient_OS_macOSApp.swift
@@ -14,11 +14,14 @@ import SwiftUI
 struct SentientOSApp: App {
     @State private var appState = AppState()
 
+    /// Scene id for the primary home window, so the menu bar's "Open Sentient OS" can reopen/focus it.
+    static let homeWindowID = "home"
+
     // To add a headless self-test, restore the one-line hook here — see
     // Documentation/Self-Testing (Eval Harness).md (the `Self Tests - Temp/` folder is kept empty).
 
     var body: some Scene {
-        WindowGroup {
+        WindowGroup(id: Self.homeWindowID) {
             RootView()
                 .environment(appState)
                 .preferredColorScheme(.dark)   // Sentient OS is dark-only — no light mode

--- a/Sentient OS macOS/Views/MenuBarView.swift
+++ b/Sentient OS macOS/Views/MenuBarView.swift
@@ -2,7 +2,7 @@
 //  MenuBarView.swift
 //  Sentient OS macOS
 //
-//  Glanceable status in the macOS menu bar. A stub today (status line + Quit) — the richer
+//  Glanceable status in the macOS menu bar. A stub today (Open + status line + Quit) — the richer
 //  dropdown ("412 / 3,000 · paused (in use)") is still to build.
 //
 
@@ -11,8 +11,12 @@ import AppKit
 
 struct MenuBarView: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.openWindow) private var openWindow
 
     var body: some View {
+        Button("Open Sentient OS") { openHome() }
+
+        Divider()
         switch appState.status {
         case .idle:                            Text("Sentient OS · idle")
         case .processing(let done, let total): Text("Processing \(done) / \(total)")
@@ -26,5 +30,21 @@ struct MenuBarView: View {
 
         Divider()
         Button("Quit Sentient OS") { NSApplication.shared.terminate(nil) }
+    }
+
+    /// Bring the proactive home window to the front — focus it if it's open, otherwise reopen it
+    /// (a red-button close destroys the WindowGroup's window, so it must be recreated).
+    private func openHome() {
+        let homeID = SentientOSApp.homeWindowID
+        if let home = NSApp.windows.first(where: {
+            guard let raw = $0.identifier?.rawValue else { return false }
+            return raw == homeID || raw.hasPrefix(homeID + "-")
+        }) {
+            home.makeKeyAndOrderFront(nil)
+            home.orderFrontRegardless()
+        } else {
+            openWindow(id: homeID)
+        }
+        NSApp.activate()
     }
 }


### PR DESCRIPTION
Adds an **Open Sentient OS** item as the topmost entry in the menu bar dropdown, in its own section above the status line.

```
Open Sentient OS      ← new
────────────
Sentient OS · idle
────────────
Check for Updates…
Version 1.0 (1)
────────────
Quit Sentient OS
```

**How it works**
- Focuses the home window if it's already open (found by scene-id prefix), otherwise reopens it via `openWindow(id:)` — a red-button close destroys a `WindowGroup` window, so it has to be recreated — then activates the app forward (`NSApp.activate()`, matching `ComputerUseGate`; avoids the deprecated `activate(ignoringOtherApps:)`).
- Gives the primary home `WindowGroup` a stable scene id (`homeWindowID = "home"`) so the menu can target it; it had none before.

Verified with an isolated Debug build (`** BUILD SUCCEEDED **`).