### PR TITLE
Dock icon belongs to the home window (+ always present home at launch)

### DIFF
--- a/Sentient OS macOS/App/AppState.swift
+++ b/Sentient OS macOS/App/AppState.swift
@@ -35,7 +35,8 @@ final class AppState {
     /// The notch overlay window — renders the coordinator's status phase as the living notch.
     private let notch: NotchWindowController
 
-    /// Drops the Dock icon when every window is closed (the menu bar item is the home then).
+    /// Drops the Dock icon whenever the home window is closed (the icon belongs to home;
+    /// the menu bar item is the anchor then).
     private let dockPolicy = DockPolicy()
 
     /// The Sparkle auto-updater + our OLED forced-update UI. Only ever built in the GUI app (this
@@ -67,7 +68,7 @@ final class AppState {
         // the coordinator: the notch experience still plays, the codex run just never fires.
         commandCoordinator.start()   // arm right-⌘ hold-to-talk + warm the speech model
         notch.start()                // raise the notch overlay window
-        dockPolicy.start()           // drop the Dock icon whenever the last window closes
+        dockPolicy.start()           // drop the Dock icon whenever the home window closes
         update.start()               // start Sparkle + one silent launch check (gates a mandatory update)
 
         // Notifications, banked silently: PROVISIONAL authorization shows NO prompt — macOS just

--- a/Sentient OS macOS/App/DockPolicy.swift
+++ b/Sentient OS macOS/App/DockPolicy.swift
@@ -2,10 +2,11 @@
 //  DockPolicy.swift
 //  Sentient OS macOS
 //
-//  Hides the Dock icon when every real Sentient window is closed — the menu bar item is the
-//  app's ever-present home, so an empty Dock tile is just clutter. Flips NSApp between
-//  .regular (a window is up) and .accessory (none are), driven by NSWindow open/close
-//  notifications. `start()` once from AppState; `reevaluate()` does the counting.
+//  The Dock icon belongs to the HOME window: it shows while home is up and drops when home
+//  closes — auxiliary windows (Settings, Knowledge, Connect AIs) float without a Dock tile,
+//  like a menu-bar app's panels, with the menu bar item as the ever-present anchor. Flips
+//  NSApp between .regular (home is up) and .accessory (it isn't), driven by NSWindow
+//  open/close notifications. `start()` once from AppState; `reevaluate()` does the check.
 //
 
 import AppKit
@@ -27,21 +28,20 @@ final class DockPolicy {
                 }
             })
         }
-        // A window appeared/focused → the Dock icon comes back; the last one closed → it drops.
+        // The home window appeared/focused → the Dock icon comes back; it closed → the icon drops.
         watch(NSWindow.didBecomeKeyNotification, closing: false)
         watch(NSWindow.willCloseNotification, closing: true)
     }
 
