### PR TITLE
Uninstall Sentient: full teardown + farewell sheet (Settings → System)

### DIFF
--- a/Sentient OS macOS/Cloud/MirrorClient.swift
+++ b/Sentient OS macOS/Cloud/MirrorClient.swift
@@ -253,6 +253,15 @@ actor MirrorClient {
                      lastAccess: last)
     }
 
+    /// Uninstall's sweep of the mirror identity — the ONE caller that deletes the Keychain password
+    /// (+ the legacy token). Everywhere else the password survives by design (the share URL pasted
+    /// into the user's connectors must outlive resets and off→on); uninstall is where that virtue
+    /// ends. Call AFTER `deleteRemote()` — the cloud DELETE needs the password to authorize.
+    nonisolated static func destroyKeychainIdentity() {
+        Keychain.delete(passwordKey)
+        Keychain.delete(legacyTokenKey)
+    }
+
     // MARK: Helpers
 
     private static let passwordKey = "mcp.mirror.password"  // Keychain: the root secret (persists)

--- a/Sentient OS macOS/Diagnostics/Analytics.swift
+++ b/Sentient OS macOS/Diagnostics/Analytics.swift
@@ -33,6 +33,7 @@
 //   - start()                          → boot TelemetryDeck (Release-only, unconditional)
 //   - signal(_:parameters:floatValue:tier:) → send one product event (.extended = opt-out gated · .core = always)
 //   - countInstallOnce()               → the one-off anonymous install count (Release-only, uncorrelatable)
+//   - countUninstall()                 → its farewell twin, fired as the uninstall teardown begins
 //   - applyEnabledChange()             → react to a mid-session flip of the extended-tier switch
 //
 //  Doc: Documentation/Product Analytics (TelemetryDeck).md · twin: Documentation/Crash Reporting (Sentry).md
