### PR TITLE
Sky door rim: mute the palette, wear it on both doors

### DIFF
--- a/Sentient OS macOS/Documentation/Knowledge Viewer.md
+++ b/Sentient OS macOS/Documentation/Knowledge Viewer.md
@@ -14,7 +14,8 @@ on-disk vault (`~/Sentient OS - Knowledge Base/`, resolved via `VaultGenerator.v
   markdown.
 
 Native **SkyDoor** toolbar buttons (plain `Label`s, same font and glass as their Edit / Reveal
-in Finder neighbours) swap between them — sky: top-center "Reader View" · reader: top-left
+in Finder neighbours, each wearing the muted moving `SkyDoorRim` so the other mode is
+discoverable) swap between them — sky: top-center "Reader View" · reader: top-left
 "Constellation View" · **⌘⇧G** either way · **Esc** leaves the sky. Clicking a star opens that
 note in the reader; **Back** walks the wikilink trail and, when the trip began with a star
 click, one more Back returns to the sky with that star glowing for a beat (`cameFromSky`). Mode switches funnel through the same unsaved-edits guard as every other
@@ -58,10 +59,12 @@ Tools via `Views/Dev/SummariesView.swift`.)*
     pans · pinch / mouse-wheel / ⌘-scroll zoom at cursor · star drag reheats the springs ·
     hover · still-click opens · Esc exits), the `SpinningLogo` sun overlay, the hover card
     (frame shared with the renderer via `hoverCardRect`), HUD whispers + "Private by design."
-    footer, and `SkyDoor` — a plain native toolbar button (`Label` + `.titleAndIcon`), so it
-    matches the reader's Edit / Reveal in Finder buttons exactly. *(The old glowing custom
-    capsule with the amber edge-flow was removed June 2026 — it read as decoration where the
-    toolbar wanted chrome.)*
+    footer, and `SkyDoor` + `SkyDoorRim` — the native toolbar button (`Label` + `.titleAndIcon`,
+    matching the reader's Edit / Reveal in Finder buttons) wearing a slow gradient rim:
+    `Theme.magicGlow` muted to a whisper (`.saturation(0.65)`, 80% edge / 45% bloom), one lap
+    every 8s, hit-testing off. *(History: the June 2026 amber edge-flow capsule was removed as
+    decoration; the rim returned July 2026 on field evidence — users never found Reader View
+    behind plain glass. Muted and riding the native button this time — jewelry, not chrome.)*
 
 **Editing:** Edit opens the RAW file (frontmatter included) in a `TextEditor`; Save writes
 atomically and refreshes the render. Navigating away with unsaved edits raises Save / Discard /

--- a/Sentient OS macOS/Views/Knowledge/Graph/NightSkyView.swift
+++ b/Sentient OS macOS/Views/Knowledge/Graph/NightSkyView.swift
@@ -113,12 +113,11 @@ struct NightSkyView: View {
 // MARK: - The door (shared by both sides: "Constellation View" in the reader, "Reader" in the sky)
 
 /// The mode switch in the titlebar (both KnowledgeView toolbars mount one via SkyDoorToolbarItem).
-/// A plain native toolbar button — same font and glass as its Edit / Reveal in Finder neighbours.
-/// ⌘⇧G fires whichever door is currently mounted.
+/// A native toolbar button — same font and glass as its Edit / Reveal in Finder neighbours —
+/// wearing the SkyDoorRim so the other mode is discoverable. ⌘⇧G fires whichever door is mounted.
 struct SkyDoor: View {
     let icon: String
     let label: String
-    var glowRim = false        // the sky's Reader View door wears the moving rim (discoverability)
     let action: () -> Void
 
     var body: some View {
@@ -127,14 +126,14 @@ struct SkyDoor: View {
         }
         .labelStyle(.titleAndIcon)
         .keyboardShortcut("g", modifiers: [.command, .shift])
-        .overlay { if glowRim { SkyDoorRim() } }
+        .overlay { SkyDoorRim() }
     }
 }
 
-/// The slow-moving gradient rim on the sky's Reader View door — field-tested: behind plain glass,
-/// users never found the reader at all. Theme.magicGlow (teal → cyan → blue → indigo → purple)
-/// circles the capsule once every 8s: a soft bloom under a crisp 1pt edge. Cosmetic only — it
-/// never intercepts the cursor.
+/// The slow-moving gradient rim both mode doors wear — field-tested: behind plain glass, users
+/// never found the reader at all. Theme.magicGlow (teal → cyan → blue → indigo → purple), muted
+/// to a whisper, circles the capsule once every 8s: a soft bloom under a crisp 1pt edge.
+/// Cosmetic only — it never intercepts the cursor.
 private struct SkyDoorRim: View {
     private static let period: Double = 8.0
 
@@ -145,9 +144,10 @@ private struct SkyDoorRim: View {
             let rim = AngularGradient(colors: Theme.magicGlow, center: .center, angle: .degrees(angle))
             ZStack {
                 Capsule(style: .continuous).strokeBorder(rim, lineWidth: 2.5)
-                    .blur(radius: 3).opacity(0.55)
-                Capsule(style: .continuous).strokeBorder(rim, lineWidth: 1)
+                    .blur(radius: 3).opacity(0.45)
+                Capsule(style: .continuous).strokeBorder(rim, lineWidth: 1).opacity(0.8)
             }
+            .saturation(0.65)
         }
         .allowsHitTesting(false)
     }
@@ -159,12 +159,11 @@ struct SkyDoorToolbarItem: ToolbarContent {
     let label: String
     let help: String
     var placement: ToolbarItemPlacement = .principal   // sky: top-center · reader: .navigation (top-left)
-    var glowRim = false
     let action: () -> Void
 
     var body: some ToolbarContent {
         ToolbarItem(placement: placement) {
-            SkyDoor(icon: icon, label: label, glowRim: glowRim, action: action).help(help)
+            SkyDoor(icon: icon, label: label, action: action).help(help)
         }
     }
 }
@@ -353,8 +352,7 @@ private final class SkyEventNSView: NSView {
     Theme.bg
         .frame(width: 460, height: 140)
         .toolbar {
-            SkyDoorToolbarItem(icon: "doc.plaintext", label: "Reader View",
-                               help: "", glowRim: true) {}
+            SkyDoorToolbarItem(icon: "doc.plaintext", label: "Reader View", help: "") {}
         }
         .preferredColorScheme(.dark)
 }

--- a/Sentient OS macOS/Views/Knowledge/KnowledgeView.swift
+++ b/Sentient OS macOS/Views/Knowledge/KnowledgeView.swift
@@ -122,8 +122,7 @@ struct KnowledgeView: View {
                      onExit: { requestMode(.reader) })
             .toolbar {
                 SkyDoorToolbarItem(icon: "doc.plaintext", label: "Reader View",
-                                   help: "Back to the reader (Esc or ⌘⇧G)",
-                                   glowRim: true) { requestMode(.reader) }
+                                   help: "Back to the reader (Esc or ⌘⇧G)") { requestMode(.reader) }
             }
     }
 


### PR DESCRIPTION
Taste pass on #181 after real-hardware review (Jesai approved the look):

- **Muted rim:** the whole rim runs through `.saturation(0.65)`; crisp edge at 80% opacity, bloom down 55% → 45%. Same `Theme.magicGlow` stops, same slow 8s lap.
- **Both doors:** the reader's top-left **Constellation View** door now wears the identical rim as the sky's **Reader View** door.
- **Cleanup:** with every door glowing, the `glowRim` flag was dead weight — deleted; the rim is simply part of `SkyDoor`.
- **Docs:** `Knowledge Viewer.md` updated (tested + confirmed on hardware), including the honest history note: the June 2026 amber edge-flow capsule was removed as decoration; this rim returns on field evidence (users never found Reader View behind plain glass), muted and riding the native button.