### PR TITLE
Gift letter: one-deck lifecycle + Save to Desktop share PNG

### DIFF
--- a/Sentient OS macOS/Documentation/Home — Proactive Intelligence (For You).md
+++ b/Sentient OS macOS/Documentation/Home — Proactive Intelligence (For You).md
@@ -78,7 +78,9 @@ ON by default):
 - **Real mode (the default):** `beginVisit` builds the deck from the persisted proactive results — the
   welcome **`GiftLetter`** envelope first (sealed, wax-stamped, addressed "For \<macFirstName\>" from
   the macOS account — "For you" when nameless; generated once from the user's own
-  knowledge base), then one card per `PreparedAction` in `ProactiveResearch.latest()`
+  knowledge base, and retired when the NEXT full cycle replaces the deck — its letter footer carries
+  the **Save to Desktop** keepsake, a branded share PNG revealed in Finder; see
+  `Proactive Intelligence (Judge).md` §The welcome gift), then one card per `PreparedAction` in `ProactiveResearch.latest()`
   (`Briefing(from:)` — method accent + `METHOD · TARGET` kicker, the `card_summary` body, the
   LLM-written fire button). **Firing is real:** `runReal` routes through
   `ProactiveExecutor.fire`, streams codex's live play-by-play into the card (`liveLines`, with a

--- a/Sentient OS macOS/Documentation/Proactive Intelligence (Judge).md
+++ b/Sentient OS macOS/Documentation/Proactive Intelligence (Judge).md
@@ -191,6 +191,24 @@ Generated ONCE by `ProactiveCycle` (best-effort — never fails the cycle), rend
 envelope card (`Briefing(fromGiftMarkdown:)`). The prompt lives in
 the code itself — `GiftLetter.prompt(vaultPath:)` is the source of truth (the old Our_Stuff scratch md is temporary).
 
