### PR TITLE
Guard model-download previews with #if DEBUG (fixes Release build)

### DIFF
--- a/Sentient OS macOS/Views/Onboarding/OnboardingModelDownloadView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingModelDownloadView.swift
@@ -81,6 +81,8 @@ struct OnboardingModelDownloadView: View {
     }
 }
 
+// previewInstance is DEBUG-only, and #Preview bodies compile in Release too — so these must be guarded.
+#if DEBUG
 #Preview("Downloading — mid-flight") {
     ZStack {
         Theme.bg.ignoresSafeArea()
@@ -99,3 +101,4 @@ struct OnboardingModelDownloadView: View {
     .frame(width: 1180, height: 880)
     .preferredColorScheme(.dark)
 }
+#endif


### PR DESCRIPTION
## What

Wraps the two `#Preview` blocks in `OnboardingModelDownloadView.swift` in `#if DEBUG` / `#endif`.

## Why

First Release packaging since the model downloader shipped failed with 4 compile errors: `#Preview` bodies compile in **every** configuration (they are not automatically DEBUG-only), but these two previews reference `ModelDownload.previewInstance`, which lives behind `#if DEBUG` in `Engine/ModelDownload.swift`. Debug builds could never see this; Release exploded on packaging day.

## Verified

Full Release build (`xcodebuild -configuration Release`, isolated DerivedData) — `** BUILD SUCCEEDED **`. Also swept the codebase: `previewInstance` was the only DEBUG-only symbol referenced from any preview.

A ⚠️ one-liner about this trap was added to the team dev notes (Our_Stuff, rides Obsidian Sync).