### PR TITLE
Sentry curation: plug the mirror-password leak, report only real defects

### DIFF
--- a/Sentient OS macOS/Cloud/CodexCLI.swift
+++ b/Sentient OS macOS/Cloud/CodexCLI.swift
@@ -305,10 +305,14 @@ actor CodexCLI {
         do {
             return try await runInner(invocation, onLine: onLine)
         } catch {
-            Self.emitCodexFailure(event: "codex.failure", error, feature: invocation.feature,
-                                  model: invocation.model, effort: invocation.effort,
-                                  resumed: invocation.resumeSessionID != nil,
-                                  durationMS: Int(Date().timeIntervalSince(t0) * 1000))
+            // A cancelled Task is the user's STOP: the SIGTERM'd process exits non-zero, which
+            // masqueraded as a real exitFailure in Sentry (field-found 2026-07-12). Not a defect.
+            if !Task.isCancelled {
+                Self.emitCodexFailure(event: "codex.failure", error, feature: invocation.feature,
+                                      model: invocation.model, effort: invocation.effort,
+                                      resumed: invocation.resumeSessionID != nil,
+                                      durationMS: Int(Date().timeIntervalSince(t0) * 1000))
+            }
             throw error
         }
     }
@@ -379,10 +383,14 @@ actor CodexCLI {
             }
             return out.stdout.isEmpty ? out.stderr : out.stdout
         } catch {
-            // §7.9: computer-use runs are the highest-risk executions (bypass-sandbox). Case name only.
-            Self.emitCodexFailure(event: "codex.agent_command", error, feature: "computer",
-                                  model: .gpt56sol, effort: .low, resumed: false,
-                                  durationMS: Int(Date().timeIntervalSince(t0) * 1000))
+            // §7.9: computer-use runs are the highest-risk executions (bypass-sandbox). Case name
+            // only — and never on a cancelled Task (the user's STOP kills codex → non-zero exit,
+            // which is not a failure; field-found polluting Sentry 2026-07-12).
+            if !Task.isCancelled {
+                Self.emitCodexFailure(event: "codex.agent_command", error, feature: "computer",
+                                      model: .gpt56sol, effort: .low, resumed: false,
+                                      durationMS: Int(Date().timeIntervalSince(t0) * 1000))
+            }
             throw error
         }
     }