@@ -126,6 +127,7 @@ enum Analytics {
 
     private static let installCountedKey = "analytics.installCounted"
     private static let installSignalType = "App.anonymousInstall"
+    private static let uninstallSignalType = "App.anonymousUninstall"
     private static let ingestURL = URL(string: "https://nom.telemetrydeck.com/v2/")!
 
     /// Send the single anonymous install ping — see the file header. Fires at most once per install
@@ -141,7 +143,7 @@ enum Analytics {
         #else
         guard !appID.hasPrefix("PASTE_") else { return }
         guard !UserDefaults.standard.bool(forKey: installCountedKey) else { return }   // one-off, forever
-        postAnonymousInstall { ok in
+        postAnonymousSignal(type: installSignalType) { ok in
             guard ok else { return }   // not latched → retried next launch until it lands exactly once
             UserDefaults.standard.set(true, forKey: installCountedKey)
             Log("Analytics: anonymous install counted (one-off)")
@@ -149,17 +151,31 @@ enum Analytics {
         #endif
     }
 
+    /// The install count's farewell twin: one anonymous "an install left" ping, fired as the
+    /// uninstall teardown begins. Same hard line as `countInstallOnce()` — a throwaway hash
+    /// correlatable to nothing, an empty payload, one direct POST (the SDK's queue may never
+    /// flush this close to quit). Release-only, fire-and-forget: the teardown never waits on the
+    /// network, and a lost ping is simply lost (no retry — the app is about to be gone).
+    static func countUninstall() {
+        #if DEBUG
+        Log("Analytics: DEBUG build — anonymous uninstall ping skipped (Release-only)")
+        #else
+        guard !appID.hasPrefix("PASTE_") else { return }
+        postAnonymousSignal(type: uninstallSignalType) { _ in }
+        #endif
+    }
+
     /// The direct one-shot ingest POST, matching TelemetryDeck's V2 signal body. `clientUser` is a
     /// throwaway random hash (never stored, never reused — so it ties to nothing), the payload is
     /// empty, and no version/device/content rides along: a truly bare count. TelemetryDeck stores no
     /// IP and salts the hash again, so this stays anonymous end to end.
-    private static func postAnonymousInstall(_ done: @escaping @Sendable (Bool) -> Void) {
+    private static func postAnonymousSignal(type: String, _ done: @escaping @Sendable (Bool) -> Void) {
         let body: [[String: Any]] = [[
             "receivedAt": ingestDateFormatter.string(from: Date()),
             "appID": appID,
             "clientUser": sha256Hex(UUID().uuidString),
             "sessionID": UUID().uuidString,
-            "type": installSignalType,
+            "type": type,
             "payload": [String: String](),
             "isTestMode": "false",
         ]]

--- a/Sentient OS macOS/Scheduling/WakeHelperInstaller.swift
+++ b/Sentient OS macOS/Scheduling/WakeHelperInstaller.swift
@@ -41,6 +41,32 @@ enum WakeHelperInstaller {
         await Task.detached { install() }.value
     }
 
+    /// True when the daemon plist exists on disk AT ALL — stale or current. `isInstalledAndCurrent()`
+    /// additionally checks the binary path; for uninstall a stale plist still must die.
+    static func isInstalled() -> Bool { FileManager.default.fileExists(atPath: plistPath) }
+
+    /// Tear the helper down — the installer's mirror image, behind the same ONE admin prompt:
+    /// restore normal sleep, cancel the armed wake (read from the helper's persisted spec, which
+    /// must happen BEFORE its dir is removed), bootout + delete the daemon, and sweep the
+    /// root-owned support/log files. Clauses are `;`-separated best-effort so a single failure
+    /// never blocks the rest (the daemon self-heals disablesleep + the armed wake anyway); the
+    /// wake is cancelled by its exact spec, never `cancelall`, so other apps' wakes survive.
+    /// No plist on disk = true with no prompt; false = the user declined the password dialog.
+    static func uninstallAsync() async -> Bool {
+        guard isInstalled() else { return true }
+        return await Task.detached { runAdmin(uninstallScript) }.value
+    }
+
+    private static var uninstallScript: String {
+        "/usr/bin/pmset -a disablesleep 0"
+            + "; spec=$(/bin/cat '/Library/Application Support/SentientOS/armed-wake' 2>/dev/null)"
+            + "; [ -n \"$spec\" ] && /usr/bin/pmset schedule cancel wake \"$spec\""
+            + "; /bin/launchctl bootout system '\(plistPath)' 2>/dev/null"
+            + "; /bin/rm -f '\(plistPath)'"
+            + "; /bin/rm -rf '/Library/Application Support/SentientOS'"
+            + "; /bin/rm -f '/Library/Logs/SentientOS-wakehelper.log'"
+    }
+
     private static func install() -> Bool {
         let tmp = (NSTemporaryDirectory() as NSString).appendingPathComponent("sentient-wakehelper.plist")
         guard (try? plistXML(binary: currentBinary).write(toFile: tmp, atomically: true, encoding: .utf8)) != nil

--- a/Sentient OS macOS/System/Permissions.swift
+++ b/Sentient OS macOS/System/Permissions.swift
@@ -117,6 +117,41 @@ enum Permissions {
         return "granted \(bundleID) → Codex Computer Use (csreq \(csreq.count)B · target \(target.count)B)"
     }
 
+    /// Undo `grantComputerUseAutomation()` — Uninstall's sweep: DELETE our kTCCServiceAppleEvents
+    /// row (scoped to our bundle id AND the Codex helper target, so no other app's Automation
+    /// grants are ever touched) from the USER TCC database, then reload tccd. Best-effort: no FDA,
+    /// no DB, or no row is a quiet no-op — an orphaned row is inert once the app is gone. The
+    /// system-DB rows (Accessibility / Screen Recording) are SIP-protected and not ours to remove.
+    static func revokeComputerUseAutomation() {
+        guard hasFullDiskAccess() else { return }
+        let bundleID = Bundle.main.bundleIdentifier ?? "jesai.Sentient-OS-macOS"
+        let dbPath = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/com.apple.TCC/TCC.db").path
+
+        var db: OpaquePointer?
+        guard sqlite3_open_v2(dbPath, &db, SQLITE_OPEN_READWRITE, nil) == SQLITE_OK else {
+            sqlite3_close(db); return
+        }
+        defer { sqlite3_close(db) }
+
+        let sql = """
+        DELETE FROM access WHERE service='kTCCServiceAppleEvents'
+          AND client=? AND client_type=0 AND indirect_object_identifier=?;
+        """
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return }
+        defer { sqlite3_finalize(stmt) }
+
+        let TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        sqlite3_bind_text(stmt, 1, bundleID, -1, TRANSIENT)
+        sqlite3_bind_text(stmt, 2, computerUseHelperBundleID, -1, TRANSIENT)
+
+        if sqlite3_step(stmt) == SQLITE_DONE, sqlite3_changes(db) > 0 {
+            reloadTCCD()
+            Log("Permissions: removed the Automation grant row (\(bundleID) → Codex Computer Use)")
+        }
+    }
+
     /// Quiet self-heal for the Automation grant (Sentient → Codex Computer Use over Apple Events):
     /// probe, and if it's missing while the prerequisites exist (FDA + the helper on disk), silently
     /// re-grant in the background — idempotent, no UI, just a log line. The user has no job here.

--- a/Sentient OS macOS/System/Uninstall.swift
+++ b/Sentient OS macOS/System/Uninstall.swift
@@ -1,0 +1,149 @@
+//
+//  Uninstall.swift
+//  Sentient OS macOS  ·  System/
+//
+//  The one full teardown — FactoryReset's strict superset, driven by Settings → System →
+//  Uninstall Sentient (UninstallView). Removes EVERYTHING Sentient ever created on this Mac:
+//  the root wake helper (+ its /Library files), the cloud mirror copy AND the Keychain identity,
+//  the knowledge base, the on-device model, the cycle store, the login item, the TCC Automation
+//  grant, caches, and the whole defaults domain. Every step is best-effort and idempotent, so a
+//  crash or relaunch mid-way just re-runs cleanly (post-wipe the app lands in onboarding).
+//
+//  Deliberately NOT touched: the .app bundle itself (the gone screen asks the user to drag it to
+//  the Trash — decided 2026-07-10), ALL of ~/.codex (the computer-use payload, config.toml, and
+//  the user's own codex login stay), the Desktop gift keepsakes, and the SIP-protected system
+//  TCC rows. A destructive sequence must never drift — change it HERE only.
+//
+//  Key members: Stage (the sheet's whisper per step) · run(appState:progress:helperDecision:)
+//  (the teardown) · finishAndQuit() (the gone screen's Quit + post-exit sweeper).
+//
+
+import Foundation
+import AppKit
+
+enum Uninstall {
+
+    /// The user-facing teardown stages, in run order — the farewell sheet renders each `whisper`
+    /// (the mono-caps voice) while its stage runs. The helper goes FIRST: it's the only stage that
+    /// can ask for the user's password (and be declined), so a cancel there aborts the uninstall
+    /// before anything irreversible has happened.
+    enum Stage: CaseIterable {
+        case helper, cloud, keychain, knowledge, model, traces
+        var whisper: String {
+            switch self {
+            case .helper:    return "STANDING DOWN THE WAKE HELPER"
+            case .cloud:     return "REMOVING THE CLOUD COPY"
+            case .keychain:  return "CLEARING YOUR KEYCHAIN KEY"
+            case .knowledge: return "ERASING YOUR KNOWLEDGE BASE"
+            case .model:     return "REMOVING THE ON-DEVICE MODEL"
+            case .traces:    return "SWEEPING THE LAST TRACES"
+            }
+        }
+    }
+
+    /// The sheet's answer when the helper's admin prompt is declined.
+    enum HelperChoice { case retry, skip, cancel }
+
+    private static var bundleID: String { Bundle.main.bundleIdentifier ?? "jesai.Sentient-OS-macOS" }
+
+    /// The full teardown. `progress` fires on the main actor before each stage so the sheet can
+    /// render its whisper; `helperDecision` is asked ONLY when the root admin prompt is declined
+    /// (Try Again / Skip / Cancel). Returns false iff the user cancelled at that prompt — before
+    /// anything irreversible ran, with the scheduler flags restored.
+    @MainActor
+    @discardableResult
+    static func run(appState: AppState? = nil,
+                    progress: @escaping @MainActor (Stage) -> Void = { _ in },
+                    helperDecision: @escaping @MainActor () async -> HelperChoice = { .skip }) async -> Bool {
+        Analytics.countUninstall()   // fire-and-forget; the teardown never waits on the network
+
+        // Quiet the scheduler FIRST so nothing re-arms a wake while the daemon comes down. The
+        // flags are snapshotted so a cancel at the password prompt restores them untouched.
+        let d = UserDefaults.standard
+        let schedulerFlags = (dev: d.bool(forKey: OvernightScheduler.enabledKey),
+                              prod: d.bool(forKey: OvernightScheduler.prodEnabledKey))
+        d.removeObject(forKey: OvernightScheduler.enabledKey)
+        d.removeObject(forKey: OvernightScheduler.prodEnabledKey)
+        appState?.scheduler.needsSchedulerSetup = false
+        appState?.scheduler.reevaluate()   // flags gone → stops the loop + cancels the armed wake
+
+        // The root daemon — the ONLY stage that can be declined, so it runs before anything
+        // irreversible. One native password prompt tears down the plist, the armed wake, and the
+        // root-owned /Library files (WakeHelperInstaller.uninstallAsync, the installer's mirror).
+        progress(.helper)
+        helperLoop: while !(await WakeHelperInstaller.uninstallAsync()) {
+            switch await helperDecision() {
+            case .retry:
+                continue helperLoop
+            case .skip:
+                Log("Uninstall: wake helper left in place (admin prompt skipped)")
+                break helperLoop
+            case .cancel:
+                if schedulerFlags.dev { d.set(true, forKey: OvernightScheduler.enabledKey) }
+                if schedulerFlags.prod { d.set(true, forKey: OvernightScheduler.prodEnabledKey) }
+                appState?.scheduler.reevaluate()
+                Log("Uninstall: cancelled at the admin prompt — nothing removed")
+                return false
+            }
+        }
+        await WakeHelperClient.shared.unregister()   // the dev-cockpit SMAppService path, if ever used
+        await LoginItem.disable()
+        await beat()
+
+        // The cloud copy dies while the Keychain password still exists to authorize the DELETE.
+        progress(.cloud)
+        try? await MirrorClient.shared.deleteRemote()
+        await beat()
+
+        progress(.keychain)
+        MirrorClient.destroyKeychainIdentity()
+        await beat()
+
+        progress(.knowledge)
+        await CycleStore.shared.wipeEverything()     // close out SwiftData cleanly before its files go
+        try? FileManager.default.removeItem(at: VaultGenerator.vaultRoot)
+        VaultGenerator.sweepOrphanStaging(keeping: nil)
+        await beat()
+
+        progress(.model)
+        try? FileManager.default.removeItem(at: URL.sentientSupport)   // model + download staging + the store
+        await beat()
+
+        progress(.traces)
+        Permissions.revokeComputerUseAutomation()
+        let library = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Library")
+        for sub in ["Caches/\(bundleID)", "HTTPStorages/\(bundleID)", "WebKit/\(bundleID)",
+                    "Saved Application State/\(bundleID).savedState", "Logs/SentientOS"] {
+            try? FileManager.default.removeItem(at: library.appendingPathComponent(sub, isDirectory: true))
+        }
+        // Every setting, flag, and latch at once — LAST, so a live observer can't re-persist a key.
+        d.removePersistentDomain(forName: bundleID)
+        d.synchronize()
+        await beat()
+
+        Log("Uninstall: removed wake helper + cloud copy + keychain identity + knowledge base + model + store + caches + TCC grant + defaults · left the .app, ~/.codex, and gift keepsakes untouched")
+        return true
+    }
+
+    /// The gone screen's Quit: spawn a detached sweeper for the files the DYING process itself can
+    /// resurrect on the way out (cfprefsd re-writing the preferences plist, SwiftData flushing store
+    /// files into a recreated support dir, the saved-state write at quit), then terminate. The
+    /// sweeper outlives us (it reparents to launchd), so the last traces die a beat after we do.
+    @MainActor
+    static func finishAndQuit() {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let stragglers = ["\(home)/Library/Application Support/SentientOS",
+                          "\(home)/Library/Preferences/\(bundleID).plist",
+                          "\(home)/Library/Caches/\(bundleID)",
+                          "\(home)/Library/Saved Application State/\(bundleID).savedState"]
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: "/bin/sh")
+        p.arguments = ["-c", "sleep 2; rm -rf " + stragglers.map { "'\($0)'" }.joined(separator: " ")]
+        try? p.run()
+        NSApp.terminate(nil)
+    }
+
+    /// A short breath between stages so each whisper is readable — the work itself is near-instant,
+    /// and a label vanishing mid-word reads as a glitch, not a considered teardown.
+    private static func beat() async { try? await Task.sleep(for: .milliseconds(500)) }
+}

--- a/Sentient OS macOS/Views/Settings/SystemPane.swift
+++ b/Sentient OS macOS/Views/Settings/SystemPane.swift
@@ -6,7 +6,8 @@
 //  not a control — 3 AM is our taste, not a dial), the launch-at-login toggle (LoginItem.swift)
 //  with its keep-Sentient-alive confirm, the privacy pledge with the two anonymous-reporting
 //  switches (crash reports → CrashReporting/Sentry · analytics → Analytics/TelemetryDeck), and
-//  the danger-zone Reset (the shared FactoryReset wipe — a system-level act, so it lives here).
+//  the danger-zone Reset (the shared FactoryReset wipe — a system-level act, so it lives here),
+//  and the Uninstall group (the farewell sheet → the full System/Uninstall teardown).
 //  The updates group lands here once Sparkle ships.
 //
 
@@ -26,7 +27,8 @@ struct SystemPane: View {
     @State private var confirmLoginOff = false
     @State private var confirmReset = false
     @State private var resetting = false
-    @State private var activity = PipelineActivity.shared   // Reset locks while a run is active
+    @State private var showUninstall = false
+    @State private var activity = PipelineActivity.shared   // Reset + Uninstall lock while a run is active
 
     var body: some View {
         SettingsPane(title: "System", whisper: "How Sentient lives on this Mac.") {
@@ -36,6 +38,7 @@ struct SystemPane: View {
                 updatesGroup
                 privacyGroup
                 dangerGroup
+                uninstallGroup
             }
         }
         .task { launchAtLogin = LoginItem.isEnabled }   // live status — revocable in System Settings
@@ -168,6 +171,25 @@ struct SystemPane: View {
         } message: {
             Text("Your knowledge base and everything Sentient understood is deleted from this Mac, and the cloud copy is removed. This can't be undone; Sentient takes you back through setup, beginning with the initial processing.")
         }
+    }
+
+    // MARK: - Uninstall (the full teardown — UninstallView + System/Uninstall.swift)
+
+    private var uninstallGroup: some View {
+        SettingsGroup(label: "Uninstall") {
+            VStack(alignment: .leading, spacing: 10) {
+                SettingsProse("Uninstall removes everything Sentient created on this Mac: the on-device model, your knowledge base, the private cloud copy your AIs read, the overnight wake helper, and every setting. Your own files stay exactly where they are.")
+                SettingsPillButton(title: "Uninstall Sentient…", tint: Self.dangerRed) {
+                    showUninstall = true
+                }
+                .disabled(activity.isRunning)
+                if activity.isRunning {
+                    Text("A run is in progress. Uninstall unlocks when it finishes.")
+                        .font(.system(size: 11)).foregroundStyle(Theme.Ink.amber)
+                }
+            }
+        }
+        .sheet(isPresented: $showUninstall) { UninstallView() }
     }
 }
 

--- a/Sentient OS macOS/Views/Settings/UninstallView.swift
+++ b/Sentient OS macOS/Views/Settings/UninstallView.swift
@@ -1,0 +1,239 @@
+//
+//  UninstallView.swift
+//  Sentient OS macOS
+//
+//  The farewell sheet (Settings → System → Uninstall Sentient…). Four phases: the farewell
+//  (the two-college-students note, Share Feedback via mailto, Keep Sentient, and the red
+//  Uninstall), the working teardown (Uninstall.Stage whispers over a quiet spinner), the
+//  helper-password interstitial (Enter Password / Skip / Cancel — shown only when the admin
+//  prompt is declined), and the gone screen (drag Sentient to the Trash, then Quit via
+//  Uninstall.finishAndQuit). Drives System/Uninstall.swift; the teardown itself lives there.
+//
+
+import SwiftUI
+
+struct UninstallView: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.dismiss) private var dismiss
+
+    fileprivate enum Phase { case farewell, working, helperPrompt, gone }
+    @State private var phase: Phase = .farewell
+    @State private var stage: Uninstall.Stage = .helper
+    /// Fulfilled by the interstitial's buttons while the teardown awaits a helper decision.
+    @State private var helperResolver: ((Uninstall.HelperChoice) -> Void)?
+
+    init() {}
+
+    /// Preview-only: open the sheet directly in a later phase.
+    fileprivate init(previewPhase: Phase) { _phase = State(initialValue: previewPhase) }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Group {
+                switch phase {
+                case .farewell:     farewell
+                case .working:      working
+                case .helperPrompt: helperPrompt
+                case .gone:         gone
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 34).padding(.top, 30).padding(.bottom, 26)
+
+            trustFooter
+        }
+        .frame(width: 470)
+        .background(Theme.bg)
+        .preferredColorScheme(.dark)
+        .interactiveDismissDisabled(phase != .farewell)   // mid-teardown there's no walking away
+        .animation(.easeInOut(duration: 0.25), value: phase)
+    }
+
+    // MARK: - Phase 1 · the farewell
+
+    private var farewell: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            MonoCaps("Before you go", size: 9.5, tracking: 2.4, color: .white.opacity(0.7), weight: .semibold)
+            Text("Sorry to see you go.")
+                .display(24).foregroundStyle(.white)
+                .padding(.top, 12)
+            prose("We are two college students who built Sentient in the open, because we believed your Mac could truly know you while keeping everything private. We are sad to see you leave, and we would genuinely love to hear what did not land for you.")
+                .padding(.top, 14)
+            prose("Uninstalling removes everything Sentient made on this Mac: the on-device model, your knowledge base, the private cloud copy your AIs read, the overnight wake helper, and every setting. Your own files are never touched.")
+                .padding(.top, 10)
+            HStack(spacing: 10) {
+                feedbackButton
+                Spacer()
+                QuietPillButton(title: "Keep Sentient") { dismiss() }
+                DangerPillButton(title: "Uninstall Sentient") { beginUninstall() }
+            }
+            .padding(.top, 24)
+        }
+    }
+
+    // MARK: - Phase 2 · the teardown
+
+    private var working: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            MonoCaps(stage.whisper, size: 9.5, tracking: 2.4, color: .white.opacity(0.7), weight: .semibold)
+                .id(stage)
+                .transition(.opacity)
+                .animation(.easeInOut(duration: 0.3), value: stage)
+            Text("Taking Sentient apart, gently.")
+                .display(24).foregroundStyle(.white)
+                .padding(.top, 12)
+            prose("Give us a moment. We are cleaning up after ourselves so nothing of ours is left behind.")
+                .padding(.top, 14)
+            ProgressView()
+                .controlSize(.small)
+                .tint(.white.opacity(0.6))
+                .padding(.top, 22)
+        }
+    }
+
+    // MARK: - Phase 3 · the helper needs a password (only if the admin prompt was declined)
+
+    private var helperPrompt: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            MonoCaps("One more step", size: 9.5, tracking: 2.4, color: .white.opacity(0.7), weight: .semibold)
+            Text("This part needs your password.")
+                .display(24).foregroundStyle(.white)
+                .padding(.top, 12)
+            prose("Sentient set up a small system helper so it could wake your Mac for the overnight run. macOS asks for your password to remove it; that is the same prompt you saw when it was installed. You can also skip it for now, and Sentient will still clear everything else.")
+                .padding(.top, 14)
+            HStack(spacing: 10) {
+                QuietPillButton(title: "Cancel Uninstall") { helperResolver?(.cancel) }
+                Spacer()
+                QuietPillButton(title: "Skip for Now") { helperResolver?(.skip) }
+                BrightPillButton(title: "Enter Password") { helperResolver?(.retry) }
+            }
+            .padding(.top, 24)
+        }
+    }
+
+    // MARK: - Phase 4 · gone
+
+    private var gone: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            MonoCaps("All clear", size: 9.5, tracking: 2.4, color: .white.opacity(0.7), weight: .semibold)
+            Text("Sentient is gone from this Mac.")
+                .display(24).foregroundStyle(.white)
+                .padding(.top, 12)
+            prose("Everything Sentient made here has been removed. To finish, drag the Sentient OS app from your Applications folder to the Trash. Thank you for giving us a try; it meant a lot to the two of us.")
+                .padding(.top, 14)
+            HStack(spacing: 10) {
+                feedbackButton
+                Spacer()
+                QuietPillButton(title: "Show App in Finder") {
+                    NSWorkspace.shared.activateFileViewerSelecting([Bundle.main.bundleURL])
+                }
+                BrightPillButton(title: "Quit Sentient") { Uninstall.finishAndQuit() }
+            }
+            .padding(.top, 24)
+        }
+    }
+
+    // MARK: - The run
+
+    private func beginUninstall() {
+        phase = .working
+        stage = .helper
+        Task { @MainActor in
+            let finished = await Uninstall.run(
+                appState: appState,
+                progress: { stage = $0 },
+                helperDecision: {
+                    await withCheckedContinuation { cont in
+                        phase = .helperPrompt
+                        helperResolver = { choice in
+                            helperResolver = nil
+                            phase = .working
+                            cont.resume(returning: choice)
+                        }
+                    }
+                })
+            phase = finished ? .gone : .farewell   // a cancel backs out with nothing removed
+        }
+    }
+
+    // MARK: - Shared bits
+
+    private func prose(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 12.5)).foregroundStyle(Theme.Ink.body)
+            .lineSpacing(3.5)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private var feedbackButton: some View {
+        Button {
+            if let url = URL(string: "mailto:feedback@sentient-os.ai?subject=Sentient%20OS%20feedback") {
+                NSWorkspace.shared.open(url)
+            }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "envelope").font(.system(size: 10))
+                Text("Share feedback").font(.system(size: 11.5))
+            }
+            .foregroundStyle(Theme.Ink.bright.opacity(0.9))
+        }
+        .buttonStyle(PressScaleStyle())
+    }
+
+    /// The same trust ribbon Settings rides — continuity to the very last screen.
+    private var trustFooter: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "shield").font(.system(size: 10.5)).foregroundStyle(Theme.Ink.label)
+            Text("Private by design. Your files never leave this Mac.")
+                .font(.system(size: 11.5)).foregroundStyle(Theme.Ink.label)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 13)
+        .overlay(alignment: .top) { Rectangle().fill(.white.opacity(0.05)).frame(height: 1) }
+    }
+}
+
+/// QuietPillButton's destructive sibling — red ink on a faint red wash. Local on purpose:
+/// Settings' small SettingsPillButton stays the pane-level danger affordance.
+private struct DangerPillButton: View {
+    let title: String
+    let action: () -> Void
+    private static let red = Color(red: 1.0, green: 0.36, blue: 0.36)
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 13.5, weight: .medium))
+                .foregroundStyle(Self.red)
+                .padding(.horizontal, 22).padding(.vertical, 12)
+                .background(Capsule().fill(Self.red.opacity(0.09)))
+                .overlay(Capsule().strokeBorder(Self.red.opacity(0.42), lineWidth: 1))
+                .contentShape(Capsule())
+        }
+        .buttonStyle(PressScaleStyle())
+    }
+}
+
+/// The sheet's one primary affordance — a white capsule, GlowButton's calm cousin (no halo:
+/// the glow is jewelry, and a farewell is not the place to wear it).
+private struct BrightPillButton: View {
+    let title: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 13.5, weight: .medium))
+                .foregroundStyle(.black)
+                .padding(.horizontal, 22).padding(.vertical, 12)
+                .background(Capsule().fill(.white))
+                .contentShape(Capsule())
+        }
+        .buttonStyle(PressScaleStyle())
+    }
+}
+
+#Preview("Farewell") { UninstallView() }
+#Preview("Working") { UninstallView(previewPhase: .working) }
+#Preview("Helper prompt") { UninstallView(previewPhase: .helperPrompt) }
+#Preview("Gone") { UninstallView(previewPhase: .gone) }


