### PR TITLE
Permission gate: block Sidekick/computer-use until all required grants are given

### DIFF
--- a/Sentient OS macOS/Notch Magic/CommandCoordinator.swift
+++ b/Sentient OS macOS/Notch Magic/CommandCoordinator.swift
@@ -159,6 +159,14 @@ final class CommandCoordinator {
             Log("hotkey blocked — knowledge-base-only plan (Sidekick needs Plus)")
             return
         }
+        // First-use permission gate — BEFORE the notch opens. If any required action grant is
+        // missing, the setup window takes the press; the notch never drops open to listen (which
+        // would only meet the gate at submit, after a whole listen-and-transcribe dance). The user
+        // grants, then presses again to talk. Same window the command bar + proactive cards raise.
+        if ComputerUseGate.shared.interceptBeforeStart() {
+            Log("hotkey press intercepted — computer-use permissions missing, gate up")
+            return
+        }
         setPhase(.opening)                                // you're pulling it open — reveal the instant you press
         if VoiceCapture.isAuthorized { startCapture() }   // never PROMPT on a press; defer to hold-confirm
     }

--- a/Sentient OS macOS/Views/Permissions/ComputerUseGate.swift
+++ b/Sentient OS macOS/Views/Permissions/ComputerUseGate.swift
@@ -51,24 +51,40 @@ final class ComputerUseGate {
 
     // MARK: The gate
 
-    private var shownThisSession = false
     private var pending: (@MainActor () -> Void)?
     private var window: NSWindow?
     private var closeObserver: NSObjectProtocol?
 
     /// The one entry point. Returns true when the action was intercepted (the setup window is up
-    /// and the action is stashed — fired by Continue, dropped by close). Returns false when the
-    /// caller should just proceed: everything granted, or the gate already had its one showing
-    /// this session.
+    /// and the action is stashed — fired by Continue once every required grant is green, dropped
+    /// by close). Returns false ONLY when everything required is already granted, so the caller
+    /// may proceed. While any required grant is missing the gate ALWAYS takes over — re-showing
+    /// (or re-focusing an already-open window) and re-holding the action on every attempt, so a
+    /// feature can never fire half-granted no matter how many times the window was dismissed.
     func intercept(_ action: @escaping @MainActor () -> Void) -> Bool {
         refresh()
-        guard !allRequiredGranted, !shownThisSession else { return false }
-        shownThisSession = true
+        guard !allRequiredGranted else { return false }
+        let wasVisible = window?.isVisible ?? false
         pending = action
         present()
-        Analytics.signal("PermissionGate.shown")
-        Log("ComputerUseGate: intercepted first computer-use action — setup window up")
+        if wasVisible {
+            Log("ComputerUseGate: re-intercepted — setup window already up, action re-held")
+        } else {
+            Analytics.signal("PermissionGate.shown")
+            Log("ComputerUseGate: intercepted computer-use action — setup window up (required grants missing)")
+        }
         return true
+    }
+
+    /// Gate a surface that must not even OPEN while a required grant is missing — the Sidekick
+    /// hotkey PRESS, which has no command to hold yet. Without this the notch drops open to listen
+    /// and only meets the gate at submit(), after a whole listen-and-transcribe dance. Same
+    /// show/re-show behavior as `intercept`; there's simply nothing to fire on Continue, so the
+    /// user re-presses to talk once everything's granted. Returns true when the gate took over and
+    /// the caller must abort (don't open the notch).
+    @discardableResult
+    func interceptBeforeStart() -> Bool {
+        intercept({})
     }
 
     /// Re-probe all four grants (cheap; the TCC reads are two tiny indexed SELECTs).
@@ -97,11 +113,18 @@ final class ComputerUseGate {
             clientBundleID: Permissions.computerUseHelperBundleID)
     }
 
-    /// The window's main button — dismiss and fire the held action (granted or not; the user decides).
+    /// The window's main button — dismiss and fire the held action. Only ever fires once every
+    /// required grant is green (the button is disabled until then); the re-probe + guard here make
+    /// that a hard invariant, so a stale tap can never launch a feature that would just fail.
     func continueNow() {
+        refresh()
+        guard allRequiredGranted else {
+            Log("ComputerUseGate: Continue blocked — a required grant is still missing")
+            return
+        }
         let action = pending
         pending = nil
-        Analytics.signal("PermissionGate.continued", parameters: ["all_granted": String(allRequiredGranted)])
+        Analytics.signal("PermissionGate.continued", parameters: ["all_granted": "true"])
         dismissWindow()
         action?()
     }

--- a/Sentient OS macOS/Views/Permissions/ComputerUseGateView.swift
+++ b/Sentient OS macOS/Views/Permissions/ComputerUseGateView.swift
@@ -78,7 +78,11 @@ struct ComputerUseGateView: View {
             }
             .padding(.top, 30)
 
-            OnboardingNextButton(title: gate.allRequiredGranted ? "Continue" : "Continue anyway") {
+            // No bypass: while any required grant is red the button is disabled and says so, so a
+            // feature can never be fired half-granted. It enables the instant every row goes green
+            // (the rows re-probe on foreground + after the mic prompt).
+            OnboardingNextButton(title: gate.allRequiredGranted ? "Continue" : "Grant permissions to continue",
+                                 enabled: gate.allRequiredGranted) {
                 gate.continueNow()
             }
             .frame(maxWidth: .infinity)


### PR DESCRIPTION
## What
The first-use permission gate had escape hatches that let Sidekick / computer-use fire while required grants were still missing — so the feature would silently fail. This closes all of them: **nothing fires until every required grant (Mic & Speech + the Codex helper's Accessibility + Screen Recording) is green.**

## The bugs
1. **One-shot-per-session (`shownThisSession`)** — after the gate showed once, `intercept()` returned false forever. Close it without granting, fire again → action ran blind. This was the main reported bug.
2. **"Continue anyway"** — the button fired the held action regardless of grant state, even on the first show.
3. **Sidekick hotkey press wasn't gated** — the gate lived only in `submit()`, which for voice runs *last* (press → notch opens → hold → talk → transcribe → submit). So pressing the hotkey dropped the listening notch open instead of raising the gate.

## The fix (3 files)
- `ComputerUseGate.swift` — dropped `shownThisSession`; the gate now always re-shows / re-focuses and re-holds the action while any required grant is missing. `continueNow()` re-probes + hard-guards on `allRequiredGranted`. Added `interceptBeforeStart()` for surfaces with no command yet.
- `ComputerUseGateView.swift` — removed "Continue anyway"; the button is disabled and reads "Grant permissions to continue" until all required rows are green.
- `CommandCoordinator.swift` — gate the hotkey press before the notch opens, next to the existing knowledge-base-only bail.

Sentient's own Screen Recording stays **optional** (never blocks), per the current architecture decision.

## Verify
Fresh-install / reset-perms state → each fire-path (prompt box, Sidekick voice, Sidekick text, proactive card) raises the gate, close+re-fire re-raises it, and Continue only works once everything's green. Isolated Debug build passes.

Doc (`Permission Guide (First-Use Grants).md`) update to follow once verified on hardware.