### PR TITLE
Cards: whole face tap-expands in the offer phase

### DIFF
--- a/Sentient OS macOS/Documentation/Home — Proactive Intelligence (For You).md
+++ b/Sentient OS macOS/Documentation/Home — Proactive Intelligence (For You).md
@@ -143,6 +143,9 @@ calendar cobalt · computer teal · research mint), `init(fromGiftMarkdown:)` (t
 `# Title` promoted to the card title), or the hard-coded demo set (kind accents; the welcome card
 alone wears the full gradient — jewelry rule). The card lives four lives: `sealed` (the envelope) →
 `offer` → `working(n)` (scripted theater, or the real `liveLines` stream + STOP) → `done`.
+In the **offer** phase the WHOLE face is the tap target for the letter (not just "read more") — the
+fire CTA and "read more" buttons sit above the ancestor tap in hit-testing, so they keep their own
+actions; working/done faces don't tap-expand (a stray click mid-run shouldn't cover the STOP).
 
 ## The command bar — "Let me DO stuff for you"
 

--- a/Sentient OS macOS/Views/BriefingCard.swift
+++ b/Sentient OS macOS/Views/BriefingCard.swift
@@ -65,6 +65,10 @@ struct BriefingCard: View {
         .overlay(RoundedRectangle(cornerRadius: 14, style: .continuous)
             .strokeBorder(border, lineWidth: 1))
         .animation(.spring(response: 0.45, dampingFraction: 0.85), value: phase)
+        // The whole offer face expands the card — the buttons (fire CTA, "read more") sit above
+        // this ancestor tap in hit-testing, so they keep their own actions.
+        .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .onTapGesture { if phase == .offer { onDetail() } }
     }
 
     private var offerFace: some View {


### PR DESCRIPTION
## What
Clicking anywhere on a suggestion card (in its offer phase) now expands it into the typeset letter — previously only the "read more" button did.

## How
- `BriefingCard.face` gets a `.contentShape` + `.onTapGesture` firing `onDetail()` when `phase == .offer`.
- Child buttons keep hit-test priority over the ancestor tap, so the fire CTA still fires and "read more" still works.
- Drag-to-fling is untouched (simultaneous gesture, 12pt minimum — a clean click never triggers it).
- Working/done faces deliberately don't tap-expand (a stray click mid-run shouldn't cover the STOP button).

Doc updated: `Home — Proactive Intelligence (For You).md` cards section.

Builds clean via Xcode MCP; click behavior verified by Jesai.