### PR TITLE
Retire .xhigh: the initial vault build now runs gpt-5.6-sol at .high

### DIFF
--- a/Sentient OS macOS/Cloud/CodexCLI.swift
+++ b/Sentient OS macOS/Cloud/CodexCLI.swift
@@ -32,7 +32,8 @@ actor CodexCLI {
 
     /// Reasoning-effort tier (codex `model_reasoning_effort`). All four are accepted by codex.
     /// Per-call: Gmail connect-check = `.low`, Gmail processing = `.high`, knowledge-base work
-    /// (and everything else) = `.high`; the initial vault build overrides to `.xhigh`.
+    /// (and everything else) = `.high`. Nothing runs `.xhigh` anymore — gpt-5.6-sol thinks far
+    /// too long there (the initial vault build was downgraded to `.high`, 2026-07-10).
     enum Effort: String, Sendable {
         case low
         case medium
@@ -60,7 +61,7 @@ actor CodexCLI {
     struct Invocation: Sendable {
         var prompt: String
         var model: Model = .gpt56sol              // gpt-5.6-sol for everything except the Gmail tier
-        var effort: Effort = .high             // gpt-5.6-sol default; initial vault build → .xhigh; Gmail tier → .medium
+        var effort: Effort = .high             // gpt-5.6-sol default (nothing overrides upward); Gmail tier → .medium
         var sandbox: Sandbox = .readOnly
         var cwd: String? = nil                 // the agent's working root (vault/staging dir)
         var addDirs: [String] = []             // extra writable roots beyond cwd

--- a/Sentient OS macOS/Documentation/CodexCLI (codex exec Compute Spine).md
+++ b/Sentient OS macOS/Documentation/CodexCLI (codex exec Compute Spine).md
@@ -46,8 +46,9 @@ plumbing).
 
 `Invocation`: `prompt` (always over **stdin**, never argv) · `model` (`.gpt56sol` = `gpt-5.6-sol`, the
 default for knowledge-base work and everything else / `.gpt56luna` = `gpt-5.6-luna`, the Gmail
-tier) · `effort` (`.low` / `.medium` / `.high` / `.xhigh`; **default `.high`** — the initial vault
-build overrides to `.xhigh`, the Gmail tier to `.medium`) · `sandbox` (`.readOnly` default / `.workspaceWrite`) · `cwd` · `addDirs`
+tier) · `effort` (`.low` / `.medium` / `.high` / `.xhigh`; **default `.high`** — the Gmail tier
+overrides to `.medium`; nothing runs `.xhigh` since 2026-07-10, gpt-5.6-sol thinks far too long
+there) · `sandbox` (`.readOnly` default / `.workspaceWrite`) · `cwd` · `addDirs`
 (extra writable roots) · `webSearch` (**default `true`** — web search is available to every call)
 · `includeUserConfig` (**default `true`** — loads `~/.codex` + the user's MCP servers, e.g. their
 Gmail MCP, on every call; set `false` for a hermetic run) · `bypassApprovals` (default `false`;

--- a/Sentient OS macOS/Documentation/Gmail Connector (Codex).md
+++ b/Sentient OS macOS/Documentation/Gmail Connector (Codex).md
@@ -52,14 +52,13 @@ The light model carries the Gmail tier; gpt-5.6-sol carries the knowledge base. 
 |---|---|---|
 | Connect-check (`probeConnected`) | `gpt-5.6-luna` | `medium` |
 | Gmail reads (`runInitial`/`runIterative`) | `gpt-5.6-luna` | `medium` |
-| Initial vault build (`VaultGenerator`) | `gpt-5.6-sol` | `xhigh` |
-| KB update + proactive + everything else | `gpt-5.6-sol` | `high` |
+| Vault build/update + proactive + everything else | `gpt-5.6-sol` | `high` |
 
 ⚠️ Not every SKU rides a **ChatGPT-account** auth (no API key): in the June 15 measurement (the
 gpt-5.5 era) `gpt-5.4-spark`, `gpt-5.5-codex`, and the older `-mini`s were all rejected. The current
 gpt-5.6 lineup (sol/luna, adopted 2026-07-09) works on ChatGPT plans — verified live — but re-verify
-any NEW model through `codex exec` before adopting it. `.high` is the `Invocation` default (the
-initial vault build overrides to `.xhigh`).
+any NEW model through `codex exec` before adopting it. `.high` is the `Invocation` default (nothing
+overrides upward since 2026-07-10 — the initial vault build's `.xhigh` overthought).
 
 ## Gotchas (measured live, June 15)
 - **The Gmail connector works regardless of `--ignore-user-config`.** The Gmail tools are

--- a/Sentient OS macOS/Documentation/Plan Gate (CodexAuth & Knowledge-Base-Only).md
+++ b/Sentient OS macOS/Documentation/Plan Gate (CodexAuth & Knowledge-Base-Only).md
@@ -1,7 +1,8 @@
 # Plan Gate — CodexAuth & Knowledge-Base-Only Mode
 
 Sentient knows the user's ChatGPT plan and adapts. Free/Go accounts carry a tiny **monthly**
-codex quota (the initial knowledge-base build alone eats ~70% of it, even at `.high`) and no
+codex quota (the initial knowledge-base build alone eats ~70% of it at `.high` — the effort every
+plan runs since 2026-07-10) and no
 ChatGPT connectors (Gmail/Calendar) — so instead of a broken full experience they get an honest
 fork at onboarding and a scoped **knowledge-base-only mode**. Everything here shipped and was
 verified on real hardware (a real Free login walked end-to-end), July 2026.
@@ -80,7 +81,6 @@ flips:
 |---|---|
 | `OvernightScheduler.maybeAutoEnable()` | Early-returns — no 18h auto-enable, no timer, no 3am runs. Deliberately NOT latched: upgrade + reset starts the clock fresh. |
 | `ProactiveCycle` | Skips decide + research (saves an empty ready-list — no stale cards). Still runs: read → KB build/update → mirror push → gift letter → wipe. |
-| `VaultGenerator` initial build | `.high` instead of `.xhigh` (the quota math above). |
 | Sidekick | Gated at **invoke**, not arming: the hotkey stays armed for everyone; on press the notch answers instantly with the 2s aside "get ChatGPT Plus to wake Sidekick" (the mic-notice pattern) and never opens for listening/typing. `submit()` carries a backstop for the command-bar path. Live-checked per press — no stale-launch-flag hole. |
 | Home | Command bar hidden. The **preview note** (orb + "This is a preview of Sentient." + feature rows + Get Plus glow + Reset Sentient… pill) is ALWAYS mounted; the gift envelope perches top-center above a compact version of it and the note blooms to full center when the letter is flung. Once the claim reads Plus (re-read every appearance), it becomes "You're on Plus. Time to go live." + a Reset & Rebuild glow. |
 | Gmail/Calendar chips | Locked (dim + lock glyph + instant `LockedChipTip` hover: "Only supported on ChatGPT Plus") in onboarding's ready screen, the Analysis popover, and Settings → Knowledge Sources. |

--- a/Sentient OS macOS/Documentation/Vault Generation (Stage 2).md
+++ b/Sentient OS macOS/Documentation/Vault Generation (Stage 2).md
@@ -2,9 +2,10 @@
 
 `VaultGenerator.generate(notes:resume:onProgress:)` turns the on-device survivor summaries
 (passed as `[CloudNote]`) into the markdown knowledge base at `~/Sentient OS - Knowledge Base/`,
-through ONE route: `codex exec` via the `CodexCLI` spine — `gpt-5.6-sol` at **`.xhigh` effort**
-(**`.high` in knowledge-base-only mode** — a free/go plan's tiny monthly quota affords exactly
-one build, and only at high; see `Plan Gate (CodexAuth & Knowledge-Base-Only).md`),
+through ONE route: `codex exec` via the `CodexCLI` spine — `gpt-5.6-sol` at **`.high` effort**
+(every plan — the initial build's `.xhigh` override was retired 2026-07-10, it thinks far too
+long; `.high` is also all a free/go plan's tiny monthly quota affords, see
+`Plan Gate (CodexAuth & Knowledge-Base-Only).md`),
 `workspace-write` sandbox, cwd = a staging dir; the model writes the `.md` files itself with its
 file tools. Without a working codex the run throws `CodexCLI`'s `.notAvailable` (no fallback — a ChatGPT
 subscription is a hard requirement; the old direct-Anthropic-API route and its
@@ -43,7 +44,7 @@ A mid-run death (limit / crash / kill) leaves the previous vault untouched and t
 **Durable resume for BOTH** — `VaultCloud` persists the `ResumeToken(sessionID, stagingPath[, vaultFingerprint])`
 to UserDefaults (`vault.create.resume` / `vault.update.resume`), loaded in `init`, discarded if the
 staging dir is gone or there's no session. So a usage limit **or an app restart** resumes over staging
-instead of re-running the expensive `xhigh` build from scratch. (`ResumeToken` is `Codable`.)
+instead of re-running the expensive initial build from scratch. (`ResumeToken` is `Codable`.)
 
 **Update freshness check (concurrent editor edits)** — the Knowledge editor writes note files directly
 into the live vault, so `update()` guards against clobbering a user edit: it (a) **skips** the merge if

--- a/Sentient OS macOS/Vault/VaultGenerator.swift
+++ b/Sentient OS macOS/Vault/VaultGenerator.swift
@@ -210,9 +210,9 @@ actor VaultGenerator {
 
         var invocation = CodexCLI.Invocation(prompt: prompt)
         invocation.feature = "vault"
-        // KB build gets the deepest pass (gpt-5.6-sol) — except in knowledge-base-only mode, where
-        // .high keeps the one build a free/go plan's tiny monthly quota can afford (~70% of it).
-        invocation.effort = CodexAuth.knowledgeBaseOnly ? .high : .xhigh
+        // Effort stays at the .high default — .xhigh thinks far too long on gpt-5.6-sol for the
+        // initial build (downgraded 2026-07-10), and .high is also what a free/go plan's tiny
+        // monthly quota can afford (~70% of it).
         invocation.sandbox = .workspaceWrite                 // writes confined to the staging dir
         invocation.cwd = staging.path
         invocation.resumeSessionID = resume?.sessionID


### PR DESCRIPTION
## What

Nothing runs `.xhigh` anymore — the initial vault build (the only call site) drops to `.high`, the `Invocation` default. gpt-5.6-sol at xhigh thinks far too long.

## Details

- `VaultGenerator`: the `knowledgeBaseOnly ? .high : .xhigh` override is deleted — every plan builds at `.high` now (which is also all a free/go quota affords).
- `CodexCLI`: effort-tier doc comments updated; the `.xhigh` case stays (it maps codex's accepted `model_reasoning_effort` vocabulary).
- Docs: `Vault Generation (Stage 2)`, `CodexCLI (codex exec Compute Spine)`, `Plan Gate` (the initial-build row no longer differs by plan), `Gmail Connector`'s model/effort table (+ the Our_Stuff architecture file, synced separately).

Note: proactive + the gift letter were already `.high` — only the initial build ever ran xhigh.

Built clean via Xcode MCP.