### PR TITLE
Hide Dock icon when no windows are open

### DIFF
--- a/Sentient OS macOS/App/AppState.swift
+++ b/Sentient OS macOS/App/AppState.swift
@@ -35,6 +35,9 @@ final class AppState {
     /// The notch overlay window — renders the coordinator's status phase as the living notch.
     private let notch: NotchWindowController
 
+    /// Drops the Dock icon when every window is closed (the menu bar item is the home then).
+    private let dockPolicy = DockPolicy()
+
     /// The Sparkle auto-updater + our OLED forced-update UI. Only ever built in the GUI app (this
     /// whole object is), never the root wake-helper. Its `model` drives UpdateGateView. (Updates/)
     let update = UpdateController()
@@ -56,6 +59,7 @@ final class AppState {
         // the coordinator: the notch experience still plays, the codex run just never fires.
         commandCoordinator.start()   // arm right-⌘ hold-to-talk + warm the speech model
         notch.start()                // raise the notch overlay window
+        dockPolicy.start()           // drop the Dock icon whenever the last window closes
         update.start()               // start Sparkle + one silent launch check (gates a mandatory update)
 
         // Notifications, banked silently: PROVISIONAL authorization shows NO prompt — macOS just

--- a/Sentient OS macOS/App/DockPolicy.swift
+++ b/Sentient OS macOS/App/DockPolicy.swift
@@ -1,0 +1,48 @@
+//
+//  DockPolicy.swift
+//  Sentient OS macOS
+//
+//  Hides the Dock icon when every real Sentient window is closed — the menu bar item is the
+//  app's ever-present home, so an empty Dock tile is just clutter. Flips NSApp between
+//  .regular (a window is up) and .accessory (none are), driven by NSWindow open/close
+//  notifications. `start()` once from AppState; `reevaluate()` does the counting.
+//
+
+import AppKit
+
+@MainActor
+final class DockPolicy {
+
+    private var observers: [NSObjectProtocol] = []
+
+    /// Begin watching windows. Call once (AppState.init). We deliberately DON'T evaluate eagerly:
+    /// the app launches .regular (no LSUIElement), the home/onboarding window opens and keeps us
+    /// there, and we only ever drop to .accessory on a real close — so there's no launch flicker.
+    func start() {
+        let nc = NotificationCenter.default
+        func watch(_ name: Notification.Name, closing: Bool) {
+            observers.append(nc.addObserver(forName: name, object: nil, queue: .main) { [weak self] note in
+                MainActor.assumeIsolated {
+                    self?.reevaluate(closing: closing ? note.object as? NSWindow : nil)
+                }
+            })
+        }
+        // A window appeared/focused → the Dock icon comes back; the last one closed → it drops.
+        watch(NSWindow.didBecomeKeyNotification, closing: false)
+        watch(NSWindow.willCloseNotification, closing: true)
+    }
+
+    /// Show the Dock icon iff at least one real Sentient window is up. `closing` is the window in
+    /// the middle of a willClose — still listed in NSApp.windows, so it's excluded from the count.
+    func reevaluate(closing: NSWindow? = nil) {
+        let hasRealWindow = NSApp.windows.contains { window in
+            window !== closing
+                && !(window is NSPanel)                    // the notch + permission-drag panels are always-on furniture
+                && window.canBecomeMain                    // skips the status-item / menu-bar helper windows
+                && (window.isVisible || window.isMiniaturized)
+        }
+        let target: NSApplication.ActivationPolicy = hasRealWindow ? .regular : .accessory
+        guard NSApp.activationPolicy() != target else { return }
+        NSApp.setActivationPolicy(target)
+    }
+}

--- a/Sentient OS macOS/Views/MenuBarView.swift
+++ b/Sentient OS macOS/Views/MenuBarView.swift
@@ -35,6 +35,10 @@ struct MenuBarView: View {
     /// Bring the proactive home window to the front — focus it if it's open, otherwise reopen it
     /// (a red-button close destroys the WindowGroup's window, so it must be recreated).
     private func openHome() {
+        // We may be .accessory (Dock icon hidden because no window is up). Restore .regular BEFORE
+        // opening/activating so the window takes focus and the Dock icon reappears cleanly — the
+        // DockPolicy observer would do it on didBecomeKey, but that lands too late for activate().
+        NSApp.setActivationPolicy(.regular)
         let homeID = SentientOSApp.homeWindowID
         if let home = NSApp.windows.first(where: {
             guard let raw = $0.identifier?.rawValue else { return false }


### PR DESCRIPTION
## What

When every real Sentient window is closed, drop the Dock icon — the menu bar item is the app's ever-present home, so an empty Dock tile is just clutter. It comes back the moment a window opens.

## How

- **New `App/DockPolicy.swift`** — watches `NSWindow` `didBecomeKey` / `willClose` notifications and flips `NSApp` between `.regular` (a real window is up) and `.accessory` (none are). The window-count filter excludes the always-on `NSPanel`s (notch overlay + permission-drag panel) and status-item helpers, and keeps the icon up for minimized-only windows.
- **`App/AppState.swift`** — owns and `start()`s it alongside the other lifecycle starts.
- **`Views/MenuBarView.swift`** — `openHome()` restores `.regular` before opening/activating, so re-opening from the menu bar reveals the Dock icon and focuses the window cleanly (wins the race against the observer).

Two deliberate calls (commented in-code): no eager evaluation at launch (starts `.regular`, only demotes on a real close → zero launch flicker) and the explicit reveal in `openHome()`.

## Test (real hardware)

- Close home → Dock icon disappears, menu bar icon stays, app keeps running.
- Menu bar → "Open Sentient OS" → Dock icon returns, window focused.
- Home + Settings open; close home only → icon stays; close Settings → drops.
- Onboarding at launch → icon present throughout, no flicker.
- Minimize the only window → icon stays.
- Notch/Sidekick hotkey + scheduler still work while windowless.

Isolated CLI build (`/tmp/sentient-verify`) passed — GUI Run's signed dylib untouched.