### PR DESCRIPTION
## What

The todo's "uninstall sentient" button: Settings → System now carries an **Uninstall** group under the Danger Zone. It opens a farewell sheet (the two-college-students note + a `mailto:feedback@sentient-os.ai` button), and on confirm removes **everything Sentient ever created on this Mac**:

- the root wake helper (one native admin prompt: `disablesleep 0`, cancel the armed wake by its exact spec, `launchctl bootout`, the plist, `/Library/Application Support/SentientOS`, the root log)
- the cloud mirror copy, then the Keychain identity (`mcp.mirror.password` + legacy token — order matters, the DELETE needs the password)
- the knowledge base + orphan staging dirs
- the on-device model + download staging + the cycle store (all of `~/Library/Application Support/SentientOS`)
- login item + dev SMAppService registration, the TCC Automation row (scoped to our client + the codex helper), per-app caches/HTTPStorages/WebKit/saved state/logs
- the whole defaults domain, last — plus a detached post-quit sweeper for what the dying process re-writes on the way out (cfprefsd, saved state)

**Deliberately untouched:** the .app bundle itself (the gone screen says "drag Sentient to the Trash" — decided with Aditya), ALL of `~/.codex` (computer-use payload, config.toml, codex login — decided), Desktop gift keepsakes, SIP-protected system TCC rows.

