### PR TITLE
Compile-gate the home's DEV TOOLS handle out of Release

### DIFF
--- a/Sentient OS macOS/Documentation/Home — Proactive Intelligence (For You).md
+++ b/Sentient OS macOS/Documentation/Home — Proactive Intelligence (For You).md
@@ -35,8 +35,8 @@ The main window's content (rendered by `RootView`). Layers, bottom-to-top:
   with a *Reset & Rebuild* glow. See `Plan Gate (CodexAuth & Knowledge-Base-Only).md`.
 - **The dock:** the `PromptBar` command bar + the trust footer (the command bar is HIDDEN in
   knowledge-base-only mode — computer use runs on quota those plans don't have). A small `DEV TOOLS`
-  handle is pinned bottom-right (→ the `Views/Dev/DevToolsView.swift` sheet; the Release strip
-  re-hides it).
+  handle is pinned bottom-right (→ the `Views/Dev/DevToolsView.swift` sheet; `#if DEBUG` — compiled
+  out of Release, and it's the sheet's only opener, so Dev Tools is unreachable there).
 - **The caution banner — `cautionBanner` / `CautionCapsule` (ONE slot, most severe first):** the
   blank space top-right beside the greeting holds at most ONE capsule; a LIVE issue outranks
   history. Both roads lead to Permissions & Health (`SettingsView.requestedPane = .health`).

--- a/Sentient OS macOS/Views/HomePopovers.swift
+++ b/Sentient OS macOS/Views/HomePopovers.swift
@@ -6,7 +6,7 @@
 //  OFF the home itself — you open them only when curious:
 //   · AnalysisPopover — the work glance: things understood, vault size, the synced stamp, an
 //     Analyze Now control, and the source chips (sources are the INPUTS to analysis, so they
-//     live under "Analysis"). A discreet Dev Tools link sits at the bottom.
+//     live under "Analysis").
 //   · YourAIsPopover — the pitch + the glowing "Connect your AIs" CTA that opens the guided
 //     setup window (ConnectAIsView owns sharing on/off, the link, and the prompt).
 //  Pure presentation; harvested from the retired Constellation home. Demo strings (synced

--- a/Sentient OS macOS/Views/HomeView.swift
+++ b/Sentient OS macOS/Views/HomeView.swift
@@ -95,7 +95,9 @@ struct HomeView: View {
                     bottomDock
                     chrome                     // on top → the nav stays clickable
                     cautionBanner              // the morning-after caution, in the blank top-right
+                    #if DEBUG
                     devToolsOverlay
+                    #endif
                 }
                 .blur(radius: letterShown ? 7 : 0)
                 .opacity(letterShown ? 0.4 : 1)
@@ -443,8 +445,10 @@ struct HomeView: View {
         }
     }
 
-    /// A discreet DEV TOOLS handle pinned bottom-right (DX continuity from the old home; the
-    /// Phase-6 Release strip re-hides it). Opens the DevToolsView sheet via RootView.
+    /// A discreet DEV TOOLS handle pinned bottom-right (DX continuity from the old home).
+    /// Opens the DevToolsView sheet via RootView. Compile-gated out of Release entirely —
+    /// this is DevToolsView's ONLY opener, so the sheet is unreachable in Release too.
+    #if DEBUG
     private var devToolsOverlay: some View {
         Button(action: onShowDevTools) {
             HStack(spacing: 5) {
@@ -462,6 +466,7 @@ struct HomeView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
         .padding(.trailing, 22).padding(.bottom, 13)
     }
+    #endif
 
     // MARK: Floor — the command bar + trust footer
 

--- a/Sentient OS macOS/Views/RootView.swift
+++ b/Sentient OS macOS/Views/RootView.swift
@@ -6,7 +6,7 @@
 //  ProcessingView takeover (today they cross-fade). RootView owns the analyze/source state and
 //  feeds HomeView its live context; Analyze Now (in the home's Analysis popover) runs whatever
 //  the dev source picker has armed (SourceSelection). The picker + all debug controls live in
-//  DevToolsView, a sheet reached from the Analysis popover's DEV TOOLS link.
+//  DevToolsView, a sheet reached from the home's DEV TOOLS handle (DEBUG builds only).
 //
 
 import SwiftUI


### PR DESCRIPTION
## What
The home's bottom-right `DEV TOOLS` capsule rendered in Release builds. It (and its usage in `body`) is now wrapped in `#if DEBUG`, matching onboarding's SKIP TO HOME idiom. Since the capsule is `DevToolsView`'s only opener, the whole dev cockpit sheet is unreachable in Release.

Also checked SKIP TO HOME — already compile-gated (`OnboardingView.swift`), no change needed.

## Verification
- Debug build clean (Xcode MCP BuildProject)
- Release build clean (isolated `-derivedDataPath /tmp/sentient-verify`)
- `strings` on the Release binary: `DEV TOOLS` and `SKIP TO HOME` both absent

## Doc truth-ups
- Home deep doc: removed the stale "Phase-6 Release strip re-hides it" promise
- `RootView.swift` + `HomePopovers.swift` headers: the sheet hasn't opened from the Analysis popover in a while