### PR TITLE
Forbid computer use in the proactive prepare stage (prompt guard)

### DIFF
--- a/Sentient OS macOS/Documentation/Proactive Intelligence (Judge).md
+++ b/Sentient OS macOS/Documentation/Proactive Intelligence (Judge).md
@@ -108,12 +108,18 @@ things **in one read-only pass** — verify then stage:
 2. **PREPARE** every survivor **ready to fire** — draft it in the user's voice (`prepared_content`) +
    write the routing-only `execution_recipe` PART 3 runs.
 
-Two inviolable rules, enforced in the prompt AND the invocation:
+Three inviolable rules, enforced in the prompt AND the invocation:
 - **Accuracy / anti-hallucination** — receipts-only (state a live fact only if a tool returned it this
   run), mandatory identity-match for any external fact, "couldn't confirm" → `status: unverified` as a
   valid outcome. Verify-only on discovery (never invents a new item — that's PART 1).
 - **Never fires** — it stages but never sends/submits/pays/RSVPs. `bypassApprovals = false` + sandbox
   means a connector WRITE (e.g. Gmail `send_email`) would auto-cancel headless anyway.
+- **Never computer use** — verification never drives the Mac, its apps, or its browser; Gmail MCP +
+  web + vault are the ONLY surfaces. Needed because `includeUserConfig = true` (for the Gmail MCP)
+  also rides the computer-use skill along from `~/.codex` — the sandbox stops writes, but nothing else
+  stopped a "let me just look at the screen to verify" detour. Computer use belongs solely to PART 3,
+  on the user's press, and only when the card's method calls for it (research cards fire nothing). The
+  judge's prompt carries a matching line for symmetry, though its hermetic call has no tools anyway.
 
 Research surfaces (all read-only): the **full last-week summary corpus** (the SAME window PART 1 saw,
 as background context), the **knowledge base** (`cwd` — identity anchor + the user's **voice** + the

--- a/Sentient OS macOS/Proactive/Proactive.swift
+++ b/Sentient OS macOS/Proactive/Proactive.swift
@@ -272,7 +272,9 @@ actor Proactive {
         step runs AFTER you and verifies each item you pick against the live sources (Gmail, the web) \
         and the user's knowledge base — correcting details and dropping anything already done. So you \
         do NOT need to be perfectly certain or fully grounded here; that's handled next. But you must \
-        NOT pad: only the genuinely strongest candidates earn a slot.
+        NOT pad: only the genuinely strongest candidates earn a slot. And you must NEVER use computer \
+        use (or any other tool) to verify anything — you judge from the summaries alone; acting on \
+        the user's Mac belongs only to a later step the user explicitly fires.
 
         ## YOUR INPUT: the last 7 days of summaries
         The last \(lookbackDays) days of summaries (at the end of this message) are your ONLY input, \

--- a/Sentient OS macOS/Proactive/ProactiveResearch.swift
+++ b/Sentient OS macOS/Proactive/ProactiveResearch.swift
@@ -316,7 +316,7 @@ actor ProactiveResearch {
 
         Today is \(today).
         \(Proactive.instructionsBlock)
-        ## TWO INVIOLABLE RULES
+        ## THREE INVIOLABLE RULES
         **1 — Total accuracy, ZERO fabrication.** The user will ACT on what you produce, so a confident \
         wrong answer is catastrophic, far worse than admitting uncertainty.
         - **Receipts only.** State a fact about the live world ONLY if a tool you actually called this \
@@ -334,6 +334,12 @@ actor ProactiveResearch {
         the irreversible action: never send an email or message, submit a form, pay, RSVP, book, post, \
         or confirm anything. Every outward action waits for the user's explicit press in PART 3. If you \
         feel the pull to "just send it to be helpful" — do not. Staging it perfectly IS the job.
+
+        **3 — You must NOT use computer use, for ANYTHING — not even to verify.** Never drive the \
+        user's Mac, its apps, or its browser. Feel free to use the Gmail MCP and web search, but you — \
+        the card-preparation worker — must NEVER invoke computer use yourself. You are only PREPARING \
+        actions so that a future codex run (PART 3, on the user's press) may, if the action calls for \
+        it, use computer use to carry them out; that step is not you.
 
         ## YOUR SURFACES (all READ-ONLY — you only gather, never act)
         You ALSO have the **full last-week summary corpus** (at the end of this message — the same \


### PR DESCRIPTION
## What
The proactive research/prepare worker (PART 2) could use computer use to "verify" items — its codex call loads the user config for the Gmail MCP, which also rides the computer-use skill along from `~/.codex`. The read-only sandbox stops connector writes, but nothing forbade a screen-driving verify detour.

## Changes
- **`ProactiveResearch.swift`** — the prompt's inviolable rules go from two to THREE: rule 3 forbids computer use outright (Gmail MCP + web + vault stay fair game); PART 2 only *prepares* so PART 3, on the user's press, may use computer use if the card's method calls for it (research cards fire nothing).
- **`Proactive.swift`** — the judge gets a matching "never computer use, judge from summaries alone" line for symmetry (its call is hermetic/tool-free anyway).
- **`Documentation/Proactive Intelligence (Judge).md`** — updated to the three inviolable rules, with the why.

Both Swift files pass `swiftc -parse`; prompt-string-only change, no logic touched.