## Flow details

- The admin-prompt stage runs FIRST, so declining it offers Enter Password / Skip for Now / **Cancel Uninstall** — and cancel aborts with nothing removed (scheduler flags restored).
- Every stage is best-effort + idempotent; a relaunch mid-way lands in onboarding and uninstall can re-run.
- One anonymous `App.anonymousUninstall` ping (the install counter's farewell twin: throwaway hash, empty payload, direct POST, Release-only).

## Testing status

Build-verified only (isolated DerivedData, zero warnings in touched files). **Not yet run on hardware** — needs the real pass below before docs/merge:

1. Best on a throwaway macOS account; on a dev Mac back up `~/Sentient OS - Knowledge Base`, the model file, and `security find-generic-password -s ai.sentient-os.app -w` first.
2. Full uninstall, then verify gone: both `SentientOS` Application Support dirs (user + `/Library`), KB folder, `~/.sentientos-vault-staging-*`, keychain item, daemon plist + `sudo launchctl print system/jesai.Sentient-OS-macOS.WakeHelper`, `pmset -g sched`, `defaults read jesai.Sentient-OS-macOS`, TCC AppleEvents row, mirror share URL dead.
3. Verify still present: `~/.codex/**`, Desktop gift PNGs, the .app; relaunch before trashing lands in onboarding.
4. Decline the password prompt once → interstitial; Cancel → back to farewell with scheduler intact.