### PR TITLE
Fix the 18h auto-enable: recognize the production helper install + close audit gaps

### DIFF
--- a/Sentient OS macOS/Ingestion/FactoryReset.swift
+++ b/Sentient OS macOS/Ingestion/FactoryReset.swift
@@ -32,7 +32,17 @@ enum FactoryReset {
         d.removeObject(forKey: CodexAuth.kbOnlyKey)     // the crossroads re-detects the plan fresh
         d.removeObject(forKey: AppState.onboardingKey)
         d.removeObject(forKey: ComputerUseGate.screenRecordingOfferedKey)   // re-offer Sentient's screen recording on rebuild
+        // The overnight scheduler starts over too: the 18h clock re-stamps at the REBUILD's first
+        // cycle (not the wiped one's), the auto-enable one-shot is re-armed, and the production
+        // flag comes off — otherwise a 3am run could fire mid-onboarding, racing the user's own
+        // first analysis on an empty store. (The dev toggle and the installed helper survive —
+        // one is a dev choice, the other a grant, not a learning.)
+        d.removeObject(forKey: OvernightScheduler.firstCycleAtKey)
+        d.removeObject(forKey: OvernightScheduler.autoEnableFiredKey)
+        d.removeObject(forKey: OvernightScheduler.prodEnabledKey)
+        appState?.scheduler.needsSchedulerSetup = false
+        appState?.scheduler.reevaluate()                // prod flag is gone → stops the loop + cancels the armed wake
         appState?.hasCompletedOnboarding = false        // live flip (didSet re-persists false)
-        Log("FactoryReset: wiped cycle store + knowledge base + proactive traces + lifetime counters + cloud mirror copy · rewound to onboarding")
+        Log("FactoryReset: wiped cycle store + knowledge base + proactive traces + lifetime counters + cloud mirror copy + scheduler state · rewound to onboarding")
     }
 }