-    /// Show the Dock icon iff at least one real Sentient window is up. `closing` is the window in
-    /// the middle of a willClose — still listed in NSApp.windows, so it's excluded from the count.
+    /// Show the Dock icon iff the home window is up. `closing` is the window in the middle of a
+    /// willClose — still listed in NSApp.windows, so it's excluded from the check.
     func reevaluate(closing: NSWindow? = nil) {
-        let hasRealWindow = NSApp.windows.contains { window in
+        let homeIsUp = NSApp.windows.contains { window in
             window !== closing
-                && !(window is NSPanel)                    // the notch + permission-drag panels are always-on furniture
-                && window.canBecomeMain                    // skips the status-item / menu-bar helper windows
+                && SentientOSApp.isHomeWindow(window)
                 && (window.isVisible || window.isMiniaturized)
         }
-        let target: NSApplication.ActivationPolicy = hasRealWindow ? .regular : .accessory
+        let target: NSApplication.ActivationPolicy = homeIsUp ? .regular : .accessory
         guard NSApp.activationPolicy() != target else { return }
         NSApp.setActivationPolicy(target)
     }

--- a/Sentient OS macOS/App/Sentient_OS_macOSApp.swift
+++ b/Sentient OS macOS/App/Sentient_OS_macOSApp.swift
@@ -9,6 +9,7 @@
 //
 
 import SwiftUI
+import AppKit
 
 // Entry point is main.swift (the binary doubles as the root wake helper) — so no @main here.
 struct SentientOSApp: App {
@@ -16,6 +17,13 @@ struct SentientOSApp: App {
 
     /// Scene id for the primary home window, so the menu bar's "Open Sentient OS" can reopen/focus it.
     static let homeWindowID = "home"
+
+    /// True when `window` is the home WindowGroup's window. SwiftUI suffixes the scene id on the
+    /// NSWindow identifier ("home-AppWindow-1"), so match the id exactly or as a prefix.
+    static func isHomeWindow(_ window: NSWindow) -> Bool {
+        guard let raw = window.identifier?.rawValue else { return false }
+        return raw == homeWindowID || raw.hasPrefix(homeWindowID + "-")
+    }
 
     // To add a headless self-test, restore the one-line hook here — see
     // Documentation/Self-Testing (Eval Harness).md (the `Self Tests - Temp/` folder is kept empty).
@@ -30,6 +38,9 @@ struct SentientOSApp: App {
         .windowStyle(.hiddenTitleBar)            // OLED black runs edge-to-edge; no gray trim
         .windowResizability(.contentMinSize)
         .defaultSize(width: 1180, height: 880)   // the proactive home's canvas
+        // Always present the home at launch: after a quit with only Settings open, state
+        // restoration would otherwise bring back JUST the Settings window — an app with no home.
+        .defaultLaunchBehavior(.presented)
 
         // PROACTIVE · EXECUTE — the dev window for PART 3 (the executor). Lists the real
         // ready-to-fire actions from the latest research+prepare run, each with a working FIRE

--- a/Sentient OS macOS/Views/MenuBarView.swift
+++ b/Sentient OS macOS/Views/MenuBarView.swift
@@ -34,20 +34,16 @@ struct MenuBarView: View {
 
     /// Bring the proactive home window to the front — focus it if it's open, otherwise reopen it
     /// (a red-button close destroys the WindowGroup's window, so it must be recreated).
-    private func openHome() {
+    @MainActor private func openHome() {
         // We may be .accessory (Dock icon hidden because no window is up). Restore .regular BEFORE
         // opening/activating so the window takes focus and the Dock icon reappears cleanly — the
         // DockPolicy observer would do it on didBecomeKey, but that lands too late for activate().
         NSApp.setActivationPolicy(.regular)
-        let homeID = SentientOSApp.homeWindowID
-        if let home = NSApp.windows.first(where: {
-            guard let raw = $0.identifier?.rawValue else { return false }
-            return raw == homeID || raw.hasPrefix(homeID + "-")
-        }) {
+        if let home = NSApp.windows.first(where: { SentientOSApp.isHomeWindow($0) }) {
             home.makeKeyAndOrderFront(nil)
             home.orderFrontRegardless()
         } else {
-            openWindow(id: homeID)
+            openWindow(id: SentientOSApp.homeWindowID)
         }
         NSApp.activate()
     }


### PR DESCRIPTION
## What

Reverts the "Settings shows the Dock icon" behavior from #142: the Dock icon now belongs to the **home window** — it shows while home is up and drops when home closes, even if Settings / Knowledge / Connect-AIs are still open (they float like a menu-bar app's panels, with the menu bar item as the anchor).

Also fixes the real cause of the quit-with-only-Settings-open edge case: on the next launch, macOS state restoration brought back JUST the Settings window with no homescreen. The home WindowGroup now carries `.defaultLaunchBehavior(.presented)` (macOS 15 API, our target), so home always presents at launch — restored windows land on top of it.

## How

- **`App/DockPolicy.swift`** — `reevaluate()` checks for the home window specifically instead of counting every real window; the NSPanel / `canBecomeMain` filters are gone (identifier matching subsumes them).
- **`App/Sentient_OS_macOSApp.swift`** — new `SentientOSApp.isHomeWindow(_:)` (the one identifier-prefix matcher, shared with `MenuBarView.openHome`, which previously inlined the same logic) + `.defaultLaunchBehavior(.presented)` on the home scene.
- **`Views/MenuBarView.swift`** — `openHome()` uses the shared matcher; explicitly `@MainActor` (it drives NSApp).

## Test

Isolated CLI build (`/tmp/sentient-verify`) passes with zero new warnings — GUI Run's signed dylib untouched. **Needs a real-hardware pass** (dock behavior is runtime-only):

- [ ] Home open → icon shows; close home with Settings still open → icon drops, Settings stays usable
- [ ] Quit with only Settings open → relaunch shows HOME (Settings restored on top)
- [ ] Menu bar → Open Sentient OS from windowless → icon returns, home focused
- [ ] Close all windows → icon drops, menu bar + Sidekick hotkey still alive