### PR TITLE
Launch demo deck + 3-way proactive card mode (real / Jesai demo / launch demo)

### DIFF
--- a/Sentient OS macOS/Views/Briefing.swift
+++ b/Sentient OS macOS/Views/Briefing.swift
@@ -12,11 +12,31 @@
 //  context). The demo plays the hard-coded `workLog` theater instead; swapping in the real
 //  call is a one-line change at the seam in HomeView (ForYouModel.run).
 //
-//  ALL content below is the hard-coded investor-demo set (mined from the real vault for
-//  authenticity). The proactive-intelligence module generates real ones post-launch.
+//  The hard-coded content below is TWO demo decks — `jesaiDemo` (the investor-pitch set, mined
+//  from the real vault) and `launchDemo` (the audience-safe launch-video set) — picked by the
+//  `BriefingDeck` dev mode (Dev Tools → Proactive Cards…). Real cards come from PreparedActions.
 //
 
 import SwiftUI
+
+/// Which deck the home deals — the dev cockpit's 3-way mode (Dev Tools → Proactive Cards…).
+/// `.real` (the shipping default) also makes Analyze Now / onboarding run the FULL proactive
+/// cycle; either demo deck plays the scripted theater instead.
+enum BriefingDeck: String {
+    case real, jesai, launch
+
+    static let key = "dev.proactive.deck"
+
+    /// The @AppStorage default: `.real`, unless this install had the old bool toggle
+    /// (`dev.proactive.realCards`) switched OFF — those devs were pitching, keep them on Jesai's deck.
+    static let defaultRaw: String = {
+        let d = UserDefaults.standard
+        if d.object(forKey: "dev.proactive.realCards") != nil, !d.bool(forKey: "dev.proactive.realCards") {
+            return BriefingDeck.jesai.rawValue
+        }
+        return BriefingDeck.real.rawValue
+    }()
+}
 
 struct Briefing: Identifiable {
     enum Kind {
@@ -51,12 +71,13 @@ struct Briefing: Identifiable {
     let doneBody: String
     let codexPrompt: String?    // what real execution hands to CodexCLI (see THE CODEX SEAM above)
     let accent: Color           // the card's one accent (jewelry rule). Demo: kind.accent; real: per method.
+    let envelopeName: String?   // welcome only: the envelope's recipient ("You" on demo decks); nil = the Mac account's first name
 
     init(id: String, kind: Kind, kicker: String, title: String, body: String,
          letter: String? = nil, draft: String? = nil, draftLabel: String? = nil,
          detailLabel: String? = nil, offer: String? = nil, workLog: [String] = [],
          doneTitle: String = "", doneBody: String = "", codexPrompt: String? = nil,
-         accent: Color? = nil) {
+         accent: Color? = nil, envelopeName: String? = nil) {
         self.id = id
         self.kind = kind
         self.kicker = kicker
@@ -72,6 +93,7 @@ struct Briefing: Identifiable {
         self.doneBody = doneBody
         self.codexPrompt = codexPrompt
         self.accent = accent ?? kind.accent
+        self.envelopeName = envelopeName
     }
 
     // MARK: Real cards — built from a prepared proactive action (the toggle's real mode)
@@ -121,7 +143,7 @@ struct Briefing: Identifiable {
             id: "welcome", kind: .welcome,
             kicker: "Welcome · Read across your whole life",
             title: title,
-            body: "A letter from your Sentient.",
+            body: "A gift from your Sentient.",
             letter: body,
             detailLabel: "read it",
             offer: nil,
@@ -159,7 +181,7 @@ struct Briefing: Identifiable {
         }
     }
 
-    // MARK: The demo six
+    // MARK: Jesai's demo six (the investor-pitch deck)
 
     /// The EXACT reply we send Serena — ONE source of truth, shared by the Anthos card's draft
     /// PREVIEW (what you read when you click the card) and the `codexPrompt` that actually sends
@@ -181,7 +203,7 @@ struct Briefing: Identifiable {
         Jesai
         """
 
-    static let demo: [Briefing] = [
+    static let jesaiDemo: [Briefing] = [
         Briefing(
             id: "charles", kind: .plan,
             kicker: "Prep · 4 PM today · Researched",
@@ -323,7 +345,161 @@ struct Briefing: Identifiable {
             """,
             detailLabel: "read it again",
             offer: nil,
-            doneTitle: "", doneBody: ""),
+            doneTitle: "", doneBody: "", envelopeName: "You"),
+    ]
+
+    // MARK: The launch five (the launch-video deck)
+    //
+    // Audience-safe cards for the launch video: one relatable persona's week, each card grounded
+    // in a visible cross-source stitch (question in one source, answer in another). No real names,
+    // no real investors — copy finalized with Jesai/Aditya 2026-07-10. Theater-only (codexPrompt
+    // nil): fires play the workLog; the video stages any real runs separately.
+
+    static let launchDemo: [Briefing] = [
+        Briefing(
+            id: "carl", kind: .overdue,
+            kicker: "Overdue · 3 days · Gmail",
+            title: "You ghosted Carl.",
+            body: "Carl asked to meet Wednesday at 1 about the event. You're free then, I checked. I've drafted your yes, and included the venue quote that came in yesterday.",
+            letter: """
+            Carl emailed Monday asking for Wednesday at 1 to talk through the event; it's been three days. Your calendar is clear, with nothing for two hours on either side.
+
+            Better still: the venue's quote arrived in your inbox yesterday, $2,400 with AV included, so I folded the numbers into the reply. You two walk in looking at the same page. Draft's below; one tap sends it and puts Wednesday on your calendar.
+            """,
+            draft: """
+            Hey Carl,
+
+            Sorry for the slow reply! Wednesday at 1 works; I've just put it on my calendar.
+
+            Good timing, too: the venue's quote came in yesterday. $2,400 all-in, AV included. I'll bring the breakdown Wednesday so we can go through it together.
+
+            See you then!
+            """,
+            draftLabel: "Draft · Gmail",
+            detailLabel: "read the draft",
+            offer: "Reply & add the meeting to your cal?",
+            workLog: ["→ opening Gmail",
+                      "→ replying to Carl…",
+                      "→ adding Wednesday 1:00 PM to Calendar",
+                      "✓ replied & scheduled"],
+            doneTitle: "Wednesday's locked in.",
+            doneBody: "Carl has your reply; the meeting's on your calendar."),
+
+        Briefing(
+            id: "canva", kind: .deadline,
+            kicker: "Renews tomorrow · $119 · Computer use",
+            title: "You signed up for Canva Pro to make one birthday invite.",
+            body: "It's going to renew tomorrow for $119 for the year. You signed up just to make that invite you'd sent out.",
+            letter: """
+            Canva's receipt is dated June 2: a Pro trial, converting tomorrow to **$119 a year**. The invite you made is in your Downloads from that same week, already sent out, and you haven't made a thing since.
+
+            I'll cancel it the way you would: open canva.com in your own logged-in browser, Settings → Billing & plans, and end the trial before it converts. Your account and the invite stay exactly as they are; only the renewal dies.
+            """,
+            draft: "Open canva.com in your logged-in browser → Settings → Billing & plans → cancel the Pro trial before it renews. Account and files untouched; only the $119 charge goes.",
+            draftLabel: "What I'll do · Computer use",
+            detailLabel: "read the plan",
+            offer: "Shall I cancel it for you?",
+            workLog: ["→ opening canva.com in your browser",
+                      "→ Settings → Billing & plans",
+                      "→ cancelling the Pro trial…",
+                      "→ confirming: free plan, files untouched",
+                      "✓ cancelled · $119 saved"],
+            doneTitle: "Canva Pro cancelled.",
+            doneBody: "The $119 stays yours; your account and the invite are untouched."),
+
+        Briefing(
+            id: "amtrak", kind: .meeting,
+            kicker: "This weekend · Computer use",
+            title: "You still need to book your train to New York.",
+            body: "Your trip to New York is this weekend, but you still haven't booked the Amtrak. The best one I found: $30, two hours, gets in at 11 AM, right as your hotel check-in opens.",
+            letter: """
+            Your New York weekend is all set except the part where you get there: the hotel confirmation has been in your inbox for two weeks, and there's still no train ticket next to it.
+
+            I compared Saturday morning's trains. The winner is the **8:53 Northeast Regional**: $30, two hours, into Moynihan at 10:58, and your check-in opens at 11. The later trains run $49 and up. I'll book the 8:53 on amtrak.com in your own browser, and the confirmation lands in your inbox.
+            """,
+            draft: "Book Saturday's 8:53 AM Northeast Regional on amtrak.com: coach, $30, arriving 10:58 AM. Pay with your saved card; confirmation goes to your inbox.",
+            draftLabel: "What I'll do · Computer use",
+            detailLabel: "read the plan",
+            offer: "Shall I book it for you?",
+            workLog: ["→ opening amtrak.com in your browser",
+                      "→ Saturday · the 8:53 Northeast Regional",
+                      "→ coach · $30 · arrives 10:58 AM",
+                      "→ checking out with your saved card…",
+                      "✓ booked · confirmation's in your inbox"],
+            doneTitle: "You're on the 8:53.",
+            doneBody: "Two hours, $30, in at 10:58; check-in opens at 11."),
+
+        Briefing(
+            id: "expenses", kind: .plan,
+            kicker: "Due Friday · 11 receipts · Gmail",
+            title: "Your Denver trip expenses are due Friday. The receipts are everywhere.",
+            body: "Two flights, the Marriott, six Ubers and a conference dinner, scattered across three weeks of inbox. I can upload and fill out everything for you, so you can just click submit.",
+            letter: """
+            Your expense report for the Denver trip is due Friday, and the receipts are scattered exactly where you left them: eleven, across three weeks of inbox.
+
+            ✦ **Flights:** $284 out, $301 back
+            ✦ **The Marriott, three nights:** $687
+            ✦ **Six Ubers:** $132
+            ✦ **The conference dinner:** $118
+
+            $1,522 total. I'll open Concur in your browser, create the report, and file all eleven lines with the right categories and every receipt attached. It stays in Draft; nothing submits until you click it.
+            """,
+            draft: "In Concur: new report 'Denver conference', 11 line items, categories set, receipt PDFs attached, $1,522 total. Left in Draft for your review; you click submit.",
+            draftLabel: "What I'll do · Computer use",
+            detailLabel: "read the plan",
+            offer: "File my expenses",
+            workLog: ["→ pulling 11 receipts from Gmail",
+                      "→ opening Concur in your browser",
+                      "→ flights · hotel · six Ubers · dinner",
+                      "→ attaching receipts, line by line…",
+                      "✓ report ready · waiting on your submit"],
+            doneTitle: "Expenses filed.",
+            doneBody: "Eleven lines, $1,522, receipts attached; it's waiting on your submit."),
+
+        Briefing(
+            id: "hawaii", kind: .promise,
+            kicker: "Group plan · Researched · WhatsApp",
+            title: "The Hawaii trip needs to leave the group chat.",
+            body: "You four have been circling July dates for days. I found three flight options and two houses that fit everyone's dates and the $1,500 budget Jake mentioned. Priced list drafted for the group.",
+            letter: """
+            Days of July-date ping-pong in the group chat, and nobody's booked anything. So I did the digging: everyone's free **July 10–17** (I checked the dates each of you floated against your calendar), and Jake said $1,500 max.
+
+            ✦ **Flights:** $389 round trip on Hawaiian, direct, if booked this week
+            ✦ **Beach house in Kailua:** sleeps four, $370 each for the week
+            ✦ **Or the North Shore cottage:** $320 each, ten minutes from the surf
+
+            All in around $1,400 a person, under Jake's line. The message below sends the priced list to the group so you four can finally pick.
+            """,
+            draft: "ok I actually looked into Hawaii 🌺 July 10–17 works for all of us. Flights are $389 round trip on Hawaiian if we book this week. Houses: beach house in Kailua ($370 each for the week) or the North Shore cottage ($320 each). All in ~$1,400 per person, under Jake's $1,500. Vote: Kailua or North Shore?",
+            draftLabel: "Draft · WhatsApp group",
+            detailLabel: "read the message",
+            offer: "Send it to the group",
+            workLog: ["→ opening WhatsApp",
+                      "→ finding the Hawaii group chat",
+                      "→ sending the priced list…",
+                      "✓ sent · the group's deciding"],
+            doneTitle: "The plan's with the group.",
+            doneBody: "Flights and two houses, priced per person; now they just have to vote."),
+
+        Briefing(
+            id: "welcome", kind: .welcome,
+            kicker: "Welcome · Read across your whole life",
+            title: "A gift: connections across your life.",
+            body: "Three patterns you might not have seen yourself, visible only with everything in one place.",
+            letter: """
+            I read **1,847 things** across your life last night. Three patterns you might not have seen yourself:
+
+            ✦ **You're the one who turns "we should" into plans.** The Hawaii dates, Carl's event, the group dinners: every plan in your circle routes through you. You book everyone's things first, and your own train last.
+
+            ✦ **You research the small money and ignore the quiet money.** You'll compare three trains to save $19 while a design tool you used once renews itself for $119. Deliberate at the register, generous with subscriptions.
+
+            ✦ **Your replies drift, but they land with care.** Carl waited three days and got a reply with the venue's numbers already folded in. You answer late and thoroughly, never carelessly.
+
+            I'll keep watch from here. — **your Sentient**
+            """,
+            detailLabel: "read it again",
+            offer: nil,
+            doneTitle: "", doneBody: "", envelopeName: "You"),
     ]
 
     // MARK: - Parked / alternate demo cards (swap-in library)

--- a/Sentient OS macOS/Views/BriefingCard.swift
+++ b/Sentient OS macOS/Views/BriefingCard.swift
@@ -34,7 +34,7 @@ struct BriefingCard: View {
     var body: some View {
         Group {
             if phase == .sealed {
-                EnvelopeFace(onOpened: onOpenEnvelope)
+                EnvelopeFace(recipient: briefing.envelopeName, onOpened: onOpenEnvelope)
             } else {
                 face
             }
@@ -219,6 +219,7 @@ struct OfferButton: View {
 /// wax seal carrying the orb mark. Tap anywhere → flap opens → `onOpened` (the parent then
 /// expands the letter and the card lives on as a normal welcome card).
 private struct EnvelopeFace: View {
+    var recipient: String?      // the briefing's override ("You" on demo decks); nil = the Mac account's first name
     var onOpened: () -> Void
     @State private var open = false
 
@@ -238,10 +239,14 @@ private struct EnvelopeFace: View {
                         .strokeBorder(BriefingCard.welcomeGradient, lineWidth: 1))
 
                 VStack(spacing: 7) {
-                    MonoCaps("A letter from your Sentient", size: 9, tracking: 2.4, color: Theme.Ink.label)
-                    // The recipient: the Mac account's first name (same source as the home
-                    // greeting); a nameless account just gets "For you".
-                    Text(HomeView.macFirstName.isEmpty ? "For you" : "For \(HomeView.macFirstName)")
+                    MonoCaps("A gift from your Sentient", size: 9, tracking: 2.4, color: Theme.Ink.label)
+                    // The recipient: the briefing's override when set (demo decks say "For You"),
+                    // else the Mac account's first name (same source as the home greeting);
+                    // a nameless account just gets "For you".
+                    Text({
+                        if let recipient { return "For \(recipient)" }
+                        return HomeView.macFirstName.isEmpty ? "For you" : "For \(HomeView.macFirstName)"
+                    }())
                         .font(.system(size: 22, design: .serif).italic())
                         .foregroundStyle(Theme.Ink.statusInk)
                 }
@@ -325,28 +330,28 @@ private struct BlinkingCursor: View {
 
 #Preview("Offer") {
     ZStack { Color.black
-        BriefingCard(briefing: Briefing.demo[0], phase: .offer,
+        BriefingCard(briefing: Briefing.jesaiDemo[0], phase: .offer,
                      onOffer: {}, onDetail: {}, onOpenEnvelope: {})
     }.frame(width: 420, height: 300)
 }
 
 #Preview("Working") {
     ZStack { Color.black
-        BriefingCard(briefing: Briefing.demo[3], phase: .working(3),
+        BriefingCard(briefing: Briefing.jesaiDemo[3], phase: .working(3),
                      onOffer: {}, onDetail: {}, onOpenEnvelope: {})
     }.frame(width: 420, height: 320)
 }
 
 #Preview("Done") {
     ZStack { Color.black
-        BriefingCard(briefing: Briefing.demo[0], phase: .done,
+        BriefingCard(briefing: Briefing.jesaiDemo[0], phase: .done,
                      onOffer: {}, onDetail: {}, onOpenEnvelope: {})
     }.frame(width: 420, height: 240)
 }
 
 #Preview("Sealed envelope") {
     ZStack { Color.black
-        BriefingCard(briefing: Briefing.demo[5], phase: .sealed,
+        BriefingCard(briefing: Briefing.jesaiDemo[5], phase: .sealed,
                      onOffer: {}, onDetail: {}, onOpenEnvelope: {})
     }.frame(width: 420, height: 300)
 }

--- a/Sentient OS macOS/Views/Dev/DevToolsView.swift
+++ b/Sentient OS macOS/Views/Dev/DevToolsView.swift
@@ -89,9 +89,9 @@ struct DevToolsView: View {
     @AppStorage("dbg.calendar.connected") private var calendarConnected = false
     @AppStorage("dbg.run.calendar")       private var runCalendar = false
 
-    // Real For-You cards — ON by default (decided 2026-07-05). OFF = the hard-coded investor-demo
-    // deck (pitch mode); the deck itself gets scrubbed before the repo goes public.
-    @AppStorage("dev.proactive.realCards") private var realCards = true
+    // The 3-way card mode (which deck the home deals) — see BriefingDeck (Briefing.swift).
+    @AppStorage(BriefingDeck.key) private var deckRaw = BriefingDeck.defaultRaw
+
 
     // MCP mirror (the hosted Render copy). Local mirrors of MirrorClient's actor state, refreshed
     // when "More" opens and after each action.
@@ -133,20 +133,37 @@ struct DevToolsView: View {
         .buttonStyle(.plain)
     }
 
-    /// Toggle: real For-You cards vs the demo deck. ON also makes Analyze Now run the full cycle.
-    private var realCardsSection: some View {
+    /// The 3-way deck mode, inline: which deck the home deals. Three segment buttons; clicking one
+    /// switches the mode and the home re-deals instantly (HomeView re-deals on the deck change).
+    private var proactiveCardsSection: some View {
         VStack(alignment: .leading, spacing: 10) {
-            HStack {
-                Text("REAL FOR-YOU CARDS").font(.caption2.weight(.bold)).tracking(2).foregroundStyle(Theme.faint)
-                Spacer()
-                Toggle("", isOn: $realCards).labelsHidden().toggleStyle(.switch).controlSize(.small)
+            Text("PROACTIVE CARDS").font(.caption2.weight(.bold)).tracking(2).foregroundStyle(Theme.faint)
+            HStack(spacing: 8) {
+                deckButton(.real, "REAL CARDS")
+                deckButton(.jesai, "JESAI'S DEMO")
+                deckButton(.launch, "LAUNCH DEMO")
             }
-            Text("ON (the default): the home shows REAL proactive cards from your processed data, and Analyze Now runs the full cycle — read → knowledge base → decide / research / prepare → wipe summaries. OFF: the hard-coded investor-demo deck (pitch mode).")
+            Text("Real cards come from your latest proactive run, and Analyze Now runs the full cycle — read → knowledge base → decide / research / prepare → wipe. The demo decks are hard-coded; fires play scripted theater.")
                 .font(.caption2).foregroundStyle(Theme.faint.opacity(0.7))
                 .fixedSize(horizontal: false, vertical: true)
         }
         .padding(12)
         .background(.white.opacity(0.03), in: RoundedRectangle(cornerRadius: 12))
+    }
+
+    /// One deck segment — lit when it's the active mode.
+    private func deckButton(_ mode: BriefingDeck, _ label: String) -> some View {
+        let selected = (BriefingDeck(rawValue: deckRaw) ?? .real) == mode
+        return Button { deckRaw = mode.rawValue } label: {
+            Text(label)
+                .font(.caption2.weight(.bold)).tracking(1.5)
+                .foregroundStyle(selected ? .white : Theme.faint)
+                .frame(maxWidth: .infinity, minHeight: 32)
+                .background(.white.opacity(selected ? 0.14 : 0.04), in: RoundedRectangle(cornerRadius: 8))
+                .overlay(RoundedRectangle(cornerRadius: 8)
+                    .strokeBorder(.white.opacity(selected ? 0.25 : 0.08), lineWidth: 1))
+        }
+        .buttonStyle(.plain)
     }
 
     /// Opens the one CODEX SETUP window (install · log in · computer use) — all three steps live in
@@ -185,7 +202,7 @@ struct DevToolsView: View {
                         await runResearch(progress: progress)
                     }
                     executeButton
-                    realCardsSection
+                    proactiveCardsSection
                     HStack(spacing: 10) {
                         viewSummariesButton
                         viewActionItemsButton

--- a/Sentient OS macOS/Views/HomeView.swift
+++ b/Sentient OS macOS/Views/HomeView.swift
@@ -36,7 +36,7 @@ struct HomeView: View {
     var sources: HomeSources = .init()
     var customRoots: [URL] = []        // session folders from RootView — shown in the Analysis popover, like Dev Tools
     var modelMissing: Bool = false
-    var realCards: Bool = false        // true → show real proactive cards from latest(); false → the demo deck
+    var deck: BriefingDeck = .jesai    // .real → real proactive cards from latest(); .jesai/.launch → a demo deck
     var previewKBOnly = false          // preview-only: force the knowledge-base-only state
     var onAnalyze: () -> Void = {}
     var onShowDevTools: () -> Void = {}
@@ -105,11 +105,11 @@ struct HomeView: View {
         .onAppear {                        // every appearance starts fresh: sealed envelope, full deal
             letter = nil
             letterShown = false
-            model.beginVisit(realCards: realCards)
+            model.beginVisit(deck: deck)
             planUpgraded = previewUpgraded ?? (kbOnly && CodexAuth.currentPlan()?.tier == .full)
             caution = OvernightCaution.latest()
         }
-        .onChange(of: realCards) { _, v in model.beginVisit(realCards: v) }   // toggle flip → re-deal
+        .onChange(of: deck) { _, v in model.beginVisit(deck: v) }   // mode flip → re-deal
         .animation(.spring(response: 0.5, dampingFraction: 0.82), value: model.entries.isEmpty)
         .sheet(isPresented: $showWhatsAppPicker) {
             ChatPicker(sourceName: "WhatsApp", loadChats: { try WhatsAppSource().listChats() },
@@ -222,7 +222,7 @@ struct HomeView: View {
     private var analysisPopover: some View {
         AnalysisPopover(thingsUnderstood: thingsUnderstood, sources: sources,
                         modelMissing: modelMissing,
-                        syncedLabel: syncedLabel, pending: realCards ? 0 : Demo.pending,
+                        syncedLabel: syncedLabel, pending: deck == .real ? 0 : Demo.pending,
                         onAnalyze: { showAnalysis = false; onAnalyze() },
                         onPickWhatsApp: { showAnalysis = false; showWhatsAppPicker = true },
                         onPickIMessage: { showAnalysis = false; showIMessagePicker = true },
@@ -234,7 +234,7 @@ struct HomeView: View {
 
     /// Real mode: the actual last-cycle stamp; demo mode: the showcase string.
     private var syncedLabel: String {
-        guard realCards else { return Demo.synced }
+        guard deck == .real else { return Demo.synced }
         guard let d = UserDefaults.standard.object(forKey: ProactiveCycle.lastCycleKey) as? Date else {
             return "Not yet analyzed"
         }
@@ -277,7 +277,8 @@ struct HomeView: View {
     /// top chrome (nav + greeting) and the command-bar dock. The two rows cluster toward the
     /// vertical centre with a tight, deliberate gap (one composed spread, not two stranded rows)
     /// and a gentle stagger. Pinned, not gridded; reflows as cards leave. (y-fraction is WITHIN
-    /// the zone.)
+    /// the zone.) Convention: the LAST slot of every population is the rightmost/lowest one —
+    /// the welcome gift envelope always rides last in the deck, so that slot is its perch.
     private static func slots(count: Int, in size: CGSize) -> [CGPoint] {
         let top = size.height * 0.20
         let bottom = size.height * 0.86
@@ -579,24 +580,27 @@ final class ForYouModel {
     }
 
     /// A fresh visit. Real mode → the verified cards from the latest proactive run (empty → the orb's
-    /// "I'm here to help."). Demo mode → the investor deck (welcome re-sealed). Then the orb deals the
-    /// cards with staggered springs from above the header.
-    func beginVisit(realCards: Bool) {
+    /// "I'm here to help."). Demo modes → the picked hard-coded deck (welcome re-sealed). Then the orb
+    /// deals the cards with staggered springs from above the header.
+    func beginVisit(deck: BriefingDeck) {
         visit += 1
         let v = visit
         runTasks.values.forEach { $0.cancel() }; runTasks.removeAll()
-        if realCards {
-            var built: [Entry] = []
-            // The day-one welcome "gift" leads the deck as a sealed envelope (generated from the user's
-            // own knowledge base by the proactive cycle; absent until that's run once).
+        switch deck {
+        case .real:
+            var built: [Entry] = (ProactiveResearch.latest()?.ready ?? [])
+                .map { Entry(b: Briefing(from: $0), action: $0, phase: .offer) }
+            // The day-one welcome "gift" rides LAST as a sealed envelope (generated from the user's
+            // own knowledge base by the proactive cycle; absent until that's run once) — last in
+            // the deck = the bottom-right scatter slot, the envelope's fixed perch in every mode.
             if let gift = GiftLetter.latest() {
                 built.append(Entry(b: Briefing(fromGiftMarkdown: gift), action: nil, phase: .sealed))
             }
-            let ready = ProactiveResearch.latest()?.ready ?? []
-            built.append(contentsOf: ready.map { Entry(b: Briefing(from: $0), action: $0, phase: .offer) })
             entries = built
-        } else {
-            entries = Briefing.demo.map { Entry(b: $0, action: nil, phase: $0.kind == .welcome ? .sealed : .offer) }
+        case .jesai, .launch:
+            // Both demo decks keep their welcome card LAST for the same bottom-right perch.
+            let cards = deck == .launch ? Briefing.launchDemo : Briefing.jesaiDemo
+            entries = cards.map { Entry(b: $0, action: nil, phase: $0.kind == .welcome ? .sealed : .offer) }
         }
         for (i, e) in entries.enumerated() {
             Task {
@@ -1012,7 +1016,7 @@ private struct LetterView: View {
     }
 }
 
-// MARK: - Demo data (the home's own showcase strings — cards live in Briefing.demo)
+// MARK: - Demo data (the home's own showcase strings — cards live in Briefing.jesaiDemo/.launchDemo)
 
 private enum Demo {
     static let synced = "Synced · 3:41 AM"
@@ -1026,11 +1030,19 @@ private enum Demo {
         .frame(width: 1180, height: 880)
 }
 
+#Preview("Home — launch demo deck") {
+    HomeView(thingsUnderstood: 3339,
+             sources: .init(files: true, whatsapp: true, imessage: true, notes: true),
+             modelMissing: false,
+             deck: .launch)
+        .frame(width: 1180, height: 880)
+}
+
 #Preview("Home — knowledge-base-only (free plan)") {
     HomeView(thingsUnderstood: 1704,
              sources: .init(files: true),
              modelMissing: false,
-             realCards: true,
+             deck: .real,
              previewKBOnly: true,
              previewUpgraded: false)
         .frame(width: 1180, height: 880)
@@ -1040,7 +1052,7 @@ private enum Demo {
     HomeView(thingsUnderstood: 1704,
              sources: .init(files: true),
              modelMissing: false,
-             realCards: true,
+             deck: .real,
              previewKBOnly: true,
              previewUpgraded: true)
         .frame(width: 1180, height: 880)

--- a/Sentient OS macOS/Views/Onboarding/OnboardingView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingView.swift
@@ -35,7 +35,7 @@ struct OnboardingView: View {
     @State private var computerUseArmed = false
 
     // The same run flags the home's Analyze Now reads (RootView).
-    @AppStorage("dev.proactive.realCards") private var realCards = true
+    @AppStorage(BriefingDeck.key) private var deckRaw = BriefingDeck.defaultRaw
     @AppStorage("dbg.gmail.connected")     private var gmailConnected = false
     @AppStorage("dbg.run.gmail")           private var runGmail = false
     @AppStorage("dbg.calendar.connected")  private var calendarConnected = false
@@ -69,7 +69,7 @@ struct OnboardingView: View {
                                    mode: .auto,
                                    runGmail: gmailConnected && runGmail,
                                    runCalendar: calendarConnected && runCalendar,
-                                   fullCycle: realCards,
+                                   fullCycle: BriefingDeck(rawValue: deckRaw) == .real,
                                    pausable: true,
                                    onExitEarly: { withAnimation(.easeInOut(duration: 0.3)) { analyzing = false } },
                                    onDone: onFinished)

--- a/Sentient OS macOS/Views/RootView.swift
+++ b/Sentient OS macOS/Views/RootView.swift
@@ -21,7 +21,10 @@ struct RootView: View {
     @AppStorage(CustomRoots.key) private var customRootsRaw = ""
     private var customRoots: [URL] { CustomRoots.decode(customRootsRaw) }
     @State private var fdaGranted = Permissions.hasFullDiskAccess()
-    @AppStorage("dev.proactive.realCards") private var realCards = true   // DEFAULT: real cards + full-cycle Analyze Now (dev toggle OFF = the investor demo deck)
+    // The 3-way card mode (Dev Tools → Proactive Cards…). DEFAULT: real cards + full-cycle
+    // Analyze Now; .jesai/.launch swap in a hard-coded demo deck (pitch / launch-video mode).
+    @AppStorage(BriefingDeck.key) private var deckRaw = BriefingDeck.defaultRaw
+    private var deck: BriefingDeck { BriefingDeck(rawValue: deckRaw) ?? .real }
     // Cloud sources — same flags the scheduler reads, so Analyze Now processes exactly what an
     // overnight run would (a no-op until Gmail/Calendar are actually connected + selected).
     @AppStorage("dbg.gmail.connected")    private var gmailConnected = false
@@ -68,7 +71,7 @@ struct RootView: View {
                                mode: .auto,
                                runGmail: gmailConnected && runGmail,
                                runCalendar: calendarConnected && runCalendar,
-                               fullCycle: realCards) {   // real mode → read + knowledge base + proactive + wipe
+                               fullCycle: deck == .real) {   // real mode → read + knowledge base + proactive + wipe
                     withAnimation(.easeInOut(duration: 0.3)) { isProcessing = false }
                     appState.scheduler.maybeAutoEnable()   // a full cycle may have just stamped "initial done" → arm the 18h clock
                 }
@@ -119,7 +122,7 @@ struct RootView: View {
                 whatsappAvailable: WhatsAppSource.isInstalled),
             customRoots: customRoots,
             modelMissing: Self.modelPath == nil,
-            realCards: realCards,
+            deck: deck,
             onAnalyze: { withAnimation(.easeInOut(duration: 0.3)) { isProcessing = true } },
             onShowDevTools: { showDevTools = true })
     }


### PR DESCRIPTION
## What

- **`BriefingDeck` enum** (`real` / `jesai` / `launch`, key `dev.proactive.deck`) replaces the old `dev.proactive.realCards` bool, with a one-time migration (old toggle OFF → Jesai's deck, so a pitching install doesn't flip). Real mode still drives the full-cycle Analyze Now, including onboarding's first analysis.
- **`Briefing.launchDemo`** — the audience-safe launch-video deck: Carl (Gmail ghost), Canva Pro, the Amtrak, Denver expenses, Hawaii group trip, plus a persona-matched welcome gift letter. Jesai's deck renamed `Briefing.jesaiDemo`, content untouched.
- **Dev Tools**: the REAL FOR-YOU CARDS toggle section is now an inline PROACTIVE CARDS segment picker (REAL CARDS · JESAI'S DEMO · LAUNCH DEMO); the home re-deals on switch.
- **Gift envelope placement**: the welcome card now rides LAST in every deck, and the last scatter slot of every population is the rightmost/lowest one — so the envelope's fixed perch is bottom-right in all modes, surviving reflows. (kb-only home keeps its deliberate top-center perch.)
- **`Briefing.envelopeName`**: demo decks' envelopes read **"For You"**; real gift cards keep the Mac account's first name. Envelope whisper is now **"A gift from your Sentient"**.

## Testing

- Isolated `xcodebuild` (Debug) passes.
- Verified live: three-way switching re-deals; launch deck renders 6 cards with the sealed For-You envelope bottom-right; card copy iterated at render size (screenshots in the session).

Note: the tree's other in-flight work (ConnectAIs revamp, analytics ping, gift keepsake) is deliberately NOT in this PR — RootView was staged per-hunk to keep the `Home.opened` analytics signal out.