### PR TITLE
Home health banners + wake-helper liveness + inline codex setup

### DIFF
--- a/Sentient OS macOS/Cloud/CodexSetup.swift
+++ b/Sentient OS macOS/Cloud/CodexSetup.swift
@@ -103,14 +103,16 @@ final class CodexSetup {
     /// the "awaiting browser" state; the user finishes in the browser, then taps "Finished logging
     /// into codex" → `confirmLogin()`. Both onboarding and the dev button call THIS.
     func startLogin(force: Bool = false) {
-        guard installed else { loginStatusLine = "✗ Install Codex first (step 1)"; return }
+        guard installed else { loginStatusLine = "✗ Install the Codex CLI first"; return }
         if !force, loggedIn { loginStatusLine = "✓ Already logged in"; return }   // self-guard; "Log in again" passes force
         loginProcess?.terminate()          // kill any stale attempt before re-opening
         loginProcess = nil
         do {
             loginProcess = try CodexCLI.startLogin { line in Log("[codex-login] \(line)") }
             loggingIn = true
-            loginStatusLine = "A browser window opened; finish signing in, then tap “Finished logging into codex”."
+            // UI-neutral on purpose: onboarding and Settings → Health both auto-notice the
+            // finished sign-in (no confirm button); only the dev sheet still has one.
+            loginStatusLine = "A browser window opened; finish signing in there. Sentient notices on its own when you're done."
         } catch {
             loggingIn = false
             loginStatusLine = "✗ \((error as? LocalizedError)?.errorDescription ?? "\(error)")"
@@ -158,7 +160,7 @@ final class CodexSetup {
             return
         }
         refreshInstalled()   // fresh probe, not the cached flag — the user may have installed codex themselves
-        guard installed else { computerUseStatus = "✗ Install Codex first (step 1)"; return }
+        guard installed else { computerUseStatus = "✗ Install the Codex CLI first"; return }
         settingUpComputerUse = true
         computerUseStatus = force ? "Re-installing…" : "Starting…"
         do {

--- a/Sentient OS macOS/Documentation/Home — Proactive Intelligence (For You).md
+++ b/Sentient OS macOS/Documentation/Home — Proactive Intelligence (For You).md
@@ -37,14 +37,27 @@ The main window's content (rendered by `RootView`). Layers, bottom-to-top:
   knowledge-base-only mode — computer use runs on quota those plans don't have). A small `DEV TOOLS`
   handle is pinned bottom-right (→ the `Views/Dev/DevToolsView.swift` sheet; the Release strip
   re-hides it).
-- **The morning-after caution — `cautionBanner` / `CautionCapsule`:** when last night's UNATTENDED
-  3am run failed for one of the three knowable reasons (codex signed out · no internet · usage
-  limit — recorded by `Scheduling/OvernightCaution` at `ProactiveCycle`'s catch sites, scheduled
-  runs only), a quiet amber capsule sits top-right in the blank space beside the greeting: amber
-  `HealthDot`, the first-person message, ✕ (clears the record), and on the logged-out one an
-  *Open Settings* pill that deep-links straight to Permissions & Health
-  (`SettingsView.requestedPane = .health`). The next fully successful cycle clears it on its own.
-  Amber on purpose: a caution, never an alarm — only the overnight magic was missed.
+- **The caution banner — `cautionBanner` / `CautionCapsule` (ONE slot, most severe first):** the
+  blank space top-right beside the greeting holds at most ONE capsule; a LIVE issue outranks
+  history. Both roads lead to Permissions & Health (`SettingsView.requestedPane = .health`).
+  - **The live health ladder (red) — `System/HealthCaution.swift`:** probes CURRENT state on
+    appear + every app foreground, rung by rung: ① an essential permission is off (Full Disk
+    Access · the overnight wake helper via `WakeHelperClient.isReachable()` — the XPC ground
+    truth a file check can't fake, see the scheduler doc · launch at login) → ② codex is gone or
+    signed out (`codex login status`, verdict cached ~5 min; cache bypassed while a codex banner
+    is up so a fix clears on the next foreground) → ③ computer use REGRESSED — gated on the
+    `computerUse.everReady` latch (set by the probe and by `ComputerUseGate` at its moment of
+    truth; cleared by FactoryReset), so a user who never set it up is never nagged. Nothing
+    persists: broken shows, fixed melts away on the next probe. ✕ mutes an issue KIND for the
+    session (lower rungs still surface). Suppressed entirely in knowledge-base-only mode (nothing
+    nightly runs there) and on demo decks (no red capsules mid-pitch).
+  - **The morning-after caution (amber):** when last night's UNATTENDED 3am run failed for one of
+    the three knowable reasons (codex signed out · no internet · usage limit — recorded by
+    `Scheduling/OvernightCaution` at `ProactiveCycle`'s catch sites, scheduled runs only): amber
+    `HealthDot`, the first-person message, ✕ (clears the record), *Open Settings* on the
+    logged-out one. The next fully successful cycle clears it on its own; the foreground refresh
+    also re-reads it. Amber on purpose: a caution, never an alarm — only the overnight magic was
+    missed.
 - **The letter layer:** an always-mounted overlay (opacity/scale-driven — view *insertion* can miss a
   redraw on hidden-titlebar windows) that expands a card into the typeset reading view, with the
   **editable draft block** for real cards (below).

--- a/Sentient OS macOS/Documentation/Overnight Scheduler (3am Wake).md
+++ b/Sentient OS macOS/Documentation/Overnight Scheduler (3am Wake).md
@@ -51,6 +51,18 @@ code-signing check. Files: `Scheduling/WakeHelper.swift` (root side) · `WakeHel
   schedule), and the loop wipes all wakes (`cancelAllWakes`) before arming exactly one.
 - ⚠️ **The code-sign gate is DEBUG-permissive** (allows-and-logs on a failed check so dev testing
   isn't blocked); Release MUST enforce it — pin the Developer ID team before launch.
+- ⚠️ **Liveness is the ONLY honest status (field-found 2026-07-11).** System Settings' App
+  Background Activity toggle boots a disabled daemon OUT of launchd while leaving its plist on
+  disk — so every file check reads green on a dead helper (and unprivileged
+  `launchctl print system/…` answers "could not find service" for *everything*, loaded or not, so
+  it can't tell either). The ground truth is `WakeHelperClient.isReachable()`: a real XPC
+  `heartbeat` (the one op harmless in every state — mid-run it's what the app sends every 60s
+  anyway; idle it arms a deadman whose firing is a no-op). `healthProbe()` classifies the verdict:
+  **ready** (answers over XPC) · **disabled** (unreachable with the files all correct → the toggle
+  is off; launchd honors it over any bootstrap, so only the user flipping it back on helps) ·
+  **notSetUp** (stale/missing plist → the installer fixes it). `ensureHelperReady`, Settings →
+  Health, onboarding's permissions step, and the home's health banner all gate on this probe —
+  never on files alone.
 
 ## The nightly run (`OvernightScheduler.runProcessing`)
 
@@ -71,7 +83,8 @@ cycle's catch sites (`Scheduling/OvernightCaution`: typed `usageLimit` first →
 NOTHING) into codex-signed-out · no-internet · usage-limit, persisted for the home's amber banner
 (`HomeView.cautionBanner`). A watched Analyze Now records nothing (the takeover UI shows failures
 live); the next fully successful cycle clears the record. Each caution also emits a PII-free
-`overnight.caution{kind}` Sentry event.
+`overnight.caution{kind}` Sentry event. *(The home's banner slot also carries a LIVE health ladder
+— `System/HealthCaution.swift`, red, outranks this amber event — see the Home doc.)*
 
 ⚠️ Known caveat: **Full Disk Access can read `false` when the app is launched from Terminal** (TCC
 attribution) — which silently excludes the DB sources. The arm-time `DETECTED …` / `FDA granted:`
@@ -111,18 +124,30 @@ dialog (osascript admin) that writes the LaunchDaemon plist (pointing at THIS bi
 `/Library/LaunchDaemons`, chowns/chmods it, and `launchctl bootstrap`s it. It's measured-and-working
 on real hardware, self-heals when the binary path goes stale (`isInstalledAndCurrent()` checks the
 plist points at the running executable), and — the UX line we hold — never sends the user into
-System Settings. **Settings → Permissions & Health's "Overnight wake" fix button runs exactly this.**
-The SMAppService.daemon migration (a Login Items approval toggle) was considered and rejected.
+System Settings. **Settings → Permissions & Health's "Overnight wake" fix button runs exactly this**
+(except the `disabled` verdict, whose only fix is the Login Items switch — the button becomes
+"Turn On…" and deep-links there). The SMAppService.daemon migration (a Login Items approval toggle)
+was considered and rejected.
+
+Two plist facts (both 2026-07-11):
+- The plist carries **`AssociatedBundleIdentifiers`**, so the System Settings background item
+  displays as **"Sentient OS"** — without it, a bare LaunchDaemon shows under the signing
+  identity's human name (the "Jesai Tarun" jumpscare, field-seen).
+- That key is part of `isInstalledAndCurrent()`'s currency check, so an old-format plist reads
+  stale and refreshes on the next setup pass. ⚠️ And remember its limit: `isInstalledAndCurrent()`
+  answers "are the files right", never "is it alive" — liveness questions go through
+  `WakeHelperClient.isReachable()` / `healthProbe()` (see the privilege-model section).
 
 **SMAppService plumbing survives for the dev cockpit only:**
 - A LaunchDaemon plist is still bundled at `Contents/Library/LaunchDaemons/…WakeHelper.plist` (repo
   file at the project root, a "Copy wake-helper daemon plist" build phase) so
   `WakeHelperClient.register()` / `.status` / `openLoginItemsSettings()` keep working for
   experiments (`OvernightDevView` step ①).
-- `OvernightScheduler.ensureHelperReady()` still checks SMAppService first (`.enabled` → go) and, in
-  DEBUG, falls back to the password installer when SMAppService reports `.notFound`/`.notRegistered`.
-  Since the production install path is the installer (via the Health pane), a user who set up through
-  Settings passes the DEBUG fallback's `isInstalledAndCurrent()` check without any SMAppService state.
+- `OvernightScheduler.ensureHelperReady()` gates on `WakeHelperClient.healthProbe()` — ONE probe
+  covers both install paths, since the production plist and the dev cockpit's SMAppService daemon
+  share the mach service. `ready` → arm; `disabled` → surface setup and stop (a reinstall can't
+  override the Login Items switch); `notSetUp` → DEBUG self-installs via the password installer,
+  Release flags `needsSchedulerSetup` for the setup UX.
 
 > **Signing note (SMAppService, dev only):** approval works on any validly-signed build — a standard
 > Apple Development Debug build is enough; only a fully unsigned `CODE_SIGNING_ALLOWED=NO` CLI build
@@ -170,7 +195,7 @@ This is the dev cockpit; the shipping onboarding/Settings UX (Jesai) binds to th
 
 - `Scheduling/OvernightScheduler.swift` — the scheduler, the 18h auto-enable state machine, `ensureHelperReady`.
 - `Scheduling/LoginItem.swift` — launch-at-login via `SMAppService.mainApp`.
-- `Scheduling/WakeHelperClient.swift` — daemon register/status/deep-link + the four XPC ops.
+- `Scheduling/WakeHelperClient.swift` — daemon register/status/deep-link + the XPC ops + `isReachable()`/`healthProbe()` (the liveness ground truth).
 - `Scheduling/WakeHelperInstaller.swift` — the PRODUCTION admin-password installer (decided 2026-07-04); also the DEBUG fallback in `ensureHelperReady`.
 - `jesai.Sentient-OS-macOS.WakeHelper.plist` (project root) — the bundled SMAppService daemon plist + its Copy Files phase.
 - `Proactive/ProactiveCycle.swift` — stamps "initial finished"; classifies scheduled failures.

--- a/Sentient OS macOS/Documentation/Settings.md
+++ b/Sentient OS macOS/Documentation/Settings.md
@@ -122,10 +122,13 @@ opens a popover to the right; `TipWarmth` makes sibling tips open instantly):
 
 - **ON-DEVICE INTELLIGENCE** (the analysis machinery): Full Disk Access (fix = the floating
   drag-panel guide with Sentient as the card — `PermissionGuide`, see `Permission Guide
-  (First-Use Grants).md` — + the relaunch link) · Overnight wake (🟢 = the installed daemon plist
-  points at THIS binary; fix runs `WakeHelperInstaller.installAsync()` — **[DECIDED 2026-07-04]
-  the password install IS production**, no Login Items migration) · Launch at login (yellow when
-  off; a needs-approval state adds the guide's instruction panel over Login Items).
+  (First-Use Grants).md` — + the relaunch link) · Overnight wake (🟢 = the daemon ANSWERS over
+  XPC — `WakeHelperClient.healthProbe()`, the only check the System Settings background toggle
+  can't fool [2026-07-11]; `notSetUp` fixes with `WakeHelperInstaller.installAsync()` —
+  **[DECIDED 2026-07-04] the password install IS production** — while `disabled` ("turned off in
+  login items") gets a **Turn On…** that deep-links to the switch, since a reinstall can't
+  override it) · Launch at login (yellow when off; a needs-approval state adds the guide's
+  instruction panel over Login Items).
 - **SIDEKICK & PROACTIVE** (the magic's grants — lazy-asked, yellow while not-asked/off; only an explicit mic/speech DENIAL goes red):
   Microphone & Speech (one row: `VoiceCapture.requestPermissions()` asks both; denied deep-links
   to the actual blocker) · **Screen Recording** (Sentient's OWN grant — Sidekick snaps a screen
@@ -143,12 +146,18 @@ opens a popover to the right; `TipWarmth` makes sibling tips open instantly):
   fallback; Sidekick degrades gracefully without the optional grants (voice needs mic; the screen
   still is skipped).
 - **SET UP CODEX:** CLI / ChatGPT account / **ChatGPT plan** / computer use — the CLI, account,
-  and computer-use rows go red when missing and their fixes open the shared `CodexSetupView`
-  (statuses re-probe when the sheet closes). The plan row (shown once logged in, decoded via
-  `CodexAuth.currentPlan()`) is amber on free/go — "free · knowledge base only" — with a
-  **Re-check** pill that runs `CodexAuth.refreshPlan()` (the on-demand token re-mint), so an
-  upgrade shows up in seconds instead of on codex's 8-day timer; a limited plan also keeps the
-  codex group expanded (it never folds into "Codex is all good").
+  and computer-use rows go red when missing, and their fixes drive the shared `CodexSetup` engine
+  **INLINE** (no sheet — the old wiring bounced through `CodexSetupView`, now dev-tools-only;
+  decided 2026-07-11): while a step runs its LED goes AMBER (a third meaning: *working on it*),
+  the note narrates ("installing…" / "finish in your browser" / "setting up…"), the pill hides,
+  and failures land as a quiet prose line under the row. The browser login is auto-noticed (the
+  same 2s `codex login status` poll onboarding uses — no "I'm done" button; the pill stays as
+  **Re-open…** so an abandoned browser never strands the row), and the computer-use bootstrap
+  streams its progress line under the row (a ~535 MB download deserves narration). The plan row
+  (shown once logged in, decoded via `CodexAuth.currentPlan()`) is amber on free/go — "free ·
+  knowledge base only" — with a **Re-check** pill that runs `CodexAuth.refreshPlan()` (the
+  on-demand token re-mint), so an upgrade shows up in seconds instead of on codex's 8-day timer;
+  a limited plan also keeps the codex group expanded (it never folds into "Codex is all good").
 - **CODEX PERMISSIONS:** the helper's Accessibility + Screen Recording — system-TCC, read via
   our FDA; shown once computer use exists. Fix = the drag-panel guide with the HELPER as the
   card (the plain deep-link survives only as the helper-missing fallback).
@@ -160,11 +169,16 @@ opens a popover to the right; `TipWarmth` makes sibling tips open instantly):
   (idempotent, logged). The user has no job there, so the UI gives them none. (The same extracted
   self-heal also runs when the first-use `ComputerUseGate` window presents — before the first fire
   ever needs it.)
-- Red = a core capability is broken · yellow = optional or fixable-later. Statuses re-probe on
-  every app foreground.
+- Red = a core capability is broken · yellow = optional, fixable-later, or working on it.
+  Statuses re-probe on every app foreground. The home's live health banner
+  (`System/HealthCaution.swift`, see the Home doc) is this board's herald: it watches the same
+  ground truths and its *Open Settings* lands here.
 
 ## Copy rules learned here
 
 No em dashes in user-facing settings copy (reads as AI slop; use commas/semicolons/colons/
 breaks). Guilt-trip confirms on the toggles that keep Sentient alive. Info-tip copy is short,
 plain, and trust-first: who the grant belongs to, what it unlocks, what stays on the Mac.
+Dense tips break into short paragraphs (`\n\n` in the string — `InfoTip` renders them natively):
+what-it-does first, mechanics/privacy after; a tip that appears on multiple surfaces carries the
+SAME copy everywhere (mic, FDA, overnight wake, screen recording all have twins).

--- a/Sentient OS macOS/Ingestion/FactoryReset.swift
+++ b/Sentient OS macOS/Ingestion/FactoryReset.swift
@@ -32,6 +32,7 @@ enum FactoryReset {
         d.removeObject(forKey: CodexAuth.kbOnlyKey)     // the crossroads re-detects the plan fresh
         d.removeObject(forKey: AppState.onboardingKey)
         d.removeObject(forKey: ComputerUseGate.screenRecordingOfferedKey)   // re-offer Sentient's screen recording on rebuild
+        d.removeObject(forKey: HealthCaution.computerUseEverReadyKey)       // the home's computer-use banner re-arms at the rebuild's own gate
         // The overnight scheduler starts over too: the 18h clock re-stamps at the REBUILD's first
         // cycle (not the wiped one's), the auto-enable one-shot is re-armed, and the production
         // flag comes off — otherwise a 3am run could fire mid-onboarding, racing the user's own

--- a/Sentient OS macOS/Scheduling/OvernightScheduler.swift
+++ b/Sentient OS macOS/Scheduling/OvernightScheduler.swift
@@ -177,24 +177,32 @@ final class OvernightScheduler {
 
     // MARK: - Helper readiness
 
-    /// Ensure the root daemon is installed before arming. Returns true when it's ready to accept
-    /// XPC. PRODUCTION path: the admin-password installer's plist at /Library/LaunchDaemons
-    /// (WakeHelperInstaller — onboarding and Settings → Health both run it). That install is
-    /// INVISIBLE to SMAppService, so the plist check comes FIRST in every config; the SMAppService
-    /// `.enabled` read second covers the dev cockpit's approval flow. Neither present → DEBUG
-    /// self-installs (the proven admin fallback, so a clean dev slate still works); Release flags
-    /// `needsSchedulerSetup` for the setup UX — it never registers or prompts on its own (a
+    /// Ensure the root daemon is ALIVE before arming — WakeHelperClient.healthProbe's XPC ground
+    /// truth, which covers both install paths (the admin-password plist AND the dev cockpit's
+    /// SMAppService daemon) and can't be fooled by the System Settings background toggle.
+    /// Toggled off → surface setup and stop (a reinstall can't override the switch). Not set up →
+    /// DEBUG self-installs (the proven admin fallback, so a clean dev slate still works); Release
+    /// flags `needsSchedulerSetup` for the setup UX — it never registers or prompts on its own (a
     /// `register()` here would park a stray "Sentient OS" approval in System Settings > Login Items).
     private func ensureHelperReady(log: SchedulerLog) async -> Bool {
-        // ① The production install — the /Library/LaunchDaemons plist pointing at this binary.
-        if WakeHelperInstaller.isInstalledAndCurrent() {
+        // WakeHelperClient.healthProbe is the ground truth: the daemon must ANSWER over XPC —
+        // one probe covers BOTH install paths (the production plist and the dev cockpit's
+        // SMAppService daemon share the mach service), and it's the only check the System
+        // Settings background toggle can't fool (the toggle boots the daemon out of launchd
+        // while leaving every file check green — field-found 2026-07-11).
+        switch await WakeHelperClient.shared.healthProbe() {
+        case .ready:
             needsSchedulerSetup = false
             return true
-        }
-        // ② The dev cockpit's SMAppService daemon, approved in System Settings.
-        if WakeHelperClient.shared.isReady {
-            needsSchedulerSetup = false
-            return true
+        case .disabled:
+            // Launchd honors the toggle over any bootstrap, so a reinstall can't help — only
+            // the user flipping it back on can (Health's row and the home's banner say so).
+            needsSchedulerSetup = true
+            statusLine = "background item turned off"
+            log.line("helper installed but unreachable — background item toggled off in System Settings")
+            return false
+        case .notSetUp:
+            break   // fall through to the install path below
         }
         #if DEBUG
         log.line("helper not installed — DEBUG fallback to the admin-password installer")

--- a/Sentient OS macOS/Scheduling/WakeHelperClient.swift
+++ b/Sentient OS macOS/Scheduling/WakeHelperClient.swift
@@ -54,6 +54,31 @@ final class WakeHelperClient {
     /// setup UX when `register()` returns `.requiresApproval`.
     func openLoginItemsSettings() { SMAppService.openSystemSettingsLoginItems() }
 
+    /// Liveness — can the daemon actually be reached over XPC right now? This catches what file
+    /// checks can't: the App Background Activity toggle in System Settings boots a disabled
+    /// daemon OUT of launchd while leaving its plist on disk, so every disk read stays green on a
+    /// dead helper (field-found 2026-07-11; `launchctl print system/…` can't tell either — it
+    /// answers "could not find service" for everything unprivileged). One probe covers BOTH
+    /// install paths (the production plist and the dev cockpit's SMAppService daemon share the
+    /// mach service). Probes with `heartbeat`, the one op harmless in every state: mid-run it's
+    /// exactly what the app already sends every 60s; idle it arms a deadman whose firing is a
+    /// no-op (disablesleep is already 0). A booted-out service invalidates immediately, so the
+    /// false case answers in milliseconds.
+    func isReachable() async -> Bool { await heartbeat() }
+
+    /// The user-facing daemon verdict, shared by Settings → Health and onboarding's permissions
+    /// step. ready = answers over XPC · disabled = unreachable with the files all correct (the
+    /// background toggle is off — launchd honors it over any bootstrap, so only the user flipping
+    /// it back on helps) · notSetUp = unreachable with a stale or missing plist (the installer
+    /// fixes it).
+    enum DaemonHealth { case ready, disabled, notSetUp }
+
+    func healthProbe() async -> DaemonHealth {
+        if await isReachable() { return .ready }
+        if WakeHelperInstaller.isInstalledAndCurrent() || isReady { return .disabled }
+        return .notSetUp
+    }
+
     // MARK: - The four ops
 
     func beginAwake(timeout: Int = 7200) async -> Bool { await call { $0.beginAwake(timeoutSeconds: timeout, withReply: $1) } }

--- a/Sentient OS macOS/Scheduling/WakeHelperInstaller.swift
+++ b/Sentient OS macOS/Scheduling/WakeHelperInstaller.swift
@@ -28,10 +28,17 @@ enum WakeHelperInstaller {
 
     /// True when the daemon plist exists AND points at this exact binary (a moved/rebuilt-to-a-new
     /// path app fails this, so we reinstall). World-readable, so no privileges needed to check.
+    /// The plist FORMAT must be current too: one without AssociatedBundleIdentifiers (added
+    /// 2026-07-11) predates the "display as Sentient OS in Login Items" fix and reads stale, so
+    /// the next setup pass refreshes it. ⚠️ This answers "are the files right", not "is it
+    /// alive" — the System Settings background toggle disables the daemon WITHOUT touching the
+    /// plist; anything asking "will the 3am machinery actually work?" must use
+    /// `WakeHelperClient.isReachable()` instead.
     static func isInstalledAndCurrent() -> Bool {
         guard let data = FileManager.default.contents(atPath: plistPath),
               let plist = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil) as? [String: Any],
-              let args = plist["ProgramArguments"] as? [String]
+              let args = plist["ProgramArguments"] as? [String],
+              plist["AssociatedBundleIdentifiers"] != nil
         else { return false }
         return args.first == currentBinary
     }
@@ -95,6 +102,7 @@ enum WakeHelperInstaller {
           <key>MachServices</key><dict><key>\(label)</key><true/></dict>
           <key>RunAtLoad</key><true/>
           <key>KeepAlive</key><false/>
+          <key>AssociatedBundleIdentifiers</key><array><string>\(Bundle.main.bundleIdentifier ?? "jesai.Sentient-OS-macOS")</string></array>
         </dict></plist>
         """
     }

--- a/Sentient OS macOS/System/HealthCaution.swift
+++ b/Sentient OS macOS/System/HealthCaution.swift
@@ -1,0 +1,153 @@
+//
+//  HealthCaution.swift
+//  Sentient OS macOS
+//
+//  The home's LIVE health banner — the sibling of OvernightCaution (which records a past event,
+//  this probes CURRENT state). One ladder, most severe first: ① an essential permission is off
+//  (Full Disk Access · the overnight wake helper · launch at login — all gated green in
+//  onboarding, so any red here is drift) → ② codex is gone or signed out → ③ computer use broke
+//  AFTER it was once seen working (the everReady latch, so a user who never set it up is never
+//  nagged). The home renders the top un-muted rung as a red capsule (HomeView.cautionBanner) and
+//  re-probes on foreground, so a fix in Settings clears the banner the moment the user returns.
+//  Nothing is persisted: no state, no record — broken shows, fixed melts away. ✕ mutes an issue
+//  KIND for the app session; lower rungs still surface. Knowledge-base-only (free plan) homes get
+//  no banners at all — nothing nightly runs for them. The codex login check shells out (seconds),
+//  so its verdict is cached ~5 min; the cache is bypassed while a codex banner is up.
+//
+//  Key methods: probe(forceCodexRecheck:) · dismiss(_:) · latchComputerUse()
+//
+
+import Foundation
+
+@MainActor
+enum HealthCaution {
+
+    // MARK: The issues
+
+    enum EssentialPermission {
+        case fullDiskAccess, overnightWake, launchAtLogin
+    }
+
+    enum Issue {
+        case permissions([EssentialPermission])
+        case codexMissing
+        case codexSignedOut
+        case computerUseBroken(payloadGone: Bool)   // true = the ~/.codex bootstrap vanished; false = the helper's grants did
+
+        /// The banner line — quiet, first-person, honest about what happens next.
+        var message: String {
+            switch self {
+            case .permissions(let missing):
+                guard missing.count == 1, let one = missing.first else {
+                    return "A few permissions I rely on are off. Overnight runs are paused."
+                }
+                switch one {
+                case .fullDiskAccess: return "Full Disk Access is off. I can't read anything new without it."
+                case .overnightWake:  return "The overnight wake helper is off, so I can't work while you sleep."
+                case .launchAtLogin:  return "Launch at login is off, so I won't be awake for the 3 AM run."
+                }
+            case .codexMissing:
+                return "Codex is missing from this Mac, so my cloud work is paused. A quick reinstall fixes it."
+            case .codexSignedOut:
+                return "Codex is signed out, so proactive work is paused. Log back in and I'll catch up tonight."
+            case .computerUseBroken(let payloadGone):
+                return payloadGone
+                    ? "Computer use needs setting up again; Codex may have updated. One click in Settings fixes it."
+                    : "Codex's computer use lost its permissions, so I can't act on your Mac for you."
+            }
+        }
+
+        /// Dismissal identity — ✕ mutes the whole KIND for the session, not one exact payload.
+        var kindKey: String {
+            switch self {
+            case .permissions:                   return "permissions"
+            case .codexMissing, .codexSignedOut: return "codex"
+            case .computerUseBroken:             return "computerUse"
+            }
+        }
+    }
+
+    // MARK: Session mutes
+
+    /// Issue kinds ✕'d this session — quiet until relaunch; lower rungs still surface.
+    private static var dismissed: Set<String> = []
+
+    static func dismiss(_ issue: Issue) { dismissed.insert(issue.kindKey) }
+
+    // MARK: The computer-use latch
+
+    /// "Computer use was seen working once" — arms rung ③, so only a REGRESSION banners (never a
+    /// setup the user hasn't done yet). Set by the probe when the whole stack reads healthy and by
+    /// ComputerUseGate at its moment of truth. FactoryReset clears it: a rebuild re-runs the gate.
+    static let computerUseEverReadyKey = "computerUse.everReady"
+
+    static func latchComputerUse() {
+        UserDefaults.standard.set(true, forKey: computerUseEverReadyKey)
+    }
+
+    private static var computerUseEverReady: Bool {
+        UserDefaults.standard.bool(forKey: computerUseEverReadyKey)
+    }
+
+    // MARK: The probe
+
+    /// `codex login status` shells out — cache the verdict so foreground flurries can't spam it.
+    private static var codexLogin: (verdict: Bool, at: Date)?
+
+    /// The ladder, most severe first. Returns the worst LIVE issue the user hasn't muted, or nil.
+    /// `forceCodexRecheck` bypasses the login cache — the home passes it while a codex banner is
+    /// showing, so logging back in clears the capsule on the very next foreground.
+    static func probe(forceCodexRecheck: Bool = false) async -> Issue? {
+        // The free-plan preview home: nightly runs, proactive, and Sidekick are all Plus-gated,
+        // so nothing this ladder checks is worth interrupting that home for.
+        guard !CodexAuth.knowledgeBaseOnly else { return nil }
+
+        // ① Essential permissions (cheap sync probes: file reads + SMAppService status).
+        let fda = Permissions.hasFullDiskAccess()
+        var missing: [EssentialPermission] = []
+        if !fda { missing.append(.fullDiskAccess) }
+        // The same ground truth the scheduler gates on: the daemon ANSWERS over XPC. A file
+        // check reads green even when the System Settings background toggle has booted the
+        // daemon out of launchd (field-found 2026-07-11).
+        if await !WakeHelperClient.shared.isReachable() {
+            missing.append(.overnightWake)
+        }
+        if !LoginItem.isEnabled { missing.append(.launchAtLogin) }
+        if !missing.isEmpty, !dismissed.contains("permissions") { return .permissions(missing) }
+
+        // ② Codex — gone, or signed out.
+        let codexInstalled = CodexCLI.locateBinary() != nil
+        if !dismissed.contains("codex") {
+            if !codexInstalled { return .codexMissing }
+            if await !loggedIn(force: forceCodexRecheck) { return .codexSignedOut }
+        }
+
+        // ③ Computer use — only once latched, and only with FDA to read the helper's system-TCC
+        // grants (without FDA rung ① already speaks; unverifiable must never claim broken).
+        if fda, codexInstalled, !dismissed.contains("computerUse") {
+            if !ComputerUseSetup.isInstalled {
+                if computerUseEverReady { return .computerUseBroken(payloadGone: true) }
+            } else {
+                let hands = Permissions.isTCCGranted(service: "kTCCServiceAccessibility",
+                                                     clientBundleID: Permissions.computerUseHelperBundleID)
+                let eyes = Permissions.isTCCGranted(service: "kTCCServiceScreenCapture",
+                                                    clientBundleID: Permissions.computerUseHelperBundleID)
+                if hands && eyes {
+                    latchComputerUse()   // healthy — arm the latch so future drift banners
+                } else if computerUseEverReady {
+                    return .computerUseBroken(payloadGone: false)
+                }
+            }
+        }
+        return nil
+    }
+
+    private static func loggedIn(force: Bool) async -> Bool {
+        if !force, let cached = codexLogin, Date().timeIntervalSince(cached.at) < 300 {
+            return cached.verdict
+        }
+        let verdict = await CodexCLI.loginStatus()
+        codexLogin = (verdict, Date())
+        return verdict
+    }
+}

--- a/Sentient OS macOS/Views/HomeView.swift
+++ b/Sentient OS macOS/Views/HomeView.swift
@@ -67,6 +67,9 @@ struct HomeView: View {
     @State private var showCalendarConnect = false
     /// The morning-after caution (last night's scheduled run hit a known snag) — nil = no banner.
     @State private var caution: OvernightCaution.Record?
+    /// The LIVE health issue (essential perms · codex · computer use) — HealthCaution's ladder;
+    /// nil = healthy or muted. Outranks the morning-after caution in the banner slot.
+    @State private var liveIssue: HealthCaution.Issue?
 
     // Chat selections the Analysis popover's WhatsApp/iMessage chips pick into (same keys as SourceSelection).
     @AppStorage("dbg.whatsapp.chats") private var whatsappCSV = ""
@@ -108,6 +111,13 @@ struct HomeView: View {
             model.beginVisit(deck: deck)
             planUpgraded = previewUpgraded ?? (kbOnly && CodexAuth.currentPlan()?.tier == .full)
             caution = OvernightCaution.latest()
+            probeHealth()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            // The user may just have fixed something in System Settings (or a cycle cleared last
+            // night's caution) — re-probe so the banner melts away the moment they return.
+            withAnimation(.easeInOut(duration: 0.25)) { caution = OvernightCaution.latest() }
+            probeHealth()
         }
         .onChange(of: deck) { _, v in model.beginVisit(deck: v) }   // mode flip → re-deal
         .animation(.spring(response: 0.5, dampingFraction: 0.82), value: model.entries.isEmpty)
@@ -164,24 +174,32 @@ struct HomeView: View {
         .padding(.leading, 30)
     }
 
-    // MARK: The morning-after caution banner
+    // MARK: The caution banner (one slot, most severe first)
     //
-    // Last night's UNATTENDED run hit one of the three knowable snags (codex signed out · no
-    // internet · usage limit) — OvernightCaution recorded it at ProactiveCycle's choke point, and
-    // this quiet amber capsule surfaces it in the blank space beside the greeting. ✕ dismisses;
-    // the next fully successful cycle clears it on its own. Amber on purpose: a caution, never an
-    // alarm — the app still works, only the overnight magic was missed.
+    // The blank space beside the greeting holds AT MOST ONE capsule. A LIVE issue outranks
+    // history: HealthCaution's ladder (an essential permission off · codex gone/signed out ·
+    // computer use regressed) renders red, because the product is broken RIGHT NOW; otherwise
+    // the morning-after caution renders amber (last night's UNATTENDED run hit a knowable snag —
+    // OvernightCaution recorded it at ProactiveCycle's choke point; the next fully successful
+    // cycle clears it on its own). Both roads lead to Settings → Permissions & Health. Live
+    // issues re-probe on foreground and melt away when fixed; ✕ mutes a live issue's kind for
+    // the session (a lower rung may then surface), while the amber ✕ clears the record.
 
     private var cautionBanner: some View {
         Group {
-            if let caution {
-                CautionCapsule(kind: caution.kind,
-                               onOpenSettings: {
-                                   // Land directly on Permissions & Health — the codex login row
-                                   // lives there; never strand the user on the default pane.
-                                   SettingsView.requestedPane = .health
-                                   openWindow(id: SettingsView.windowID)
-                               },
+            if let issue = liveIssue {
+                CautionCapsule(message: issue.message, accent: Theme.Ink.red, showsSettings: true,
+                               onOpenSettings: openHealthSettings,
+                               onDismiss: {
+                                   HealthCaution.dismiss(issue)
+                                   withAnimation(.easeInOut(duration: 0.25)) { liveIssue = nil }
+                                   probeHealth()   // the muted kind may have been hiding a lower rung
+                               })
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            } else if let caution {
+                CautionCapsule(message: caution.kind.message,
+                               showsSettings: caution.kind == .loggedOut,
+                               onOpenSettings: openHealthSettings,
                                onDismiss: {
                                    OvernightCaution.clear()
                                    withAnimation(.easeInOut(duration: 0.25)) { self.caution = nil }
@@ -191,6 +209,25 @@ struct HomeView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
         .padding(.trailing, 30).padding(.top, 64)
+    }
+
+    /// Land directly on Permissions & Health — every banner's fix lives there; never strand the
+    /// user on the default pane.
+    private func openHealthSettings() {
+        SettingsView.requestedPane = .health
+        openWindow(id: SettingsView.windowID)
+    }
+
+    /// Run HealthCaution's ladder off the main thread of thought: cheap sync probes, plus a
+    /// cached codex login check (forced fresh while a codex banner is up, so a fix clears on the
+    /// very next foreground). Quiet on pitch decks (demo cards must never share the stage with a
+    /// red capsule) and on the free home (HealthCaution guards kbOnly too — defense in depth).
+    private func probeHealth() {
+        guard deck == .real, !kbOnly else { return }
+        Task {
+            let issue = await HealthCaution.probe(forceCodexRecheck: liveIssue?.kindKey == "codex")
+            withAnimation(.easeInOut(duration: 0.25)) { liveIssue = issue }
+        }
     }
 
     private var greeting: String {
@@ -476,22 +513,25 @@ struct HomeView: View {
     }
 }
 
-// MARK: - The morning-after caution capsule (rendered by cautionBanner)
+// MARK: - The caution capsule (rendered by cautionBanner — amber for the morning-after event,
+// red for a live HealthCaution issue)
 
 private struct CautionCapsule: View {
-    let kind: OvernightCaution.Kind
+    let message: String
+    var accent: Color = Theme.Ink.amber
+    var showsSettings = false
     let onOpenSettings: () -> Void
     let onDismiss: () -> Void
 
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: 10) {
-            HealthDot(color: Theme.Ink.amber)
-            Text(kind.message)
+            HealthDot(color: accent)
+            Text(message)
                 .font(.system(size: 12.5))
                 .foregroundStyle(Theme.Ink.statusInk)
                 .lineSpacing(3)
                 .fixedSize(horizontal: false, vertical: true)
-            if kind == .loggedOut {
+            if showsSettings {
                 SettingsPillButton(title: "Open Settings", action: onOpenSettings)
             }
             Button(action: onDismiss) {
@@ -507,7 +547,7 @@ private struct CautionCapsule: View {
         .frame(maxWidth: 480, alignment: .leading)
         .background(Color.white.opacity(0.04), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
         .overlay(RoundedRectangle(cornerRadius: 14, style: .continuous)
-            .strokeBorder(Theme.Ink.amber.opacity(0.28), lineWidth: 1))
+            .strokeBorder(accent.opacity(0.28), lineWidth: 1))
     }
 }
 
@@ -515,13 +555,28 @@ private struct CautionCapsule: View {
     ZStack {
         Color.black.ignoresSafeArea()
         VStack(alignment: .trailing, spacing: 14) {
-            CautionCapsule(kind: .loggedOut, onOpenSettings: {}, onDismiss: {})
-            CautionCapsule(kind: .noInternet, onOpenSettings: {}, onDismiss: {})
-            CautionCapsule(kind: .usageLimit, onOpenSettings: {}, onDismiss: {})
+            CautionCapsule(message: OvernightCaution.Kind.loggedOut.message, showsSettings: true,
+                           onOpenSettings: {}, onDismiss: {})
+            CautionCapsule(message: OvernightCaution.Kind.noInternet.message,
+                           onOpenSettings: {}, onDismiss: {})
+            CautionCapsule(message: OvernightCaution.Kind.usageLimit.message,
+                           onOpenSettings: {}, onDismiss: {})
+            CautionCapsule(message: HealthCaution.Issue.permissions([.fullDiskAccess]).message,
+                           accent: Theme.Ink.red, showsSettings: true,
+                           onOpenSettings: {}, onDismiss: {})
+            CautionCapsule(message: HealthCaution.Issue.permissions([.fullDiskAccess, .launchAtLogin]).message,
+                           accent: Theme.Ink.red, showsSettings: true,
+                           onOpenSettings: {}, onDismiss: {})
+            CautionCapsule(message: HealthCaution.Issue.codexSignedOut.message,
+                           accent: Theme.Ink.red, showsSettings: true,
+                           onOpenSettings: {}, onDismiss: {})
+            CautionCapsule(message: HealthCaution.Issue.computerUseBroken(payloadGone: true).message,
+                           accent: Theme.Ink.red, showsSettings: true,
+                           onOpenSettings: {}, onDismiss: {})
         }
         .padding(40)
     }
-    .frame(width: 620, height: 320)
+    .frame(width: 620, height: 560)
     .preferredColorScheme(.dark)
 }
 

--- a/Sentient OS macOS/Views/Onboarding/OnboardingPermissionsView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingPermissionsView.swift
@@ -23,7 +23,7 @@ struct OnboardingPermissionsView: View {
     @State private var loginOn = LoginItem.isEnabled
     @State private var loginNeedsApproval = LoginItem.needsApproval
 
-    private enum DaemonState { case ready, installing, notSetUp }
+    private enum DaemonState { case ready, installing, notSetUp, disabled }
 
     private var allGreen: Bool { fdaGranted && daemon == .ready && loginOn }
 
@@ -56,7 +56,7 @@ struct OnboardingPermissionsView: View {
                         StatusLine(title: "Overnight wake",
                                    health: daemon == .ready ? .ok : .bad,
                                    note: daemonNote,
-                                   tip: "A tiny system helper that wakes your Mac at 3 AM so Sentient's on-device intelligence can work while you sleep. It only runs while your Mac is plugged in and Sentient is open in your menu bar. Installed once with your password.",
+                                   tip: "A tiny system helper that wakes your Mac at 3 AM so Sentient's on-device intelligence can work while you sleep.\n\nIt only runs while your Mac is plugged in and Sentient is open in your menu bar. Installed once with your password.",
                                    fixTitle: "Set Up…") {
                             fixDaemon()
                         }
@@ -77,7 +77,7 @@ struct OnboardingPermissionsView: View {
                               StatusLine(title: "Full Disk Access",
                                          health: fdaGranted ? .ok : .bad,
                                          note: fdaGranted ? "granted" : "not granted",
-                                         tip: "Lets Sentient's on-device LLM read your files & folders, and the databases WhatsApp, iMessage, and Notes keep on this Mac. Everything is read right here on your Mac; your data never leaves it.",
+                                         tip: "Lets Sentient's on-device LLM read your files & folders, and the databases WhatsApp, iMessage, and Notes keep on this Mac.\n\nEverything is read right here on your Mac; your data never leaves it.",
                                          fixTitle: "Grant…") {
                             // The floating guide carries Sentient itself as the drag card — no
                             // hunting through the "+" file picker.
@@ -127,15 +127,25 @@ struct OnboardingPermissionsView: View {
         case .ready:      return "ready"
         case .installing: return "installing…"
         case .notSetUp:   return "not set up"
+        case .disabled:   return "turned off in login items"
         }
     }
 
+    /// Install for the normal case; a daemon that's installed but toggled off in System Settings
+    /// (possible after a Reset on a machine that had flipped it) can only be fixed at the switch.
     private func fixDaemon() {
-        guard daemon == .notSetUp else { return }
-        daemon = .installing
-        Task {
-            _ = await WakeHelperInstaller.installAsync()
-            daemon = WakeHelperInstaller.isInstalledAndCurrent() ? .ready : .notSetUp
+        switch daemon {
+        case .ready, .installing:
+            return
+        case .disabled:
+            WakeHelperClient.shared.openLoginItemsSettings()
+        case .notSetUp:
+            daemon = .installing
+            Task {
+                _ = await WakeHelperInstaller.installAsync()
+                try? await Task.sleep(for: .seconds(1))   // let launchd settle before the XPC probe
+                daemon = await WakeHelperClient.shared.healthProbe() == .ready ? .ready : .notSetUp
+            }
         }
     }
 
@@ -143,8 +153,17 @@ struct OnboardingPermissionsView: View {
         fdaGranted = Permissions.hasFullDiskAccess()
         loginOn = LoginItem.isEnabled
         loginNeedsApproval = LoginItem.needsApproval
-        if daemon != .installing {
-            daemon = WakeHelperInstaller.isInstalledAndCurrent() ? .ready : .notSetUp
+        guard daemon != .installing else { return }
+        Task {
+            // The XPC ground truth, same as Settings → Health (a file check reads green even
+            // when the System Settings background toggle has the daemon off).
+            let verdict = await WakeHelperClient.shared.healthProbe()
+            guard daemon != .installing else { return }   // an install started mid-probe wins
+            switch verdict {
+            case .ready:    daemon = .ready
+            case .disabled: daemon = .disabled
+            case .notSetUp: daemon = .notSetUp
+            }
         }
     }
 }

--- a/Sentient OS macOS/Views/Permissions/ComputerUseGate.swift
+++ b/Sentient OS macOS/Views/Permissions/ComputerUseGate.swift
@@ -79,6 +79,8 @@ final class ComputerUseGate {
         refresh()
         let blocking = !allRequiredGranted
         if !blocking {
+            // Seen working — arm the home's regression banner (HealthCaution rung ③).
+            HealthCaution.latchComputerUse()
             // Nothing required is missing — the only reason to appear is the one-time optional offer.
             guard !sentientScreen, !Self.screenRecordingOffered else { return false }
         }
@@ -142,6 +144,7 @@ final class ComputerUseGate {
             Log("ComputerUseGate: Continue blocked — a required grant is still missing")
             return
         }
+        HealthCaution.latchComputerUse()   // the gate's moment of truth — regressions may now banner
         let action = pending
         pending = nil
         Analytics.signal("PermissionGate.continued", parameters: ["all_granted": "true"])

--- a/Sentient OS macOS/Views/Permissions/ComputerUseGateView.swift
+++ b/Sentient OS macOS/Views/Permissions/ComputerUseGateView.swift
@@ -43,14 +43,14 @@ struct ComputerUseGateView: View {
                         StatusLine(title: "Microphone & Speech",
                                    health: micSpeechHealth,
                                    note: micSpeechNote,
-                                   tip: "Lets Sidekick hear you and turn your words into text when you hold the shortcut key. Your voice is heard and transcribed on this Mac, never in the cloud.",
+                                   tip: "Lets Sidekick hear you and turn your words into text when you hold the shortcut key.\n\nYour voice is heard and transcribed on this Mac, never in the cloud.",
                                    fixTitle: gate.micSpeech == .notAsked ? "Allow…" : "Fix…") {
                             fixMicSpeech()
                         }
                         StatusLine(title: "Screen Recording",
                                    health: gate.sentientScreen ? .ok : .warn,   // optional — amber, never blocking
                                    note: gate.sentientScreen ? "granted" : "recommended",
-                                   tip: "Optional, but heavily recommended. Lets Sentient snap a still of your screen the moment you fire a command, so it can see the thing you're asking about. Without it, commands run without screen context. Takes effect after you restart Sentient.",
+                                   tip: "Optional but recommended.\nLets Sentient see a screenshot of your screen the moment you fire a command, so it can see the thing you're asking about (\u{201C}finish this\u{201D}, \u{201C}reply to this\u{201D}).\n\nWithout it, you'll have to explicitly tell it which app you want it to start controlling.",
                                    fixTitle: "Allow…") {
                             fixSentientScreen()
                         }

--- a/Sentient OS macOS/Views/Settings/HealthPane.swift
+++ b/Sentient OS macOS/Views/Settings/HealthPane.swift
@@ -9,10 +9,12 @@
 //  helper's Accessibility + Screen
 //  Recording — system-TCC, status-only, shown once computer use exists). The Automation grant has
 //  NO row: it self-heals silently shortly after the pane opens (the user has no job there).
-//  Red = a core capability is broken · yellow = optional or fixable-later. When the whole codex
+//  Red = a core capability is broken · yellow = optional, fixable-later, or working on it. The
+//  codex fix buttons drive the shared engine INLINE (install / browser login with auto-notice /
+//  computer-use bootstrap — no sheet; CodexSetupView is dev-tools-only now). When the whole codex
 //  stack is green it collapses to one glowing summary line (tap for details) — a browsing user
-//  shouldn't wade through five rows of "fine". Statuses re-probe on app foreground and after the
-//  codex sheet closes. (Reset lives in Settings → System.)
+//  shouldn't wade through five rows of "fine". Statuses re-probe on app foreground.
+//  (Reset lives in Settings → System.)
 //
 
 import SwiftUI
@@ -42,12 +44,11 @@ struct HealthPane: View {
     @State private var plan: CodexAuth.Plan?
     @State private var planChecking = false
 
-    @State private var showCodexSetup = false
     @State private var codexExpanded = false
     @State private var checked = false        // first full probe done (codex login check is seconds)
     @State private var revealed = false       // drives the rise-in cascade after the first probe
 
-    private enum DaemonState { case ready, installing, notSetUp }
+    private enum DaemonState { case ready, installing, notSetUp, disabled }
     private enum MicSpeechState { case granted, notAsked, denied }
 
     private var showCodexPermissions: Bool { fdaGranted && codex.computerUseReady }
@@ -103,8 +104,15 @@ struct HealthPane: View {
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             Task { await refresh() }   // the user may just have fixed something in System Settings
         }
-        .sheet(isPresented: $showCodexSetup, onDismiss: { Task { await refresh() } }) {
-            CodexSetupView()
+        .task(id: codex.loggingIn) {
+            // The browser-login auto-notice, same as onboarding: while a login is out, poll
+            // `codex login status` every 2s so the row flips green the moment they finish —
+            // no "I'm done" button. The task re-keys (and cancels) with the loggingIn flag.
+            while !Task.isCancelled, codex.loggingIn, !codex.loggedIn {
+                try? await Task.sleep(for: .seconds(2))
+                await codex.refreshLoginStatus()
+            }
+            if codex.loggedIn { plan = CodexAuth.currentPlan() }   // the plan row rides the login
         }
     }
 
@@ -129,7 +137,7 @@ struct HealthPane: View {
                     StatusLine(title: "Full Disk Access",
                                health: fdaGranted ? .ok : .bad,
                                note: fdaGranted ? "granted" : "not granted",
-                               tip: "Lets Sentient's on-device LLM read your files & folders, and the databases WhatsApp, iMessage, and Notes keep on this Mac. Everything is read right here on your Mac; your data never leaves it.",
+                               tip: "Lets Sentient's on-device LLM read your files & folders, and the databases WhatsApp, iMessage, and Notes keep on this Mac.\n\nEverything is read right here on your Mac; your data never leaves it.",
                                fixTitle: "Grant…") {
                         PermissionGuide.shared.guide(.fullDiskAccess, dragging: Bundle.main.bundleURL)
                     }
@@ -151,8 +159,8 @@ struct HealthPane: View {
                 StatusLine(title: "Overnight wake",
                            health: daemon == .ready ? .ok : .bad,
                            note: daemonNote,
-                           tip: "A tiny system helper that wakes your Mac at 3 AM so Sentient's on-device intelligence can work while you sleep. It only runs while your Mac is plugged in and Sentient is open in your menu bar. Installed once with your password.",
-                           fixTitle: "Set Up…") {
+                           tip: "A tiny system helper that wakes your Mac at 3 AM so Sentient's on-device intelligence can work while you sleep.\n\nIt only runs while your Mac is plugged in and Sentient is open in your menu bar. Installed once with your password.",
+                           fixTitle: daemon == .disabled ? "Turn On…" : "Set Up…") {
                     fixDaemon()
                 }
                 .rise(1, revealed: revealed)
@@ -178,7 +186,7 @@ struct HealthPane: View {
                 StatusLine(title: "Microphone & Speech",
                            health: micSpeechHealth,
                            note: micSpeechNote,
-                           tip: "Lets Sidekick hear you and turn your words into text when you hold the shortcut key. Your voice is heard and transcribed on this Mac, never in the cloud.",
+                           tip: "Lets Sidekick hear you and turn your words into text when you hold the shortcut key.\n\nYour voice is heard and transcribed on this Mac, never in the cloud.",
                            fixTitle: micSpeech == .notAsked ? "Allow…" : "Fix…") {
                     fixMicSpeech()
                 }
@@ -186,7 +194,7 @@ struct HealthPane: View {
                 StatusLine(title: "Screen Recording",
                            health: screenRec ? .ok : .warn,   // optional — Sidekick runs text-only without it
                            note: screenRec ? "granted" : "optional",
-                           tip: "Optional. Lets Sidekick snap a still of your screen the moment you summon it, so it can see the thing you're asking about (\u{201C}finish this\u{201D}, \u{201C}reply to this\u{201D}). Without it, Sidekick may not know which open app to start controlling to help you. Takes effect after you restart Sentient.",
+                           tip: "Optional but recommended.\nLets Sidekick see a screenshot of your screen the moment you summon it, so it can see the thing you're asking about (\u{201C}finish this\u{201D}, \u{201C}reply to this\u{201D}).\n\nWithout it, you'll have to explicitly tell Sidekick which app you want it to start controlling.",
                            fixTitle: "Allow…") {
                     fixScreenRecording()
                 }
@@ -210,26 +218,41 @@ struct HealthPane: View {
         case .ready:      return "ready"
         case .installing: return "installing…"
         case .notSetUp:   return "not set up"
+        case .disabled:   return "turned off in login items"
         }
     }
 
     /// [DECIDED 2026-07-04] The password install IS the production path (no Login Items
-    /// migration — one native admin prompt, no trip to System Settings). Fix = run the installer.
+    /// migration — one native admin prompt, no trip to System Settings). Fix = run the installer —
+    /// EXCEPT when the daemon is installed but toggled off in System Settings: launchd honors that
+    /// switch over any bootstrap, so the only fix is the user flipping it back on.
     private func fixDaemon() {
-        guard daemon == .notSetUp else { return }
-        daemon = .installing
-        Task {
-            _ = await WakeHelperInstaller.installAsync()
-            refreshDaemon()
-            // A fresh install may be the last missing prerequisite — re-run the 18h check now
-            // instead of waiting for the next launch (this app rarely relaunches).
-            if daemon == .ready { appState?.scheduler.maybeAutoEnable() }
+        switch daemon {
+        case .ready, .installing:
+            return
+        case .disabled:
+            WakeHelperClient.shared.openLoginItemsSettings()
+        case .notSetUp:
+            daemon = .installing
+            Task {
+                _ = await WakeHelperInstaller.installAsync()
+                try? await Task.sleep(for: .seconds(1))   // let launchd settle before the XPC probe
+                await refreshDaemon()
+                // A fresh install may be the last missing prerequisite — re-run the 18h check now
+                // instead of waiting for the next launch (this app rarely relaunches).
+                if daemon == .ready { appState?.scheduler.maybeAutoEnable() }
+            }
         }
     }
 
-    /// Green = the installed daemon plist exists AND points at this exact binary.
-    private func refreshDaemon() {
-        daemon = WakeHelperInstaller.isInstalledAndCurrent() ? .ready : .notSetUp
+    /// Green = the daemon ANSWERS over XPC (the only check the System Settings background toggle
+    /// can't fool) — WakeHelperClient.healthProbe is the shared verdict.
+    private func refreshDaemon() async {
+        switch await WakeHelperClient.shared.healthProbe() {
+        case .ready:    daemon = .ready
+        case .disabled: daemon = .disabled
+        case .notSetUp: daemon = .notSetUp
+        }
     }
 
     // MARK: Microphone & Speech (one row — one call asks for both)
@@ -348,35 +371,63 @@ struct HealthPane: View {
     }
 
     // MARK: - SET UP CODEX (the cloud brain — all three are core, red when missing)
+    //
+    // The fix buttons drive the shared CodexSetup engine DIRECTLY — no intermediate sheet (the
+    // old wiring bounced every button through CodexSetupView, which is the dev cockpit; decided
+    // gone 2026-07-11). While a step runs, its LED goes amber, the note narrates, and the pill
+    // hides; failures surface as a quiet prose line under the row. The browser login is
+    // noticed automatically (the same 2s poll onboarding uses) — no "I'm done" button.
 
     private var codexSetupGroup: some View {
         SettingsGroup(label: "Set Up Codex") {
             VStack(alignment: .leading, spacing: 2) {
                 StatusLine(title: "Codex CLI",
-                           health: codex.installed ? .ok : .bad,
-                           note: codex.installed ? "installed" : "not installed",
-                           tip: "OpenAI's official Codex command line tool. Sentient runs its cloud steps through it, using your own ChatGPT subscription.",
-                           fixTitle: "Install…") { showCodexSetup = true }
+                           health: codex.installed ? .ok : (codex.installing ? .warn : .bad),
+                           note: codex.installing ? "installing…" : (codex.installed ? "installed" : "not installed"),
+                           tip: "OpenAI's official Codex command line tool. Sentient runs its cloud thinking through it, using your own ChatGPT subscription.\n\nInstall runs OpenAI's own installer; if codex is already there it simply updates in place, and your login and settings are untouched.",
+                           fixTitle: "Install…",
+                           fix: codex.installing ? nil : { Task { await codex.installCodex() } })
+                failureLine(codex.installStatus)
                 StatusLine(title: "ChatGPT account",
-                           health: codex.loggedIn ? .ok : .bad,
-                           note: codex.loggedIn ? "logged in" : "not logged in",
-                           tip: "Your own OpenAI login for Codex. The sign in happens in your browser; Sentient never sees your password.",
-                           fixTitle: "Log in…") { showCodexSetup = true }
+                           health: codex.loggedIn ? .ok : (codex.loggingIn ? .warn : .bad),
+                           note: codex.loggedIn ? "logged in"
+                               : codex.loggingIn ? "finish in your browser" : "not logged in",
+                           tip: "Your own OpenAI login for Codex CLI.\n\n\u{201C}Log in\u{201D} asks Codex to open your browser to sign in. Sentient never sees your credentials.",
+                           fixTitle: codex.loggingIn ? "Re-open…" : "Log in…",
+                           fix: codex.loggedIn ? nil : { codex.startLogin() })
+                failureLine(codex.loginStatusLine)
                 if codex.loggedIn, let plan {
                     StatusLine(title: "ChatGPT plan",
                                health: plan.tier == .limited ? .warn : .ok,
                                note: planChecking ? "checking…"
                                    : plan.tier == .limited ? "\(plan.displayName.lowercased()) · knowledge base only"
                                                            : plan.displayName.lowercased(),
-                               tip: "Read from your own codex login. Free and Go plans carry a tiny monthly Codex quota and no Gmail or Calendar connectors, so Sentient runs in knowledge-base-only mode; Plus unlocks proactive mornings, Sidekick, and nightly updates. Upgraded? Re-check picks it up right away.",
+                               tip: "Free and Go plans carry a tiny monthly Codex quota and no Gmail or Calendar connectors, so Sentient runs in a one-time knowledge-base-only mode.\n\nChatGPT Plus unlocks Proactive Intelligence, Sidekick, and nightly knowledge-base updates.\n\nUpgraded? Reset Sentient (in the System tab) to activate the full Sentient OS experience.",
                                fixTitle: "Re-check") { recheckPlan() }
                 }
                 StatusLine(title: "Computer use",
-                           health: codex.computerUseReady ? .ok : .bad,
-                           note: codex.computerUseReady ? "ready" : "not set up",
-                           tip: "The Codex add-on that can click, type, and act on your Mac when you fire an action. Downloaded once from OpenAI.",
-                           fixTitle: "Set up…") { showCodexSetup = true }
+                           health: codex.computerUseReady ? .ok : (codex.settingUpComputerUse ? .warn : .bad),
+                           note: codex.settingUpComputerUse ? "setting up…"
+                               : (codex.computerUseReady ? "ready" : "not set up"),
+                           tip: "The Codex add-on that can click, type, and act on your Mac when you fire an action.\n\nSet up downloads OpenAI's official Codex Desktop app package straight from OpenAI (about 535 MB), lifts out its computer-use plugin, and wires it into Codex CLI on this Mac. No desktop app installs; nothing is hosted by us.",
+                           fixTitle: "Set up…",
+                           fix: codex.settingUpComputerUse ? nil : { Task { await codex.setupComputerUse() } })
+                // The ~535 MB download deserves live narration, not just an amber dot.
+                if codex.settingUpComputerUse, let line = codex.computerUseStatus {
+                    SettingsProse(line).padding(.top, 2).padding(.bottom, 6)
+                } else {
+                    failureLine(codex.computerUseStatus)
+                }
             }
+        }
+    }
+
+    /// A quiet prose line under a row, shown only when the engine's last word was a failure —
+    /// success is already the row's green dot, and progress has its own treatment.
+    @ViewBuilder
+    private func failureLine(_ status: String?) -> some View {
+        if let status, status.hasPrefix("✗") {
+            SettingsProse(status).padding(.top, 2).padding(.bottom, 6)
         }
     }
 
@@ -434,7 +485,7 @@ struct HealthPane: View {
     private func refresh() async {
         fdaGranted = Permissions.hasFullDiskAccess()
         loginOn = LoginItem.isEnabled
-        refreshDaemon()
+        await refreshDaemon()
         refreshMicSpeech()
         screenRec = Permissions.hasScreenRecording()
         notifStatus = await UNUserNotificationCenter.current().notificationSettings().authorizationStatus

--- a/Sentient OS macOS/Views/Settings/SettingsComponents.swift
+++ b/Sentient OS macOS/Views/Settings/SettingsComponents.swift
@@ -312,12 +312,12 @@ struct StatusLine: View {
     var fixTitle: String = "Fix…"
     var fix: (() -> Void)? = nil
 
-    /// Punchier than the ink palette on purpose — these are status LEDs, not labels.
+    /// Status-LED colors — warn stays punchier than the ink amber on purpose.
     private var dot: Color {
         switch health {
         case .ok:   return Theme.Ink.green
         case .warn: return Color(red: 1.0, green: 0.72, blue: 0.30)
-        case .bad:  return Color(red: 1.0, green: 0.36, blue: 0.36)
+        case .bad:  return Theme.Ink.red
         }
     }
 

--- a/Sentient OS macOS/Views/Theme.swift
+++ b/Sentient OS macOS/Views/Theme.swift
@@ -72,6 +72,7 @@ enum Theme {
         static let bright = Color(red: 0.812, green: 0.804, blue: 0.839)       // #cfcdd6
         static let green = Color(red: 0.290, green: 0.871, blue: 0.502)        // #4ade80 (was mint #47d7ac — too seafoam)
         static let amber = Color(red: 1.0, green: 0.765, blue: 0.443)          // #ffc371
+        static let red = Color(red: 1.0, green: 0.36, blue: 0.36)              // status-LED red (StatusLine .bad · the home's live caution)
         static let chipInk = Color(red: 0.541, green: 0.537, blue: 0.565)      // #8a8990
         static let chipBorder = Color(red: 0.114, green: 0.114, blue: 0.133)   // #1d1d22
     }


### PR DESCRIPTION
One day, four shipped threads — built, hardware-tested by Jesai, docs updated.

## 1. The live health banner (the home's caution ladder)
The blank top-right slot now holds at most ONE capsule, most severe first: a **red live issue** outranks the amber morning-after caution. `System/HealthCaution.swift` (new) probes on appear + every foreground:
1. **Essential permission off** — FDA · overnight wake helper · launch at login
2. **Codex gone / signed out** — login verdict cached ~5 min, bypassed while its banner shows
3. **Computer use regressed** — armed only after it was once seen working (`computerUse.everReady` latch, set by the probe + `ComputerUseGate`, cleared by FactoryReset)

No persistence: broken shows, fixed melts on the next foreground. ✕ mutes a kind per session (lower rungs still surface). Suppressed on kb-only homes and demo decks. Every banner's **Open Settings** lands on Permissions & Health.

## 2. Wake-helper liveness (the background-toggle blind spot)
System Settings' **App Background Activity toggle boots the daemon out of launchd while leaving its plist on disk** — every file check read green on a dead helper, and unprivileged `launchctl print` answers "could not find service" for everything, so it can't tell either.

- `WakeHelperClient.isReachable()` — a real XPC `heartbeat` (the one op harmless in every state) is now the ground truth
- `healthProbe()` classifies: **ready** / **disabled** (files correct, toggle off → the only fix is the switch; Health + onboarding show "turned off in login items" with **Turn On…** deep-linking there) / **notSetUp** (installer fixes it)
- The scheduler's `ensureHelperReady`, Health, onboarding, and the home banner all gate on the probe
- The plist gains **`AssociatedBundleIdentifiers`** so the Login Items row displays as **Sentient OS** instead of the code-signer's human name; the key rides `isInstalledAndCurrent()` so old-format plists refresh on the next setup pass

## 3. Inline codex setup (Settings → Health)
The three fix buttons drive the shared `CodexSetup` engine **directly** — no more bouncing into the `CodexSetupView` sheet (now dev-tools-only). Amber LED + narrated note while a step runs, failure prose under the row, live streamed progress for the ~535 MB computer-use bootstrap, and the browser login is **auto-noticed** (onboarding's 2s poll; the pill becomes **Re-open…** so an abandoned browser never strands the row). Also fixed: the engine's browser-login status line referenced the sheet-only confirm button — onboarding was already showing that impossible instruction.

## 4. Tip copy pass
Dense InfoTips split into short paragraphs (`\n\n`, rendered natively); codex tips now explain what each action actually does in no-context language; twins synced across Health / the permission gate / onboarding.

## Docs
`Overnight Scheduler (3am Wake).md` (the liveness sharp edge + plist facts) · `Home — Proactive Intelligence (For You).md` (the ladder) · `Settings.md` (three-state daemon row, inline codex, tip conventions). Context files updated in Our_Stuff.

## Tested
Builds green throughout (Xcode MCP). Hardware-verified by Jesai: fresh helper install, toggle-off → red banner + "turned off in login items" → toggle-on → melts; codex login flow inline; uninstall interplay reviewed (domain wipe covers the new latch key).