### PR TITLE
docs: release.sh symbol gate + beta-dSYM epilogue

### DIFF
--- a/Sentient OS macOS/Documentation/Auto-Update (Sparkle).md
+++ b/Sentient OS macOS/Documentation/Auto-Update (Sparkle).md
@@ -119,9 +119,16 @@ and does the rest — no notary credentials needed in the script:
 
 1. **Validates** the DMG is genuinely signed + notarized + stapled (mounts it, `spctl` + `stapler`),
    and refuses a placeholder-key build — a broken DMG can't reach users.
-2. Reads the version from the DMG, **EdDSA-signs** it, runs `generate_appcast`.
-3. Cuts a **GitHub Release** (uploads the DMG the appcast points at) and bumps the **Homebrew cask**.
-4. Prints the final manual step: publish the emitted `appcast.xml` to the `SUFeedURL`. The feed lives
+2. **Ensures the build's crash symbols are on Sentry** (added 2026-07-12): reads the app binary's
+   UUIDs from the mounted DMG, finds the matching dSYMs in `~/Library/Developer/Xcode/Archives`, and
+   idempotently uploads them (`--include-sources`). No matching archive or a failed upload **aborts
+   the release** — the Xcode upload build phase fails silently by design, and a build shipped without
+   its dSYM has unreadable crashes forever (the beta-wave lesson; see `Crash Reporting (Sentry).md`).
+   `SKIP_SENTRY=1` skips knowingly; `DSYM_SEARCH=<dir>` overrides the search root. *(Match + upload +
+   abort paths verified against the live org; first full-release run still pending.)*
+3. Reads the version from the DMG, **EdDSA-signs** it, runs `generate_appcast`.
+4. Cuts a **GitHub Release** (uploads the DMG the appcast points at) and bumps the **Homebrew cask**.
+5. Prints the final manual step: publish the emitted `appcast.xml` to the `SUFeedURL`. The feed lives
    in the `sentient-os-website` repo at `public/appcast.xml` (Vercel deploys it).
 
 `./release.sh keys` is the one-time key generator. Sparkle's CLI tools resolve automatically from the

--- a/Sentient OS macOS/Documentation/Crash Reporting (Sentry).md
+++ b/Sentient OS macOS/Documentation/Crash Reporting (Sentry).md
@@ -119,6 +119,13 @@ automatically — **Release only** (Debug has symbols locally; the phase skips w
   after any Release/Archive build it's worth glancing at the build log for the
   "Sentry: uploading dSYMs" line. A missed build can be repaired after the fact:
   `sentry-cli debug-files upload --include-sources <archive>.xcarchive/dSYMs`.
+  *(Epilogue, 2026-07-12: the main beta build's dSYMs were uploaded after the fact and its events
+  symbolicate; three other beta builds' dSYMs were already gone — overwritten Debug products — so
+  their events stay unreadable permanently. Keep the archive of any build that leaves a dev Mac.)*
+- **`release.sh` now hard-gates on this** (step 2/6, added 2026-07-12): publishing a DMG requires
+  its matching dSYMs to be found locally and (re-)uploaded to Sentry, or the release aborts — a loud
+  seatbelt over the silent build phase, at the moment it matters. `SKIP_SENTRY=1` opts out knowingly.
+  Details: `Auto-Update (Sparkle).md` §Releasing.
 
 Build settings already cooperate: Release is `dwarf-with-dsym`, Debug is `dwarf` (no dSYM, fast),
 and user script sandboxing is off so the upload script can reach the network.


### PR DESCRIPTION
Doc follow-up to #173: the Sparkle doc's Releasing section now describes the new step 2 (Sentry dSYM gate + escape hatches), and the Crash Reporting doc's field lesson gets its epilogue (main beta build repaired + symbolicating with sources; the 3 lost builds are permanently unreadable) plus a cross-reference to the release.sh hard gate.