--- a/Sentient OS macOS/Scheduling/OvernightScheduler.swift
+++ b/Sentient OS macOS/Scheduling/OvernightScheduler.swift
@@ -29,9 +29,10 @@ final class OvernightScheduler {
     /// One-line status for the dev UI ("off" / "armed for 4:00 PM" / "running…").
     var statusLine = "off"
 
-    /// Set true when the 18h auto-enable wants to arm but the prerequisites (approved root helper +
-    /// launch-at-login) aren't in place yet. The setup UX (dev section today, onboarding later) reads
-    /// this to prompt the user; it clears itself once auto-enable succeeds.
+    /// Set true when the 18h auto-enable wants to arm but a prerequisite is missing: the root
+    /// helper isn't installed (onboarding's permissions step and Settings → Health own the
+    /// install), or launch-at-login is off. The setup UX reads this to prompt the user; it
+    /// clears itself once auto-enable succeeds.
     var needsSchedulerSetup = false
 
     // The DEV toggle (testing) and the PRODUCTION flag are separate keys but either one runs the
@@ -116,8 +117,8 @@ final class OvernightScheduler {
     /// Decide whether to auto-enable the production scheduler. Idempotent + safe to call repeatedly —
     /// from launch (AppState.init), right after any cycle finishes, and from the one-shot timer it arms.
     /// Fires at most once (a latch), never fights a user who toggled the scheduler off, and only arms
-    /// when the prerequisites (approved root helper + launch-at-login) are in place — otherwise it flags
-    /// `needsSchedulerSetup` for the setup UX and retries on the next tick.
+    /// when the prerequisites (installed root helper + launch-at-login) are in place — otherwise it
+    /// flags `needsSchedulerSetup` for the setup UX and retries on the next tick.
     func maybeAutoEnable() {
         // Free/go knowledge-base-only mode: no quota for nightly runs — auto-enable never fires.
         // Deliberately NOT latched, so an upgrade (+ reset) later starts the 18h clock fresh.
@@ -125,21 +126,35 @@ final class OvernightScheduler {
         let d = UserDefaults.standard
         guard !d.bool(forKey: Self.autoEnableFiredKey) else { return }      // already handled once
 
-        // The user already turned the scheduler on (dev or prod) — latch and never auto-touch it.
-        if d.bool(forKey: Self.enabledKey) || d.bool(forKey: Self.prodEnabledKey) {
+        // The production scheduler is already on — latch and never auto-touch it. ONLY the prod
+        // flag latches: the DEV toggle is a test arm, and burning the one-shot on it would kill
+        // auto-enable for the install (the exact drift the two-keys design exists to prevent).
+        if d.bool(forKey: Self.prodEnabledKey) {
             d.set(true, forKey: Self.autoEnableFiredKey); return
         }
 
         guard let fireAt = Self.autoEnableFireDate else { return }          // initial not finished yet
         if Date() < fireAt { armAutoEnableTimer(at: fireAt); return }       // not time yet — wait
 
-        // Time's up. Only enable if the overnight run can actually happen: approved helper + login item.
-        guard WakeHelperClient.shared.isReady else {
+        // Time's up. Only enable if the overnight run can actually happen: an installed helper.
+        // The PRODUCTION install (WakeHelperInstaller — onboarding + Settings → Health) lives at
+        // /Library/LaunchDaemons and is INVISIBLE to SMAppService, so the plist check comes first;
+        // `isReady` is the dev cockpit's SMAppService approval path.
+        guard WakeHelperInstaller.isInstalledAndCurrent() || WakeHelperClient.shared.isReady else {
             needsSchedulerSetup = true                                      // surface setup; retry next tick
-            Log("Scheduler: 18h elapsed but root helper not approved — awaiting setup")
+            Log("Scheduler: 18h elapsed but root helper not installed — awaiting setup")
             return
         }
-        LoginItem.enable()                                                  // ensure the app relaunches to host 3am
+        // The app must be alive at 3am to host the run — enable launch-at-login, and treat a
+        // refusal (the user revoked it in System Settings; macOS won't let us silently re-enable)
+        // as a missing prerequisite. Enabling anyway would mean silent empty mornings with no
+        // caution banner: the run never starts, so nothing ever classifies as failed.
+        LoginItem.enable()
+        guard LoginItem.isEnabled else {
+            needsSchedulerSetup = true
+            Log("Scheduler: 18h elapsed but launch-at-login is off (revoked?) — awaiting setup")
+            return
+        }
         d.set(true, forKey: Self.prodEnabledKey)
         d.set(true, forKey: Self.autoEnableFiredKey)
         needsSchedulerSetup = false
@@ -162,45 +177,40 @@ final class OvernightScheduler {
 
     // MARK: - Helper readiness
 
-    /// Ensure the root daemon is registered & approved before arming. Returns true when it's ready to
-    /// accept XPC. PRODUCTION path: SMAppService (one-click System Settings approval, no password) —
-    /// `.enabled` means go, `.requiresApproval` bails and lets the setup UX walk the user through it.
-    /// DEBUG dev builds (unsigned, or the plist not bundled → `.notFound`) fall back to the proven
-    /// admin-password installer so testing keeps working without a signed distribution build.
+    /// Ensure the root daemon is installed before arming. Returns true when it's ready to accept
+    /// XPC. PRODUCTION path: the admin-password installer's plist at /Library/LaunchDaemons
+    /// (WakeHelperInstaller — onboarding and Settings → Health both run it). That install is
+    /// INVISIBLE to SMAppService, so the plist check comes FIRST in every config; the SMAppService
+    /// `.enabled` read second covers the dev cockpit's approval flow. Neither present → DEBUG
+    /// self-installs (the proven admin fallback, so a clean dev slate still works); Release flags
+    /// `needsSchedulerSetup` for the setup UX — it never registers or prompts on its own (a
+    /// `register()` here would park a stray "Sentient OS" approval in System Settings > Login Items).
     private func ensureHelperReady(log: SchedulerLog) async -> Bool {
-        let client = WakeHelperClient.shared
-        if client.isReady { return true }
-
-        let status = client.register()   // may surface the System Settings approval prompt
-        log.line("helper SMAppService status after register: \(status.rawValue)")
-        switch status {
-        case .enabled:
-            try? await Task.sleep(for: .seconds(1))   // let launchd settle before the first connection
+        // ① The production install — the /Library/LaunchDaemons plist pointing at this binary.
+        if WakeHelperInstaller.isInstalledAndCurrent() {
             needsSchedulerSetup = false
             return true
-        case .requiresApproval:
-            needsSchedulerSetup = true
-            statusLine = "approve in System Settings"
-            log.line("helper needs approval in System Settings > Login Items — awaiting user")
-            return false
-        default:   // .notRegistered / .notFound — plist not bundled or build not signed for SMAppService
-            #if DEBUG
-            log.line("SMAppService unavailable (\(status.rawValue)) — DEBUG fallback to admin-password installer")
-            if !WakeHelperInstaller.isInstalledAndCurrent() {
-                statusLine = "installing helper…"
-                let ok = await WakeHelperInstaller.installAsync()
-                log.line("helper install (admin): \(ok ? "OK" : "declined/failed")")
-                guard ok else { statusLine = "needs your password; toggle off then on to retry"; return false }
-                try? await Task.sleep(for: .seconds(1))
-            }
-            return true
-            #else
-            needsSchedulerSetup = true
-            statusLine = "helper unavailable"
-            log.line("helper unavailable in Release (status \(status.rawValue)) — awaiting setup")
-            return false
-            #endif
         }
+        // ② The dev cockpit's SMAppService daemon, approved in System Settings.
+        if WakeHelperClient.shared.isReady {
+            needsSchedulerSetup = false
+            return true
+        }
+        #if DEBUG
+        log.line("helper not installed — DEBUG fallback to the admin-password installer")
+        statusLine = "installing helper…"
+        let ok = await WakeHelperInstaller.installAsync()
+        log.line("helper install (admin): \(ok ? "OK" : "declined/failed")")
+        guard ok else { statusLine = "needs your password; toggle off then on to retry"; return false }
+        try? await Task.sleep(for: .seconds(1))   // let launchd settle before the first connection
+        needsSchedulerSetup = false
+        return true
+        #else
+        needsSchedulerSetup = true
+        statusLine = "helper not set up"
+        log.line("helper not installed — awaiting setup (onboarding / Settings → Health)")
+        return false
+        #endif
     }
 
     private func loop() async {

--- a/Sentient OS macOS/Views/RootView.swift
+++ b/Sentient OS macOS/Views/RootView.swift
@@ -50,6 +50,10 @@ struct RootView: View {
                 // knowledge base, before the cards (or the free-plan preview message) behind it.
                 OnboardingView {
                     withAnimation(.easeInOut(duration: 0.3)) { appState.hasCompletedOnboarding = true }
+                    // The first full cycle just stamped "initial done" — arm the 18h clock NOW.
+                    // (The app lives in the menu bar and rarely relaunches, so waiting for the
+                    // next launch tick could delay auto-enable by days.)
+                    appState.scheduler.maybeAutoEnable()
                     Task {
                         try? await Task.sleep(for: .seconds(0.6))   // let the home settle first
                         openWindow(id: KnowledgeView.windowID)

--- a/Sentient OS macOS/Views/Settings/HealthPane.swift
+++ b/Sentient OS macOS/Views/Settings/HealthPane.swift
@@ -22,6 +22,8 @@ import Speech
 import UserNotifications
 
 struct HealthPane: View {
+    /// Optional on purpose: the pane's #Preview renders without an AppState in the environment.
+    @Environment(AppState.self) private var appState: AppState?
     @State private var codex = CodexSetup.shared
 
     // Sentient's own grants
@@ -219,6 +221,9 @@ struct HealthPane: View {
         Task {
             _ = await WakeHelperInstaller.installAsync()
             refreshDaemon()
+            // A fresh install may be the last missing prerequisite — re-run the 18h check now
+            // instead of waiting for the next launch (this app rarely relaunches).
+            if daemon == .ready { appState?.scheduler.maybeAutoEnable() }
         }
     }
 


### PR DESCRIPTION
## What

A full re-audit of the 18h auto-enable (every file in its blast radius, read end to end) found the feature could never fire for real users, plus four smaller gaps. This PR fixes all of them.

## The critical one (F1)

The readiness gate asked SMAppService `.enabled` — but the DECIDED production install path (`WakeHelperInstaller` → `/Library/LaunchDaemons`, used by onboarding's permissions step and Settings → Health) is invisible to SMAppService. So for every real user: 18h elapses → "helper not ready" → `needsSchedulerSetup` (surfaced only in the dev cockpit) → **the production scheduler never turns on. No 3am runs, no morning cards.** It looked fine in dev because the dev cockpit's step ① uses SMAppService approval.

- `maybeAutoEnable()` and `ensureHelperReady()` now check `WakeHelperInstaller.isInstalledAndCurrent()` **first, in all configs**, with SMAppService kept as the OR'd dev-cockpit path.
- Release no longer calls `register()` — which would have parked a stray "Sentient OS" approval row in System Settings › Login Items (the exact UX the 2026-07-04 decision rejected).
- The DEBUG self-install fallback survives for clean dev slates.

## The rest of the audit

- **F2:** `maybeAutoEnable()` now also runs when onboarding finishes (the moment the 18h clock starts) and after a Health-pane helper install. The app lives in the menu bar and rarely relaunches, so launch-only ticks could delay auto-enable by days.
- **F3:** `FactoryReset` now clears the scheduler's state (first-cycle stamp · auto-enable latch · prod flag) and stops the loop, cancelling any armed wake. Previously a post-reset 3am run could fire mid-onboarding and race the user's own first analysis; this also makes the doc's "upgrade + reset restarts the 18h clock fresh" actually true, and un-breaks ProcessingView's display-keep-awake heuristic on a rebuild.
- **F4:** only the production flag latches `autoEnableFired` — the dev test toggle can no longer permanently burn the one-shot (the code now matches its own header comment).
- **F5:** launch-at-login is a real prerequisite: a revoked login item holds auto-enable with `needsSchedulerSetup` instead of enabling a scheduler whose runs would silently never happen (no run → no failure → no morning-after caution).

## Testing

- Isolated CLI build passes (`/tmp/sentient-verify`; GUI DerivedData untouched).
- **Needs a hardware pass before merge:** (1) helper installed ONLY via the password installer (no cockpit approval) → dev cockpit's "Simulate first analyze done" + 10s wait + "Run check now" should flip to "enabled ✓" (previously "needs setup"); (2) Factory Reset → confirm no armed wake survives and the 18h readout restarts at the rebuild's first cycle.

Docs (`Overnight Scheduler (3am Wake).md` §A + the architecture file's scheduler lines) will be updated in a follow-up once the hardware pass confirms, per the docs-after-tested rule.