### PR TITLE
Constellation View: slow-moving Starlight rim on the Reader View door

### DIFF
--- a/Sentient OS macOS/Views/Knowledge/Graph/NightSkyView.swift
+++ b/Sentient OS macOS/Views/Knowledge/Graph/NightSkyView.swift
@@ -118,6 +118,7 @@ struct NightSkyView: View {
 struct SkyDoor: View {
     let icon: String
     let label: String
+    var glowRim = false        // the sky's Reader View door wears the moving rim (discoverability)
     let action: () -> Void
 
     var body: some View {
@@ -126,6 +127,29 @@ struct SkyDoor: View {
         }
         .labelStyle(.titleAndIcon)
         .keyboardShortcut("g", modifiers: [.command, .shift])
+        .overlay { if glowRim { SkyDoorRim() } }
+    }
+}
+
+/// The slow-moving gradient rim on the sky's Reader View door — field-tested: behind plain glass,
+/// users never found the reader at all. Theme.magicGlow (teal → cyan → blue → indigo → purple)
+/// circles the capsule once every 8s: a soft bloom under a crisp 1pt edge. Cosmetic only — it
+/// never intercepts the cursor.
+private struct SkyDoorRim: View {
+    private static let period: Double = 8.0
+
+    var body: some View {
+        TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { ctx in
+            let t = ctx.date.timeIntervalSinceReferenceDate
+            let angle = (t.truncatingRemainder(dividingBy: Self.period) / Self.period) * 360.0
+            let rim = AngularGradient(colors: Theme.magicGlow, center: .center, angle: .degrees(angle))
+            ZStack {
+                Capsule(style: .continuous).strokeBorder(rim, lineWidth: 2.5)
+                    .blur(radius: 3).opacity(0.55)
+                Capsule(style: .continuous).strokeBorder(rim, lineWidth: 1)
+            }
+        }
+        .allowsHitTesting(false)
     }
 }
 
@@ -135,11 +159,12 @@ struct SkyDoorToolbarItem: ToolbarContent {
     let label: String
     let help: String
     var placement: ToolbarItemPlacement = .principal   // sky: top-center · reader: .navigation (top-left)
+    var glowRim = false
     let action: () -> Void
 
     var body: some ToolbarContent {
         ToolbarItem(placement: placement) {
-            SkyDoor(icon: icon, label: label, action: action).help(help)
+            SkyDoor(icon: icon, label: label, glowRim: glowRim, action: action).help(help)
         }
     }
 }
@@ -322,6 +347,16 @@ private final class SkyEventNSView: NSView {
     }
     .frame(width: 400, height: 240)
     .preferredColorScheme(.dark)
+}
+
+#Preview("Sky door — glow rim") {
+    Theme.bg
+        .frame(width: 460, height: 140)
+        .toolbar {
+            SkyDoorToolbarItem(icon: "doc.plaintext", label: "Reader View",
+                               help: "", glowRim: true) {}
+        }
+        .preferredColorScheme(.dark)
 }
 
 #Preview("Night Sky — real vault") {

--- a/Sentient OS macOS/Views/Knowledge/KnowledgeView.swift
+++ b/Sentient OS macOS/Views/Knowledge/KnowledgeView.swift
@@ -122,7 +122,8 @@ struct KnowledgeView: View {
                      onExit: { requestMode(.reader) })
             .toolbar {
                 SkyDoorToolbarItem(icon: "doc.plaintext", label: "Reader View",
-                                   help: "Back to the reader (Esc or ⌘⇧G)") { requestMode(.reader) }
+                                   help: "Back to the reader (Esc or ⌘⇧G)",
+                                   glowRim: true) { requestMode(.reader) }
             }
     }
 


### PR DESCRIPTION
## What

Users testing the Knowledge window never realized the Constellation View had a reader behind the plain glass toolbar button. The sky's **Reader View** door now wears a slow-moving gradient rim: `Theme.magicGlow` (teal → cyan → blue → indigo → purple) circling the capsule once every 8s — a soft 2.5pt bloom under a crisp 1pt edge, `allowsHitTesting(false)` so the button behaves exactly as before.

## How

- `SkyDoor` gains a `glowRim` option (default **off** — the reader-side Constellation View door stays plain native glass), worn only by the sky pane's toolbar seat.
- New private `SkyDoorRim` beside it: `TimelineView` re-angling an `AngularGradient` each frame at 30fps, same mechanism as `GlowHalo`.
- Reuses the existing `magicGlow` palette (the Stage-2 vault CTA's glow), so the gradient keeps one meaning: a door into your knowledge.
- Adds a door-only `#Preview` (the full-window preview host currently times out on launch).

## Testing

Builds clean via Xcode MCP. Motion + capsule-hug need a real-hardware eyeball (Jesai has it running); rim speed and stroke insets are one-line tunables if taste says so.