### PR TITLE
Two-tier analytics: always-on core telemetry + agent-seconds, suggestions, home-opens signals

### DIFF
--- a/Sentient OS macOS/Diagnostics/Analytics.swift
+++ b/Sentient OS macOS/Diagnostics/Analytics.swift
@@ -4,30 +4,36 @@
 //
 //  TelemetryDeck integration — the app's privacy-safe PRODUCT analytics (how many people use the app,
 //  how far they get in onboarding, which features actually fire). The twin of CrashReporting.swift
-//  (Sentry, which is crashes/errors). Two gates, mirroring Sentry's:
+//  (Sentry, which is crashes/errors). Two gates:
 //    1. RELEASE builds only — a no-op in DEBUG, so a dev's day-to-day Debug runs never pollute the
 //       real usage numbers. Verify the pipeline from a Release build (same rule as Sentry).
-//    2. Its OWN opt-OUT switch — `analyticsEnabled` (default ON), the "Share anonymous analytics"
-//       toggle in Settings → System. Crash reports keep their separate switch (CrashReporting's
-//       `diagnosticsEnabled`) — the two consents split when the real Settings shipped, so a user
-//       can keep crash reports on while opting out of usage analytics (or vice versa).
+//    2. A TIERED consent switch — `analyticsEnabled` (default ON), the "Share anonymous analytics"
+//       toggle in Settings → System, gates the EXTENDED tier: the rich funnel + health signals
+//       (onboarding, processing stats, scheduler, mirror, gates). A tiny CORE tier keeps sending
+//       even when the switch is off: the handful of feature-use counts that tell us Sentient is
+//       alive and used (Sidekick/command runs, proactive fires, suggestions prepared, computer-use
+//       seconds, home opens) plus the SDK's automatic launch/session signals — so the SDK now boots
+//       unconditionally in Release. The core tier is disclosed in the switch's own off-state
+//       caption (SystemPane), so the toggle is never a lie: off = "share the richer picture: no",
+//       not "invisible". Crash reports keep their separate switch (CrashReporting's
+//       `diagnosticsEnabled`), so a user can keep crash reports on while opting out (or vice versa).
 //  Identity is the same anonymous per-install UUID (`CrashReporting.installID`); TelemetryDeck hashes
 //  it again on-device and once more on their server, and stores no PII and no IP address by design —
 //  so this upholds the Privacy Constitution (no accounts, nothing personal leaves the Mac). Signals
 //  carry structure only (names + counts/enums/versions), never user content — clean at the source.
+//  `floatValue` is TelemetryDeck's one numeric field — dashboards can SUM it, which is how the
+//  worldwide totals work (suggestions generated, agent-seconds worked).
 //
-//  The ONE thing the opt-out switch does NOT silence: `countInstallOnce()`, a single, totally
-//  anonymous "an install exists" ping that fires at most once per install EVEN when analytics are
-//  off, so we can always count how many people use Sentient. It carries no identity (a throwaway
-//  random hash, never stored, uncorrelatable to the install id or the crash-report id), no device
-//  info, and no content — just a bare count. It is disclosed in the opt-out's own Settings copy, so
-//  the switch is never a lie. All richer product analytics remain fully behind the opt-out.
+//  `countInstallOnce()` predates the tiers and stays deliberately harder-line than core: a single
+//  "an install exists" ping, at most once per install, carrying a throwaway random hash that is
+//  uncorrelatable to anything (not the install id, not the crash-report id) — the one complete,
+//  uniform count across every install ever.
 //
 //  Key members:
-//   - start()                 → boot TelemetryDeck (Release-only, opt-out gated)
-//   - signal(_:parameters:)   → send one product event (no-op until started / when opted out)
-//   - countInstallOnce()      → the one-off anonymous install count (Release-only, opt-out-INDEPENDENT)
-//   - applyEnabledChange()    → react to a mid-session flip of the shared opt-out switch
+//   - start()                          → boot TelemetryDeck (Release-only, unconditional)
+//   - signal(_:parameters:floatValue:tier:) → send one product event (.extended = opt-out gated · .core = always)
+//   - countInstallOnce()               → the one-off anonymous install count (Release-only, uncorrelatable)
+//   - applyEnabledChange()             → react to a mid-session flip of the extended-tier switch
 //
 //  Doc: Documentation/Product Analytics (TelemetryDeck).md · twin: Documentation/Crash Reporting (Sentry).md
 //
