### PR TITLE
Auto-advance the analysis completion screen after 5s

### DIFF
--- a/Sentient OS macOS/Documentation/Home — Proactive Intelligence (For You).md
+++ b/Sentient OS macOS/Documentation/Home — Proactive Intelligence (For You).md
@@ -56,7 +56,11 @@ HomeView ⟷ ProcessingView cross-fade. **Analyze Now runs the shared `SourceSel
 mirror → gift → proactive → wipe), byte-for-byte what the 3am scheduler runs. `RootView` also owns
 **the onboarding finale**: when the first analysis finishes, onboarding dissolves into the home and
 the Knowledge window (the Constellation) opens ON TOP a beat later — every user's first sight of
-their knowledge base, whatever their plan. `RootView` also mounts the screen-agnostic
+their knowledge base, whatever their plan. ProcessingView's "Analysis complete" screen
+**auto-advances after 5s** (the Done button stays as a skip; a cancellation check stops a manual
+Done from double-firing the finale) — so someone who left the first run going overnight wakes up
+to the Constellation + cards, never a stale complete screen. Dev runs (`showPrompt`) keep the
+manual Done so final counts can be inspected. `RootView` also mounts the screen-agnostic
 **computer-use setup whisper** — a small spinner + "Setting up Codex computer use in the
 background." bottom-left, keyed to the live `CodexSetup.settingUpComputerUse` flag, so it rides
 onboarding's takeover, the knowledge-base phase, and (rarely) the home for exactly as long as the

--- a/Sentient OS macOS/Views/ProcessingView.swift
+++ b/Sentient OS macOS/Views/ProcessingView.swift
@@ -336,6 +336,16 @@ struct ProcessingView: View {
             }
             .buttonStyle(.plain).padding(.top, 6)
         }
+        // Auto-advance: 5s after completion the takeover dismisses itself, so a user who left
+        // the analysis running returns to the home + cards (onboarding: the Constellation
+        // finale), never a stale "complete" screen. The Done button stays for the impatient;
+        // dev runs (showPrompt) keep manual Done so the final counts can be inspected. The
+        // cancellation check keeps a manual Done from double-firing the finale.
+        .task {
+            guard !showPrompt else { return }
+            try? await Task.sleep(for: .seconds(5))
+            if !Task.isCancelled { onDone() }
+        }
     }
 
     private func failedView(_ message: String) -> some View {


### PR DESCRIPTION
## What

The `ProcessingView` "Analysis complete" screen now auto-fires `onDone` 5 seconds after it appears, instead of waiting for a click.

## Why

If the user left the first analysis running (or overnight), they now return to the magic — home + cards, and in onboarding the Constellation finale — never a stale "processing complete" screen.

## Details

- The **Done button stays** as a skip for the impatient.
- A `Task.isCancelled` check stops a manual Done from double-firing the finale (which could double-open the Knowledge window).
- **Dev runs (`showPrompt`) are exempt** — manual Done kept so final counts can be inspected.
- Docs updated: `Home — Proactive Intelligence (For You).md` (+ the Our_Stuff architecture file, synced separately).

Built clean via Xcode MCP.