### PR TITLE
Show the update card in the window that asked for it

### DIFF
--- a/Sentient OS macOS/Documentation/Auto-Update (Sparkle).md
+++ b/Sentient OS macOS/Documentation/Auto-Update (Sparkle).md
@@ -50,13 +50,15 @@ requires first shipping a build that carries a new public key.
 
 | File | Job |
 |---|---|
-| `UpdateController.swift` | Owns the `SPUUpdater` (targets the main bundle), the driver, and the model. `AppState` holds one and calls `start()` on launch — **GUI path only**, never the root wake-helper. `start()` also fires one background check so a fresh launch discovers updates immediately. Implements the **silent-relaunch hook** (`willInstallUpdateOnQuit` → idle-gated `installIfSafe` → self-relaunch) and the `SPUUpdaterDelegate`. Exposes `checkForUpdatesNow()` + version/last-checked for the menu and Settings. |
+| `UpdateController.swift` | Owns the `SPUUpdater` (targets the main bundle), the driver, and the model. `AppState` holds one and calls `start()` on launch — **GUI path only**, never the root wake-helper. `start()` also fires one background check so a fresh launch discovers updates immediately. Implements the **silent-relaunch hook** (`willInstallUpdateOnQuit` → idle-gated `installIfSafe` → self-relaunch) and the `SPUUpdaterDelegate`. Exposes `checkForUpdatesNow(from:)` (tagging the originating window — see `CheckOrigin`) + version/last-checked for the menu and Settings. |
 | `SentientUpdateDriver.swift` | Our custom `SPUUserDriver`. Translates Sparkle's callbacks into `UpdateModel` state and stashes the reply closures. **Mandatory:** `showUpdateFound…` only ever replies `.install`; `showReady(toInstallAndRelaunch:)` auto-installs. ⚠️ The method labels must match Sparkle's imported Swift signatures exactly (Swift matches these witnesses by signature, not `@objc` selector). |
-| `UpdateModel.swift` | `@Observable` bridge between the driver and the UI. A `Phase` state machine (idle → checking → found → downloading → extracting → installing / failed) and a `Surface` (`none` / `gate` / `info`). |
-| `UpdateGateView.swift` | The OLED UI. Two faces: the full-screen **gate** (mandatory — Update / Quit, no skip/remind) and a small dismissible **info card** (user-initiated "Checking…" / "You're up to date" / "Couldn't check"). Presented as an overlay by `RootView`; draws nothing at rest. |
+| `UpdateModel.swift` | `@Observable` bridge between the driver and the UI. A `Phase` state machine (idle → checking → found → downloading → extracting → installing / failed), a `Surface` (`none` / `gate` / `info`), and `CheckOrigin` (`home` / `settings`) — which window a user-initiated check came from. |
+| `UpdateGateView.swift` | The OLED UI. Two faces: the full-screen **gate** (mandatory — Update / Quit, no skip/remind) and a small dismissible **info card** (user-initiated "Checking…" / "You're up to date" / "Couldn't check"). Mounted as an overlay by BOTH the home (`RootView`) and the Settings window, each passing its `host`: the **info card renders only in the check's origin window** (Settings' Check Now shows over Settings, never buried under it), while the **gate takes over every hosting window**. Draws nothing at rest. |
 
-**Wiring:** `App/AppState.swift` (owns + `start()`s) · `Views/RootView.swift` (`.overlay { UpdateGateView() }`)
-· `Views/MenuBarView.swift` ("Check for Updates…") · `Views/Settings/SystemPane.swift` (Updates group).
+**Wiring:** `App/AppState.swift` (owns + `start()`s) · `Views/RootView.swift` (`.overlay { UpdateGateView(host: .home) }`)
+· `Views/Settings/SettingsView.swift` (`.overlay { UpdateGateView(host: .settings) }`)
+· `Views/MenuBarView.swift` ("Check for Updates…" — opens/focuses the home window first, since that's
+where its card appears) · `Views/Settings/SystemPane.swift` (Updates group, checks `from: .settings`).
 
 ## The update model — silent self-relaunch, gate as fallback
 
@@ -79,11 +81,13 @@ requires first shipping a build that carries a new public key.
 - **Fail-open.** If the feed is unreachable (offline, server down), Sparkle surfaces nothing — nobody
   is locked out of their own local AI.
 - **Info card** shows only for *user-initiated* checks: "Checking…" / "You're up to date" / "Couldn't
-  check". A silent background check that finds nothing shows nothing.
+  check" — and only in the window the check came from (`CheckOrigin`): Settings' Check Now over the
+  Settings window, the menu bar's over the home (the menu item opens/focuses the home first so the
+  card always has a visible stage). A silent background check that finds nothing shows nothing.
 
