### PR TITLE
Wake helper: system-enforced client code-sign gate (designated requirement)

### DIFF
--- a/Sentient OS macOS/Documentation/Overnight Scheduler (3am Wake).md
+++ b/Sentient OS macOS/Documentation/Overnight Scheduler (3am Wake).md
@@ -49,8 +49,17 @@ code-signing check. Files: `Scheduling/WakeHelper.swift` (root side) · `WakeHel
 - **Stale-wake hygiene:** the helper persists the armed wake spec, cancels it when the app's XPC
   connection drops (quit / crash / force-quit — a Mac with Sentient closed never wakes on a stale
   schedule), and the loop wipes all wakes (`cancelAllWakes`) before arming exactly one.
-- ⚠️ **The code-sign gate is DEBUG-permissive** (allows-and-logs on a failed check so dev testing
-  isn't blocked); Release MUST enforce it — pin the Developer ID team before launch.
+- **The code-sign gate is system-enforced in EVERY config (reworked 2026-07-11):**
+  `conn.setCodeSigningRequirement` armed with the daemon's OWN designated requirement — the app
+  and the helper are the same signed binary, so "signed exactly like me" is airtight AND
+  signer-agnostic (the Developer ID release, a dev's Apple Development build, an OSS self-build,
+  even ad-hoc dev signing). The static identifier+anchor string in
+  `WakeHelperConfig.clientRequirement` survives only as the fallback if self-inspection fails.
+  This replaced a hand-rolled audit-token check whose private `value(forKey: "auditToken")` read
+  came back empty on macOS 26 — every client "failed", DEBUG allowed-and-logged it, and the first
+  Release build would have slammed the door on our own app (field-found 2026-07-11). Debug now
+  exercises the exact gate Release ships. Client-side, `isReachable()` probes log quietly (a
+  missing daemon is an expected state, not an error); real ops keep the loud XPC error line.
 - ⚠️ **Liveness is the ONLY honest status (field-found 2026-07-11).** System Settings' App
   Background Activity toggle boots a disabled daemon OUT of launchd while leaving its plist on
   disk — so every file check reads green on a dead helper (and unprivileged

--- a/Sentient OS macOS/Scheduling/WakeHelper.swift
+++ b/Sentient OS macOS/Scheduling/WakeHelper.swift
@@ -24,7 +24,7 @@ final class WakeHelper: NSObject, WakeHelperProtocol, NSXPCListenerDelegate {
         let listener = NSXPCListener(machServiceName: WakeHelperConfig.machServiceName)
         listener.delegate = helper
         listener.resume()
-        helper.log("listening on \(WakeHelperConfig.machServiceName)")
+        helper.log("listening on \(WakeHelperConfig.machServiceName) · client requirement: \(clientRequirement)")
         RunLoop.current.run()
         fatalError("wake helper run loop exited")
     }
@@ -37,16 +37,35 @@ final class WakeHelper: NSObject, WakeHelperProtocol, NSXPCListenerDelegate {
 
     // MARK: - NSXPCListenerDelegate
 
-    func listener(_ listener: NSXPCListener, shouldAcceptNewConnection conn: NSXPCConnection) -> Bool {
-        let trusted = isClientTrusted(conn)
-        log("connection from pid \(conn.processIdentifier): codesign check \(trusted ? "PASSED" : "FAILED")")
-        if !trusted {
-            #if DEBUG
-            log("DEBUG build: allowing despite failed check (verify the codesign gate before Release).")
-            #else
-            return false
-            #endif
+    /// The requirement a connecting client must satisfy: this daemon's OWN designated
+    /// requirement — the app and the daemon are the same signed binary, so "signed exactly like
+    /// me" is airtight AND signer-agnostic (holds for the Developer ID release, a dev's Apple
+    /// Development build, and an OSS self-build alike; even ad-hoc dev signing works, its DR
+    /// being the shared binary's cdhash). Falls back to the static identifier+anchor requirement
+    /// if self-inspection somehow fails. Computed once; both sources are valid requirement
+    /// strings by construction (setCodeSigningRequirement raises on a malformed one).
+    private static let clientRequirement: String = {
+        var code: SecCode?
+        var staticCode: SecStaticCode?
+        var requirement: SecRequirement?
+        var text: CFString?
+        if SecCodeCopySelf([], &code) == errSecSuccess, let code,
+           SecCodeCopyStaticCode(code, [], &staticCode) == errSecSuccess, let staticCode,
+           SecCodeCopyDesignatedRequirement(staticCode, [], &requirement) == errSecSuccess, let requirement,
+           SecRequirementCopyString(requirement, [], &text) == errSecSuccess, let text {
+            return text as String
         }
+        return WakeHelperConfig.clientRequirement
+    }()
+
+    func listener(_ listener: NSXPCListener, shouldAcceptNewConnection conn: NSXPCConnection) -> Bool {
+        // The client gate, enforced by the SYSTEM per message via the official API (macOS 13+).
+        // This replaced a hand-rolled audit-token check whose private `value(forKey: "auditToken")`
+        // read came back empty on macOS 26 — every client "failed", DEBUG allowed-and-logged it,
+        // and the first Release build slammed the door on our own app (field-found 2026-07-11).
+        // Enforced in ALL configs now, so Debug exercises the same gate Release ships.
+        conn.setCodeSigningRequirement(Self.clientRequirement)
+        log("connection from pid \(conn.processIdentifier): accepted (code-sign requirement armed)")
         conn.exportedInterface = NSXPCInterface(with: WakeHelperProtocol.self)
         conn.exportedObject = self
         conn.invalidationHandler = { [weak self] in
@@ -173,19 +192,6 @@ final class WakeHelper: NSObject, WakeHelperProtocol, NSXPCListenerDelegate {
     private func loadArmed() -> String? {
         (try? String(contentsOf: URL(fileURLWithPath: Self.armedFile), encoding: .utf8))?
             .trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    /// Verifies the connecting process is our signed app via its audit token (PID is racy).
-    private func isClientTrusted(_ conn: NSXPCConnection) -> Bool {
-        guard let tokenData = conn.value(forKey: "auditToken") as? Data,
-              tokenData.count == MemoryLayout<audit_token_t>.size else { return false }
-        let attrs = [kSecGuestAttributeAudit: tokenData] as CFDictionary
-        var code: SecCode?
-        guard SecCodeCopyGuestWithAttributes(nil, attrs, [], &code) == errSecSuccess, let code else { return false }
-        var req: SecRequirement?
-        guard SecRequirementCreateWithString(WakeHelperConfig.clientRequirement as CFString, [], &req) == errSecSuccess,
-              let req else { return false }
-        return SecCodeCheckValidity(code, [], req) == errSecSuccess
     }
 
     /// Root-side diagnostics. Goes to a root-writable log + stderr (visible in Console.app).

--- a/Sentient OS macOS/Scheduling/WakeHelperClient.swift
+++ b/Sentient OS macOS/Scheduling/WakeHelperClient.swift
@@ -63,8 +63,9 @@ final class WakeHelperClient {
     /// mach service). Probes with `heartbeat`, the one op harmless in every state: mid-run it's
     /// exactly what the app already sends every 60s; idle it arms a deadman whose firing is a
     /// no-op (disablesleep is already 0). A booted-out service invalidates immediately, so the
-    /// false case answers in milliseconds.
-    func isReachable() async -> Bool { await heartbeat() }
+    /// false case answers in milliseconds. Quiet on purpose: a miss here is an EXPECTED state
+    /// (not installed / toggled off), not an error worth a scary log line — real ops keep theirs.
+    func isReachable() async -> Bool { await call(quiet: true) { $0.heartbeat(withReply: $1) } }
 
     /// The user-facing daemon verdict, shared by Settings → Health and onboarding's permissions
     /// step. ready = answers over XPC · disabled = unreachable with the files all correct (the
@@ -102,13 +103,17 @@ final class WakeHelperClient {
 
     /// Every call is guarded three ways so it can NEVER hang at 3am: the reply block, the XPC
     /// error handler (fires if the helper is unreachable), and a 30s timeout — all resume-once.
-    private func call(_ body: @escaping (WakeHelperProtocol, @escaping (Bool) -> Void) -> Void) async -> Bool {
+    /// `quiet` softens the error line for probes, where a miss is an expected state, not a fault.
+    private func call(quiet: Bool = false,
+                      _ body: @escaping (WakeHelperProtocol, @escaping (Bool) -> Void) -> Void) async -> Bool {
         let connection = conn()
         return await withCheckedContinuation { cont in
             let once = Once { cont.resume(returning: $0) }
             DispatchQueue.global().asyncAfter(deadline: .now() + 30) { once.fire(false) }
             guard let proxy = connection.remoteObjectProxyWithErrorHandler({ err in
-                Log("WakeHelper XPC error: \(err)"); once.fire(false)
+                if quiet { Log("WakeHelper probe: no daemon answering") }
+                else { Log("WakeHelper XPC error: \(err)") }
+                once.fire(false)
             }) as? WakeHelperProtocol else { once.fire(false); return }
             body(proxy) { ok in once.fire(ok) }
         }

--- a/Sentient OS macOS/Scheduling/WakeHelperProtocol.swift
+++ b/Sentient OS macOS/Scheduling/WakeHelperProtocol.swift
@@ -37,7 +37,9 @@ enum WakeHelperConfig {
     static let daemonPlistName = "jesai.Sentient-OS-macOS.WakeHelper.plist"
     /// CLI flag that puts the shared binary into root helper mode.
     static let helperFlag = "--wake-helper"
-    /// Code-signing requirement a client must satisfy to talk to the root helper. Bundle id +
-    /// Apple anchor blocks arbitrary/other code; pin the Developer ID team for Release hardening.
+    /// FALLBACK code-signing requirement for the helper's client gate. The primary gate is the
+    /// daemon's OWN designated requirement ("signed exactly like me" — `WakeHelper.clientRequirement`,
+    /// enforced by the system via `setCodeSigningRequirement`); this static string steps in only
+    /// if self-inspection fails. Bundle id + Apple anchor blocks arbitrary/other code.
     static let clientRequirement = "anchor apple generic and identifier \"jesai.Sentient-OS-macOS\""
 }


### PR DESCRIPTION
## What

The root wake helper's client gate is now the real thing: `conn.setCodeSigningRequirement` armed with the daemon's OWN designated requirement ("signed exactly like me"), enforced by the system per message, in EVERY build config.

## Why

The old hand-rolled audit-token check read the private `value(forKey: "auditToken")`, which comes back empty on macOS 26 — so every client "failed" the check, DEBUG allowed-and-logged it, and the first Release build would have slammed the door on our own app (field-found 2026-07-11).

## How

- The requirement is computed once from the helper's own code signature (`SecCodeCopyDesignatedRequirement`) — signer-agnostic by construction: Developer ID release, Apple Development dev builds, OSS self-builds, even ad-hoc signing (its DR is the shared binary's cdhash). The static identifier+anchor string in `WakeHelperConfig` survives only as a fallback if self-inspection fails.
- Debug now exercises the exact gate Release ships (the DEBUG allow-and-log path is gone).
- Client side: `isReachable()` probes log quietly — an unreachable daemon is an expected state (not installed / toggled off), not an error; real ops keep the loud XPC error line.
- `Overnight Scheduler (3am Wake).md` updated: the ⚠️ DEBUG-permissive warning bullet is retired and replaced with the new gate's description.

## Verified

Field-found and fixed live 2026-07-11; compiles clean in every isolated verify build run since (the changes rode the working tree through all of today's builds).