### PR TITLE
Security fixes: root LPE verified launch, env-override lockdown, PII/email cleanup

### DIFF
--- a/Sentient OS macOS/Cloud/MirrorClient.swift
+++ b/Sentient OS macOS/Cloud/MirrorClient.swift
@@ -75,9 +75,17 @@ actor MirrorClient {
 
     static let shared = MirrorClient()
 
-    /// Production mirror. Overridable for local server testing via SENTIENT_MIRROR_BASE.
+    /// Production mirror. Overridable for local server testing via SENTIENT_MIRROR_BASE — but
+    /// DEBUG ONLY: the password rides in the URL path, so in a Release build a same-user process
+    /// must NOT be able to redirect the push (and thereby harvest the password + encrypted vault)
+    /// merely by launching the app with an env var. Self-tests run the Debug binary, so they keep it.
     static var baseURL: String {
-        ProcessInfo.processInfo.environment["SENTIENT_MIRROR_BASE"] ?? "https://mcp.sentient-os.ai"
+        #if DEBUG
+        if let override = ProcessInfo.processInfo.environment["SENTIENT_MIRROR_BASE"], !override.isEmpty {
+            return override
+        }
+        #endif
+        return "https://mcp.sentient-os.ai"
     }
 
     /// The coached system prompt the user pastes into ChatGPT/Claude/Gemini (custom instructions).

--- a/Sentient OS macOS/Engine/ModelLocator.swift
+++ b/Sentient OS macOS/Engine/ModelLocator.swift
@@ -20,10 +20,14 @@ enum ModelLocator {
     static func resolve() -> String? {
         let fm = FileManager.default
 
+        #if DEBUG
+        // DEBUG-only: a Release build must not let a same-user process point the engine at a
+        // planted (poisoned) model via an env var. Self-tests run the Debug binary, so they keep it.
         if let env = ProcessInfo.processInfo.environment["SENTIENT_MODEL_PATH"],
            fm.fileExists(atPath: env) {
             return env
         }
+        #endif
 
         if let bundled = Bundle.main.path(forResource: "gemma-4-E4B-it", ofType: "litertlm") {
             return bundled

--- a/Sentient OS macOS/Scheduling/WakeHelper.swift
+++ b/Sentient OS macOS/Scheduling/WakeHelper.swift
@@ -44,19 +44,26 @@ final class WakeHelper: NSObject, WakeHelperProtocol, NSXPCListenerDelegate {
     /// being the shared binary's cdhash). Falls back to the static identifier+anchor requirement
     /// if self-inspection somehow fails. Computed once; both sources are valid requirement
     /// strings by construction (setCodeSigningRequirement raises on a malformed one).
-    private static let clientRequirement: String = {
+    private static let clientRequirement: String = selfDesignatedRequirement() ?? WakeHelperConfig.clientRequirement
+
+    /// This binary's OWN designated requirement string ("signed exactly like me"), or nil if the
+    /// system can't produce it. Shared by TWO callers: the XPC client gate here (which decides who
+    /// may connect) AND `WakeHelperInstaller`, which bakes it into the daemon's launch-time
+    /// `codesign --verify` so launchd never runs a tampered or foreign-signed binary as root. The
+    /// app and the daemon are the same signed binary, so the value the installer captures in the
+    /// app process matches what this gate expects in the daemon process.
+    static func selfDesignatedRequirement() -> String? {
         var code: SecCode?
         var staticCode: SecStaticCode?
         var requirement: SecRequirement?
         var text: CFString?
-        if SecCodeCopySelf([], &code) == errSecSuccess, let code,
-           SecCodeCopyStaticCode(code, [], &staticCode) == errSecSuccess, let staticCode,
-           SecCodeCopyDesignatedRequirement(staticCode, [], &requirement) == errSecSuccess, let requirement,
-           SecRequirementCopyString(requirement, [], &text) == errSecSuccess, let text {
-            return text as String
-        }
-        return WakeHelperConfig.clientRequirement
-    }()
+        guard SecCodeCopySelf([], &code) == errSecSuccess, let code,
+              SecCodeCopyStaticCode(code, [], &staticCode) == errSecSuccess, let staticCode,
+              SecCodeCopyDesignatedRequirement(staticCode, [], &requirement) == errSecSuccess, let requirement,
+              SecRequirementCopyString(requirement, [], &text) == errSecSuccess, let text
+        else { return nil }
+        return text as String
+    }
 
     func listener(_ listener: NSXPCListener, shouldAcceptNewConnection conn: NSXPCConnection) -> Bool {
         // The client gate, enforced by the SYSTEM per message via the official API (macOS 13+).

--- a/Sentient OS macOS/Scheduling/WakeHelperInstaller.swift
+++ b/Sentient OS macOS/Scheduling/WakeHelperInstaller.swift
@@ -4,9 +4,21 @@
 //
 //  Self-install for the root wake helper — so the user never touches Terminal. When the scheduler
 //  needs the helper and it isn't installed (or points at a stale binary), the app installs the
-//  LaunchDaemon itself behind ONE native "enter your password" dialog (osascript admin):
-//    write the plist (with THIS app's current binary path) to a temp file → privileged cp into
-//    /Library/LaunchDaemons → chown/chmod → launchctl bootstrap.
+//  LaunchDaemon itself behind ONE native "enter your password" dialog (osascript admin): root
+//  decodes the plist straight into /Library/LaunchDaemons (from a base64 blob in the command — no
+//  swappable temp file) → chown/chmod → launchctl bootstrap.
+//
+//  ⚠️ SECURITY — verified launch (guards against local root escalation): the daemon does NOT point
+//  straight at the app binary. A drag-installed app lives in a USER-writable bundle, so pointing a
+//  root LaunchDaemon at it would let any same-user process overwrite the binary and get their code
+//  run as root at the next wake/boot. Instead ProgramArguments runs, as root:
+//      /bin/sh -c "codesign --verify -R='<app DR>' '<app>' && exec '<binary>' --wake-helper"
+//  codesign (a root-owned system tool the attacker can't touch) verifies the bundle is our genuine,
+//  untampered, correctly-signed code BEFORE exec'ing it; any tamper or foreign signature exits
+//  non-zero and `&&` blocks the exec — nothing runs as root. `exec` then REPLACES the shell with the
+//  real app binary, so the running daemon IS our app and the XPC "signed like me" gate is unchanged.
+//  The requirement is the app's OWN designated requirement, captured at install (signer-agnostic,
+//  like the XPC gate) — it survives same-team Sparkle updates but rejects any other signer.
 //
 //  [DECIDED 2026-07-04] This IS the production path. The SMAppService.daemon migration (Login
 //  Items toggle) was considered and rejected: this works, it's measured on real hardware, and one
@@ -21,26 +33,33 @@ enum WakeHelperInstaller {
     private static var label: String { WakeHelperConfig.machServiceName }   // plist Label == Mach service name
     private static var plistPath: String { "/Library/LaunchDaemons/\(label).plist" }
 
-    /// This app's running executable — what the daemon must launch (with --wake-helper).
+    /// This app's running executable — what the daemon ultimately exec's (with --wake-helper).
     private static var currentBinary: String {
         Bundle.main.executableURL?.path ?? CommandLine.arguments[0]
     }
 
-    /// True when the daemon plist exists AND points at this exact binary (a moved/rebuilt-to-a-new
-    /// path app fails this, so we reinstall). World-readable, so no privileges needed to check.
-    /// The plist FORMAT must be current too: one without AssociatedBundleIdentifiers (added
-    /// 2026-07-11) predates the "display as Sentient OS in Login Items" fix and reads stale, so
-    /// the next setup pass refreshes it. ⚠️ This answers "are the files right", not "is it
-    /// alive" — the System Settings background toggle disables the daemon WITHOUT touching the
-    /// plist; anything asking "will the 3am machinery actually work?" must use
-    /// `WakeHelperClient.isReachable()` instead.
+    /// This app's bundle (the `.app`) — what `codesign --verify` checks at launch.
+    private static var bundlePath: String { Bundle.main.bundleURL.path }
+
+    /// True when the daemon plist exists AND is the CURRENT verified-launch form for this exact
+    /// binary + signature. Fails (→ reinstall) for: a plist missing AssociatedBundleIdentifiers
+    /// (pre-2026-07-11), an OLD plain-binary plist (pre-verified-launch), a moved app (binary path
+    /// changed), or a re-signed build (designated requirement changed) — so a stale check can never
+    /// leave the daemon unable to pass its own codesign gate. World-readable, so no privileges to
+    /// check. ⚠️ This answers "are the files right", not "is it alive" — the System Settings
+    /// background toggle disables the daemon WITHOUT touching the plist; anything asking "will the
+    /// 3am machinery actually work?" must use `WakeHelperClient.isReachable()` instead.
     static func isInstalledAndCurrent() -> Bool {
         guard let data = FileManager.default.contents(atPath: plistPath),
               let plist = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil) as? [String: Any],
               let args = plist["ProgramArguments"] as? [String],
-              plist["AssociatedBundleIdentifiers"] != nil
+              plist["AssociatedBundleIdentifiers"] != nil,
+              args.first == "/bin/sh", let script = args.last, script.contains(currentBinary)
         else { return false }
-        return args.first == currentBinary
+        // If we can read our current requirement, it must be the one baked into the launcher (a
+        // re-signed build changes it → reinstall). If we can't, don't tear down a working install.
+        if let requirement = WakeHelper.selfDesignatedRequirement() { return script.contains(requirement) }
+        return true
     }
 
     /// Install (or refresh) the daemon via one admin prompt. Blocking — call off the main actor.
@@ -75,36 +94,53 @@ enum WakeHelperInstaller {
     }
 
     private static func install() -> Bool {
-        let tmp = (NSTemporaryDirectory() as NSString).appendingPathComponent("sentient-wakehelper.plist")
-        guard (try? plistXML(binary: currentBinary).write(toFile: tmp, atomically: true, encoding: .utf8)) != nil
-        else { return false }
+        // The requirement the daemon will verify at launch: the app's OWN designated requirement,
+        // captured now. Falls back to the static identifier+anchor rule only if the system can't
+        // produce the DR (effectively never for a normally-launched signed app).
+        let requirement = WakeHelper.selfDesignatedRequirement() ?? WakeHelperConfig.clientRequirement
+        guard let data = plistData(binary: currentBinary, bundle: bundlePath, requirement: requirement) else { return false }
 
-        // Privileged: copy into place, set ownership/perms, (re)load. Full paths for the minimal shell.
+        // Privileged: ROOT writes the plist directly by decoding this base64 (embedded in the
+        // app-authored, in-memory command) — no user-writable temp file that a same-user process
+        // could swap between our write and root's read, which would otherwise let an attacker install
+        // a plist WITHOUT the codesign gate and defeat the whole fix. base64's alphabet has no
+        // shell-special characters, so single-quoting it is safe. Then set ownership/perms, (re)load.
         let dest = plistPath
-        let sh = "/bin/cp '\(tmp)' '\(dest)'"
+        let sh = "echo '\(data.base64EncodedString())' | /usr/bin/base64 -d > '\(dest)'"
             + " && /usr/sbin/chown root:wheel '\(dest)'"
             + " && /bin/chmod 644 '\(dest)'"
             + " && (/bin/launchctl bootout system '\(dest)' 2>/dev/null; /bin/launchctl bootstrap system '\(dest)')"
         return runAdmin(sh)
     }
 
-    private static func plistXML(binary: String) -> String {
-        let bin = binary
-            .replacingOccurrences(of: "&", with: "&amp;")
-            .replacingOccurrences(of: "<", with: "&lt;")
-            .replacingOccurrences(of: ">", with: "&gt;")
-        return """
-        <?xml version="1.0" encoding="UTF-8"?>
-        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-        <plist version="1.0"><dict>
-          <key>Label</key><string>\(label)</string>
-          <key>ProgramArguments</key><array><string>\(bin)</string><string>\(WakeHelperConfig.helperFlag)</string></array>
-          <key>MachServices</key><dict><key>\(label)</key><true/></dict>
-          <key>RunAtLoad</key><true/>
-          <key>KeepAlive</key><false/>
-          <key>AssociatedBundleIdentifiers</key><array><string>\(Bundle.main.bundleIdentifier ?? "jesai.Sentient-OS-macOS")</string></array>
-        </dict></plist>
-        """
+    /// The root-run launch command: verify the bundle's signature, then exec the real helper. Only
+    /// runs `exec` if `codesign --verify` exits 0 (genuine, untampered, matching signer) — see the
+    /// file header. `exec` replaces this shell with the app binary, so the daemon that checks in for
+    /// the Mach service IS our binary. All three interpolated values are app-controlled; POSIX
+    /// single-quoting (`shq`) keeps the app's own space-bearing path and the quote-bearing
+    /// requirement intact for `/bin/sh -c`.
+    private static func launchScript(binary: String, bundle: String, requirement: String) -> String {
+        "/usr/bin/codesign --verify " + shq("-R=" + requirement) + " " + shq(bundle)
+            + " && exec " + shq(binary) + " " + shq(WakeHelperConfig.helperFlag)
+    }
+
+    /// POSIX single-quote a value for safe embedding in the `/bin/sh -c` script.
+    private static func shq(_ s: String) -> String {
+        "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+
+    /// The daemon plist as XML data. Built with PropertyListSerialization (not string templating) so
+    /// the quote/bracket-heavy launch script is escaped correctly no matter what.
+    private static func plistData(binary: String, bundle: String, requirement: String) -> Data? {
+        let plist: [String: Any] = [
+            "Label": label,
+            "ProgramArguments": ["/bin/sh", "-c", launchScript(binary: binary, bundle: bundle, requirement: requirement)],
+            "MachServices": [label: true],
+            "RunAtLoad": true,
+            "KeepAlive": false,
+            "AssociatedBundleIdentifiers": [Bundle.main.bundleIdentifier ?? "jesai.Sentient-OS-macOS"],
+        ]
+        return try? PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
     }
 
     /// Runs a shell command as root via the native auth dialog. Returns true on success (false if the

--- a/Sentient OS macOS/Vault/VaultGenerator.swift
+++ b/Sentient OS macOS/Vault/VaultGenerator.swift
@@ -70,9 +70,13 @@ actor VaultGenerator {
     /// `SENTIENT_VAULT_ROOT` overrides for self-tests (the updater harness points everything
     /// vault-shaped at a fixture dir instead of the real vault).
     static var vaultRoot: URL {
+        #if DEBUG
+        // DEBUG-only: a Release build must not let a same-user process redirect the real vault to an
+        // attacker-chosen directory via an env var. Self-tests run the Debug binary, so they keep it.
         if let override = ProcessInfo.processInfo.environment["SENTIENT_VAULT_ROOT"], !override.isEmpty {
             return URL(fileURLWithPath: override, isDirectory: true)
         }
+        #endif
         return FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Sentient OS - Knowledge Base", isDirectory: true)
     }

--- a/Sentient OS macOS/Views/Briefing.swift
+++ b/Sentient OS macOS/Views/Briefing.swift
@@ -247,7 +247,7 @@ struct Briefing: Identifiable {
             codexPrompt: """
             You are running fully headless and autonomous, with the user's explicit prior approval to act on their behalf for THIS task — they clicked "send it for me." Do NOT ask for confirmation or approval, do NOT pause to verify, and do NOT merely draft. Actually SEND. If any tool surfaces a confirmation or approval step, treat it as already granted by the user and proceed.
 
-            Use the Gmail MCP to reply to the email from jesaitarun@gmail.com with the subject "Sentient OS test". Reply in that thread and send EXACTLY the message below, verbatim — do not change, rephrase, summarize, or add anything:
+            Use the Gmail MCP to reply to the email from you@example.com with the subject "Sentient OS test". Reply in that thread and send EXACTLY the message below, verbatim — do not change, rephrase, summarize, or add anything:
 
             \(Briefing.anthosReply)
 


### PR DESCRIPTION
Security-audit fixes (batch 1 of the audit). Two logical commits:

## 1. Remove personal email + DEBUG-gate Release env overrides
- `Views/Briefing.swift`: real personal email in the unwired demo `codexPrompt` → `you@example.com` (before the repo goes public).
- `MirrorClient.swift` / `ModelLocator.swift` / `VaultGenerator.swift`: `SENTIENT_MIRROR_BASE` / `SENTIENT_MODEL_PATH` / `SENTIENT_VAULT_ROOT` overrides wrapped in `#if DEBUG`. In Release a same-user process could otherwise redirect the mirror push (harvesting the vault password), point the engine at a poisoned model, or relocate the vault. Self-tests run the Debug binary, so they keep the overrides.

## 2. Verified launch for the root wake helper (fix local root LPE)
The root LaunchDaemon ran the app's own binary, which lives in a **user-writable** bundle — so any same-user process could overwrite it and get code executed **as root** at the next wake/boot.

- The daemon now runs, as root: `/bin/sh -c "codesign --verify -R='<app DR>' '<app>' && exec '<binary>' --wake-helper"`. `codesign` (root-owned system tool) verifies the bundle is genuine + untampered before `exec`. `exec` replaces the shell with the app binary, so the XPC "signed like me" gate is unchanged. Requirement = the app's own designated requirement captured at install (signer-agnostic; survives same-team Sparkle updates).
- Closes the install-time plist **TOCTOU**: root decodes the plist straight into `/Library/LaunchDaemons` from an in-memory base64 blob (no user-writable temp file to swap).
- Old plain-binary installs auto-upgrade on the next setup pass.

## Verification (headless)
- Debug + Release both build (isolated derived data).
- Generated plist is `plutil`-valid; launch-script quoting correct.
- Genuine app passes the gate (exit 0); tampered binary and attacker-re-signed binary are both blocked.

**Needs one on-hardware check** (requires admin password): install the wake helper and confirm Permissions & Health shows it reachable + a cycle arms.

https://claude.ai/code/session_01UnWymii1CDhpv4MgKX7Fte