-⚠️ **Known limitation:** the gate overlays the **main window**; a user focused on a secondary window
-(Settings/Knowledge) could keep using it during a found-update gate. `NSApplication.activate` mitigates
-it; a true all-window blocker is possible future hardening.
+⚠️ **Known limitation:** the gate overlays the **home and Settings** windows; a user focused on
+another window (Knowledge/Connect AIs) could keep using it during a found-update gate.
+`NSApplication.activate` mitigates it; a true all-window blocker is possible future hardening.
 
 ## Config — `Info.plist`
 

--- a/Sentient OS macOS/Updates/UpdateController.swift
+++ b/Sentient OS macOS/Updates/UpdateController.swift
@@ -5,7 +5,7 @@
 //  Owns the Sparkle updater and wires it to our own UI. Creates one SPUUpdater targeting the app's
 //  main bundle, driven by SentientUpdateDriver (our OLED gate) with this object as the SPUUpdaterDelegate.
 //  AppState holds one of these and calls `start()` — GUI path only (never the root wake-helper). The
-//  menu bar and Settings call `checkForUpdatesNow()`.
+//  menu bar and Settings call `checkForUpdatesNow(from:)`, tagging which window hosts the info card.
 //
 //  Chrome-style silent relaunch: once Sparkle has silently downloaded + staged an update, it calls our
 //  `willInstallUpdateOnQuit` hook. We take over and, the moment it's SAFE (no pipeline run in flight and
@@ -60,10 +60,12 @@ final class UpdateController: NSObject, SPUUpdaterDelegate {
     }
 
     /// A user-asked check (menu bar / Settings). Shows the small info card for "checking" and