@@ -45,12 +51,21 @@ enum Analytics {
 
     private static var started = false
 
-    // MARK: - Opt-out gate
+    /// Process-boot timestamp, stamped by `start()` — lets Home.opened tell a window that opened
+    /// with the launch apart from a deliberate later reopen (menu bar / Dock).
+    static let bootTime = Date()
+
+    // MARK: - The consent tiers
+
+    /// Which consent a signal rides. `.extended` (the default) is the rich picture, gated by the
+    /// "Share anonymous analytics" switch; `.core` is the bare-minimum telemetry that always sends
+    /// (Release-only) — the feature-use counts disclosed in the switch's off-state caption.
+    enum Tier { case core, extended }
 
     private static let analyticsKey = "analyticsEnabled"
 
-    /// The opt-OUT switch: default ON, gates all TelemetryDeck sends. Treats an unset key as ON
-    /// (a bare `bool(forKey:)` reads a missing key as false → would wrongly read as opted out).
+    /// The extended-tier switch: default ON. Treats an unset key as ON (a bare `bool(forKey:)`
+    /// reads a missing key as false → would wrongly read as opted out).
     nonisolated static var analyticsEnabled: Bool {
         let d = UserDefaults.standard
         if d.object(forKey: analyticsKey) == nil { return true }
@@ -59,15 +74,14 @@ enum Analytics {
 
     // MARK: - Boot
 
-    /// Boot TelemetryDeck for the GUI app — Release-only, and only if analytics are on. A deliberate
-    /// no-op in DEBUG and while the App ID is still the placeholder. Called from main.swift's `.app`
-    /// branch (NOT the root wake-helper — the privileged path sends no analytics). Idempotent.
+    /// Boot TelemetryDeck for the GUI app — Release-only, UNCONDITIONAL of the analytics switch
+    /// (the switch gates the extended tier per-signal; the SDK must run for the core tier and its
+    /// automatic launch/session signals). A deliberate no-op in DEBUG and while the App ID is still
+    /// the placeholder. Called from main.swift's `.app` branch (NOT the root wake-helper — the
+    /// privileged path sends no analytics). Idempotent.
     static func start() {
         guard !started else { return }
-        guard analyticsEnabled else {
-            Log("Analytics: analytics opted out — TelemetryDeck disabled")
-            return
-        }
+        _ = bootTime   // stamp process boot now, so Home.opened's launch-vs-reopen read is true
         #if DEBUG
         Log("Analytics: DEBUG build — TelemetryDeck disabled (Release-only, like Sentry)")
         #else
@@ -80,7 +94,7 @@ enum Analytics {
         config.defaultParameters = { ["model": ModelLocator.fileName] }  // stamps every signal
         TelemetryDeck.initialize(config: config)
         started = true
-        Log("Analytics: TelemetryDeck started")
+        Log("Analytics: TelemetryDeck started (extended signals \(analyticsEnabled ? "on" : "off"))")
         #endif
     }
 
@@ -88,39 +102,39 @@ enum Analytics {
 
     /// Send one product event. Guard-railed to structure only — a dotted name plus count/enum/version
     /// parameters, NEVER user content (TelemetryDeck stores no PII; same clean-at-source rule as
-    /// diagnostics). No-op until started and whenever analytics are opted out.
-    static func signal(_ name: String, parameters: [String: String] = [:]) {
-        guard started, analyticsEnabled else { return }
-        TelemetryDeck.signal(name, parameters: parameters)
+    /// diagnostics). `floatValue` is the SDK's one numeric field — the dashboard can sum/average it
+    /// (durations, per-cycle counts). `.extended` signals no-op when the switch is off; `.core`
+    /// signals always send once the SDK is up (never in DEBUG — `started` stays false there).
+    static func signal(_ name: String, parameters: [String: String] = [:],
+                       floatValue: Double? = nil, tier: Tier = .extended) {
+        guard started else { return }
+        if tier == .extended, !analyticsEnabled { return }
+        TelemetryDeck.signal(name, parameters: parameters, floatValue: floatValue)
     }
 
     // MARK: - Opt-out
 
-    /// React to a mid-session flip of the "Share anonymous analytics" switch (Settings → System). On →
-    /// boot; off → latch off so nothing more is sent (TelemetryDeck has no explicit teardown, and the
-    /// per-signal gate already blocks sends the instant the switch is off).
+    /// React to a mid-session flip of the "Share anonymous analytics" switch (Settings → System).
+    /// The SDK stays up either way (the core tier keeps sending); the per-signal tier gate starts or
+    /// stops the extended signals the instant the switch flips, so there's nothing to tear down.
     static func applyEnabledChange() {
-        if analyticsEnabled {
-            start()
-        } else {
-            started = false
-            Log("Analytics: analytics turned off — TelemetryDeck silenced")
-        }
+        start()   // a first-ever flip on a boot that somehow never started — harmless if already up
+        Log("Analytics: extended analytics \(analyticsEnabled ? "on" : "off") — core telemetry unaffected")
     }
 
-    // MARK: - The one-off anonymous install count (opt-out-INDEPENDENT)
+    // MARK: - The one-off anonymous install count (uncorrelatable, switch-independent)
 
     private static let installCountedKey = "analytics.installCounted"
     private static let installSignalType = "App.anonymousInstall"
     private static let ingestURL = URL(string: "https://nom.telemetrydeck.com/v2/")!
 
     /// Send the single anonymous install ping — see the file header. Fires at most once per install
-    /// (latched in UserDefaults once it lands), and — unlike everything else here — does so even when
-    /// analytics are OPTED OUT: it's the bare "an install exists" beacon that lets us count how many
-    /// people use Sentient, and it's disclosed in the opt-out's Settings copy so the switch stays
-    /// honest. Release-only (a dev's Debug launches never inflate the count). It goes NOT through the
-    /// SDK (which would spin up ongoing session tracking) but as one direct, minimal POST carrying no
-    /// identity, no device info, and no content. Fire-and-forget; called once from main.swift.
+    /// (latched in UserDefaults once it lands), independent of the analytics switch, and harder-line
+    /// than even the core tier: where core signals ride the anonymous install id, this one carries a
+    /// throwaway hash correlatable to NOTHING — the bare "an install exists" beacon. Release-only
+    /// (a dev's Debug launches never inflate the count). It goes NOT through the SDK but as one
+    /// direct, minimal POST carrying no identity, no device info, and no content. Fire-and-forget;
+    /// called once from main.swift.
     static func countInstallOnce() {
         #if DEBUG
         Log("Analytics: DEBUG build — anonymous install ping skipped (Release-only)")

--- a/Sentient OS macOS/Notch Magic/CommandCoordinator.swift
+++ b/Sentient OS macOS/Notch Magic/CommandCoordinator.swift
@@ -30,7 +30,9 @@ enum NotchPhase: Equatable {
 }
 
 /// Where a task came from — voice gets a 4–9s read-back grace (scaled to length); typed doesn't.
-enum TriggerSource: String { case promptBar, voice }
+/// promptBar = the home command bar · notchTyped = the notch's tap-to-type field — split so the
+/// analytics can see Sidekick-only users who never open the home window.
+enum TriggerSource: String { case promptBar, notchTyped, voice }
 
 @MainActor @Observable
 final class CommandCoordinator {
@@ -107,7 +109,9 @@ final class CommandCoordinator {
     private func launch(_ trimmed: String, mode: AgentMode, source: TriggerSource) {
         guard !run.isRunning else { Log("launch ignored — a task is already running"); return }
         if source == .voice { setReadBack(trimmed) } else { clearReadBack() }
-        Analytics.signal("Command.submitted", parameters: ["source": source.rawValue, "mode": mode.label])   // count only, never the text
+        // Core tier: THE Sidekick-usage count (count only, never the text) — one of the handful of
+        // always-on telemetry signals disclosed in Settings.
+        Analytics.signal("Command.submitted", parameters: ["source": source.rawValue, "mode": mode.label], tier: .core)
         run.start(trimmed, mode: mode, source: source.rawValue)
         // Every command is computer use, which raises the notch.
         setPhase(.running)
@@ -272,7 +276,7 @@ final class CommandCoordinator {
         guard phase == .typing else { return }
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { dismissTyping(); return }
-        submit(trimmed, mode: .computer, source: .promptBar)   // typed → no read-back
+        submit(trimmed, mode: .computer, source: .notchTyped)   // typed → no read-back
     }
 
     /// Esc · click-away · empty-⏎ — close the type field with no action.

--- a/Sentient OS macOS/Notch Magic/CommandRunModel.swift
+++ b/Sentient OS macOS/Notch Magic/CommandRunModel.swift
@@ -191,6 +191,13 @@ final class CommandRunModel {
             ExecutorScoreboard.record(method: "computer", source: source, outcome: board,
                                       durationS: Date().timeIntervalSince(runStarted))
         }
+        // Core tier: how long the agent worked this run — EVERY outcome (a stopped run still had
+        // the notch lit that long). floatValue sums server-side into total agent-seconds, the
+        // "Sidekick saved users N hours" headline.
+        let outcomeTag = outcome == .success ? "success" : (outcome == .stopped ? "stopped" : "failed")
+        Analytics.signal("ComputerUse.finished",
+                         parameters: ["source": source, "method": mode.rawValue, "outcome": outcomeTag],
+                         floatValue: Date().timeIntervalSince(runStarted), tier: .core)
         clearRemembering()
         statusLine = line
         isRunning = false

--- a/Sentient OS macOS/Proactive/ProactiveCycle.swift
+++ b/Sentient OS macOS/Proactive/ProactiveCycle.swift
@@ -125,8 +125,11 @@ actor ProactiveCycle {
                 progress(.researching(items.count))
                 do {
                     let result = try await ProactiveResearch.shared.researchAndPrepare(items: items, notes: notes, calendarContext: calCtx)
+                    // Core tier; floatValue = the staged-card count, so a dashboard Sum is the
+                    // "suggestions Sentient has prepared across the world" total.
                     Analytics.signal("Proactive.prepared", parameters: [
-                        "ready": "\(result.ready.count)", "dropped": "\(result.dropped.count)"])
+                        "ready": "\(result.ready.count)", "dropped": "\(result.dropped.count)"],
+                        floatValue: Double(result.ready.count), tier: .core)
                 } catch {
                     let m = "Preparing: \(Self.msg(error))"
                     if scheduled { await OvernightCaution.note(error) }

--- a/Sentient OS macOS/Proactive/ProactiveExecutor.swift
+++ b/Sentient OS macOS/Proactive/ProactiveExecutor.swift
@@ -73,13 +73,22 @@ actor ProactiveExecutor {
             outcome: r.board, durationS: Date().timeIntervalSince(t0),
             statusPresent: r.statusPresent, errorClass: r.errorClass)
         // The single most important number: a user fired a real action — which channel, did it land.
+        // Core tier — the proactive-click count is always-on telemetry (disclosed in Settings).
         let landed: String
         switch r.outcome {
         case .fired:       landed = "fired"
         case .notFireable: landed = "not_fireable"
         case .failed:      landed = "failed"
         }
-        Analytics.signal("Proactive.actionFired", parameters: ["method": action.method.rawValue, "outcome": landed])
+        Analytics.signal("Proactive.actionFired", parameters: ["method": action.method.rawValue, "outcome": landed], tier: .core)
+        // Core tier: agent working time for this fire, but only when a channel actually ran (the
+        // notFireable early-outs burn no agent time). Same signal CommandRunModel emits, so ONE
+        // dashboard Sum over ComputerUse.finished's floatValue = total agent-seconds everywhere.
+        if action.method != .research, hasRecipe(recipe) {
+            Analytics.signal("ComputerUse.finished",
+                parameters: ["source": "proactiveCard", "method": action.method.rawValue, "outcome": landed],
+                floatValue: Date().timeIntervalSince(t0), tier: .core)
+        }
         return r.outcome
     }
 

--- a/Sentient OS macOS/Views/RootView.swift
+++ b/Sentient OS macOS/Views/RootView.swift
@@ -78,6 +78,16 @@ struct RootView: View {
             }
         }
         .frame(minWidth: 1040, minHeight: 800)
+        // Core tier: the home window came up (fires once per window instantiation — launch opens it
+        // automatically; anything later is a deliberate menu-bar/Dock reopen, hence the trigger
+        // param). Sidekick-only users who never look at home are exactly who this measures.
+        // Onboarding appearances don't count; the SDK's session signals cover day one.
+        .onAppear {
+            guard appState.hasCompletedOnboarding else { return }
+            let sinceBoot = Date().timeIntervalSince(Analytics.bootTime)
+            Analytics.signal("Home.opened",
+                             parameters: ["trigger": sinceBoot < 5 ? "launch" : "reopen"], tier: .core)
+        }
         // The computer-use setup whisper — screen-agnostic on purpose: the bootstrap is an
         // unstructured background task that outlives onboarding's processing takeover (knowledge
         // base creation, even the home in rare cases), so as long as it's actually running, this

--- a/Sentient OS macOS/Views/Settings/SystemPane.swift
+++ b/Sentient OS macOS/Views/Settings/SystemPane.swift
@@ -119,10 +119,12 @@ struct SystemPane: View {
                                   isOn: $crashReportsEnabled)
                 SettingsHairline()
                 SettingToggleLine(title: "Share anonymous analytics",
-                                  sub: "Anonymous usage signals through a privacy-first, open-source analytics framework; structure only, never any of your personal information.",
+                                  sub: "Share the fuller picture: anonymous usage signals through a privacy-first, open-source analytics framework; structure only, never any of your personal information.",
                                   isOn: $analyticsEnabled)
                 if !analyticsEnabled {
-                    Text("Even with this off, Sentient sends a single anonymous ping so we can count how many people use it. No identity, no device details, nothing else, ever.")
+                    // The core-tier disclosure — keeps the switch honest (Analytics.swift, Tier.core):
+                    // a bare minimum of anonymous feature-use counts always sends.
+                    Text("Even with this off, Sentient keeps a bare minimum of anonymous telemetry: simple counts of app opens and feature use that are core to building Sentient. Never your content, never anything personal.")
                         .font(.system(size: 10.5))
                         .foregroundStyle(Theme.Ink.deepMuted)
                         .fixedSize(horizontal: false, vertical: true)


### PR DESCRIPTION
## What

Splits TelemetryDeck consent into two tiers and instruments the feature-pulse metrics.

**The tier model** (`Analytics.swift`): `Analytics.signal()` gains a `tier:` parameter. `.extended` (default, all pre-existing signals) stays gated by the Settings switch; `.core` always sends in Release. The SDK now boots unconditionally, so its automatic launch/session signals (retention) flow for everyone. The wrapper also passes `floatValue`, TelemetryDeck's summable numeric field.

**Core signals:**
- `Command.submitted` promoted to core; `TriggerSource` gains `.notchTyped` so notch-typed and home-bar uses are separable
- `Proactive.actionFired` promoted to core
- `Proactive.prepared` promoted to core + `floatValue` = staged-card count (Sum = suggestions prepared worldwide)
- NEW `ComputerUse.finished` from `CommandRunModel.complete()` (every outcome — a stopped run still lit the notch that long) and `ProactiveExecutor.fire()` (when a channel actually ran); `floatValue` = elapsed seconds (Sum = total agent-seconds)
- NEW `Home.opened` from RootView post-onboarding, with `trigger: launch|reopen`

**Settings → System:** the off-state caption now discloses the always-on basic telemetry honestly; the on-state sub reads 'Share the fuller picture: …'. No em dashes.

## Notes

- The 'Core Metrics' TelemetryDeck dashboard (6 insights, incl. the two floatValue Sum tiles) is already live and pointed at these signal names.
- Docs (`Product Analytics (TelemetryDeck).md`, arch §12) still describe the single-toggle model — updating them after the Release-build verification, per the doc law.

## Verification

- Compile-checked green on a clean worktree of current main (isolated DerivedData).
- End-to-end send verification needs a Release build (analytics are Release-only by design).