+**Lifecycle — the gift lives exactly one deck.** `ProactiveCycle` notes whether a gift already
+existed before the run (`giftPreexisted`); when the proactive stage successfully replaces the deck,
+a pre-existing gift is cleared. A failed cycle never eats it (the clear sits after the research leg's
+early returns), and knowledge-base-only mode never reaches it (no proactive stage — the envelope is
+the free home's only card, so it lives on). A gift whose generation failed on cycle 1 regenerates on
+cycle 2 and still gets its full day.
+
+**The keepsake — `Views/GiftShareImage.swift`.** The expanded welcome letter carries a footer only
+the gift wears: **Save to Desktop** + the whisper "Your gift will be cleared from the home screen
+soon." The button renders the letter as a @2x poster PNG — the letter card in the welcome-gradient
+hairline on OLED black, plus the left-aligned branding colophon (orb + wordmark, the one-line pitch,
+sentient-os.ai) — via `ImageRenderer`, drawn by the SAME shared `LetterBody` renderer as the
+on-screen letter (extracted from `LetterView` for exactly this parity). It saves as
+`~/Desktop/Gift from Sentient.png` (counter-suffixed, never overwrites) and reveals the file
+selected in Finder, so sharing it is one drag. The share view takes the built `Briefing`, not raw
+markdown — the gift init promotes `# Title` out of the letter text, so the briefing is the only
+faithful carrier of both.
+
 ## Not wired yet (next steps)
 
 - **Retiring the demo deck** — real cards are the default now; deleting the hard-coded demo cards

--- a/Sentient OS macOS/Proactive/ProactiveCycle.swift
+++ b/Sentient OS macOS/Proactive/ProactiveCycle.swift
@@ -85,7 +85,11 @@ actor ProactiveCycle {
 
         // 2.5) The welcome "gift" — write it ONCE, the first time a knowledge base exists to read.
         //      Best-effort: it's a delight, never load-bearing, so a failure never fails the cycle.
-        if GiftLetter.latest() == nil {
+        //      A gift that ALREADY existed before this cycle has had its day-one morning — it retires
+        //      when this cycle's proactive stage replaces the deck (kb-only mode has no replace, so
+        //      the free home's lone envelope lives on).
+        let giftPreexisted = GiftLetter.latest() != nil
+        if !giftPreexisted {
             progress(.knowledgeBase("Writing your welcome…"))
             do { _ = try await GiftLetter.shared.generate() }
             catch { Log("GiftLetter: welcome skipped — \(Self.msg(error))") }
@@ -129,6 +133,8 @@ actor ProactiveCycle {
                     progress(.failed(m)); return m
                 }
             }
+            // The deck was replaced (new cards or a clean empty) — a pre-existing gift's day is done.
+            if giftPreexisted { GiftLetter.clear() }
         }
 
         // 4) Wipe this cycle's summaries — the knowledge base is the durable memory now. Success only.

--- a/Sentient OS macOS/Views/BriefingCard.swift
+++ b/Sentient OS macOS/Views/BriefingCard.swift
@@ -189,13 +189,14 @@ struct BriefingCard: View {
 struct OfferButton: View {
     let label: String
     let accent: Color
+    var icon: String = "sparkles"
     let action: () -> Void
     @State private var hovering = false
 
     var body: some View {
         Button(action: action) {
             HStack(spacing: 7) {
-                Image(systemName: "sparkles").font(.system(size: 10.5, weight: .semibold))
+                Image(systemName: icon).font(.system(size: 10.5, weight: .semibold))
                 Text(label).font(.system(size: 12.5, weight: .semibold))
             }
             .foregroundStyle(.white)

--- a/Sentient OS macOS/Views/GiftShareImage.swift
+++ b/Sentient OS macOS/Views/GiftShareImage.swift
@@ -1,0 +1,114 @@
+//
+//  GiftShareImage.swift
+//  Sentient OS macOS  ·  Views/
+//
+//  The gift letter as a keepsake — a poster-framed PNG of the welcome letter, saved to the Desktop
+//  from the letter's "Save to Desktop" button. The composition: the letter on OLED black inside the
+//  welcome-gradient hairline, and a quiet branding footer below it (the orb + wordmark, the one-line
+//  pitch, sentient-os.ai) so a shared screenshot carries its own attribution. The body renders
+//  through the SAME LetterBody as the on-screen letter, so what you read is exactly what you save.
+//
+//  Key pieces:
+//   - GiftShareView                        (the export composition; #Preview'd for design work)
+//   - GiftShareImage.save(letter:) → URL   (ImageRenderer @2x → PNG on the Desktop, never overwrites)
+//
+
+import SwiftUI
+
+/// The export composition: the gift letter card + the branding footer, on true black.
+/// Takes the built Briefing (not raw markdown) — the gift init promotes `# Title` out of the letter
+/// text, so the briefing is the only faithful carrier of both.
+struct GiftShareView: View {
+    let briefing: Briefing
+
+    /// The export's point width; the PNG renders at 2x (1520 px) for retina-crisp sharing.
+    static let width: CGFloat = 760
+
+    var body: some View {
+        VStack(spacing: 26) {
+            // The letter card — the same frame the expanded letter wears in the app.
+            VStack(alignment: .leading, spacing: 0) {
+                MonoCaps(briefing.kicker, size: 10, tracking: 2.2, color: briefing.accent)
+                Text(briefing.title)
+                    .font(.system(size: 30, design: .serif)).foregroundStyle(.white)
+                    .padding(.top, 8)
+                LetterBody(text: briefing.letter ?? briefing.body, accent: briefing.accent)
+                    .padding(.top, 18)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(34)
+            .background(Theme.Ink.cardBG, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+            .overlay(RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .strokeBorder(BriefingCard.welcomeGradient, lineWidth: 1))
+
+            // The branding footer — the line below the gift that travels with every share.
+            VStack(spacing: 9) {
+                HStack(spacing: 9) {
+                    OrbMark(size: 16)
+                    Text("Sentient OS")
+                        .font(.system(size: 14, weight: .semibold)).foregroundStyle(.white)
+                }
+                Text("On-device intelligence that understands your entire life to proactively help you. Open-source & free.")
+                    .font(.system(size: 12)).foregroundStyle(.white.opacity(0.55))
+                    .multilineTextAlignment(.center)
+                MonoCaps("sentient-os.ai", size: 10, tracking: 2.4, color: .white.opacity(0.4))
+            }
+            .frame(maxWidth: .infinity)
+        }
+        .padding(.horizontal, 40).padding(.top, 40).padding(.bottom, 30)
+        .frame(width: Self.width)
+        .fixedSize(horizontal: false, vertical: true)
+        .background(Color.black)
+        .environment(\.colorScheme, .dark)
+    }
+}
+
+enum GiftShareImage {
+
+    enum ShareError: LocalizedError {
+        case renderFailed
+        var errorDescription: String? { "Couldn't render the gift image." }
+    }
+
+    /// Render the letter as a @2x PNG and save it to the Desktop as "Gift from Sentient.png"
+    /// (counter-suffixed if one already exists — a keepsake is never overwritten). Returns the file.
+    @MainActor
+    static func save(briefing: Briefing) throws -> URL {
+        let renderer = ImageRenderer(content: GiftShareView(briefing: briefing))
+        renderer.scale = 2
+        renderer.proposedSize = ProposedViewSize(width: GiftShareView.width, height: nil)
+        guard let cg = renderer.cgImage,
+              let png = NSBitmapImageRep(cgImage: cg).representation(using: .png, properties: [:])
+        else { throw ShareError.renderFailed }
+
+        let desktop = FileManager.default.urls(for: .desktopDirectory, in: .userDomainMask)[0]
+        var url = desktop.appendingPathComponent("Gift from Sentient.png")
+        var n = 2
+        while FileManager.default.fileExists(atPath: url.path) {
+            url = desktop.appendingPathComponent("Gift from Sentient \(n).png"); n += 1
+        }
+        try png.write(to: url)
+        Log("GiftShareImage: saved the gift keepsake → \(url.lastPathComponent) (\(png.count) bytes)")
+        return url
+    }
+}
+
+#Preview("Gift share image") {
+    GiftShareView(briefing: Briefing(fromGiftMarkdown: """
+    # The System Builder's Map
+
+    I just analyzed your entire digital life to understand you. So much stands out :)
+    ### Something you might not know about yourself
+
+    **Your real pattern is not just building AI products; it is turning recurring ambiguity into reusable systems.**
+    In IB Math AA HL, you made decision-tree guides for integration, trig, logs, complex numbers, and proofs. Sentient OS is the same reflex at startup scale: take the chaos of screenshots, files, notes, and messages, then compress it into a queryable vault.
+
+    ## Also noticed
+
+    ✦ Your breakout projects keep starting from Apple-shaped constraints: Writing Tools as an open-source Apple Intelligence port, and Sentient's on-device macOS layer.
+    ✦ You care about assistants having the right "operating manual" for a person: you maintain prompts across ChatGPT, Claude, Gemini, and Perplexity.
+    ✦ Your public technical credibility is unusually concrete: 30,000+ Writing Tools users, WIRED coverage, and a 2025 UMass Tech Challenge win.
+
+    -- Your Sentient
+    """))
+}

--- a/Sentient OS macOS/Views/GiftShareImage.swift
+++ b/Sentient OS macOS/Views/GiftShareImage.swift
@@ -41,8 +41,10 @@ struct GiftShareView: View {
             .overlay(RoundedRectangle(cornerRadius: 18, style: .continuous)
                 .strokeBorder(BriefingCard.welcomeGradient, lineWidth: 1))
 
-            // The branding footer — the line below the gift that travels with every share.
-            VStack(spacing: 9) {
+            // The branding colophon — left-aligned flush with the card, one shared edge (wordmark,
+            // tagline, and URL all start together), so a shared screenshot carries its attribution
+            // like a poster credit, not a greeting card.
+            VStack(alignment: .leading, spacing: 8) {
                 HStack(spacing: 9) {
                     OrbMark(size: 16)
                     Text("Sentient OS")
@@ -50,12 +52,12 @@ struct GiftShareView: View {
                 }
                 Text("On-device intelligence that understands your entire life to proactively help you. Open-source & free.")
                     .font(.system(size: 12)).foregroundStyle(.white.opacity(0.55))
-                    .multilineTextAlignment(.center)
                 MonoCaps("sentient-os.ai", size: 10, tracking: 2.4, color: .white.opacity(0.4))
+                    .padding(.top, 1)
             }
-            .frame(maxWidth: .infinity)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding(.horizontal, 40).padding(.top, 40).padding(.bottom, 30)
+        .padding(.horizontal, 40).padding(.top, 40).padding(.bottom, 34)
         .frame(width: Self.width)
         .fixedSize(horizontal: false, vertical: true)
         .background(Color.black)

--- a/Sentient OS macOS/Views/HomeView.swift
+++ b/Sentient OS macOS/Views/HomeView.swift
@@ -805,6 +805,7 @@ private struct LetterView: View {
     @State private var editedDraft = ""        // the live editor text
     @State private var savedDraft = ""         // the last COMMITTED text — drift from editedDraft = unsaved edits
     @State private var saveTask: Task<Void, Never>?   // in-flight debounced auto-save
+    @State private var giftSaved = false       // the welcome letter's keepsake PNG landed on the Desktop
 
     /// Auto-save is pending (unsaved edits still settling). Drives the ambient "Saving…" status.
     private var isDirty: Bool { editable && editedDraft != savedDraft }
@@ -861,6 +862,7 @@ private struct LetterView: View {
                 })
                     .padding(.top, 16)
             }
+            if briefing.kind == .welcome { giftFooter.padding(.top, 16) }
         }
         .padding(28)
         .background(Theme.Ink.cardBG, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
@@ -879,79 +881,49 @@ private struct LetterView: View {
         // and reseed. editedDraft + savedDraft start equal — a freshly-opened card has no unsaved edits.
         .onChange(of: briefing.id) { _, _ in
             saveTask?.cancel(); editedDraft = liveDraft; savedDraft = liveDraft; copied = false
+            giftSaved = false
         }
         // Every keystroke reschedules the debounced commit, so edits persist without a Save click.
         .onChange(of: editedDraft) { _, _ in if isDirty { scheduleAutoSave() } }
         .onDisappear { saveTask?.cancel() }
     }
 
-    /// The letter body, rendered line-by-line. Supports the editorial Markdown subset our letters use:
-    /// `##`/`###` section headings, `✦ ` accent bullets, a closing sign-off line, and plain paragraphs
-    /// (with `**bold**` inline). A blank line is a paragraph break. (`# H1` is promoted to the card
-    /// title upstream, but we still render one defensively.)
-    @ViewBuilder
+    /// The letter body — the shared editorial-Markdown renderer (LetterBody), so the expanded letter
+    /// and the saved share image draw the exact same thing.
     private var paragraphs: some View {
-        let lines = (briefing.letter ?? briefing.body).components(separatedBy: "\n")
-        VStack(alignment: .leading, spacing: 10) {
-            ForEach(Array(lines.enumerated()), id: \.offset) { _, raw in
-                letterBlock(raw.trimmingCharacters(in: .whitespaces))
+        LetterBody(text: briefing.letter ?? briefing.body, accent: briefing.accent)
+    }
+
+    /// The welcome letter's keepsake row: "Save to Desktop" (a poster PNG of the gift, revealed in
+    /// Finder so sharing is one drag) + the quiet why ("it will be cleared soon" — the gift retires
+    /// when the next cycle replaces the deck).
+    private var giftFooter: some View {
+        HStack(spacing: 14) {
+            if giftSaved {
+                HStack(spacing: 6) {
+                    Image(systemName: "checkmark").font(.system(size: 10.5, weight: .semibold))
+                    Text("Saved to your Desktop").font(.system(size: 12.5, weight: .semibold))
+                }
+                .foregroundStyle(Theme.Ink.green)
+                .padding(.vertical, 8)
+            } else {
+                OfferButton(label: "Save to Desktop", accent: briefing.accent,
+                            icon: "square.and.arrow.down", action: saveGift)
             }
+            Text("Your gift will be cleared from the home screen soon.")
+                .font(.system(size: 11.5)).foregroundStyle(Theme.Ink.label)
+            Spacer(minLength: 0)
         }
     }
 
-    @ViewBuilder
-    private func letterBlock(_ line: String) -> some View {
-        if line.isEmpty {
-            Color.clear.frame(height: 2)                              // a paragraph break
-        } else if line.hasPrefix("### ") {
-            Text(Self.inline(String(line.dropFirst(4))))             // soulful subhead (serif italic)
-                .font(.system(size: 16, design: .serif).italic())
-                .foregroundStyle(.white.opacity(0.92))
-                .padding(.top, 6)
-        } else if line.hasPrefix("## ") {
-            MonoCaps(String(line.dropFirst(3)).uppercased(), size: 10, tracking: 2.2,
-                     color: briefing.accent.opacity(0.95))           // section whisper (mono-caps)
-                .padding(.top, 12)
-        } else if line.hasPrefix("# ") {
-            Text(Self.inline(String(line.dropFirst(2))))             // a stray title, defensive
-                .font(.system(size: 22, design: .serif)).foregroundStyle(.white)
-                .padding(.top, 4)
-        } else if let bullet = Self.bulletText(line) {
-            HStack(alignment: .firstTextBaseline, spacing: 9) {
-                Text("✦").font(.system(size: 12)).foregroundStyle(briefing.accent)
-                Text(Self.inline(bullet))
-                    .font(.system(size: 13.5)).foregroundStyle(.white.opacity(0.84)).lineSpacing(4.5)
-            }
-        } else if Self.isSignoff(line) {
-            Text(Self.inline(line))                                  // "-- Your Sentient"
-                .font(.system(size: 13, design: .serif).italic())
-                .foregroundStyle(.white.opacity(0.55))
-                .padding(.top, 10)
-        } else {
-            Text(Self.inline(line))
-                .font(.system(size: 14)).foregroundStyle(.white.opacity(0.84)).lineSpacing(5)
+    private func saveGift() {
+        do {
+            let url = try GiftShareImage.save(briefing: briefing)
+            withAnimation(.easeInOut(duration: 0.2)) { giftSaved = true }
+            NSWorkspace.shared.activateFileViewerSelecting([url])   // sharing = one drag from here
+        } catch {
+            Log("GiftShareImage: save failed — \(error)")
         }
-    }
-
-    /// "✦ …" (tolerating a stray word-joiner / nbsp the model sometimes slips in) → the bullet's text;
-    /// nil if the line isn't a bullet.
-    private static func bulletText(_ line: String) -> String? {
-        guard line.first == "✦" else { return nil }
-        let rest = line.dropFirst().drop { $0 == " " || $0 == "\t" || $0 == "\u{2060}" || $0 == "\u{00A0}" }
-        return rest.isEmpty ? nil : String(rest)
-    }
-
-    /// A closing line like "-- Your Sentient" / "— your Sentient" (line-start only, so inline em-dashes
-    /// mid-paragraph aren't mistaken for a sign-off).
-    private static func isSignoff(_ line: String) -> Bool {
-        line.hasPrefix("--") || line.hasPrefix("—") || line.hasPrefix("– ")
-    }
-
-    /// Inline-markdown parse (**bold** etc.) so letters can carry a skimmable bold rail.
-    private static func inline(_ s: String) -> AttributedString {
-        (try? AttributedString(markdown: s,
-                               options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)))
-            ?? AttributedString(s)
     }
 
     private func draftBlock(_ draft: String) -> some View {

--- a/Sentient OS macOS/Views/LetterBody.swift
+++ b/Sentient OS macOS/Views/LetterBody.swift
@@ -1,0 +1,82 @@
+//
+//  LetterBody.swift
+//  Sentient OS macOS  ·  Views/
+//
+//  The letter renderer — the editorial Markdown subset our letters use (the gift letter, research
+//  briefings), drawn line-by-line: `##`/`###` section headings, `✦ ` accent bullets, a closing
+//  sign-off line, and plain paragraphs with `**bold**` inline. A blank line is a paragraph break.
+//  (`# H1` is promoted to the card title upstream, but a stray one still renders defensively.)
+//  Shared by the expanded letter (LetterView) and the saved share image (GiftShareImage), so what
+//  you read is exactly what you save.
+//
+
+import SwiftUI
+
+struct LetterBody: View {
+    let text: String
+    let accent: Color
+
+    var body: some View {
+        let lines = text.components(separatedBy: "\n")
+        VStack(alignment: .leading, spacing: 10) {
+            ForEach(Array(lines.enumerated()), id: \.offset) { _, raw in
+                letterBlock(raw.trimmingCharacters(in: .whitespaces))
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func letterBlock(_ line: String) -> some View {
+        if line.isEmpty {
+            Color.clear.frame(height: 2)                              // a paragraph break
+        } else if line.hasPrefix("### ") {
+            Text(Self.inline(String(line.dropFirst(4))))             // soulful subhead (serif italic)
+                .font(.system(size: 16, design: .serif).italic())
+                .foregroundStyle(.white.opacity(0.92))
+                .padding(.top, 6)
+        } else if line.hasPrefix("## ") {
+            MonoCaps(String(line.dropFirst(3)).uppercased(), size: 10, tracking: 2.2,
+                     color: accent.opacity(0.95))                     // section whisper (mono-caps)
+                .padding(.top, 12)
+        } else if line.hasPrefix("# ") {
+            Text(Self.inline(String(line.dropFirst(2))))             // a stray title, defensive
+                .font(.system(size: 22, design: .serif)).foregroundStyle(.white)
+                .padding(.top, 4)
+        } else if let bullet = Self.bulletText(line) {
+            HStack(alignment: .firstTextBaseline, spacing: 9) {
+                Text("✦").font(.system(size: 12)).foregroundStyle(accent)
+                Text(Self.inline(bullet))
+                    .font(.system(size: 13.5)).foregroundStyle(.white.opacity(0.84)).lineSpacing(4.5)
+            }
+        } else if Self.isSignoff(line) {
+            Text(Self.inline(line))                                  // "-- Your Sentient"
+                .font(.system(size: 13, design: .serif).italic())
+                .foregroundStyle(.white.opacity(0.55))
+                .padding(.top, 10)
+        } else {
+            Text(Self.inline(line))
+                .font(.system(size: 14)).foregroundStyle(.white.opacity(0.84)).lineSpacing(5)
+        }
+    }
+
+    /// "✦ …" (tolerating a stray word-joiner / nbsp the model sometimes slips in) → the bullet's text;
+    /// nil if the line isn't a bullet.
+    private static func bulletText(_ line: String) -> String? {
+        guard line.first == "✦" else { return nil }
+        let rest = line.dropFirst().drop { $0 == " " || $0 == "\t" || $0 == "\u{2060}" || $0 == "\u{00A0}" }
+        return rest.isEmpty ? nil : String(rest)
+    }
+
+    /// A closing line like "-- Your Sentient" / "— your Sentient" (line-start only, so inline em-dashes
+    /// mid-paragraph aren't mistaken for a sign-off).
+    private static func isSignoff(_ line: String) -> Bool {
+        line.hasPrefix("--") || line.hasPrefix("—") || line.hasPrefix("– ")
+    }
+
+    /// Inline-markdown parse (**bold** etc.) so letters can carry a skimmable bold rail.
+    private static func inline(_ s: String) -> AttributedString {
+        (try? AttributedString(markdown: s,
+                               options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)))
+            ?? AttributedString(s)
+    }
+}


### PR DESCRIPTION
## What

- **The gift now retires on the first iterative replace.** `ProactiveCycle` captures `giftPreexisted` before the gift step; when the proactive stage successfully replaces the deck, a pre-existing gift is cleared. A failed cycle never eats it; knowledge-base-only mode keeps its lone envelope (no replace ever happens there).
- **Save to Desktop keepsake.** The welcome letter's footer (welcome-only) gets a "Save to Desktop" pill + the whisper "Your gift will be cleared from the home screen soon." It renders the letter as a @2x poster PNG — letter card in the welcome-gradient hairline on OLED black + a left-aligned branding colophon (orb + wordmark, tagline, sentient-os.ai) — saves to the Desktop (counter-suffixed, never overwrites), and reveals it selected in Finder, one drag from shared.
- **`LetterBody` extracted** from `LetterView` (new `Views/LetterBody.swift`) so the on-screen letter and the saved PNG render through the same code — read == saved by construction. `OfferButton` gained an `icon` param (default "sparkles", unchanged at existing call sites).
- New file: `Views/GiftShareImage.swift` (the export composition + `save(briefing:)`).
- Docs updated: the Judge deep doc (gift lifecycle + keepsake section) and the Home doc's real-mode bullet.

## Why

The day-one gift was immortal — re-dealt sealed at the top of the For You deck on every visit, forever. Now it lives exactly one deck, and the save button turns it into a shareable branded artifact before it goes (the viral nudge: limited edition, grab it now).

## Tested

Verified by Jesai on real hardware: envelope → letter → Save to Desktop → PNG on Desktop + Finder reveal (screenshot reviewed against the design bar; footer re-laid per feedback).