-    /// "you're up to date"; escalates to the full gate if a real update is found.
-    func checkForUpdatesNow() {
+    /// "you're up to date" in the originating window; escalates to the full gate if a real
+    /// update is found.
+    func checkForUpdatesNow(from origin: UpdateModel.CheckOrigin) {
         guard updater.canCheckForUpdates else { return }
         model.userInitiated = true
+        model.checkOrigin = origin
         updater.checkForUpdates()
     }
 

--- a/Sentient OS macOS/Updates/UpdateGateView.swift
+++ b/Sentient OS macOS/Updates/UpdateGateView.swift
@@ -7,7 +7,10 @@
 //     One action: Update. (Plus Quit, so a modal never traps the user.) No "skip" / "remind me".
 //   • info — a small dismissible card for a user-initiated check: "Checking…", "You're up to date",
 //     or "Couldn't check". Never shown for a silent background check.
-//  Rendered as an overlay by RootView; draws nothing when surface == .none.
+//  Rendered as an overlay by BOTH the home (RootView) and the Settings window, each passing its
+//  `host`: the info card draws only in the window the check came from (so Settings' Check Now
+//  shows over Settings, not buried under it), while the gate takes over every hosting window.
+//  Draws nothing when surface == .none.
 //
 //  Design bar: true-black, bold display titles, mono-caps whispers, the spinning AI-spectrum
 //  logo as the living mark, the glow CTA. Reuses Theme / GlowButton / SpinningLogo.
@@ -17,6 +20,9 @@ import SwiftUI
 import AppKit
 
 struct UpdateGateView: View {
+    /// The window this instance overlays — the info card renders only in the check's origin window.
+    let host: UpdateModel.CheckOrigin
+
     @Environment(AppState.self) private var appState
     private var model: UpdateModel { appState.update.model }
 
@@ -28,7 +34,11 @@ struct UpdateGateView: View {
             case .gate:
                 gate.transition(.opacity)
             case .info:
-                infoCard.transition(.opacity)
+                if model.checkOrigin == host {
+                    infoCard.transition(.opacity)
+                } else {
+                    Color.clear.allowsHitTesting(false)
+                }
             }
         }
         .animation(.easeInOut(duration: 0.3), value: model.surface)
@@ -122,7 +132,7 @@ struct UpdateGateView: View {
                     .fixedSize(horizontal: false, vertical: true)
                 GlowButton(title: "Try Again", systemImage: "arrow.clockwise") {
                     model.dismissInfo()                 // acknowledge the error, reset
-                    appState.update.checkForUpdatesNow()
+                    appState.update.checkForUpdatesNow(from: host)
                 }
                 .frame(maxWidth: 320)
                 quitButton

--- a/Sentient OS macOS/Updates/UpdateModel.swift
+++ b/Sentient OS macOS/Updates/UpdateModel.swift
@@ -32,11 +32,19 @@ final class UpdateModel {
     /// Which surface to present over the app, if any.
     enum Surface: Equatable { case none, gate, info }
 
+    /// Which window a user-initiated check came from. The small info card renders only in that
+    /// window (so a Settings-triggered check shows over Settings, not buried under it in the
+    /// home); the mandatory gate takes over every hosting window regardless.
+    enum CheckOrigin { case home, settings }
+
     private(set) var phase: Phase = .idle
 
     /// Was the in-flight check user-triggered? Governs whether "checking"/"up to date"/"check
     /// failed" surface a small info card (yes) or stay silent (a background check finding nothing).
     var userInitiated = false
+
+    /// Where the in-flight user-initiated check was started (see CheckOrigin).
+    var checkOrigin: CheckOrigin = .home
 
     // Download byte accounting (feeds the determinate progress bar).
     private var expectedBytes: UInt64 = 0

--- a/Sentient OS macOS/Views/MenuBarView.swift
+++ b/Sentient OS macOS/Views/MenuBarView.swift
@@ -25,7 +25,10 @@ struct MenuBarView: View {
         }
 
         Divider()
-        Button("Check for Updates…") { appState.update.checkForUpdatesNow() }
+        Button("Check for Updates…") {
+            openHome()   // the check's info card lives in the home window — make sure it's up front
+            appState.update.checkForUpdatesNow(from: .home)
+        }
         Text("Version \(UpdateController.currentVersionString)")
 
         Divider()

--- a/Sentient OS macOS/Views/RootView.swift
+++ b/Sentient OS macOS/Views/RootView.swift
@@ -114,7 +114,7 @@ struct RootView: View {
         .animation(.easeInOut(duration: 0.35), value: codex.settingUpComputerUse)
         // The mandatory update gate floats above everything (home, processing, dev sheet) — when a
         // required update is found it takes over; otherwise it draws nothing. (Updates/)
-        .overlay { UpdateGateView() }
+        .overlay { UpdateGateView(host: .home) }
         .sheet(isPresented: $showDevTools) {
             DevToolsView()
         }

--- a/Sentient OS macOS/Views/Settings/SettingsView.swift
+++ b/Sentient OS macOS/Views/Settings/SettingsView.swift
@@ -54,6 +54,10 @@ struct SettingsView: View {
         }
         .background(Theme.bg.ignoresSafeArea())
         .frame(minWidth: 880, minHeight: 600)
+        // The update surface, hosted here too: System's "Check for Updates Now" shows its info
+        // card over THIS window (not buried in the home behind it), and a mandatory gate takes
+        // this window over as well. Draws nothing otherwise. (Updates/)
+        .overlay { UpdateGateView(host: .settings) }
         .onAppear {
             if let pane = Self.requestedPane { selection = pane; Self.requestedPane = nil }
         }
@@ -89,7 +93,7 @@ struct SettingsView: View {
     /// The About corner — what used to want its own tab, tucked where it belongs.
     private var aboutFooter: some View {
         VStack(alignment: .leading, spacing: 9) {
-            MonoCaps("Sentient OS · v\(appVersion)", size: 8, tracking: 1.6, color: Theme.Ink.deepMuted)
+            MonoCaps("Sentient OS · v\(UpdateController.currentVersionString)", size: 8, tracking: 1.6, color: Theme.Ink.deepMuted)
             footerLink("Open source on GitHub", icon: "heart.fill",
                        url: "https://github.com/Sentient-OS-Labs/sentient-os")
             footerLink("Report an issue", icon: "ladybug",
@@ -109,10 +113,6 @@ struct SettingsView: View {
             .foregroundStyle(Theme.Ink.label)
         }
         .buttonStyle(PressScaleStyle())
-    }
-
-    private var appVersion: String {
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1"
     }
 
     // MARK: - Detail

--- a/Sentient OS macOS/Views/Settings/SystemPane.swift
+++ b/Sentient OS macOS/Views/Settings/SystemPane.swift
@@ -104,7 +104,7 @@ struct SystemPane: View {
                     }
                 }
                 SettingsPillButton(title: "Check for Updates Now") {
-                    appState.update.checkForUpdatesNow()
+                    appState.update.checkForUpdatesNow(from: .settings)
                 }
             }
         }


### PR DESCRIPTION
## What

Three fixes around the Sparkle update UI:

1. **Settings' Check for Updates now shows its popup over Settings.** `UpdateGateView` was mounted only in the home window's `RootView`, so a check from Settings drew the "Checking…" / "You're up to date" card in the home window, hidden behind Settings. `UpdateModel` gains a `CheckOrigin` (`home`/`settings`), `checkForUpdatesNow(from:)` tags the origin, and the Settings window now hosts its own `UpdateGateView(host: .settings)` overlay. The info card renders only in the origin window; the mandatory full-screen gate takes over every hosting window (so an update found from Settings isn't invisible either). The gate's Try Again re-checks from the window it was clicked in.

2. **Menu bar's Check for Updates opens/focuses the home window first** (the existing `openHome()` — same as "Open Sentient OS"), so the card always has a visible stage even when no window is up.

3. **Settings sidebar footer shows the full version incl. the build number** — `v1.0 (1)`, same format as the menu bar — via the existing `UpdateController.currentVersionString`; the short-only `appVersion` helper is deleted.

Doc updated: `Documentation/Auto-Update (Sparkle).md` (mount points, wiring, the now-narrower known limitation).

## Verified

Builds clean via Xcode's own build system (MCP `BuildProject`); behavior confirmed by Jesai in the running app.