### PR TITLE
Uninstall fixes: hard-exit on Quit + browser-proof feedback mailto

### DIFF
--- a/Sentient OS macOS/System/Uninstall.swift
+++ b/Sentient OS macOS/System/Uninstall.swift
@@ -127,10 +127,15 @@ enum Uninstall {
 
     /// The gone screen's Quit: spawn a detached sweeper for the files the DYING process itself can
     /// resurrect on the way out (cfprefsd re-writing the preferences plist, SwiftData flushing store
-    /// files into a recreated support dir, the saved-state write at quit), then terminate. The
+    /// files into a recreated support dir, the saved-state write at quit), then hard-exit. The
     /// sweeper outlives us (it reparents to launchd), so the last traces die a beat after we do.
+    /// ⚠️ `exit(0)`, NOT `NSApp.terminate`: graceful termination is exactly wrong after a full
+    /// wipe — it invites the frameworks to write state back, and SwiftUI's scene teardown can
+    /// wedge behind the presented farewell sheet, leaving a zombie app the user can't quit
+    /// (field-seen 2026-07-11). There is deliberately nothing left to clean up; just die.
     @MainActor
-    static func finishAndQuit() {
+    static func finishAndQuit() -> Never {
+        Log("Uninstall: goodbye — spawning the post-exit sweeper and exiting")
         let home = FileManager.default.homeDirectoryForCurrentUser.path
         let stragglers = ["\(home)/Library/Application Support/SentientOS",
                           "\(home)/Library/Preferences/\(bundleID).plist",
@@ -140,7 +145,7 @@ enum Uninstall {
         p.executableURL = URL(fileURLWithPath: "/bin/sh")
         p.arguments = ["-c", "sleep 2; rm -rf " + stragglers.map { "'\($0)'" }.joined(separator: " ")]
         try? p.run()
-        NSApp.terminate(nil)
+        exit(0)
     }
 
     /// A short breath between stages so each whisper is readable — the work itself is near-instant,

--- a/Sentient OS macOS/Views/Settings/UninstallView.swift
+++ b/Sentient OS macOS/Views/Settings/UninstallView.swift
@@ -21,6 +21,8 @@ struct UninstallView: View {
     @State private var stage: Uninstall.Stage = .helper
     /// Fulfilled by the interstitial's buttons while the teardown awaits a helper decision.
     @State private var helperResolver: ((Uninstall.HelperChoice) -> Void)?
+    /// Feedback fallback: true briefly after the address was copied because no mail app answered.
+    @State private var feedbackCopied = false
 
     init() {}
 
@@ -166,18 +168,49 @@ struct UninstallView: View {
     }
 
     private var feedbackButton: some View {
-        Button {
-            if let url = URL(string: "mailto:feedback@sentient-os.ai?subject=Sentient%20OS%20feedback") {
-                NSWorkspace.shared.open(url)
-            }
-        } label: {
+        Button(action: shareFeedback) {
             HStack(spacing: 6) {
-                Image(systemName: "envelope").font(.system(size: 10))
-                Text("Share feedback").font(.system(size: 11.5))
+                Image(systemName: feedbackCopied ? "checkmark" : "envelope").font(.system(size: 10))
+                Text(feedbackCopied ? "feedback@sentient-os.ai copied" : "Share feedback")
+                    .font(.system(size: 11.5))
             }
             .foregroundStyle(Theme.Ink.bright.opacity(0.9))
         }
         .buttonStyle(PressScaleStyle())
+        .animation(.easeInOut(duration: 0.2), value: feedbackCopied)
+    }
+
+    /// Open a pre-addressed compose in a real mail app. The naive `open(mailto:)` is not enough:
+    /// when a BROWSER owns the mailto scheme (Chrome et al. — field-seen 2026-07-11), it reports
+    /// success and then silently swallows the link unless the user once opted into its webmail
+    /// handling. So: a dedicated mail app as handler → the default route; the handler is the web
+    /// browser (or nothing) → Apple Mail directly; Mail missing too → copy the address and say so
+    /// on the button. The click must never silently do nothing.
+    private func shareFeedback() {
+        let mailto = URL(string: "mailto:feedback@sentient-os.ai?subject=Sentient%20OS%20feedback")!
+        let mailtoHandler = NSWorkspace.shared.urlForApplication(toOpen: mailto)
+        let webHandler = NSWorkspace.shared.urlForApplication(toOpen: URL(string: "https://example.com")!)
+
+        if let mailtoHandler, mailtoHandler != webHandler {
+            Log("UninstallView: feedback compose via the default mail app (\(mailtoHandler.lastPathComponent))")
+            NSWorkspace.shared.open(mailto)
+        } else if let mailApp = NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.apple.mail") {
+            Log("UninstallView: mailto handler is the web browser — opening Apple Mail directly")
+            NSWorkspace.shared.open([mailto], withApplicationAt: mailApp,
+                                    configuration: NSWorkspace.OpenConfiguration()) { _, error in
+                if error != nil { Task { @MainActor in copyFeedbackAddress() } }
+            }
+        } else {
+            copyFeedbackAddress()
+        }
+    }
+
+    private func copyFeedbackAddress() {
+        Log("UninstallView: no mail app answered — copied the feedback address instead")
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString("feedback@sentient-os.ai", forType: .string)
+        feedbackCopied = true
+        Task { try? await Task.sleep(for: .seconds(4)); feedbackCopied = false }
     }
 
     /// The same trust ribbon Settings rides — continuity to the very last screen.


### PR DESCRIPTION
Fixes the two hardware-test findings on the shipped uninstall flow (#158, spec in closed #157):

1. **Quit Sentient did nothing.** `NSApp.terminate` entered SwiftUI's graceful termination and wedged in scene teardown behind the presented farewell sheet, leaving a zombie process (log-verified: teardown completed at 11:19:18, process still alive minutes later). After a full wipe, graceful shutdown is the wrong primitive anyway — frameworks write state back. `finishAndQuit()` now spawns the post-exit sweeper and `exit(0)`s.

2. **Share feedback did nothing.** Aditya's default mailto handler is Chrome (`LSHandlers`), and browsers report success then swallow mailto unless webmail handling was opted into. Now: a dedicated mail app as handler → default route; handler == the default web browser (or absent) → open Apple Mail directly with the pre-addressed compose; Mail missing → copy `feedback@sentient-os.ai` to the clipboard with an on-button "copied" confirmation. Never a silent no-op.

Build-verified (isolated DerivedData). To test: run from this branch, uninstall, on the gone screen hit Share feedback (should open Mail compose) and Quit Sentient (app must exit immediately; `ps` shows no process).