### PR TITLE
Live codex thought ticker in the processing takeover + patience footer

### DIFF
--- a/Sentient OS macOS/Documentation/Home — Proactive Intelligence (For You).md
+++ b/Sentient OS macOS/Documentation/Home — Proactive Intelligence (For You).md
@@ -66,7 +66,13 @@ The main window's content (rendered by `RootView`). Layers, bottom-to-top:
 `modelMissing`, the `realCards` flag, and the `onAnalyze`/`onShowDevTools` callbacks) and owns the
 HomeView ⟷ ProcessingView cross-fade. **Analyze Now runs the shared `SourceSelection` picks through
 `ProcessingView` `.auto`** — with real cards ON it's the FULL cycle (read → `ProactiveCycle`: KB →
-mirror → gift → proactive → wipe), byte-for-byte what the 3am scheduler runs. `RootView` also owns
+mirror → gift → proactive → wipe), byte-for-byte what the 3am scheduler runs. During the cycle's
+cloud tail the takeover shows the phase line plus codex's own reasoning as a one-line mono ticker
+under a "THINKING" whisper (`ProcessingView.liveThought`, fed by `ProactiveCycle`'s `onLine` hook —
+shell `$ ` lines filtered as noise, thoughts promoted at a 1.4s cadence, cleared per phase), and the
+footer sets expectations in three lines: the ~15-minute estimate (with the 10-minute warm flip), the
+keep-Sentient-open/lid-up instruction, and the reassurance that 3am runs wake a lid-shut, plugged-in
+Mac on their own. `RootView` also owns
 **the onboarding finale**: when the first analysis finishes, onboarding dissolves into the home and
 the Knowledge window (the Constellation) opens ON TOP a beat later — every user's first sight of
 their knowledge base, whatever their plan. ProcessingView's "Analysis complete" screen

--- a/Sentient OS macOS/Documentation/Proactive Intelligence (Judge).md
+++ b/Sentient OS macOS/Documentation/Proactive Intelligence (Judge).md
@@ -22,6 +22,9 @@ step keeps them for retry). The results land in `ProactiveResearch.latest()` (Us
 home's For You deck renders as real cards. **Knowledge-base-only mode (free/go plans) skips decide +
 research entirely** (an empty ready-list is saved so stale cards can't linger); the KB → mirror →
 gift → wipe legs still run — see `Plan Gate (CodexAuth & Knowledge-Base-Only).md`.
+`run(progress:onLine:)` also streams codex's humanized play-by-play from every cloud stage (KB
+build/update · gift · judge · research) — the takeover's live "THINKING" line (see the Progress
+section of `Vault Generation (Stage 2).md`); the scheduler passes no `onLine` and streams nothing.
 
 ## PART 1 — What the judge does
 

--- a/Sentient OS macOS/Documentation/Vault Generation (Stage 2).md
+++ b/Sentient OS macOS/Documentation/Vault Generation (Stage 2).md
@@ -1,6 +1,6 @@
 # Vault Generation — Stage 2 (the agentic build)
 
-`VaultGenerator.generate(notes:resume:onProgress:)` turns the on-device survivor summaries
+`VaultGenerator.generate(notes:resume:onProgress:onLine:)` turns the on-device survivor summaries
 (passed as `[CloudNote]`) into the markdown knowledge base at `~/Sentient OS - Knowledge Base/`,
 through ONE route: `codex exec` via the `CodexCLI` spine — `gpt-5.6-sol` at **`.high` effort**
 (every plan — the initial build's `.xhigh` override was retired 2026-07-10, it thinks far too
@@ -59,9 +59,16 @@ that whole choreography, B1, is now deleted.)*
 
 ## Progress
 