@@ -394,7 +402,7 @@ actor CodexCLI {
         let caseName: String
         let level: CrashReporting.DiagLevel
         switch error {
-        case CLIError.usageLimit:   (caseName, level) = ("usageLimit", .info)      // expected, not a defect
+        case CLIError.usageLimit:   return   // expected, not a defect — the amber caution + resume own it
         case CLIError.notAvailable: (caseName, level) = ("notAvailable", .warning)
         case CLIError.timedOut:     (caseName, level) = ("timedOut", .warning)
         case CLIError.launchFailed: (caseName, level) = ("launchFailed", .error)

--- a/Sentient OS macOS/Cloud/CodexSetup.swift
+++ b/Sentient OS macOS/Cloud/CodexSetup.swift
@@ -108,7 +108,11 @@ final class CodexSetup {
         loginProcess?.terminate()          // kill any stale attempt before re-opening
         loginProcess = nil
         do {
-            loginProcess = try CodexCLI.startLogin { line in Log("[codex-login] \(line)") }
+            // URLs elided from the stream: the login flow prints the OAuth auth URL (PKCE/state
+            // params), and every Log() line ships as a Release breadcrumb.
+            loginProcess = try CodexCLI.startLogin { line in
+                Log("[codex-login] \(line.contains("://") ? "<url elided>" : line)")
+            }
             loggingIn = true
             // UI-neutral on purpose: onboarding and Settings → Health both auto-notice the
             // finished sign-in (no confirm button); only the dev sheet still has one.

--- a/Sentient OS macOS/Diagnostics/CrashReporting.swift
+++ b/Sentient OS macOS/Diagnostics/CrashReporting.swift
@@ -101,23 +101,35 @@ enum CrashReporting {
         SentrySDK.start { options in
             options.dsn = dsn
 
-            // Crashes: native signals + unhandled NSExceptions, with the full stack on every event.
+            // Crashes: native signals + uncaught NSExceptions, with the full stack on every event.
+            // ⚠️ NSException reporting DEFAULTS OFF on macOS (unlike iOS) — without the explicit
+            // flag a whole class of AppKit/ObjC crashes never reached Sentry (found 2026-07-12).
             options.attachStacktrace = true
             options.enableCrashHandler = true
+            options.enableUncaughtNSExceptionReporting = true
 
-            // Performance: trace + profile everything — a single-user desktop app, so 100% is cheap.
-            options.tracesSampleRate = 1.0
-            options.configureProfiling = {
-                $0.sessionSampleRate = 1.0
-                $0.lifecycle = .trace
-            }
+            // No APM: tracing/profiling stays at the OFF default. The SDK's auto transactions
+            // never fire on a macOS SwiftUI app (measured: 0 ingested over the whole beta) — the
+            // old 100% traces+profiling config was dead weight. Sentry is the smoke detector;
+            // durations live in TelemetryDeck.
 
-            // App-hang ("beachball") detection. Auto session tracking is deliberately OFF: release-
-            // health sessions are a "how many people use Sentient" signal, and ALL usage counting
-            // belongs to the ANALYTICS toggle (TelemetryDeck), never the crash toggle. So a user who
-            // keeps crash reports on but opts OUT of analytics is never counted here.
-            options.enableAutoSessionTracking = false
+            // App-hang ("beachball") detection at 10s — NOT the SDK's 2s default: onboarding and
+            // codex-install legs stall the main thread for a beat routinely, and 2s pages us with
+            // unactionable noise (field-proven by the beta wave, 2026-07-12). Only a real freeze
+            // should report. Auto session tracking is deliberately OFF: release-health sessions
+            // are a "how many people use Sentient" signal, and ALL usage counting belongs to the
+            // ANALYTICS toggle (TelemetryDeck), never the crash toggle.
             options.enableAppHangTracking = true
+            options.appHangTimeoutInterval = 10
+            options.enableAutoSessionTracking = false
+
+            // ⚠️ The SDK's URL-capturing defaults are a LEAK VECTOR and must stay OFF: network
+            // breadcrumbs and failed-request capture both record full request URLs — and the MCP
+            // mirror's URL carries the user's mirror password in its path (the §8 invariant:
+            // request paths must NEVER be logged; found leaking via these defaults 2026-07-12).
+            // The beforeBreadcrumb data scrub below is the backstop, not the defense.
+            options.enableNetworkBreadcrumbs = false
+            options.enableCaptureFailedRequests = false
 
             options.environment = "release"
 
@@ -126,6 +138,12 @@ enum CrashReporting {
             options.beforeSend = { event in scrub(event) }
             options.beforeBreadcrumb = { crumb in
                 crumb.message = crumb.message.map(scrub(text:))
+                // SDK-authored crumbs carry their payload in `data`, not `message` (URLs live
+                // here) — it never met the scrubber before, which is how the mirror password
+                // leaked. Scrub every string value as the backstop.
+                if let data = crumb.data {
+                    crumb.data = data.mapValues { ($0 as? String).map(scrub(text:)) ?? $0 }
+                }
                 return crumb
             }
         }
@@ -238,6 +256,10 @@ enum CrashReporting {
         func re(_ p: String) -> NSRegularExpression { try! NSRegularExpression(pattern: p) }
         return [
             (re("/Users/[^/\\s\"']+"), "/Users/<redacted>"),                 // home-dir paths
+            // The mirror password's URL path segment (/u_<id>/p_<password>/…) — the §8 invariant.
+            // Network breadcrumbs are off, but ANY future surface that logs the share URL is
+            // covered here by construction.
+            (re("/p_[A-Za-z0-9_\\-]{8,}"), "/p_<redacted>"),
             (re("[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"), "<email>"),
             (re("\\+?\\d[\\d ()\\-]{7,}\\d"), "<phone>"),                     // 9+ digit runs w/ separators
             // Long tokens / base64 blobs — but ONLY high-entropy runs (≥1 uppercase or digit). This

--- a/Sentient OS macOS/Diagnostics/ExecutorScoreboard.swift
+++ b/Sentient OS macOS/Diagnostics/ExecutorScoreboard.swift
@@ -4,11 +4,13 @@
 //
 //  The health metric for the flagship feature — AI that DOES things (§7.19). One sink, fed from
 //  ProactiveExecutor.fire() (the proactive cards) and CommandRunModel.complete() (the command bar /
-//  voice), records the outcome of every executed action so the Sentry dashboard can answer "how
-//  often does computer-use / Gmail-send actually work?".
+//  voice). Sentry sees DEFECTS only — failures, refusals, dead fire buttons, and unverifiable
+//  "fired" claims (no STATUS sentinel). Verified successes are USAGE, and usage lives in
+//  TelemetryDeck (ComputerUse.finished / Proactive.actionFired), never the crash feed — Sentry
+//  turned every success into an "issue" and buried the real errors (field-found 2026-07-12).
 //
-//  ⚠️ `fired` means codex CLAIMED it finished — NOT verified completion. The dashboard reads it as
-//  "claimed done"; true end-to-end verification (did the email actually leave?) is a separate problem.
+//  ⚠️ `fired` means codex CLAIMED it finished — NOT verified completion. True end-to-end
+//  verification (did the email actually leave?) is a separate problem.
 //  Structure only — method/source/outcome/duration, never the draft, recipients, or codex output.
 //
 
@@ -21,15 +23,16 @@ enum ExecutorScoreboard {
 
     static func record(method: String, source: String, outcome: Outcome,
                        durationS: Double, statusPresent: Bool = true, errorClass: String? = nil) {
-        let level: CrashReporting.DiagLevel = (outcome == .failed || outcome == .refused) ? .warning : .info
+        // A verified success is not a defect — TelemetryDeck counts it; Sentry stays quiet. A
+        // "fired" WITHOUT the STATUS sentinel still reports: that's the false-success RISK the
+        // sentinel exists to measure.
+        guard outcome != .fired || !statusPresent else { return }
         var extra: [String: String] = [
             "duration_s": String(format: "%.1f", durationS),
-            // false = codex omitted the STATUS sentinel → we can't confirm it, so "fired" here is a
-            // false-success RISK. Tracking this rate is the whole point of the sentinel.
             "status_present": String(statusPresent),
         ]
         if let errorClass { extra["error_class"] = errorClass }
-        CrashReporting.captureEvent("executor.fire", level: level,
+        CrashReporting.captureEvent("executor.fire", level: .warning,
             tags: ["method": method, "source": source, "outcome": outcome.rawValue],
             extra: extra, fingerprint: ["executor", "fire", method, outcome.rawValue])
     }

--- a/Sentient OS macOS/Diagnostics/Log.swift
+++ b/Sentient OS macOS/Diagnostics/Log.swift
@@ -21,6 +21,25 @@ func Log(_ items: Any..., separator: String = " ", terminator: String = "\n") {
     #endif
 }
 
+/// Content-safe error rendering for `Log()` error paths. In RELEASE it yields the enum case /
+/// type name only ("CLIError.exitFailure", "CocoaError(NSCocoaErrorDomain 512)") — never the
+/// description, because error payloads embed content (CLIError carries up to 300 chars of codex
+/// stderr; Cocoa file errors carry note titles in paths) and every Log() line ships to Sentry as
+/// a Release breadcrumb. DEBUG builds return the full description (the dev log wants the meat;
+/// Sentry never boots in DEBUG).
+func ErrorLabel(_ error: Error) -> String {
+    #if DEBUG
+    return "\(error)"
+    #else
+    let mirror = Mirror(reflecting: error)
+    if mirror.displayStyle == .enum, let caseName = mirror.children.first?.label {
+        return "\(type(of: error)).\(caseName)"
+    }
+    let ns = error as NSError
+    return "\(type(of: error))(\(ns.domain) \(ns.code))"
+    #endif
+}
+
 #if DEBUG
 /// Serial appender for /tmp/sentient-dev.log. All writes funnel through one queue,
 /// so calls are safe from any thread or actor.

--- a/Sentient OS macOS/Documentation/Crash Reporting (Sentry).md
+++ b/Sentient OS macOS/Documentation/Crash Reporting (Sentry).md
@@ -1,10 +1,11 @@
 # Crash Reporting (Sentry)
 
 `CrashReporting.swift` wires the app to [Sentry](https://sentry.io) so we get crash logs,
-unhandled errors, and performance/profiling from real runs. It's the "black box" for diagnosing
-a crash we can't reproduce — including a crash during the root overnight run, when nobody's
-watching. Runtime reporting needs only the DSN (already in the code); readable production stack
-traces additionally need the Release dSYM-upload build phase (below).
+unhandled errors, and app-hangs from real runs. It's the "black box" for diagnosing a crash we
+can't reproduce — including a crash during the root overnight run, when nobody's watching. Runtime
+reporting needs only the DSN (already in the code); readable production stack traces additionally
+need the Release dSYM-upload build phase (below). Sentry is the smoke detector, NOT an APM: there
+is no performance tracing or profiling (see the options note below).
 
 ## How it boots
 
@@ -25,18 +26,33 @@ if CommandLine.arguments.contains(WakeHelperConfig.helperFlag) {
 Each role tags every event with `process: app` or `process: wakeHelper`, so a 3am overnight-run
 crash is told apart from a UI crash in the dashboard.
 
-`start(_:)` boots Sentry with the crash surface on: native crash handler + attached stack traces,
-app-hang ("beachball") detection, 100% trace sampling, and trace-lifecycle profiling. It's
-idempotent (guarded by `started`), a no-op if the DSN is blank, and — the two hard gates — a no-op
-in DEBUG and whenever the `diagnosticsEnabled` opt-out is off (the full gate story:
+`start(_:)` boots Sentry with the crash surface on — and only the crash surface (curated
+2026-07-12):
+
+- **Native crash handler + attached stack traces**, PLUS `enableUncaughtNSExceptionReporting =
+  true` — ⚠️ that flag **defaults OFF on macOS** (unlike iOS), so without it a whole class of
+  AppKit/ObjC crashes silently never reports.
+- **App-hang ("beachball") detection at 10s** (`appHangTimeoutInterval = 10`, not the SDK's 2s
+  default — 2s paged us for harmless onboarding/codex-install stalls all through the beta).
+- **No tracing, no profiling.** The old 100%-traces + profiling config never produced a single
+  ingested transaction (the SDK's auto-instrumentation is UIKit-shaped; macOS SwiftUI generates
+  none) — deleted as dead weight.
+- **⚠️ `enableNetworkBreadcrumbs = false` and `enableCaptureFailedRequests = false` — a LEAK
+  GUARD, never re-enable.** Both SDK defaults record full request URLs, and the MCP mirror URL
+  carries the user's mirror password in its path (§8's "request paths must NEVER be logged").
+  Found leaking a real password into stored events on 2026-07-12; the events were deleted and
+  both flags forced off. The `beforeBreadcrumb` scrub of `crumb.data` is the backstop only.
+
+It's idempotent (guarded by `started`), a no-op if the DSN is blank, and — the two hard gates — a
+no-op in DEBUG and whenever the `diagnosticsEnabled` opt-out is off (the full gate story:
 `Diagnostics (Sentry).md`).
 
 ⚠️ **Auto session tracking is deliberately OFF** (`enableAutoSessionTracking = false`). Release-
 health sessions are a "how many people use Sentient" signal, and **all** usage counting belongs to
 the *analytics* toggle (TelemetryDeck), never the *crash* toggle. If it were on, a user who keeps
 crash reports on but opts OUT of analytics would still be counted here — which would break the
-promise the analytics toggle makes. Sentry therefore reports crashes, errors, hangs, and traces
-only; user/session counting lives solely in `Analytics.swift`. (This costs us Sentry's crash-free-
+promise the analytics toggle makes. Sentry therefore reports crashes, errors, and hangs only;
+user/session counting lives solely in `Analytics.swift`. (This costs us Sentry's crash-free-
 session % — TelemetryDeck's counts plus crash volume cover it.)
 
 ## The DSN — safe in the code
@@ -54,6 +70,15 @@ handled by Sentry's inbound filters + rate limits, and the DSN rotates in one cl
 
 Every `Log()` call (Log.swift) also feeds a Sentry breadcrumb, so a crash report arrives carrying
 the recent log trail that led to it. No-op until Sentry has started.
+
+**⚠️ That means every non-`#if DEBUG` `Log()` line SHIPS in Release.** Two rules keep the trail
+content-free:
+- Content-bearing logs (prompts, transcripts, codex output, proactive dumps) are `#if DEBUG`.
+- Error paths use **`ErrorLabel(error)`** (Log.swift), never `\(error)` or
+  `error.localizedDescription`: in Release it renders the enum case / type name only
+  ("CLIError.exitFailure"), in DEBUG the full description. Raw interpolation leaked codex stderr
+  (which embeds Gmail/calendar/screen content) and note titles through ~22 error logs until the
+  2026-07-12 sweep — don't reintroduce.
 
 ## Verifying the pipeline
 
@@ -86,6 +111,14 @@ automatically — **Release only** (Debug has symbols locally; the phase skips w
 - The phase **fails safe**: every guard exits 0, so a missing token, missing `sentry-cli`, or a
   failed upload never breaks the build — Debug builds, OSS clones, and CI without the config just
   skip it.
+- ⚠️ **Fail-safe cuts both ways — the phase fails SILENTLY.** Field lesson (2026-07-12): the first
+  beta DMG shipped with no dSYM on Sentry — it was built on a Mac whose gitignored `.sentryclirc`
+  didn't exist, and the other Mac's copy held a dead (revoked) token — so every beta crash/hang
+  arrived unsymbolicated ("Processing Error" badge, `<redacted>` frames). **Both dev Macs need a
+  current `.sentryclirc` at the repo root** (hand-copy it — AirDrop/Signal, never commit), and
+  after any Release/Archive build it's worth glancing at the build log for the
+  "Sentry: uploading dSYMs" line. A missed build can be repaired after the fact:
+  `sentry-cli debug-files upload --include-sources <archive>.xcarchive/dSYMs`.
 
 Build settings already cooperate: Release is `dwarf-with-dsym`, Debug is `dwarf` (no dSYM, fast),
 and user script sandboxing is off so the upload script can reach the network.

--- a/Sentient OS macOS/Documentation/Diagnostics (Sentry).md
+++ b/Sentient OS macOS/Documentation/Diagnostics (Sentry).md
@@ -13,6 +13,11 @@ Verified end-to-end on real hardware (2026-07-02/03): a **Release** build delive
 type below to Sentry — confirmed via the Sentry API — including a real native crash (`EXC_BREAKPOINT`,
 symbolicated) and an app-hang.
 
+**Curated 2026-07-12 (the first beta wave):** Sentry now reports **defects only**. Telemetry-shaped
+events moved to TelemetryDeck, user STOPs and usage limits no longer report, app-hangs report at
+10s (not 2s), uncaught-NSException reporting is on, and the SDK's URL-capturing defaults are OFF
+after they were caught leaking a mirror password (§2.5). Sections below reflect the curated state.
+
 ---
 
 ## 1. The two gates — nothing reaches Sentry unless BOTH pass
@@ -53,16 +58,39 @@ Two defenses:
 - **Clean at the source (primary).** `captureEvent` only ever takes enums/counts/strings the caller
   controls. Content-bearing `Log()` lines (proactive drafts, command transcripts, codex output) were
   scrubbed in B7: the verbose ones are `#if DEBUG` (Sentry is Release-only, so DEBUG-only can never
-  breadcrumb), and success logs were reduced to lengths.
+  breadcrumb), and success logs were reduced to lengths. **Error paths use `ErrorLabel(error)`
+  (Log.swift), never `\(error)` / `localizedDescription`** — in Release it renders the enum case /
+  type name only. Raw interpolation shipped codex stderr (`CLIError`'s description embeds up to
+  300 chars of it — Gmail/calendar/screen content), note titles (Cocoa file errors carry the path),
+  and the mirror server's response body through ~22 error logs until the 2026-07-12 sweep.
 - **`beforeSend` / `beforeBreadcrumb` scrubber (backstop).** A pure closure set in `boot()` that
   redacts free text on outgoing events + `Log()`-fed breadcrumbs: home-dir paths → `/Users/<redacted>`,
-  emails → `<email>`, phone runs → `<phone>`, and **high-entropy** long tokens → `<token>`.
+  the mirror password path segment `/p_…` → `/p_<redacted>`, emails → `<email>`, phone runs →
+  `<phone>`, and **high-entropy** long tokens → `<token>`. Since 2026-07-12 the breadcrumb scrub
+  also walks `crumb.data` string values (SDK-authored crumbs carry their payload there, not in
+  `message` — see §2.5).
   ⚠️ The token rule requires ≥1 uppercase/digit on purpose — a plain `{24,}` rule wrongly redacted our
   own snake_case event names (`zero_sessions_despite_install` → `<token>`); real tokens/hashes always
   carry entropy. (Caught + fixed during the Release verification.)
 
-> The scrubber covers **message / exception / breadcrumb** text — NOT `extra`/`tags` (those are
-> structure-only by contract). So never put free text in `extra`/`tags`.
+> The scrubber covers **message / exception / breadcrumb** text + breadcrumb `data` strings — NOT
+> `extra`/`tags` (those are structure-only by contract). So never put free text in `extra`/`tags`.
+
+---
+
+## 2.5 The SDK's own defaults are part of the firewall (war story)
+
+The sentry-cocoa SDK ships with **URL-capturing features ON by default**: network breadcrumbs
+(every URLSession request → a crumb with the full `url` + `http.query` in `crumb.data`) and
+failed-request capture (any HTTP 5xx from ANY URL → its own event with request details). The MCP
+mirror's URL carries the user's **mirror password in its path** — the §8 invariant ("request paths
+must NEVER be logged") that was already enforced server-side (uvicorn access log) was silently
+re-broken client-side by these defaults: on 2026-07-12 a real, complete mirror password was found
+in stored Sentry breadcrumbs (a `/u_…/p_…/vault` push URL). The poisoned events were deleted, and
+`boot()` now forces **`enableNetworkBreadcrumbs = false`** and
+**`enableCaptureFailedRequests = false`** — never re-enable either. The `crumb.data` scrub (§2) is
+the backstop, not the defense. Lesson: **when the SDK updates, re-check what its new defaults
+capture.**
 
 ---
 
@@ -87,7 +115,10 @@ off-main with no `await`.
 
 ## 4. The event catalog (everything that's wired today)
 
-Native **crashes** + **app-hangs** are automatic via the SDK. The structured events:
+Native **crashes** (signals + uncaught NSExceptions — the latter needs
+`enableUncaughtNSExceptionReporting = true`, which defaults OFF on macOS) + **app-hangs at 10s**
+are automatic via the SDK. The structured events (defects only — telemetry-shaped events live in
+TelemetryDeck since 2026-07-12):
 
 | Event | Emitted from | Fires when | Key fields | Level |
 |---|---|---|---|---|
@@ -100,22 +131,28 @@ Native **crashes** + **app-hangs** are automatic via the SDK. The structured eve
 | `files.extraction_degraded` | `SourceHealth` (rolling) | PDF/Word/txt extraction rate <50% over a week window (≥30) | `attempts`, `success_pct` | warning |
 | `db.schema_error` | `SQLiteDB` | any `prepare` fails — our SQL is static, so this = a column rename (all 4 DB sources) | `db`, `msg` (sqlite3_errmsg) | error |
 | `gmail.parse.shape_mismatch` / `calendar.parse.shape_mismatch` | `GmailConnect` / `CalendarConnect` | the cloud reply's JSON won't parse or the required `notable` key is absent (vs a genuine quiet week) | `source`, `missing` | warning |
-| `codex.failure` | `CodexCLI.run` | any codex call fails | `feature`, `error` (CLIError case), `model`, `effort`, `duration_ms`, `resumed` | error (usageLimit → info) |
-| `codex.agent_command` | `CodexCLI.runAgentCommand` | a computer-use codex run fails | `feature: computer`, `error` | error |
+| `codex.failure` | `CodexCLI.run` | a codex call fails for a REAL reason — a cancelled Task (the user's STOP; its SIGTERM exit used to masquerade as `exitFailure`) and `usageLimit` (expected; the amber caution owns it) never report | `feature`, `error` (CLIError case), `model`, `effort`, `duration_ms`, `resumed` | error |
+| `codex.agent_command` | `CodexCLI.runAgentCommand` | a computer-use codex run fails (same cancel/usage-limit exclusions) | `feature: computer`, `error` | error |
+| `codex_auth.refresh_failed` | `CodexAuth` | the on-demand codex token re-mint gets a non-OK HTTP status | `status` | warning |
 | `engine.load_failed` | `IterativeRun` | the on-device model won't load (→ a 0-item run) | `error`, `model_present` | error |
+| `model.download.failed` | `ModelDownload` | the onboarding model download exhausted its retries / aborted | `reason` | error |
 | `source.dropped` | `IterativeRun` | `connector.buckets()` throws (FDA denied / DB-copy failed) → whole source skipped | `source`, `error` | error |
 | `engine.hard_stop` | `IterativeRun` | the GPU-wedge cascade the reloads couldn't clear | `reloads_without_progress`, `consecutive_failures` | error |
 | `triage.parse_failure_spike` | `IterativeRun` | ≥20% of a run's items were garbled model replies (not real junk), ≥30 items | `parse_failures`, `done` | warning |
 | `mirror.push_failed` | `VaultCloud.pushIfDirty` | the MCP mirror push (swallow-and-retry path) fails | `http_status` (0 = non-HTTP) | warning |
 | `fda.probe` | `Permissions` (once/run, DB source present) | Full Disk Access isn't cleanly granted | `which_probe`, `errno` | warning |
-| `notify.not_authorized` / `notify.add_failed` | `Notify` | a denied notification permission silently kills reminders / add fails | `auth_status` | warning |
+| `notify.add_failed` | `Notify` | the notification-center add call throws | `error` | warning |
 | `addressbook.no_store` | `AddressBookNames` | the `v22` contacts store is absent (the v22→v23 rename) → contacts stop resolving | `path_version` | warning |
 | `codex_setup.step_failed` | `CodexSetup` | a setup step fails | `step`, `error`, `binary_found` | warning |
-| `executor.fire` | `ExecutorScoreboard` | EVERY executor action (see §5) | `method`, `source`, `outcome`, `duration_s`, `status_present` | info / warning |
-| `vault.update.stale_swap_averted` | `VaultCloud.update` | the user edited the vault in the editor mid-update → swap aborted (see §6) | — | info |
-| `overnight.gated` | `OvernightScheduler` | the 3am run was skipped (battery / Low Power / thermal-critical) | `reason` | info |
+| `executor.fire` | `ExecutorScoreboard` | a DEFECT-shaped executor outcome only (see §5): failed / refused / notFireable / fired-without-STATUS-sentinel. Verified successes go to TelemetryDeck, never here | `method`, `source`, `outcome`, `duration_s`, `status_present` | warning |
 
 Plus `CrashReporting.capture(error)` on the critical vault-restore/swap failure paths (B1/B2).
+
+**Moved to TelemetryDeck (2026-07-12) — telemetry, not defects; they no longer touch Sentry:**
+`Scheduler.gated` (was `overnight.gated`), `Scheduler.caution` (was `overnight.caution` — the
+morning-after classification: codex signed out / no internet / usage limit),
+`KnowledgeBase.staleSwapAverted` (was `vault.update.stale_swap_averted`), and
+`Notify.notAuthorized` (was `notify.not_authorized` — a declined permission is a user choice).
 
 ---
 
@@ -126,12 +163,16 @@ overrun it stops that source and moves on (per-item marks are atomic, so it just
 emits `source.hit_time_cap`.
 
 **The executor scoreboard** (`ExecutorScoreboard.swift`, §7.19) — the health metric for the flagship
-"AI that DOES things." `record(method:source:outcome:duration:)` emits `executor.fire`, fed from
+"AI that DOES things." `record(method:source:outcome:duration:)` is fed from
 `ProactiveExecutor.fire()` (source `proactive_card`) AND `CommandRunModel.complete()` (source
-`voice`/`promptBar`). Outcomes: `fired` / `notFireable` / `failed` / `refused`. Success/refusal is read
-from a **`STATUS: DONE | COULD_NOT` sentinel** the executor wrapper prompts now require (replacing a
-brittle `hasPrefix("COULD NOT")` guess); a missing sentinel → optimistic `fired` with
+`voice`/`promptBar`/`notchTyped`; user STOPs are skipped by the caller). Outcomes: `fired` /
+`notFireable` / `failed` / `refused`, read from a **`STATUS: DONE | COULD_NOT` sentinel** the
+executor wrapper prompts require; a missing sentinel → optimistic `fired` with
 `status_present:false`, which measures the false-success RISK.
+**Sentry sees defects only** (since 2026-07-12): a verified success returns without emitting —
+the success counts live in TelemetryDeck (`ComputerUse.finished`, `Proactive.actionFired`, both
+core-tier), because success telemetry in the issue feed buried the real errors and tripped
+Sentry's escalation detector.
 > ⚠️ `fired` means codex **claimed** done, NOT verified completion. Read the dashboard that way.
 
 **`SourceHealth.swift`** backs the anomaly sensors: run-over-run listing counts
@@ -155,10 +196,13 @@ brittle `hasPrefix("COULD NOT")` guess); a missing sentinel → optimistic `fire
 
 ## 7. Verified vs deferred
 
-**Verified (real hardware, Release, via the Sentry API):** all 21 structured event types + real-path
+**Verified (real hardware, Release, via the Sentry API):** all structured event types + real-path
 triggers (`db.schema_error`, `listing_collapsed`, `extraction_degraded`, `executor.fire`,
-`capture(error)`) + a native crash (`EXC_BREAKPOINT`, symbolicated) + app-hang. B8 (300/dir cap) and
-B11 (create+update stage-swap) verified on real codex.
+`capture(error)`) + a native crash (`EXC_BREAKPOINT`, symbolicated) + app-hang (2026-07-02/03,
+pre-curation). **The 2026-07-12 curation itself:** Release build compiles clean (including
+`ErrorLabel`'s Release-only branch) and the dSYM upload phase ran end-to-end with the new org
+token (files confirmed on Sentry via the API). The curated event flow (10s hangs, STOP silence,
+defect-only scoreboard) still wants a runtime spot-check on the next real Release session.
 
 **Deferred (not built):** the full `OvernightReport` (§7.20, with the production scheduler + overnight
 hardware), **voice internals** (§7.21 — hotkey/permission/engine-start signals; needs a mic + human to

--- a/Sentient OS macOS/Documentation/Product Analytics (TelemetryDeck).md
+++ b/Sentient OS macOS/Documentation/Product Analytics (TelemetryDeck).md
@@ -59,14 +59,17 @@ existing B7 "length, not the command text" log — same discipline.
 | `Engine.reloaded` | `Ingestion/IterativeRun.swift` | GPU-wedge self-heal fired (`reason`: preemptive/reactive) |
 | `Scheduler.overnightStarted` / `.overnightCompleted` | `Scheduling/OvernightScheduler.swift` | 3am run began / finished |
 | `Scheduler.gated` | `Scheduling/OvernightScheduler.swift` | Nightly run skipped (`reason`: battery/lowPower/thermal) |
+| `Scheduler.caution` | `Scheduling/OvernightCaution.swift` | An unattended run failed for a knowable reason (`kind`: usageLimit/loggedOut/noInternet) — was Sentry's `overnight.caution` until the 2026-07-12 curation |
 | `Scheduler.autoEnabled` | `Scheduling/OvernightScheduler.swift` | The 18h auto-enable flipped the scheduler on |
 | `KnowledgeBase.built` / `.updated` / `.failed` | `Proactive/ProactiveCycle.swift` | First build / incremental update / error |
+| `KnowledgeBase.staleSwapAverted` | `Vault/VaultCloud.swift` | The freshness check aborted a swap over a mid-run editor save (working as designed — was Sentry's `vault.update.stale_swap_averted`) |
 | `Proactive.decided` | `Proactive/ProactiveCycle.swift` | # things-worth-doing found |
 | `Proactive.prepared` | `Proactive/ProactiveCycle.swift` | # survived research (+ # dropped) |
 | `Proactive.actionFired` | `Proactive/ProactiveExecutor.swift` | A user fired an action — `method` + `outcome` (the headline number) |
 | `Mirror.enabled` / `.pushed` / `.disabled` / `.regenerated` | `Cloud/MirrorClient.swift` | MCP mirror lifecycle |
 | `Command.submitted` | `Notch Magic/CommandCoordinator.swift` | "Do stuff for me" bar used (`source` + `mode`) |
 | `Source.connected` | `Views/{Gmail,Calendar}ConnectSheet.swift` | A source hooked up (`source`) |
+| `Notify.notAuthorized` | `System/Notify.swift` | A reminder was suppressed by a declined notification permission (`status`) — user choice, not a defect (was Sentry's `notify.not_authorized`) |
 
 Plus what the SDK sends automatically: app launches, sessions, new-install, and device/OS/version.
 

--- a/Sentient OS macOS/Notch Magic/CommandRunModel.swift
+++ b/Sentient OS macOS/Notch Magic/CommandRunModel.swift
@@ -88,7 +88,7 @@ final class CommandRunModel {
                     self?.complete(.stopped, line: "■ stopped")
                 } else {
                     Log("──────── 🤖 ✗ FAILED after \(secs)s ────────")
-                    Log("CMD: \(error)")
+                    Log("CMD: \(ErrorLabel(error))")
                     self?.complete(.failed, line: "✗ \(Self.short(error))")
                 }
             }

--- a/Sentient OS macOS/Proactive/ProactiveExecutor.swift
+++ b/Sentient OS macOS/Proactive/ProactiveExecutor.swift
@@ -166,7 +166,7 @@ actor ProactiveExecutor {
             case .noSentinel:          return FireResult(outcome: .fired(env.result), board: .fired, statusPresent: false, errorClass: nil)
             }
         } catch {
-            Log("ProactiveExecutor/\(channel): ✗ \(error)")
+            Log("ProactiveExecutor/\(channel): ✗ \(ErrorLabel(error))")
             return FireResult(outcome: .failed(describe(error)), board: .failed, statusPresent: true,
                               errorClass: String(describing: type(of: error)))
         }
@@ -191,7 +191,7 @@ actor ProactiveExecutor {
             case .noSentinel:          return FireResult(outcome: .fired(String(final.prefix(300))), board: .fired, statusPresent: false, errorClass: nil)
             }
         } catch {
-            Log("ProactiveExecutor/computer: ✗ \(error)")
+            Log("ProactiveExecutor/computer: ✗ \(ErrorLabel(error))")
             return FireResult(outcome: .failed(describe(error)), board: .failed, statusPresent: true,
                               errorClass: String(describing: type(of: error)))
         }

--- a/Sentient OS macOS/Scheduling/OvernightCaution.swift
+++ b/Sentient OS macOS/Scheduling/OvernightCaution.swift
@@ -69,8 +69,9 @@ enum OvernightCaution {
             UserDefaults.standard.set(data, forKey: key)
         }
         Log("OvernightCaution: recorded .\(kind.rawValue)")
-        CrashReporting.captureEvent("overnight.caution", level: .info,
-            tags: ["kind": kind.rawValue], fingerprint: ["overnight", "caution", kind.rawValue])
+        // Environment weather (signed out / offline / usage limit), not an app defect — product
+        // telemetry, so TelemetryDeck, never the Sentry issue feed (2026-07-12).
+        Analytics.signal("Scheduler.caution", parameters: ["kind": kind.rawValue])
     }
 
     /// One NWPathMonitor snapshot — the first path update arrives immediately; guarded so the

--- a/Sentient OS macOS/Scheduling/OvernightScheduler.swift
+++ b/Sentient OS macOS/Scheduling/OvernightScheduler.swift
@@ -277,11 +277,8 @@ final class OvernightScheduler {
         log.line("power: ac=\(PowerState.onACPower()) lowPower=\(PowerState.lowPowerMode) thermal=\(PowerState.thermalLabel)")
         if let blocked = PowerState.overnightBlockReason() {
             log.line("GATED — \(blocked); skipping this run (retry next night).")
+            // Telemetry, not a defect — TelemetryDeck counts it; Sentry stays quiet (2026-07-12).
             Analytics.signal("Scheduler.gated", parameters: ["reason": blocked])
-            CrashReporting.captureEvent("overnight.gated", level: .info,
-                tags: ["reason": blocked],
-                extra: ["thermal": PowerState.thermalLabel],
-                fingerprint: ["overnight", "gated", blocked])
             return
         }
 
@@ -314,11 +311,12 @@ final class OvernightScheduler {
                 case .deciding:             log.line("proactive: deciding what's worth doing…")
                 case .researching(let n):   log.line("proactive: researching + preparing \(n) item(s)…")
                 case .done(let ready):      log.line("proactive: ✅ cycle done — \(ready) card(s) ready.")
-                case .failed(let m):        log.line("proactive: FAILED — \(m)")
+                case .failed:               log.line("proactive: FAILED")   // reason withheld — it can embed codex output, and every log line is a Release breadcrumb
                 }
             }
         }) {
-            log.line("proactive cycle ended with a failure (summaries kept for retry): \(failure)")
+            // Detail withheld (can embed codex output); the morning caution + codex.failure carry the kind.
+            log.line("proactive cycle ended with a failure (summaries kept for retry)")
         }
 
         heart.cancel()
@@ -330,7 +328,7 @@ final class OvernightScheduler {
     private func cloudLeg(_ name: String, log: SchedulerLog, _ body: () async throws -> Void) async {
         log.line("\(name) leg…")
         do { try await body(); log.line("\(name) DONE") }
-        catch { log.line("\(name) FAILED: \((error as? LocalizedError)?.errorDescription ?? "\(error)")") }
+        catch { log.line("\(name) FAILED: \(ErrorLabel(error))") }
     }
 
     // MARK: - Time helpers

--- a/Sentient OS macOS/Sources/CalendarConnect.swift
+++ b/Sentient OS macOS/Sources/CalendarConnect.swift
@@ -79,10 +79,10 @@ enum CalendarConnect {
             let env = try await CodexCLI.shared.run(inv)
             let answer = env.result.uppercased()
             let yes = answer.contains("YES") && !answer.contains("NO")
-            Log("CalendarConnect.probe: codex → \"\(env.result.prefix(40))\" ⇒ \(yes ? "connected" : "NOT connected")")
+            Log("CalendarConnect.probe: codex replied (\(env.result.count) chars) ⇒ \(yes ? "connected" : "NOT connected")")
             return yes
         } catch {
-            Log("CalendarConnect.probe: ⚠️ \(error) — treating as NOT connected")
+            Log("CalendarConnect.probe: ⚠️ \(ErrorLabel(error)) — treating as NOT connected")
             return false
         }
     }
@@ -190,7 +190,7 @@ enum CalendarConnect {
             Log("CalendarConnect.fetchProactiveContext: ✅ \(text.count) chars of live calendar context")
             return text
         } catch {
-            Log("CalendarConnect.fetchProactiveContext: ⚠️ \(error) — proactive runs without calendar")
+            Log("CalendarConnect.fetchProactiveContext: ⚠️ \(ErrorLabel(error)) — proactive runs without calendar")
             return nil
         }
     }

--- a/Sentient OS macOS/Sources/GmailConnect.swift
+++ b/Sentient OS macOS/Sources/GmailConnect.swift
@@ -89,10 +89,10 @@ enum GmailConnect {
             let env = try await CodexCLI.shared.run(inv)
             let answer = env.result.uppercased()
             let yes = answer.contains("YES") && !answer.contains("NO")
-            Log("GmailConnect.probe: codex → \"\(env.result.prefix(40))\" ⇒ \(yes ? "connected" : "NOT connected")")
+            Log("GmailConnect.probe: codex replied (\(env.result.count) chars) ⇒ \(yes ? "connected" : "NOT connected")")
             return yes
         } catch {
-            Log("GmailConnect.probe: ⚠️ \(error) — treating as NOT connected")
+            Log("GmailConnect.probe: ⚠️ \(ErrorLabel(error)) — treating as NOT connected")
             return false
         }
     }

--- a/Sentient OS macOS/System/Notify.swift
+++ b/Sentient OS macOS/System/Notify.swift
@@ -50,9 +50,9 @@ enum Notify {
         let status = await center.notificationSettings().authorizationStatus
         guard status == .authorized || status == .provisional else {
             Log("Notify: not authorized (status \(status.rawValue)) — reminder suppressed")
-            CrashReporting.captureEvent("notify.not_authorized", level: .warning,
-                tags: ["auth_status": String(status.rawValue)],
-                fingerprint: ["notify", "not_authorized"])
+            // A declined permission is the user's choice, not an app defect — product telemetry
+            // (how many run with reminders off), so TelemetryDeck, never Sentry (2026-07-12).
+            Analytics.signal("Notify.notAuthorized", parameters: ["status": String(status.rawValue)])
             return
         }
 

--- a/Sentient OS macOS/Vault/VaultCloud.swift
+++ b/Sentient OS macOS/Vault/VaultCloud.swift
@@ -176,8 +176,9 @@ actor VaultCloud {
             // next cycle re-seeds from the now-current vault (their edit included).
             guard VaultGenerator.vaultFingerprint(vault) == baseline else {
                 Log("VaultCloud.update: ⚠️ vault changed during the run (editor?) — swap aborted, re-run next cycle")
-                CrashReporting.captureEvent("vault.update.stale_swap_averted", level: .info,
-                    fingerprint: ["vault", "update", "stale_swap_averted"])
+                // Working as designed (the freshness check doing its job) — a counter for
+                // TelemetryDeck, not a Sentry issue (2026-07-12).
+                Analytics.signal("KnowledgeBase.staleSwapAverted")
                 setUpdateResume(nil)
                 try? fm.removeItem(at: staging)
                 return 0
@@ -185,7 +186,7 @@ actor VaultCloud {
             try VaultGenerator.swapStagingIntoVault(staging)        // atomic; live vault untouched until here
             setUpdateResume(nil)
             await markDirty()
-            Log("VaultCloud.update: ✅ \(notes.count) notes (turns \(envelope.numTurns ?? -1)) — \(envelope.result.prefix(120))")
+            Log("VaultCloud.update: ✅ \(notes.count) notes (turns \(envelope.numTurns ?? -1), \(envelope.result.count) char report)")
             return notes.count
         } catch let VaultGenerator.VaultError.usageLimit(message, resume) {
             // Staging is kept; the live vault was never touched. Carry the seed baseline forward so a
@@ -236,7 +237,7 @@ actor VaultCloud {
                 tags: ["error": String(describing: type(of: error))],
                 extra: ["http_status": status],
                 fingerprint: ["mirror", "push_failed"])
-            Log("VaultCloud: mirror push failed — \((error as? LocalizedError)?.errorDescription ?? "\(error)") (retries next trigger)")
+            Log("VaultCloud: mirror push failed — \(ErrorLabel(error)) (retries next trigger)")
         }
     }
 

--- a/Sentient OS macOS/Vault/VaultGenerator.swift
+++ b/Sentient OS macOS/Vault/VaultGenerator.swift
@@ -167,7 +167,7 @@ actor VaultGenerator {
             return try await CodexCLI.shared.run(invocation, onLine: onLine)
         } catch let CodexCLI.CLIError.usageLimit(message, sessionID) {
             // Staging is deliberately KEPT — the resume token points at it (survives an app restart).
-            Log("VaultGenerator: ⚠️ usage limit (session \(sessionID ?? "nil")); staging kept for resume — \(message.prefix(160))")
+            Log("VaultGenerator: ⚠️ usage limit (session \(sessionID ?? "nil")); staging kept for resume")
             throw VaultError.usageLimit(message: message,
                                         resume: ResumeToken(sessionID: sessionID, stagingPath: staging.path))
         }
@@ -237,7 +237,7 @@ actor VaultGenerator {
         do {
             try Self.swapStagingIntoVault(staging)
         } catch {
-            Log("VaultGenerator: ❌ swap failed, vault left intact — \(error)")
+            Log("VaultGenerator: ❌ swap failed, vault left intact — \(ErrorLabel(error))")
             CrashReporting.capture(error)                            // TODO(P2): structured `vault_swap_failed`
             throw error
         }

--- a/Sentient OS macOS/Views/Knowledge/KnowledgeView.swift
+++ b/Sentient OS macOS/Views/Knowledge/KnowledgeView.swift
@@ -247,7 +247,7 @@ struct KnowledgeView: View {
         do {
             try editText.write(to: url, atomically: true, encoding: .utf8)
         } catch {
-            Log("Knowledge editor: save failed — \(error.localizedDescription)")
+            Log("Knowledge editor: save failed — \(ErrorLabel(error))")
             return   // stay in edit mode so the user's text isn't lost
         }
         savedText = editText
@@ -289,7 +289,7 @@ struct KnowledgeView: View {
         do {
             try FileManager.default.trashItem(at: url, resultingItemURL: nil)
         } catch {
-            Log("Knowledge: delete failed — \(error.localizedDescription)")
+            Log("Knowledge: delete failed — \(ErrorLabel(error))")
             return
         }
         let lostSelection = selection == url || (selection?.path.hasPrefix(url.path + "/") ?? false)
@@ -318,7 +318,7 @@ struct KnowledgeView: View {
         do {
             try "# \(title)\n\n".write(to: url, atomically: true, encoding: .utf8)
         } catch {
-            Log("Knowledge: create note failed — \(error.localizedDescription)")
+            Log("Knowledge: create note failed — \(ErrorLabel(error))")
             return
         }
         reloadVault()
@@ -333,7 +333,7 @@ struct KnowledgeView: View {
         do {
             try FileManager.default.createDirectory(at: url, withIntermediateDirectories: false)
         } catch {
-            Log("Knowledge: create folder failed — \(error.localizedDescription)")
+            Log("Knowledge: create folder failed — \(ErrorLabel(error))")
             return
         }
         reloadVault()

--- a/Sentient OS macOS/Views/ProcessingView.swift
+++ b/Sentient OS macOS/Views/ProcessingView.swift
@@ -663,7 +663,7 @@ struct ProcessingView: View {
             p.lastFilePath = nil
             box.value = p
             yield(p)
-            Log("ProcessingView.gmail: ✗ \(error)")
+            Log("ProcessingView.gmail: ✗ \(ErrorLabel(error))")
         }
         return box.value
     }
@@ -713,7 +713,7 @@ struct ProcessingView: View {
             p.lastFilePath = nil
             box.value = p
             yield(p)
-            Log("ProcessingView.calendar: ✗ \(error)")
+            Log("ProcessingView.calendar: ✗ \(ErrorLabel(error))")
         }
         return box.value
     }


### PR DESCRIPTION
## What this is
The full Sentry noise + privacy sweep (investigated live on Sentry with the API + a codebase audit).

## The headline: a real leak, plugged
The Sentry SDK's default **network breadcrumbs** and **failed-request capture** record full request URLs — and the MCP mirror URL carries the user's **mirror password** in its path. A full password was found in 2 stored Sentry events (deleted from Sentry; almost certainly one of our two dev installs — the events were 1 AM PDT Sidekick voice testing). Both SDK defaults are now OFF, `beforeBreadcrumb` scrubs `crumb.data` strings as a backstop, and the scrubber gained a `/p_<password>` rule so no future surface can log it.

## Noise → signal
- **STOP ≠ error**: cancelling a run SIGTERMs codex → non-zero exit → was reported as `codex.agent_command exitFailure` (error). Cancelled Tasks no longer emit. `usageLimit` no longer reports at all (expected condition; the amber caution owns it).
- **`executor.fire`**: defect outcomes only (failed / refused / notFireable / fired-without-STATUS-sentinel). Verified successes are usage → TelemetryDeck already counts them (`ComputerUse.finished`, `Proactive.actionFired`).
- **`overnight.gated` / `overnight.caution` / `vault.update.stale_swap_averted` / `notify.not_authorized`** → TelemetryDeck signals (telemetry, not defects).
- **App hangs**: 2s → **10s** threshold (the beta wave was all harmless onboarding stalls).
- **Uncaught NSExceptions now report** (`enableUncaughtNSExceptionReporting` defaults OFF on macOS — a whole crash class was invisible while 2s hangs paged us).
- **Dead config removed**: 100% tracing + profiling never produced a single ingested transaction on macOS SwiftUI.
- **`ErrorLabel()`** (Log.swift): Release-safe error rendering (enum case / type name; full description in DEBUG). Applied to ~22 `Log()` error paths that shipped CLIError stderr (up to 300 chars of codex output = Gmail/calendar/screen content), note titles, and the mirror server's response body into Release breadcrumbs. Codex-login stream now elides URLs (OAuth params).

## ⚠️ Jesai — two manual steps
1. **Copy the repo-root `.sentryclirc` from Aditya's Mac** (AirDrop/Signal, never commit — it's gitignored by design). It has a fresh org token; the old one was dead, so dSYM uploads have been silently failing, which is why every beta event is unsymbolicated.
2. **Retro-upload the beta build's dSYM** from your Xcode archive so beta crashes symbolicate:
   `sentry-cli debug-files upload --include-sources ~/Library/Developer/Xcode/Archives/<date>/<the 1.0(1) archive>.xcarchive/dSYMs`
   (missing UUID: `64b1dc1f-34b3-31ef-884c-89d33b2ace38`)

## Testing + docs
Debug-builds clean (isolated DerivedData). The Sentry pipeline is Release-only, so the real verification is the next Release build (hang threshold, NSException flag, quiet feed). Docs (`Diagnostics (Sentry).md` — also 3 events were undocumented — and context file §12) get updated after that verification, per doc practice.

## Sentry-side (already done, not in this diff)
63 stale self-test issues archived; the leaked-password issue deleted; new personal + org tokens minted (`claude-code-cli`, `dsym-upload-build-phase`).