### PR TITLE
Connect your AIs: guided per-AI setup window

### DIFF
--- a/Sentient OS macOS/App/Sentient_OS_macOSApp.swift
+++ b/Sentient OS macOS/App/Sentient_OS_macOSApp.swift
@@ -64,15 +64,15 @@ struct SentientOSApp: App {
         .windowResizability(.contentMinSize)
         .defaultSize(width: 940, height: 660)
 
-        // Connect your AIs — opened by the glowing CTA in the Your AIs popover (setup guide is
-        // a deferred stub for now).
+        // Connect your AIs — the guided setup (per-AI video steps + the sharing toggle), opened
+        // by the glow CTAs in the Your AIs popover and Settings → Your AIs.
         Window("", id: ConnectAIsView.windowID) {
             ConnectAIsView()
                 .environment(appState)
                 .preferredColorScheme(.dark)
         }
         .windowResizability(.contentMinSize)
-        .defaultSize(width: 520, height: 560)
+        .defaultSize(width: 880, height: 900)
 
         // Overnight Processing — the dev cockpit for the 3am scheduler (helper approval, launch-at-
         // login, 18h auto-enable, manual arm). Opened from DEV TOOLS → "Overnight Processing…".

--- a/Sentient OS macOS/Cloud/MirrorClient.swift
+++ b/Sentient OS macOS/Cloud/MirrorClient.swift
@@ -86,22 +86,15 @@ actor MirrorClient {
     /// Documentation/MCP Mirror Client.md).
     /// Lives here (the MCP owner) so every surface that offers "Copy System Prompt" shares one copy.
     static let systemPrompt = """
-        Use the Sentient OS MCP whenever relevant. It gives you access to the user's personal knowledge \
-        base, created just for you! It's basically an Obsidian vault of notes about their actual life: \
-        their work, projects, plans, relationships, places, preferences, and history, built from their \
-        entire digital life (notes, messages, emails, etc.) using on-device LLMs that analyzed their \
-        whole digital life.
+        You have access to the user's personal knowledge base through the Sentient OS MCP: an \
+        Obsidian-style vault of markdown notes created just for you, to give you context about their \
+        entire life (work, projects, plans, relationships, places, preferences, history…). It was \
+        built by Sentient OS privately on their own device from their notes, messages, emails, and files.
 
-        In fact, using it would help you improve almost anything you need to help the user with!
-
-        ALWAYS call get_structure at the start of ANY chat with the user.
-
-        It returns the folder and file-name index structure of the vault (so you can know if there's \
-        anything you want to read in full), and it also returns the README file of the vault with some \
-        incredible general context. So ALWAYS call this at the start of EVERY chat.
-
-        And yeah, any time you think another file is really relevant to a conversation/prompt, go read \
-        it in full using get_files!
+        At the start of any conversation where knowing the user could help (that's most of them!), \
+        call `get_structure`. It returns the vault's folder and file index, plus the README: a \
+        portrait of the user with the most important context. Then call `get_files` to actually \
+        read any relevant notes you may want to read.
         """
 
     struct Stats: Sendable {

--- a/Sentient OS macOS/Views/ConnectAIsView.swift
+++ b/Sentient OS macOS/Views/ConnectAIsView.swift
@@ -2,99 +2,229 @@
 //  ConnectAIsView.swift
 //  Sentient OS macOS
 //
-//  The "Connect your AIs" window — the REAL two-step guided setup (was a stub until 2026-07-04),
-//  opened by the glowing CTA in Settings → Your AIs and the home's Your AIs popover:
-//   ① copy your private MCP link (masked here; the real one lands on the clipboard) and add it
-//     as a connector in ChatGPT / Claude,
-//   ② copy the coached system prompt (MirrorClient.systemPrompt) into the AI's instructions.
-//  Closes with the magic demo line: ask it "What do you know about me?". If sharing is off, the
-//  window says so and points at Settings instead of showing dead controls.
+//  The "Connect your AIs" window — the guided setup, opened by the glow CTAs in Settings →
+//  Your AIs and the home's Your AIs popover. Owns the whole story:
+//   · sharing OFF → the single glowing "Connect your AIs" CTA (enables the mirror + first push,
+//     then the guide assembles in place); a quiet MCP ON/OFF pill top-right mirrors the state
+//     and flips it off behind the same confirm-and-delete alert Settings uses.
+//   · sharing ON → per-AI tabs (ChatGPT · Claude · Other AIs). ChatGPT/Claude each show two
+//     portrait video steps side by side: ① paste the private MCP link (masked; the real one
+//     lands on the clipboard), ② copy the coached system prompt (MirrorClient.systemPrompt) —
+//     with a take-me-there link under each card (GuideSpec URLs are placeholders until the real
+//     deep links land). Other AIs is the compact no-video pair of the same two steps.
+//  Tutorial clips load from the bundle by name — connect-chatgpt-1/2.mp4, connect-claude-1/2.mp4;
+//  a missing file renders a quiet glass placeholder, so the recordings can land later with zero
+//  code changes. Closes with the magic demo line: ask it "What do you know about me?".
 //  (Uses the static OrbMark glyph, not the living Orb — the orb lives only on the empty home.)
 //
 
 import SwiftUI
 import AppKit
+import AVFoundation
 
 struct ConnectAIsView: View {
     static let windowID = "connect-ais"
 
+    private enum AITab: String, CaseIterable, Identifiable {
+        case chatgpt = "ChatGPT"
+        case claude = "Claude"
+        case other = "Other AIs"
+        var id: String { rawValue }
+    }
+
+    @State private var tab: AITab = .chatgpt
+    @State private var enabled = false
     @State private var shareURL: String?
     @State private var loaded = false
+    @State private var busy = false
+    @State private var confirmOff = false
+    @State private var errorLine: String?
     @State private var copiedLink = false
     @State private var copiedPrompt = false
 
     var body: some View {
         ZStack {
             Theme.bg.ignoresSafeArea()
-            VStack(spacing: 20) {
-                OrbMark(size: 38)
-                Text("Connect your AIs.")
-                    .display(25)
-                    .foregroundStyle(Theme.Ink.statusInk)
-                Text("Offer your knowledge base to ChatGPT, Claude, and every AI you use. Private, over MCP, in two simple steps.")
-                    .font(.system(size: 13)).foregroundStyle(Theme.Ink.body)
-                    .multilineTextAlignment(.center).lineSpacing(3.5)
-                    .frame(maxWidth: 380)
-
-                if loaded, shareURL != nil {
-                    VStack(spacing: 11) {
-                        linkStep
-                        promptStep
-                    }
-                    .padding(.top, 8)
-
-                    Text("Then ask it: \u{201C}What do you know about me?\u{201D}")
-                        .font(.system(size: 13))
-                        .foregroundStyle(Theme.Ink.body)
-                        .padding(.top, 10)
-                } else if loaded {
-                    Text("Sharing is off. Turn on \u{201C}Offer your knowledge base to your AIs\u{201D} in Settings → Connect AIs to Knowledge first.")
-                        .font(.system(size: 12)).foregroundStyle(Theme.Ink.amber)
-                        .multilineTextAlignment(.center)
-                        .frame(maxWidth: 360)
-                        .padding(.top, 12)
+            VStack(spacing: 0) {
+                header
+                if loaded {
+                    if enabled { guide } else { connectPitch }
                 }
             }
-            .padding(44)
+            .padding(.horizontal, 40).padding(.vertical, 36)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        .frame(minWidth: 480, minHeight: 540)
-        .task {
-            if await MirrorClient.shared.isEnabled {
-                shareURL = await MirrorClient.shared.shareURL
-            }
-            loaded = true
+        .overlay(alignment: .topTrailing) {
+            if loaded { sharingPill.padding(16) }
+        }
+        .frame(minWidth: 820, minHeight: 880)
+        .task { await refresh() }
+        .alert("Stop sharing your knowledge base?", isPresented: $confirmOff) {
+            Button("Keep Sharing", role: .cancel) {}
+            Button("Stop & Delete Cloud Copy", role: .destructive) { disconnect() }
+        } message: {
+            Text("The cloud copy is deleted immediately and your AIs lose access. Your knowledge base stays safe on this Mac, and turning sharing back on restores the same link.")
         }
     }
 
-    // MARK: - Step 1: the private link
+    // MARK: - Header (unchanged voice: orb glyph, display line, the pitch)
 
-    private var linkStep: some View {
-        step(1, "Copy your private link", "In ChatGPT or Claude, add it as a connector (Settings → Connectors).") {
-            HStack(spacing: 9) {
-                Text(MirrorClient.maskedURL(shareURL))
-                    .font(.system(size: 11, design: .monospaced))
-                    .foregroundStyle(Theme.Ink.bright)
-                    .lineLimit(1)
-                    .padding(.horizontal, 11).padding(.vertical, 6)
-                    .background(Color.white.opacity(0.03), in: Capsule())
-                    .overlay(Capsule().strokeBorder(Theme.stroke, lineWidth: 1))
-                SettingsPillButton(title: copiedLink ? "Copied ✓" : "Copy",
-                                   tint: copiedLink ? Theme.Ink.green : Theme.Ink.bright) {
-                    copy(shareURL ?? "", flag: $copiedLink)
+    private var header: some View {
+        VStack(spacing: 20) {
+            OrbMark(size: 38)
+            Text("Connect your AIs.")
+                .display(25)
+                .foregroundStyle(Theme.Ink.statusInk)
+            Text("Offer your knowledge base to ChatGPT, Claude, and every AI you use. Private, over MCP, in two simple steps.")
+                .font(.system(size: 13)).foregroundStyle(Theme.Ink.body)
+                .multilineTextAlignment(.center).lineSpacing(3.5)
+                .frame(maxWidth: 420)
+        }
+    }
+
+    // MARK: - Sharing off: the one glowing object in the window
+
+    private var connectPitch: some View {
+        VStack(spacing: 0) {
+            GlowButton(title: busy ? "Connecting…" : "Connect your AIs",
+                       systemImage: "link", glowIntensity: 0.5) { connect() }
+                .frame(width: 280)
+                .padding(.top, 40)
+            MonoCaps("Private · no account · delete anytime",
+                     size: 8.5, tracking: 1.6, color: Theme.Ink.deepMuted)
+                .padding(.top, 22)
+            if let errorLine {
+                Text(errorLine)
+                    .font(.system(size: 11)).foregroundStyle(Theme.Ink.amber)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 380)
+                    .padding(.top, 14)
+            }
+        }
+    }
+
+    // MARK: - Sharing on: the per-AI guide
+
+    private var guide: some View {
+        VStack(spacing: 0) {
+            tabSwitcher.padding(.top, 26)
+            ZStack {
+                switch tab {
+                case .chatgpt: videoPair(Self.chatgptGuide)
+                case .claude:  videoPair(Self.claudeGuide)
+                case .other:   otherPair
                 }
             }
+            .padding(.top, 20)
+            .animation(.easeOut(duration: 0.22), value: tab)
+            Text("Then ask it: \u{201C}What do you know about me?\u{201D}")
+                .font(.system(size: 13))
+                .foregroundStyle(Theme.Ink.body)
+                .padding(.top, 24)
         }
     }
 
-    // MARK: - Step 2: the system prompt
+    /// One AI's guide content: captions + the take-me-there destinations under each card.
+    private struct GuideSpec {
+        let name: String
+        let videoPrefix: String
+        let linkCaption: String
+        let promptCaption: String
+        let connectorsURL: String
+        let instructionsLabel: String
+        let instructionsURL: String
+    }
 
-    private var promptStep: some View {
-        step(2, "Tell your AI to use it", "Paste this into your AI's instructions so it checks your knowledge base.") {
-            SettingsPillButton(title: copiedPrompt ? "Copied ✓" : "Copy the instructions",
-                               tint: copiedPrompt ? Theme.Ink.green : Theme.Ink.bright) {
-                copy(MirrorClient.systemPrompt, flag: $copiedPrompt)
+    // ⚠️ The two URLs per AI are PLACEHOLDERS (the AI's home) until the real deep links to the
+    // connector / instructions screens land — swap them here, nothing else changes.
+    private static let chatgptGuide = GuideSpec(
+        name: "ChatGPT", videoPrefix: "connect-chatgpt",
+        linkCaption: "In ChatGPT: Settings → Connectors → Create, then paste your link.",
+        promptCaption: "In ChatGPT: Settings → Personalization → Custom instructions, then paste.",
+        connectorsURL: "https://chatgpt.com",
+        instructionsLabel: "Open ChatGPT's instructions",
+        instructionsURL: "https://chatgpt.com")
+    private static let claudeGuide = GuideSpec(
+        name: "Claude", videoPrefix: "connect-claude",
+        linkCaption: "In Claude: Settings → Connectors → Add custom connector, then paste your link.",
+        promptCaption: "In Claude: Settings → Profile → your preferences, then paste.",
+        connectorsURL: "https://claude.ai",
+        instructionsLabel: "Open Claude's preferences",
+        instructionsURL: "https://claude.ai")
+
+    private var tabSwitcher: some View {
+        HStack(spacing: 4) {
+            ForEach(AITab.allCases) { t in
+                Button { tab = t } label: {
+                    Text(t.rawValue)
+                        .font(.system(size: 12.5, weight: .semibold))
+                        .foregroundStyle(tab == t ? .black : Theme.Ink.chipInk)
+                        .padding(.horizontal, 18).padding(.vertical, 7)
+                        .background(Capsule().fill(tab == t ? Color.white : .clear))
+                        .contentShape(Capsule())
+                }
+                .buttonStyle(PressScaleStyle())
             }
+        }
+        .padding(4)
+        .background(Capsule().fill(Color.white.opacity(0.04)))
+        .overlay(Capsule().strokeBorder(Theme.stroke, lineWidth: 1))
+    }
+
+    /// ChatGPT / Claude: the two video steps side by side, a take-me-there link under each.
+    private func videoPair(_ g: GuideSpec) -> some View {
+        HStack(alignment: .top, spacing: 14) {
+            VStack(spacing: 12) {
+                videoStep(1, "Paste your private link",
+                          video: "\(g.videoPrefix)-1", caption: g.linkCaption) { linkRow }
+                StepLink(title: "Open \(g.name)'s connectors", urlString: g.connectorsURL)
+            }
+            VStack(spacing: 12) {
+                videoStep(2, "Tell \(g.name) to use it",
+                          video: "\(g.videoPrefix)-2", caption: g.promptCaption) { promptButton }
+                StepLink(title: g.instructionsLabel, urlString: g.instructionsURL)
+            }
+        }
+        .fixedSize(horizontal: false, vertical: true)
+        .transition(.opacity)
+    }
+
+    /// Other AIs: the same two steps, compact, no videos.
+    private var otherPair: some View {
+        VStack(spacing: 11) {
+            step(1, "Copy your private link",
+                 "Add it as a connector wherever your AI takes MCP servers.") { linkRow }
+            step(2, "Tell your AI to use it",
+                 "Paste this into its instructions so it checks your knowledge base.") { promptButton }
+            MonoCaps("Works with any AI that speaks MCP",
+                     size: 8.5, tracking: 1.6, color: Theme.Ink.deepMuted)
+                .padding(.top, 10)
+        }
+        .transition(.opacity)
+    }
+
+    // MARK: - The two shared controls (every tab pastes the same two things)
+
+    private var linkRow: some View {
+        HStack(spacing: 9) {
+            Text(MirrorClient.maskedURL(shareURL))
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundStyle(Theme.Ink.bright)
+                .lineLimit(1).truncationMode(.middle)
+                .padding(.horizontal, 11).padding(.vertical, 6)
+                .background(Color.white.opacity(0.03), in: Capsule())
+                .overlay(Capsule().strokeBorder(Theme.stroke, lineWidth: 1))
+            SettingsPillButton(title: copiedLink ? "Copied ✓" : "Copy",
+                               tint: copiedLink ? Theme.Ink.green : Theme.Ink.bright) {
+                copy(shareURL ?? "", flag: $copiedLink)
+            }
+        }
+    }
+
+    private var promptButton: some View {
+        SettingsPillButton(title: copiedPrompt ? "Copied ✓" : "Copy the instructions",
+                           tint: copiedPrompt ? Theme.Ink.green : Theme.Ink.bright) {
+            copy(MirrorClient.systemPrompt, flag: $copiedPrompt)
         }
     }
 
@@ -105,8 +235,33 @@ struct ConnectAIsView: View {
         Task { try? await Task.sleep(for: .seconds(1.8)); flag.wrappedValue = false }
     }
 
-    // MARK: - The step card
+    // MARK: - The step cards
 
+    /// A video step (ChatGPT / Claude tabs): clip on top, whisper + title + controls + caption below.
+    private func videoStep<Controls: View>(_ n: Int, _ title: String, video: String, caption: String,
+                                           @ViewBuilder controls: () -> Controls) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            StepVideo(resource: video)
+            MonoCaps("Step \(n)", size: 9, tracking: 2.2, color: Theme.Ink.label)
+                .padding(.top, 14)
+            Text(title).font(.system(size: 13.5, weight: .medium)).foregroundStyle(.white)
+                .padding(.top, 6)
+            controls().padding(.top, 10)
+            Text(caption).font(.system(size: 11.5)).foregroundStyle(Theme.Ink.body)
+                .lineSpacing(2.5)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.top, 9)
+            Spacer(minLength: 0)
+        }
+        .padding(16)
+        .frame(width: 330, alignment: .leading)
+        .frame(maxHeight: .infinity, alignment: .top)
+        .background(Theme.Ink.cardBG, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: 14, style: .continuous)
+            .strokeBorder(.white.opacity(0.06), lineWidth: 1))
+    }
+
+    /// A compact numbered step (the Other AIs tab).
     private func step<Controls: View>(_ n: Int, _ title: String, _ sub: String,
                                       @ViewBuilder controls: () -> Controls) -> some View {
         HStack(alignment: .top, spacing: 13) {
@@ -124,13 +279,172 @@ struct ConnectAIsView: View {
             Spacer(minLength: 0)
         }
         .padding(14)
-        .frame(width: 400, alignment: .leading)
+        .frame(width: 430, alignment: .leading)
         .background(Theme.Ink.cardBG, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
         .overlay(RoundedRectangle(cornerRadius: 12, style: .continuous)
             .strokeBorder(.white.opacity(0.06), lineWidth: 1))
     }
+
+    // MARK: - The sharing pill (top-right): state at a glance, off behind the confirm
+
+    private var sharingPill: some View {
+        Button {
+            if enabled { confirmOff = true } else { connect() }
+        } label: {
+            HStack(spacing: 5) {
+                if busy { ProgressView().controlSize(.mini) }
+                else { Circle().fill(enabled ? Theme.Ink.green : Theme.Ink.deepMuted).frame(width: 6, height: 6) }
+                Text(enabled ? "MCP ON" : "MCP OFF")
+            }
+            .font(.system(size: 8.5, weight: .semibold, design: .monospaced)).tracking(1.4)
+            .foregroundStyle(enabled ? Theme.Ink.green : Theme.Ink.label)
+            .padding(.horizontal, 9).padding(.vertical, 4)
+            .overlay(Capsule().strokeBorder((enabled ? Theme.Ink.green : Theme.Ink.label).opacity(0.3), lineWidth: 1))
+            .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .disabled(busy)
+    }
+
+    // MARK: - MirrorClient plumbing (the SAME path Settings + the popover drive)
+
+    @MainActor private func refresh() async {
+        enabled = await MirrorClient.shared.isEnabled
+        shareURL = await MirrorClient.shared.shareURL
+        loaded = true
+    }
+
+    private func connect() {
+        guard !busy else { return }
+        busy = true; errorLine = nil
+        Task { @MainActor in
+            do {
+                _ = try await MirrorClient.shared.enable()
+                // First fill is best-effort: no vault yet / a transient push failure just means
+                // the next cycle (or the on-launch catch-up) syncs it.
+                do { try await MirrorClient.shared.push(); VaultActivity.shared.vaultDirty = false }
+                catch {}
+                shareURL = await MirrorClient.shared.shareURL
+                withAnimation(.easeOut(duration: 0.35)) { enabled = true }
+            } catch {
+                errorLine = (error as? LocalizedError)?.errorDescription ?? "\(error)"
+            }
+            busy = false
+        }
+    }
+
+    private func disconnect() {
+        guard !busy else { return }
+        busy = true; errorLine = nil
+        Task { @MainActor in
+            await MirrorClient.shared.disable()
+            withAnimation(.easeOut(duration: 0.3)) { enabled = false }
+            busy = false
+        }
+    }
+}
+
+// MARK: - The take-me-there link (under each video card)
+
+/// A quiet inline link that opens the AI's own screen in the browser — body ink, brightens on
+/// hover, the small arrow marking it as a door out of the app.
+private struct StepLink: View {
+    let title: String
+    let urlString: String
+    @State private var hover = false
+
+    var body: some View {
+        Button {
+            if let url = URL(string: urlString) { NSWorkspace.shared.open(url) }
+        } label: {
+            HStack(spacing: 5) {
+                Text(title)
+                Image(systemName: "arrow.up.right").font(.system(size: 8.5, weight: .semibold))
+            }
+            .font(.system(size: 11, weight: .medium))
+            .foregroundStyle(hover ? Theme.Ink.bright : Theme.Ink.body)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hover = $0 }
+        .animation(.easeOut(duration: 0.15), value: hover)
+    }
+}
+
+// MARK: - The tutorial clip
+
+/// A looping, muted tutorial clip loaded from the bundle by resource name. Until the Screen
+/// Studio recordings land, a missing file renders a quiet glass placeholder, so the window
+/// ships now and the .mp4s drop in later with zero code changes.
+private struct StepVideo: View {
+    let resource: String   // e.g. "connect-chatgpt-1" → connect-chatgpt-1.mp4 in the bundle
+
+    var body: some View {
+        Group {
+            if let url = Bundle.main.url(forResource: resource, withExtension: "mp4") {
+                LoopingVideo(url: url)
+            } else {
+                ZStack {
+                    Rectangle().fill(Color.white.opacity(0.025))
+                    Image(systemName: "play.circle")
+                        .font(.system(size: 26, weight: .light))
+                        .foregroundStyle(.white.opacity(0.16))
+                }
+            }
+        }
+        // The frame matches the recordings' shape (908×1080 portrait) so aspect-fill never crops;
+        // keep new clips at this aspect.
+        .aspectRatio(908.0 / 1080.0, contentMode: .fit)
+        .frame(maxWidth: .infinity)
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: 10, style: .continuous)
+            .strokeBorder(.white.opacity(0.07), lineWidth: 1))
+    }
+}
+
+/// AVPlayerLayer in an NSView — chromeless, muted, seamlessly looping (AVPlayerLooper).
+private struct LoopingVideo: NSViewRepresentable {
+    let url: URL
+
+    func makeNSView(context: Context) -> PlayerView {
+        let view = PlayerView()
+        let player = AVQueuePlayer()
+        player.isMuted = true
+        context.coordinator.looper = AVPlayerLooper(player: player, templateItem: AVPlayerItem(url: url))
+        view.playerLayer.player = player
+        view.playerLayer.videoGravity = .resizeAspectFill
+        player.play()
+        return view
+    }
+
+    func updateNSView(_ view: PlayerView, context: Context) {}
+
+    static func dismantleNSView(_ view: PlayerView, coordinator: Coordinator) {
+        view.playerLayer.player?.pause()
+        coordinator.looper = nil
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+    final class Coordinator { var looper: AVPlayerLooper? }
+
+    final class PlayerView: NSView {
+        let playerLayer = AVPlayerLayer()
+        init() {
+            super.init(frame: .zero)
+            wantsLayer = true
+            layer?.addSublayer(playerLayer)
+        }
+        required init?(coder: NSCoder) { fatalError("unused") }
+        override func layout() {
+            super.layout()
+            CATransaction.begin()
+            CATransaction.setDisableActions(true)   // no stretchy implicit animation on resize
+            playerLayer.frame = bounds
+            CATransaction.commit()
+        }
+    }
 }
 
 #Preview("Connect your AIs") {
-    ConnectAIsView().frame(width: 520, height: 580)
+    ConnectAIsView().frame(width: 920, height: 760)
 }

--- a/Sentient OS macOS/Views/HomePopovers.swift
+++ b/Sentient OS macOS/Views/HomePopovers.swift
@@ -7,8 +7,8 @@
 //   · AnalysisPopover — the work glance: things understood, vault size, the synced stamp, an
 //     Analyze Now control, and the source chips (sources are the INPUTS to analysis, so they
 //     live under "Analysis"). A discreet Dev Tools link sits at the bottom.
-//   · YourAIsPopover — the access-log glance ("ChatGPT read 5 notes yesterday") + the glowing
-//     "Connect your AIs" CTA that opens the setup window.
+//   · YourAIsPopover — the pitch + the glowing "Connect your AIs" CTA that opens the guided
+//     setup window (ConnectAIsView owns sharing on/off, the link, and the prompt).
 //  Pure presentation; harvested from the retired Constellation home. Demo strings (synced
 //  stamp, access log) stand in until the real polls land; the vault counts ARE real (disk).
 //
@@ -157,171 +157,32 @@ struct AnalysisPopover: View {
 
 // MARK: - Your AIs
 
-/// The MCP glance + control. Wires straight to MirrorClient: an on/off toggle (mint pill) that
-/// mints the token + pushes the vault (or deletes the cloud copy), live access stats when on, and
-/// Copy Link / Copy System Prompt — the two things the user pastes into ChatGPT/Claude. Same
-/// MirrorClient the Dev Tools MCP panel drives, so the home and Dev Tools are one system.
+/// The MCP door. One job: the glowing "Connect your AIs" CTA, always shown, opening the guided
+/// setup window — ConnectAIsView owns sharing on/off, the private link, and the system prompt,
+/// so the popover carries no state and no controls of its own.
 struct YourAIsPopover: View {
-    @State private var enabled = false
-    @State private var url: String?
-    @State private var stats: MirrorClient.Stats?
-    @State private var busy = false
-    @State private var note: String?       // transient feedback (copied / turned on) — overrides the footer
-    @State private var flashID = 0
+    @Environment(\.openWindow) private var openWindow
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            HStack {
-                MonoCaps("Connect AIs", size: 10, tracking: 2.4, color: Theme.Ink.label)
-                Spacer()
-                togglePill
-            }
+            MonoCaps("Connect AIs", size: 10, tracking: 2.4, color: Theme.Ink.label)
 
-            Text(headline)
+            Text("Offer your life to every AI.")
                 .display(20).foregroundStyle(.white)
                 .padding(.top, 11)
-            if let sub = subLineText {
-                MonoCaps(sub, size: 10, tracking: 1.0, color: Theme.Ink.body).padding(.top, 7)
+
+            GlowButton(title: "Connect your AIs", systemImage: "link", glowIntensity: 0.28) {
+                openWindow(id: ConnectAIsView.windowID)
             }
+            .padding(.top, 18)
 
-            actions.padding(.top, 18)
-
-            MonoCaps(note ?? "Your whole life · offered to every AI", size: 8.5, tracking: 1.6,
-                     color: note == nil ? Theme.Ink.deepMuted : Theme.Ink.green)
+            MonoCaps("Your whole life · offered to every AI", size: 8.5, tracking: 1.6,
+                     color: Theme.Ink.deepMuted)
                 .padding(.top, 13)
         }
         .padding(20)
         .frame(width: 300)
         .background(Theme.Ink.cardBG)
-        .task { await refresh() }
-    }
-
-    // MARK: Pieces
-
-    /// The on/off toggle — a tappable mint pill mirroring the Analysis popover's synced stamp.
-    private var togglePill: some View {
-        Button(action: toggle) {
-            HStack(spacing: 5) {
-                if busy { ProgressView().controlSize(.mini) }
-                else { Circle().fill(enabled ? Theme.Ink.green : Theme.Ink.deepMuted).frame(width: 6, height: 6) }
-                Text(enabled ? "ON" : "OFF")
-            }
-            .font(.system(size: 8.5, weight: .semibold, design: .monospaced)).tracking(1.4)
-            .foregroundStyle(enabled ? Theme.Ink.green : Theme.Ink.label)
-            .padding(.horizontal, 9).padding(.vertical, 4)
-            .overlay(Capsule().strokeBorder((enabled ? Theme.Ink.green : Theme.Ink.label).opacity(0.3), lineWidth: 1))
-            .contentShape(Capsule())
-        }
-        .buttonStyle(.plain)
-        .disabled(busy)
-    }
-
-    private var headline: String {
-        if !enabled { return "Offer your life to every AI." }
-        if let n = stats?.notesRead24h, n > 0 { return "Read \(n) note\(n == 1 ? "" : "s") today." }
-        return "Connected. Ready for your AIs."
-    }
-
-    /// The mono sub-line — shown only when ON (live access stats). OFF shows nothing; the footer
-    /// already carries the "offered to every AI" pitch, so no "private · no account · lease" line.
-    private var subLineText: String? {
-        guard enabled else { return nil }
-        if let s = stats, s.toolCalls24h > 0 || s.lastAccess != nil {
-            let last = s.lastAccess.map { RelativeDateTimeFormatter().localizedString(for: $0, relativeTo: Date()) }
-            return "\(s.toolCalls24h) calls" + (last.map { " · \($0)" } ?? "")
-        }
-        return "No reads yet · paste your link into ChatGPT"
-    }
-
-    /// On → Copy Link + Copy System Prompt (the two things to paste). Off → the glow CTA that turns it on.
-    @ViewBuilder private var actions: some View {
-        if enabled {
-            HStack(spacing: 8) {
-                CopyPill(title: "Copy Link", systemImage: "link", action: copyLink)
-                CopyPill(title: "Copy Prompt", systemImage: "text.quote", action: copyPrompt)
-            }
-        } else {
-            GlowButton(title: "Connect your AIs", systemImage: "link", glowIntensity: 0.28, action: toggle)
-        }
-    }
-
-    // MARK: Actions (all through MirrorClient — the SAME path Dev Tools uses)
-
-    @MainActor private func refresh() async {
-        enabled = await MirrorClient.shared.isEnabled
-        url = await MirrorClient.shared.shareURL
-        stats = enabled ? (try? await MirrorClient.shared.stats()) : nil
-    }
-
-    private func toggle() {
-        guard !busy else { return }
-        Task { @MainActor in
-            busy = true
-            if enabled {
-                await MirrorClient.shared.disable()
-                flash("Mirror off · cloud copy deleted")
-            } else {
-                do {
-                    _ = try await MirrorClient.shared.enable()
-                    try await MirrorClient.shared.push()
-                    VaultActivity.shared.vaultDirty = false
-                    flash("On · your knowledge is live")
-                } catch MirrorClient.MirrorError.noVault {
-                    flash("On · syncs on your first analysis")
-                } catch MirrorClient.MirrorError.tokenGenerationFailed, MirrorClient.MirrorError.keychainWriteFailed {
-                    flash("Couldn't turn on; try again")
-                } catch {
-                    flash("On · sync will retry")
-                }
-            }
-            await refresh()
-            busy = false
-        }
-    }
-
-    private func copyLink() {
-        guard let url else { return }
-        setPasteboard(url); flash("Link copied · add it as a connector")
-    }
-    private func copyPrompt() {
-        setPasteboard(MirrorClient.systemPrompt); flash("Prompt copied · paste into custom instructions")
-    }
-    private func setPasteboard(_ s: String) {
-        NSPasteboard.general.clearContents(); NSPasteboard.general.setString(s, forType: .string)
-    }
-
-    /// Show a transient feedback line in place of the footer, then revert (unless superseded).
-    private func flash(_ s: String) {
-        note = s; flashID += 1; let id = flashID
-        Task { @MainActor in
-            try? await Task.sleep(for: .seconds(2.6))
-            if flashID == id { note = nil }
-        }
-    }
-}
-
-/// A quiet outlined copy button (the popover's secondary action — glow is reserved for the ON CTA).
-private struct CopyPill: View {
-    let title: String
-    let systemImage: String
-    let action: () -> Void
-    @State private var hover = false
-
-    var body: some View {
-        Button(action: action) {
-            HStack(spacing: 5) {
-                Image(systemName: systemImage).font(.system(size: 9))
-                Text(title)
-            }
-            .font(.system(size: 9.5, weight: .medium, design: .monospaced)).tracking(0.5)
-            .foregroundStyle(.white.opacity(0.82))
-            .frame(maxWidth: .infinity).padding(.vertical, 9)
-            .background(Capsule().fill(.white.opacity(hover ? 0.08 : 0.04)))
-            .overlay(Capsule().strokeBorder(.white.opacity(0.12), lineWidth: 1))
-            .contentShape(Capsule())
-        }
-        .buttonStyle(.plain)
-        .onHover { hover = $0 }
     }
 }
 


### PR DESCRIPTION
## What

Rebuilds the Connect your AIs window into the real guided setup, and simplifies the home popover to a single door into it.

- **ConnectAIsView**: same header, now with per-AI tabs (ChatGPT / Claude / Other AIs). ChatGPT and Claude each show two portrait video steps side by side (looping muted clips; glass placeholders until the Screen Studio recordings land as `connect-{chatgpt,claude}-{1,2}.mp4` bundle resources), with the masked private link + Copy under step 1, Copy-the-instructions under step 2, and a take-me-there link beneath each card (GuideSpec URLs are placeholders pending the real deep links). Other AIs keeps the compact no-video pair.
- **Sharing lifecycle lives in the window**: sharing off shows one glowing Connect your AIs CTA (enables + first push, then the guide assembles); a quiet MCP ON/OFF pill top-right flips it off behind the same confirm-and-delete alert Settings uses.
- **YourAIsPopover**: stateless now; always the glow CTA that opens the window (no more toggle / copy pills / stats in the popover).
- **MirrorClient.systemPrompt**: replaced with the new copy from the team vault (softer, get_structure + get_files coaching).
- Window default size 880x900.

## Testing

- Built clean against latest main (isolated DerivedData).
- Manually exercised: popover -> window, Settings CTA -> window, connect flow off->on, MCP pill off with confirm, all three tabs, both copy buttons.