### PR TITLE
Pre-grant Codex Automation right at computer-use install time

### DIFF
--- a/Sentient OS macOS/Cloud/CodexSetup.swift
+++ b/Sentient OS macOS/Cloud/CodexSetup.swift
@@ -168,6 +168,14 @@ final class CodexSetup {
             }
             computerUseReady = true
             computerUseStatus = "✓ Computer use ready"
+            // The helper is now on disk, so pre-grant the Automation right (Sentient → the helper
+            // over Apple Events) HERE — user-invisible, FDA-writable — so the first fire never
+            // waits on it. Idempotent + fully guarded (no-op without FDA, or if already granted).
+            // A short settle first: the code-signature blob is read off the freshly-laid bundle.
+            Task {
+                try? await Task.sleep(for: .seconds(2))
+                Permissions.selfHealComputerUseAutomation(context: "CodexSetup.computerUse")
+            }
         } catch {
             computerUseReady = ComputerUseSetup.isInstalled
             computerUseStatus = "✗ \((error as? LocalizedError)?.errorDescription ?? "\(error)")"

--- a/Sentient OS macOS/Documentation/Permission Guide (First-Use Grants).md
+++ b/Sentient OS macOS/Documentation/Permission Guide (First-Use Grants).md
@@ -46,7 +46,15 @@ with no row to flip. The drag panel works on every macOS.
   coordinator.
 - Presenting the gate also runs `Permissions.selfHealComputerUseAutomation` — the Apple Events
   grant (Sentient → the helper) is user-invisible and FDA-writable, so it's healed before the
-  first fire ever needs it. (Settings → Health runs the same self-heal on open.)
+  first fire ever needs it.
+- **The self-heal has FOUR triggers**, all idempotent and fully guarded (no-op without FDA, or if
+  the helper's not on disk, or if it's already granted): the gate above, Settings → Health on open,
+  the Dev Tools button, and — earliest — **right after a successful computer-use install**
+  (`CodexSetup.setupComputerUse`, 2s after `✓ Computer use ready`). That last one is the ideal
+  moment: the helper is freshly on disk and onboarding already holds FDA, so the row is written
+  proactively *during setup* — the grant is in place well before the first fire, and the gate's
+  copy is just a backstop. The 2s delay lets the just-written helper bundle settle before its
+  code-signature blob is read.
 - Analytics: `PermissionGate.shown` / `PermissionGate.continued` (all_granted flag only).
 
 ## PermissionGuide (the floating drag panel)

--- a/Sentient OS macOS/Views/ProcessingView.swift
+++ b/Sentient OS macOS/Views/ProcessingView.swift
@@ -78,6 +78,8 @@ struct ProcessingView: View {
     private enum UIState: Equatable { case loadingModel, processing, preparing, completed, failed(String) }
     @State private var state: UIState = .loadingModel
     @State private var prepStatus = "Preparing your suggestions…"
+    /// The 10-minute patience flip for the cloud tail's bottom line (see `patienceLine`).
+    @State private var patienceLong = false
     /// Phase-appropriate caption under the phase line (nil = none) — the proactive stages get
     /// the "things worth doing" promise; the knowledge-base/welcome phases speak for themselves.
     @State private var prepSubtext: String?
@@ -116,6 +118,8 @@ struct ProcessingView: View {
                 Spacer(minLength: 0)
                 if state == .loadingModel || state == .processing {
                     footer.padding(.bottom, 30)
+                } else if state == .preparing {
+                    patienceLine.padding(.bottom, 30)
                 }
             }
             .padding(.horizontal, 28)
@@ -299,6 +303,21 @@ struct ProcessingView: View {
             }
             ProgressView().tint(.white.opacity(0.4)).padding(.top, 2)
         }
+    }
+
+    /// The quiet expectation-setter under the cloud phases (knowledge base + proactive) — honest
+    /// about the wait, and warmer once the wait is genuinely long (the 10-minute flip).
+    private var patienceLine: some View {
+        Text(patienceLong
+             ? "You've got an incredible knowledge base; still working hard to make it perfect. It's going to take another 15 mins or so."
+             : "This can take around 15 minutes.")
+            .font(.caption).foregroundStyle(.white.opacity(0.35))
+            .multilineTextAlignment(.center)
+            .frame(maxWidth: 440)
+            .task {
+                try? await Task.sleep(for: .seconds(600))
+                withAnimation(.easeInOut(duration: 0.6)) { patienceLong = true }
+            }
     }
 
     private var completedView: some View {
@@ -496,7 +515,7 @@ struct ProcessingView: View {
                     case .knowledgeBase(let s):
                         prepStatus = s; prepSubtext = nil            // the phase line says it all
                     case .deciding:
-                        prepStatus = "Deciding what's worth doing…"
+                        prepStatus = "Creating proactive intelligence…"
                         prepSubtext = "Reading what's new, then preparing a few things worth doing."
                     case .researching(let n):
                         prepStatus = "Preparing \(n) suggestion\(n == 1 ? "" : "s")…"


### PR DESCRIPTION
## What
The Sentient → Codex Computer Use helper **Automation** grant (Apple Events, `kTCCServiceAppleEvents`) is now written **proactively at install time**, not just lazily at first fire.

## Why
Today `selfHealComputerUseAutomation()` fires from three places, all *reactive*: the first-use gate, Settings → Health on open, and the dev button. This adds a fourth, *earliest* trigger — 2s after a successful computer-use install, in `CodexSetup.setupComputerUse()`'s success branch (the single code path both onboarding and the dev button share, so no duplication).

At that moment the helper is freshly on disk **and** onboarding already holds Full Disk Access, so the self-heal actually **writes the TCC row** — the Automation toggle is flipped on *during setup*, well before the first computer-use action needs it.

## Safety
The self-heal is fully idempotent and guarded — no-op without FDA, without the helper on disk, or when already granted (the write is `INSERT OR REPLACE`). So the existing gate call stays as a harmless backstop, and re-firing costs nothing. The 2s delay lets the just-written helper bundle's code-signature blob be read cleanly.

## Verify
Live: run onboarding (or the dev "set up computer use" after `tccutil reset AppleEvents`) and watch for `CodexSetup.computerUse: automation self-heal — granted…` ~2s after `✓ Computer use ready`, then confirm the Automation toggle (Privacy & Security → Automation → Sentient OS → Codex Computer Use) is on.

Isolated CLI build passes. Doc updated: *Permission Guide (First-Use Grants).md*.