-Progress is the filesystem itself: a 2s poll of the staging dir's `.md` count →
-`Progress.writing(notes:)` → the caller's status line (Dev Tools shows "… writing N notes"; the
-home's takeover shows the preparing phase). No CLI stream parsing.
+Two channels, both optional:
+- **The filesystem poller** — a 2s poll of the staging dir's `.md` count → `Progress.writing(notes:)`
+  → the caller's status line (Dev Tools shows "… writing N notes").
+- **The live thought stream (2026-07-11)** — `generate`/`runCodexInStaging` (and
+  `VaultCloud.create/update`) take an optional `onLine`, forwarded to `CodexCLI.run(_:onLine:)`,
+  whose `humanLine` adapter reduces the `--json` events to readable play-by-play (reasoning ·
+  `$ commands` · tool calls · web searches). `ProactiveCycle.run(progress:onLine:)` threads it from
+  EVERY cloud stage (build/update · gift · judge · research) into the takeover's "THINKING" ticker
+  (`ProcessingView.liveThought`) — which drops the `$ ` shell lines as noise and promotes one quiet
+  mono line at a 1.4s cadence. The 3am scheduler passes nothing.
 
 ## The prompt
 

--- a/Sentient OS macOS/Proactive/GiftLetter.swift
+++ b/Sentient OS macOS/Proactive/GiftLetter.swift
@@ -47,7 +47,7 @@ actor GiftLetter {
     /// no stray note ever lingers (or gets mirrored). Hermetic — no web, no user MCP. Throws on
     /// no-vault / empty / usage-limit / failure.
     @discardableResult
-    func generate() async throws -> String {
+    func generate(onLine: (@Sendable (String) -> Void)? = nil) async throws -> String {
         let vault = VaultGenerator.vaultRoot
         let fm = FileManager.default
         guard fm.fileExists(atPath: vault.path) else { throw GiftError.noVault }
@@ -67,7 +67,7 @@ actor GiftLetter {
 
         Log("GiftLetter: writing the welcome gift from the knowledge base at \(vault.lastPathComponent)…")
         do {
-            let env = try await CodexCLI.shared.run(inv)
+            let env = try await CodexCLI.shared.run(inv, onLine: onLine)
             // The letter is the file the model wrote; fall back to its final message if it skipped it.
             let fromFile = (try? String(contentsOf: giftFile, encoding: .utf8)) ?? ""
             let letter = Self.cleanMarkdown(fromFile.isEmpty ? env.result : fromFile)

--- a/Sentient OS macOS/Proactive/Proactive.swift
+++ b/Sentient OS macOS/Proactive/Proactive.swift
@@ -109,7 +109,8 @@ actor Proactive {
     /// does not verify, write, or notify. Throws on no-recent / usage-limit / failure so the caller
     /// can surface a clear status.
     func findActionItems(from notes: [CloudNote], now: Date = Date(),
-                         calendarContext: String? = nil) async throws -> [ActionItem] {
+                         calendarContext: String? = nil,
+                         onLine: (@Sendable (String) -> Void)? = nil) async throws -> [ActionItem] {
         // 1. Window the summaries to the last N days (shared with PART 2 via Self.recent).
         let recent = Self.recent(from: notes, now: now)
         guard !recent.isEmpty else { throw ProError.noRecent }
@@ -133,7 +134,7 @@ actor Proactive {
 
         Log("Proactive.judge: \(recent.count) summaries in the last \(Self.lookbackDays)d → asking Codex (summaries-only, hermetic)…")
         do {
-            let env = try await CodexCLI.shared.run(inv)
+            let env = try await CodexCLI.shared.run(inv, onLine: onLine)
             let items = Array(Self.parse(env.result).prefix(Self.maxItems))
             Log("Proactive.judge: ✅ \(items.count) action item(s) (turns \(env.numTurns ?? -1), \(env.outputTokens ?? -1) out-tokens)")
             #if DEBUG   // B7: title/action/importance/sources are the user's life — DEBUG-only so it can

--- a/Sentient OS macOS/Proactive/ProactiveCycle.swift
+++ b/Sentient OS macOS/Proactive/ProactiveCycle.swift
@@ -15,7 +15,8 @@
 //
 //  The read leg itself stays with the caller (ProcessingView's takeover UI / the scheduler's keep-
 //  awake loop). The wipe happens ONLY on a fully successful chain — a failure leaves the summaries in
-//  place so a retry can pick up where it stopped. `progress` carries human-readable phases for the UI.
+//  place so a retry can pick up where it stopped. `progress` carries human-readable phases for the UI;
+//  `onLine` streams codex's live play-by-play (the takeover's thought line — unused by the 3am run).
 //
 //  Key method: run(progress:) → String?  (nil = cycle completed; a message = the step that failed)
 //
@@ -54,9 +55,12 @@ actor ProactiveCycle {
     /// `scheduled` marks the UNATTENDED 3am run: its failures additionally classify into the
     /// morning-after caution (OvernightCaution → the home's banner); a watched Analyze Now doesn't
     /// (the takeover UI already shows those live).
+    /// `onLine` streams codex's humanized play-by-play (reasoning · commands · tool calls) from
+    /// every cloud stage — the takeover's live thought line. nil (the 3am run) streams nothing.
     @discardableResult
     func run(scheduled: Bool = false,
-             progress: @escaping @Sendable (ProactiveCyclePhase) -> Void) async -> String? {
+             progress: @escaping @Sendable (ProactiveCyclePhase) -> Void,
+             onLine: (@Sendable (String) -> Void)? = nil) async -> String? {
         PipelineActivity.begin()                 // Settings' Reset is disabled while the tail runs
         defer { PipelineActivity.end() }
         let notes = await CycleStore.shared.notes().map(CloudNote.init)
@@ -71,8 +75,8 @@ actor ProactiveCycle {
         progress(.knowledgeBase(exists ? "Updating your knowledge…"
                                        : "Creating your perfect knowledge base from everything we've analyzed…"))
         do {
-            if exists { _ = try await VaultCloud.shared.update(notes: notes) }
-            else      { _ = try await VaultCloud.shared.create(notes: notes) }
+            if exists { _ = try await VaultCloud.shared.update(notes: notes, onLine: onLine) }
+            else      { _ = try await VaultCloud.shared.create(notes: notes, onLine: onLine) }
             Analytics.signal(exists ? "KnowledgeBase.updated" : "KnowledgeBase.built",
                              parameters: ["newSummaries": "\(notes.count)"])
         } catch {
@@ -91,7 +95,7 @@ actor ProactiveCycle {
         let giftPreexisted = GiftLetter.latest() != nil
         if !giftPreexisted {
             progress(.knowledgeBase("Writing your welcome…"))
-            do { _ = try await GiftLetter.shared.generate() }
+            do { _ = try await GiftLetter.shared.generate(onLine: onLine) }
             catch { Log("GiftLetter: welcome skipped — \(Self.msg(error))") }
         }
 
@@ -109,7 +113,7 @@ actor ProactiveCycle {
             progress(.deciding)
             let items: [ActionItem]
             do {
-                items = try await Proactive.shared.findActionItems(from: notes, calendarContext: calCtx)
+                items = try await Proactive.shared.findActionItems(from: notes, calendarContext: calCtx, onLine: onLine)
             } catch Proactive.ProError.noRecent {
                 items = []                                   // nothing recent enough — clear cards, still success
             } catch {
@@ -124,7 +128,7 @@ actor ProactiveCycle {
             } else {
                 progress(.researching(items.count))
                 do {
-                    let result = try await ProactiveResearch.shared.researchAndPrepare(items: items, notes: notes, calendarContext: calCtx)
+                    let result = try await ProactiveResearch.shared.researchAndPrepare(items: items, notes: notes, calendarContext: calCtx, onLine: onLine)
                     // Core tier; floatValue = the staged-card count, so a dashboard Sum is the
                     // "suggestions Sentient has prepared across the world" total.
                     Analytics.signal("Proactive.prepared", parameters: [

--- a/Sentient OS macOS/Proactive/ProactiveResearch.swift
+++ b/Sentient OS macOS/Proactive/ProactiveResearch.swift
@@ -116,7 +116,8 @@ actor ProactiveResearch {
     /// recipe). Read-only — it researches and stages, it NEVER fires. Verify-only — it never adds a new
     /// item. Returns the ready + dropped split; throws on no-items / no-vault / usage-limit / failure.
     func researchAndPrepare(items: [ActionItem], notes: [CloudNote] = [], now: Date = Date(),
-                            calendarContext: String? = nil) async throws -> ReadyResult {
+                            calendarContext: String? = nil,
+                            onLine: (@Sendable (String) -> Void)? = nil) async throws -> ReadyResult {
         guard !items.isEmpty else { throw ResError.noItems }
         let recent = Proactive.recent(from: notes, now: now)   // the SAME last-week corpus PART 1 saw
 
@@ -138,7 +139,7 @@ actor ProactiveResearch {
 
         Log("ProactiveResearch: verify + prepare \(items.count) item(s) → Codex (read-only, vault cwd, Gmail MCP + web, never fire)…")
         do {
-            let env = try await CodexCLI.shared.run(inv)
+            let env = try await CodexCLI.shared.run(inv, onLine: onLine)
             let parsed = Self.parse(env.result)
             // Backstop the prompt's prune: PART 2 returns at most maxReady (5) of the strongest cards.
             let result = ReadyResult(ready: Array(parsed.ready.prefix(Self.maxReady)), dropped: parsed.dropped)

--- a/Sentient OS macOS/Vault/VaultCloud.swift
+++ b/Sentient OS macOS/Vault/VaultCloud.swift
@@ -101,10 +101,11 @@ actor VaultCloud {
 
     @discardableResult
     func create(notes: [CloudNote],
-                onProgress: @Sendable @escaping (VaultGenerator.Progress) -> Void = { _ in }) async throws -> VaultGenerator.Result {
+                onProgress: @Sendable @escaping (VaultGenerator.Progress) -> Void = { _ in },
+                onLine: (@Sendable (String) -> Void)? = nil) async throws -> VaultGenerator.Result {
         guard !notes.isEmpty else { throw CloudError.empty }
         do {
-            let result = try await VaultGenerator().generate(notes: notes, resume: createResume, onProgress: onProgress)
+            let result = try await VaultGenerator().generate(notes: notes, resume: createResume, onProgress: onProgress, onLine: onLine)
             setCreateResume(nil)
             await markDirty()
             return result
@@ -123,7 +124,7 @@ actor VaultCloud {
     /// corrupt the real vault — worst case the staging copy is discarded (or kept for a durable
     /// resume). This replaced the old in-place edit + `.bak` restore (B1), which is now obsolete.
     @discardableResult
-    func update(notes: [CloudNote]) async throws -> Int {
+    func update(notes: [CloudNote], onLine: (@Sendable (String) -> Void)? = nil) async throws -> Int {
         guard !notes.isEmpty else { return 0 }
         let fm = FileManager.default
         let vault = VaultGenerator.vaultRoot
@@ -168,7 +169,7 @@ actor VaultCloud {
 
         Log("VaultCloud.update: merging \(notes.count) notes in staging (\(updateResume == nil ? "fresh" : "resume"))…")
         do {
-            let envelope = try await VaultGenerator().runCodexInStaging(invocation, staging: staging)
+            let envelope = try await VaultGenerator().runCodexInStaging(invocation, staging: staging, onLine: onLine)
             // Freshness check (B11): did the live vault change under us — i.e. did the user save a note
             // in the Knowledge editor during the run? If so, our staging snapshot is stale and swapping
             // would CLOBBER their edit. Discard staging instead; the notes stay in CycleStore and the

--- a/Sentient OS macOS/Vault/VaultGenerator.swift
+++ b/Sentient OS macOS/Vault/VaultGenerator.swift
@@ -152,7 +152,8 @@ actor VaultGenerator {
     /// mapping a usage limit to a resumable `VaultError.usageLimit` carrying the staging path. Shared
     /// by build + update so both get identical resume semantics.
     func runCodexInStaging(_ invocation: CodexCLI.Invocation, staging: URL,
-                           onProgress: @Sendable @escaping (Progress) -> Void = { _ in }) async throws -> CodexCLI.Envelope {
+                           onProgress: @Sendable @escaping (Progress) -> Void = { _ in },
+                           onLine: (@Sendable (String) -> Void)? = nil) async throws -> CodexCLI.Envelope {
         onProgress(.calling)
         let poller = Task.detached {
             while !Task.isCancelled {
@@ -163,7 +164,7 @@ actor VaultGenerator {
         }
         defer { poller.cancel() }
         do {
-            return try await CodexCLI.shared.run(invocation)
+            return try await CodexCLI.shared.run(invocation, onLine: onLine)
         } catch let CodexCLI.CLIError.usageLimit(message, sessionID) {
             // Staging is deliberately KEPT — the resume token points at it (survives an app restart).
             Log("VaultGenerator: ⚠️ usage limit (session \(sessionID ?? "nil")); staging kept for resume — \(message.prefix(160))")
@@ -182,7 +183,8 @@ actor VaultGenerator {
     func generate(
         notes: [CloudNote],
         resume: ResumeToken? = nil,
-        onProgress: @Sendable @escaping (Progress) -> Void = { _ in }
+        onProgress: @Sendable @escaping (Progress) -> Void = { _ in },
+        onLine: (@Sendable (String) -> Void)? = nil
     ) async throws -> Result {
         onProgress(.gathering(notes.count))
         let fm = FileManager.default
@@ -220,7 +222,7 @@ actor VaultGenerator {
 
         Log("VaultGenerator: \(resume == nil ? "starting" : "RESUMING") initial generation — \(notes.count) summaries → \(staging.lastPathComponent)")
 
-        let envelope = try await runCodexInStaging(invocation, staging: staging, onProgress: onProgress)
+        let envelope = try await runCodexInStaging(invocation, staging: staging, onProgress: onProgress, onLine: onLine)
 
         let (notes, folders) = Self.census(of: staging)
         Log("VaultGenerator: codex finished (turns \(envelope.numTurns ?? -1), \(envelope.durationMS ?? -1)ms) — \(notes) notes / \(folders) folders in staging")

--- a/Sentient OS macOS/Views/ProcessingView.swift
+++ b/Sentient OS macOS/Views/ProcessingView.swift
@@ -7,7 +7,9 @@
 //  IterativeRun (synchronous generate() + GPU-wedge recovery — NO streaming) over the selected
 //  connectors, optionally followed by the cloud Gmail leg, and shows a breathing sparkle, an
 //  "Analyzing ___" cycling-gradient title, a glowing progress bar, live verdict counts, and a
-//  "just processed" preview (thumbnail + verdict + title + summary).
+//  "just processed" preview (thumbnail + verdict + title + summary). The real-mode cloud tail
+//  (knowledge base → gift → proactive) streams codex's live play-by-play as a one-line mono
+//  "thought" under the phase line (liveThought — ProactiveCycle's onLine hook).
 //
 //  The ONLY dev/prod difference is `showPrompt`: the dev buttons pass `true`, which adds a left
 //  pane showing the EXACT prompt fed to the model for the item currently on the card. Same engine,
@@ -83,6 +85,11 @@ struct ProcessingView: View {
     /// Phase-appropriate caption under the phase line (nil = none) — the proactive stages get
     /// the "things worth doing" promise; the knowledge-base/welcome phases speak for themselves.
     @State private var prepSubtext: String?
+    /// The cloud tail's live "thought" — codex's latest reasoning/action line (humanized by
+    /// CodexCLI). `pending` updates freely as lines stream in; `shown` is what's actually on
+    /// screen, promoted at a readable cadence so bursts never strobe. Cleared per phase.
+    @State private var thoughtPending: String?
+    @State private var thoughtShown: String?
     @State private var progress = RunProgress()
     @State private var started = false
     @State private var paused = false           // pausable only: frozen at the last item, awaiting Resume
@@ -289,7 +296,8 @@ struct ProcessingView: View {
     }
 
     /// Real-mode tail: the read is done; now we're filing into the knowledge base + preparing the
-    /// proactive suggestions. A calm breathing sparkle with the live phase line.
+    /// proactive suggestions. A calm breathing sparkle, the live phase line, and — once codex
+    /// starts thinking — its live thought stream where the anonymous spinner used to sit.
     private var preparingView: some View {
         VStack(spacing: 22) {
             Image(systemName: "sparkles").font(.system(size: 46))
@@ -301,23 +309,85 @@ struct ProcessingView: View {
                 Text(prepSubtext)
                     .font(.caption).foregroundStyle(.white.opacity(0.4))
             }
-            ProgressView().tint(.white.opacity(0.4)).padding(.top, 2)
+            liveThought.padding(.top, 2)
         }
     }
 
-    /// The quiet expectation-setter under the cloud phases (knowledge base + proactive) — honest
-    /// about the wait, and warmer once the wait is genuinely long (the 10-minute flip).
-    private var patienceLine: some View {
-        Text(patienceLong
-             ? "You've got an incredible knowledge base; still working hard to make it perfect. It's going to take another 15 mins or so."
-             : "This can take around 15 minutes.")
-            .font(.caption).foregroundStyle(.white.opacity(0.35))
-            .multilineTextAlignment(.center)
-            .frame(maxWidth: 440)
-            .task {
-                try? await Task.sleep(for: .seconds(600))
-                withAnimation(.easeInOut(duration: 0.6)) { patienceLong = true }
+    /// The spinner until the first thought lands, then codex's live play-by-play: a tiny
+    /// "THINKING" whisper (so a passing thought never reads as an app statement) over one quiet
+    /// mono line, blur-morphing as thoughts arrive. Fixed-height slot so the layout never jumps;
+    /// the pump task gives the stream a readable cadence.
+    private var liveThought: some View {
+        ZStack {
+            if let thought = thoughtShown {
+                VStack(spacing: 7) {
+                    Text("THINKING").font(.caption2).tracking(1.5)
+                        .foregroundStyle(.white.opacity(0.3))
+                    Text(thought)
+                        .font(.system(size: 11.5, design: .monospaced))
+                        .foregroundStyle(.white.opacity(0.52))
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .frame(maxWidth: 620)
+                        .id(thought)
+                        .transition(.blurReplace)
+                }
+                .transition(.blurReplace)
+            } else {
+                ProgressView().tint(.white.opacity(0.4))
+                    .transition(.blurReplace)
             }
+        }
+        .frame(height: 46)
+        .animation(.easeInOut(duration: 0.55), value: thoughtShown)
+        .task {
+            // Promote the newest streamed line at a readable pace — raw JSONL arrives in bursts
+            // that would strobe the transition into noise. Dedup is free: identical consecutive
+            // lines (codex emits items as both .started and .completed) never trigger a swap.
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(1.4))
+                if thoughtShown != thoughtPending { thoughtShown = thoughtPending }
+            }
+        }
+    }
+
+    /// One streamed codex line → a clean single-line thought (nil = nothing showable). Shell
+    /// commands are dropped outright — "$ /bin/zsh -lc …" is machinery, not narration; reasoning,
+    /// tool calls, and web searches make the cut. The humanized lines can carry markdown bold +
+    /// multi-paragraph reasoning; the ticker wants one quiet line, so markup is stripped and
+    /// paragraphs join with the house "·".
+    private static func thought(_ raw: String) -> String? {
+        guard !raw.hasPrefix("$ ") else { return nil }
+        let flat = raw.replacingOccurrences(of: "**", with: "")
+            .replacingOccurrences(of: "`", with: "")
+            .split(separator: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " · ")
+        return flat.isEmpty ? nil : flat
+    }
+
+    /// The quiet expectation-setter under the cloud phases (knowledge base + proactive) — honest
+    /// about the wait (warmer once it's genuinely long — the 10-minute flip), the one instruction
+    /// that matters (app open, lid up), and the reassurance that the ask is first-run-only: the
+    /// 3am runs wake a lid-shut, plugged-in Mac themselves (the root wake helper).
+    private var patienceLine: some View {
+        VStack(spacing: 7) {
+            Text(patienceLong
+                 ? "You've got an incredible knowledge base; still working hard to make it perfect. It's going to take another 15 mins or so."
+                 : "This can take around 15 minutes.")
+                .font(.callout).foregroundStyle(.white.opacity(0.55))
+            Text("Leave Sentient open and don't shut the lid of your Mac for this initial processing.")
+                .font(.callout).foregroundStyle(.white.opacity(0.6))
+            Text("Future 3 AM knowledge base updates can work even when your Mac's asleep with the lid closed, as long as it's plugged in & Sentient was alive in your menu bar.")
+                .font(.caption).foregroundStyle(.white.opacity(0.35))
+        }
+        .multilineTextAlignment(.center)
+        .frame(maxWidth: 520)
+        .task {
+            try? await Task.sleep(for: .seconds(600))
+            withAnimation(.easeInOut(duration: 0.6)) { patienceLong = true }
+        }
     }
 
     private var completedView: some View {
@@ -519,8 +589,10 @@ struct ProcessingView: View {
         // steps + wipe the summaries — surfacing each phase — then reveal the real cards on the home.
         if fullCycle {
             withAnimation { state = .preparing }
-            let failure = await ProactiveCycle.shared.run { phase in
+            thoughtPending = nil; thoughtShown = nil
+            let failure = await ProactiveCycle.shared.run(progress: { phase in
                 Task { @MainActor in
+                    thoughtPending = nil; thoughtShown = nil         // a new phase, a fresh thought stream
                     switch phase {
                     case .knowledgeBase(let s):
                         prepStatus = s; prepSubtext = nil            // the phase line says it all
@@ -534,7 +606,11 @@ struct ProcessingView: View {
                         break
                     }
                 }
-            }
+            }, onLine: { line in
+                Task { @MainActor in
+                    if let t = Self.thought(line) { thoughtPending = t }
+                }
+            })
             if let failure { withAnimation { state = .failed(failure) }; return }
         }
         withAnimation { state = .completed }


### PR DESCRIPTION
## What

The knowledge-base/proactive 'preparing' phase of the processing takeover now shows codex's live reasoning instead of an anonymous spinner, and the footer sets honest expectations for the first run.

## How

- **Streaming seam:** an optional `onLine` callback threaded through the whole cloud tail — `VaultGenerator` (build + `runCodexInStaging`), `VaultCloud.create/update`, `Proactive` (judge), `ProactiveResearch`, `GiftLetter`, fanned out by `ProactiveCycle.run(progress:onLine:)`. Rides `CodexCLI.run(_:onLine:)`'s existing `humanLine` adapter. Default `nil` everywhere — the 3am scheduler and dev paths are byte-for-byte unaffected.
- **The ticker (`ProcessingView.liveThought`):** spinner until the first thought, then one quiet mono line under a `THINKING` whisper (so reasoning never reads as an app statement). `blurReplace` morphs, 1.4s promotion cadence (bursty JSONL can't strobe), dedup free (started/completed duplicates), reset per phase. Shell `$`-command lines are filtered as noise.
- **Footer:** the patience line bumped to legible callout, plus two new lines — keep Sentient open / lid up for the initial run, and the smaller reassurance that 3 AM updates work lid-shut while plugged in with Sentient in the menu bar.
- **Docs:** Vault Generation (Progress section — retired the stale 'No CLI stream parsing'), Judge (the cycle's onLine seam), Home (takeover ticker + footer).

## Verified

Built clean (isolated DerivedData); ticker verified live on real runs (screenshots in the session) — reasoning, phase resets, and command filtering all exercised against a real codex KB build.