### PR TITLE
Honest failure recovery: never cache a failed codex probe + classified failed screen

### DIFF
--- a/Sentient OS macOS/Cloud/CodexCLI.swift
+++ b/Sentient OS macOS/Cloud/CodexCLI.swift
@@ -14,7 +14,7 @@
 //   - CodexCLI.locateBinary()  → cached absolute-path discovery (known paths + zsh -lc which)
 //   - install(onLine:)         → run OpenAI's standalone installer (the codex-setup onboarding step)
 //   - startLogin / loginStatus → step 2: interactive `codex login` (browser) + the status check
-//   - validate(force:)         → Availability via ping (cached per launch)
+//   - validate(force:)         → Availability via ping (only a good verdict is cached)
 //   - run(_:)                  → Envelope (blocking JSONL mode)
 //
 //  Doc: Documentation/CodexCLI (codex exec Compute Spine).md
@@ -270,12 +270,15 @@ actor CodexCLI {
 
     private var cachedAvailability: Availability?
 
-    /// Is `codex exec` actually usable (installed AND logged in)? Cached per app launch —
-    /// pass `force: true` to re-probe (e.g. right after the installer flow).
+    /// Is `codex exec` actually usable (installed AND logged in)? Only a GOOD verdict is cached —
+    /// a failed probe re-checks on every call, so codex fixed mid-session (re-login, reinstall) is
+    /// seen by the very next retry (a cached failure once made the processing screen's Retry
+    /// unwinnable until relaunch — field-found 2026-07-12). `force: true` re-probes past a good
+    /// cache too (e.g. right after the installer flow).
     func validate(force: Bool = false) async -> Availability {
         if !force, let cachedAvailability { return cachedAvailability }
         let result = await Self.ping()
-        cachedAvailability = result
+        if case .available = result { cachedAvailability = result } else { cachedAvailability = nil }
         return result
     }
 

--- a/Sentient OS macOS/Documentation/CodexCLI (codex exec Compute Spine).md
+++ b/Sentient OS macOS/Documentation/CodexCLI (codex exec Compute Spine).md
@@ -28,8 +28,13 @@ plumbing).
 - `startLogin(onLine:)` / `loginStatus()` — step 2: spawns `codex login` as a background process (it
   opens the browser + runs the localhost OAuth callback server, self-exits once `~/.codex/auth.json`
   lands); `loginStatus()` is the ground-truth `codex login status` check (exit 0 = logged in).
-- `validate(force:)` — ping (`Reply with exactly: PIGGYBACK_OK`, 30 s), cached per app launch;
-  `force: true` re-probes (the installer flow).
+- `validate(force:)` — ping (`Reply with exactly: PIGGYBACK_OK`, 30 s). **Only a good verdict is
+  cached** (per app launch); a failed probe re-checks on every call, so codex fixed mid-session
+  (re-login, reinstall) is seen by the very next retry. ⚠️ Never cache the failure: it once made
+  the processing takeover's Retry unwinnable until relaunch (field-found 2026-07-12 — a
+  server-side-invalidated token 401'd the ping, the user re-logged in, and four more retries
+  still failed in 0 ms off the cached verdict). `force: true` re-probes past a good cache too
+  (the installer flow).
 - `run(Invocation) → Envelope` — one headless `--json` call, typed errors. An optional `onLine:`
   streams a human-readable play-by-play (each JSONL item reduced by `humanLine` — agent messages,
   `$ command`s, `→ mcp.tool`s, `🔎 search`es) for live UIs (the For You cards).

--- a/Sentient OS macOS/Documentation/Home — Proactive Intelligence (For You).md
+++ b/Sentient OS macOS/Documentation/Home — Proactive Intelligence (For You).md
@@ -52,8 +52,9 @@ The main window's content (rendered by `RootView`). Layers, bottom-to-top:
     session (lower rungs still surface). Suppressed entirely in knowledge-base-only mode (nothing
     nightly runs there) and on demo decks (no red capsules mid-pitch).
   - **The morning-after caution (amber):** when last night's UNATTENDED 3am run failed for one of
-    the three knowable reasons (codex signed out · no internet · usage limit — recorded by
-    `Scheduling/OvernightCaution` at `ProactiveCycle`'s catch sites, scheduled runs only): amber
+    the three knowable reasons (codex signed out · no internet · usage limit — classified by
+    `OvernightCaution.classify` at `ProactiveCycle`'s catch sites, persisted on scheduled runs
+    only; a watched run shows the same kind live on the takeover's failed screen instead): amber
     `HealthDot`, the first-person message, ✕ (clears the record), *Open Settings* on the
     logged-out one. The next fully successful cycle clears it on its own; the foreground refresh
     also re-reads it. Amber on purpose: a caution, never an alarm — only the overnight magic was
@@ -72,7 +73,14 @@ under a "THINKING" whisper (`ProcessingView.liveThought`, fed by `ProactiveCycle
 shell `$ ` lines filtered as noise, thoughts promoted at a 1.4s cadence, cleared per phase), and the
 footer sets expectations in three lines: the ~15-minute estimate (with the 10-minute warm flip), the
 keep-Sentient-open/lid-up instruction, and the reassurance that 3am runs wake a lid-shut, plugged-in
-Mac on their own. `RootView` also owns
+Mac on their own. **The failed screen speaks the classified failure** (2026-07-12): `ProactiveCycle`
+returns a `CycleFailure` (message + `OvernightCaution.Kind?`), and `ProcessingView.failedView`
+renders the kind — "Codex isn't logged in" gets a prominent **Log in to Codex** button (the shared
+`CodexSetup.startLogin` browser flow; a 1.5s `codex login status` poll auto-notices the finished
+sign-in and auto-retries the cycle, same pattern as Settings → Health), usage-limit and no-internet
+get honest progress-is-saved one-liners, and unclassified failures show the step's raw message with
+plain Back/Retry. Retry is honest in every case: `CodexCLI.validate` never caches a failed probe
+(see the CodexCLI doc), so a fixed codex is seen on the very next attempt. `RootView` also owns
 **the onboarding finale**: when the first analysis finishes, onboarding dissolves into the home and
 the Knowledge window (the Constellation) opens ON TOP a beat later — every user's first sight of
 their knowledge base, whatever their plan. ProcessingView's "Analysis complete" screen

--- a/Sentient OS macOS/Documentation/Overnight Scheduler (3am Wake).md
+++ b/Sentient OS macOS/Documentation/Overnight Scheduler (3am Wake).md
@@ -85,15 +85,19 @@ re-armed for tomorrow; thermal is start-only) → `beginAwake` + a 60s heartbeat
 the Mac idle-sleeps (lid shut) → re-arm for the next night. Production default is **3:00 AM**
 (`defaultMinutes`; the dev UI can override).
 
-**The morning-after caution:** the scheduler is the ONE caller that passes
-`ProactiveCycle.run(scheduled: true, …)` — a failure in an unattended run classifies at the
-cycle's catch sites (`Scheduling/OvernightCaution`: typed `usageLimit` first → a local
-`codex login status` probe (works offline) → an `NWPathMonitor` snapshot → anything else records
-NOTHING) into codex-signed-out · no-internet · usage-limit, persisted for the home's amber banner
-(`HomeView.cautionBanner`). A watched Analyze Now records nothing (the takeover UI shows failures
-live); the next fully successful cycle clears the record. Each caution also emits a PII-free
-`overnight.caution{kind}` Sentry event. *(The home's banner slot also carries a LIVE health ladder
-— `System/HealthCaution.swift`, red, outranks this amber event — see the Home doc.)*
+**The morning-after caution:** EVERY cycle failure classifies at the cycle's catch sites
+(`OvernightCaution.classify`, since 2026-07-12: typed `usageLimit` first → a `401`/`unauthorized`
+marker in codex's own output (⚠️ a token invalidated SERVER-side still reads logged-in to the
+local probe — that marker is the only tell; field-found 2026-07-12) → a local `codex login
+status` probe (works offline) → an `NWPathMonitor` snapshot → anything else classifies as
+NOTHING) into codex-signed-out · no-internet · usage-limit. The scheduler is the ONE caller that
+passes `ProactiveCycle.run(scheduled: true, …)`, which PERSISTS the kind
+(`OvernightCaution.record`) for the home's amber banner (`HomeView.cautionBanner`) and emits the
+PII-free `Scheduler.caution{kind}` TelemetryDeck signal. A watched Analyze Now records nothing —
+the takeover's failed screen speaks the same classified kind live instead ("Codex isn't logged
+in" + an inline login button; see the Home doc). The next fully successful cycle clears the
+record. *(The home's banner slot also carries a LIVE health ladder —
+`System/HealthCaution.swift`, red, outranks this amber event — see the Home doc.)*
 
 ⚠️ Known caveat: **Full Disk Access can read `false` when the app is launched from Terminal** (TCC
 attribution) — which silently excludes the DB sources. The arm-time `DETECTED …` / `FDA granted:`
@@ -226,8 +230,8 @@ This is the dev cockpit; the shipping onboarding/Settings UX (Jesai) binds to th
 - `Scheduling/WakeHelperClient.swift` — daemon register/status/deep-link + the XPC ops + `isReachable()`/`healthProbe()` (the liveness ground truth).
 - `Scheduling/WakeHelperInstaller.swift` — the PRODUCTION admin-password installer (decided 2026-07-04); also the DEBUG fallback in `ensureHelperReady`.
 - `jesai.Sentient-OS-macOS.WakeHelper.plist` (project root) — the bundled SMAppService daemon plist + its Copy Files phase.
-- `Proactive/ProactiveCycle.swift` — stamps "initial finished"; classifies scheduled failures.
-- `Scheduling/OvernightCaution.swift` — the morning-after caution: classify + persist + clear.
+- `Proactive/ProactiveCycle.swift` — stamps "initial finished"; classifies EVERY failure (returns `CycleFailure`), persists the caution on scheduled runs only.
+- `Scheduling/OvernightCaution.swift` — `classify` (shared with the takeover's failed screen) + `record` + `latest`/`clear`.
 - `AppState.swift` / `Views/RootView.swift` — call `maybeAutoEnable()` at launch / after each cycle.
 - `Views/Dev/OvernightDevView.swift` — the standalone dev window (checklist + live status).
 - `Views/Dev/DevToolsView.swift` — the "Overnight Processing…" button that opens it.

--- a/Sentient OS macOS/Proactive/ProactiveCycle.swift
+++ b/Sentient OS macOS/Proactive/ProactiveCycle.swift
@@ -18,7 +18,8 @@
 //  place so a retry can pick up where it stopped. `progress` carries human-readable phases for the UI;
 //  `onLine` streams codex's live play-by-play (the takeover's thought line — unused by the 3am run).
 //
-//  Key method: run(progress:) → String?  (nil = cycle completed; a message = the step that failed)
+//  Key method: run(progress:) → CycleFailure?  (nil = cycle completed; else the step that failed,
+//  classified so the UI can offer the right fix)
 //
 
 import Foundation
@@ -29,7 +30,14 @@ enum ProactiveCyclePhase: Sendable {
     case deciding                // PART 1 — the judge
     case researching(Int)        // PART 2 — verifying + preparing N items
     case done(ready: Int)        // finished; N ready-to-fire cards await
-    case failed(String)          // a step errored; summaries were kept for retry
+    case failed(CycleFailure)    // a step errored; summaries were kept for retry
+}
+
+/// A failed cycle step. `kind` is the verified, user-actionable reason (codex signed out ·
+/// offline · usage limit) when one could be established — nil means show `message` as-is.
+struct CycleFailure: Sendable, Equatable {
+    let message: String
+    let kind: OvernightCaution.Kind?
 }
 
 actor ProactiveCycle {
@@ -50,17 +58,18 @@ actor ProactiveCycle {
     }
 
     /// Run the post-read tail (knowledge base → mirror → proactive → wipe). Returns nil on a fully
-    /// successful cycle (summaries wiped), or the failure message if a step errored (summaries kept).
-    /// Never throws — every failure is ALSO reported through `progress(.failed(…))` for the live UI.
-    /// `scheduled` marks the UNATTENDED 3am run: its failures additionally classify into the
-    /// morning-after caution (OvernightCaution → the home's banner); a watched Analyze Now doesn't
-    /// (the takeover UI already shows those live).
+    /// successful cycle (summaries wiped), or the classified failure if a step errored (summaries
+    /// kept). Never throws — every failure is ALSO reported through `progress(.failed(…))` for the
+    /// live UI. Every failure classifies (OvernightCaution.classify — signed out · offline · usage
+    /// limit); `scheduled` marks the UNATTENDED 3am run, which additionally persists the kind as
+    /// the morning-after caution (the home's banner) — a watched Analyze Now instead shows it live
+    /// on the takeover's failed screen.
     /// `onLine` streams codex's humanized play-by-play (reasoning · commands · tool calls) from
     /// every cloud stage — the takeover's live thought line. nil (the 3am run) streams nothing.
     @discardableResult
     func run(scheduled: Bool = false,
              progress: @escaping @Sendable (ProactiveCyclePhase) -> Void,
-             onLine: (@Sendable (String) -> Void)? = nil) async -> String? {
+             onLine: (@Sendable (String) -> Void)? = nil) async -> CycleFailure? {
         PipelineActivity.begin()                 // Settings' Reset is disabled while the tail runs
         defer { PipelineActivity.end() }
         let notes = await CycleStore.shared.notes().map(CloudNote.init)
@@ -80,10 +89,10 @@ actor ProactiveCycle {
             Analytics.signal(exists ? "KnowledgeBase.updated" : "KnowledgeBase.built",
                              parameters: ["newSummaries": "\(notes.count)"])
         } catch {
-            let m = "Knowledge base: \(Self.msg(error))"
             Analytics.signal("KnowledgeBase.failed", parameters: ["phase": exists ? "update" : "build"])
-            if scheduled { await OvernightCaution.note(error) }   // the morning-after banner
-            progress(.failed(m)); return m                   // half-edited vault isn't dirty; summaries kept
+            // half-edited vault isn't dirty; summaries kept
+            return await Self.fail("Knowledge base: \(Self.msg(error))", error: error,
+                                   scheduled: scheduled, progress: progress)
         }
         await VaultCloud.pushIfDirty()                       // no-op if the mirror is off
 
@@ -117,9 +126,8 @@ actor ProactiveCycle {
             } catch Proactive.ProError.noRecent {
                 items = []                                   // nothing recent enough — clear cards, still success
             } catch {
-                let m = "Deciding: \(Self.msg(error))"
-                if scheduled { await OvernightCaution.note(error) }
-                progress(.failed(m)); return m
+                return await Self.fail("Deciding: \(Self.msg(error))", error: error,
+                                       scheduled: scheduled, progress: progress)
             }
             Analytics.signal("Proactive.decided", parameters: ["items": "\(items.count)"])
 
@@ -135,9 +143,8 @@ actor ProactiveCycle {
                         "ready": "\(result.ready.count)", "dropped": "\(result.dropped.count)"],
                         floatValue: Double(result.ready.count), tier: .core)
                 } catch {
-                    let m = "Preparing: \(Self.msg(error))"
-                    if scheduled { await OvernightCaution.note(error) }
-                    progress(.failed(m)); return m
+                    return await Self.fail("Preparing: \(Self.msg(error))", error: error,
+                                           scheduled: scheduled, progress: progress)
                 }
             }
             // The deck was replaced (new cards or a clean empty) — a pre-existing gift's day is done.
@@ -154,4 +161,14 @@ actor ProactiveCycle {
     }
 
     private static func msg(_ e: Error) -> String { (e as? LocalizedError)?.errorDescription ?? "\(e)" }
+
+    /// The one shape every catch site shares: classify the failure, persist the caution on the
+    /// unattended run, surface it to the live UI, and hand it back for the caller's return.
+    private static func fail(_ message: String, error: Error, scheduled: Bool,
+                             progress: @Sendable (ProactiveCyclePhase) -> Void) async -> CycleFailure {
+        let failure = CycleFailure(message: message, kind: await OvernightCaution.classify(error))
+        if scheduled { OvernightCaution.record(failure.kind) }   // the morning-after banner
+        progress(.failed(failure))
+        return failure
+    }
 }

--- a/Sentient OS macOS/Scheduling/OvernightCaution.swift
+++ b/Sentient OS macOS/Scheduling/OvernightCaution.swift
@@ -2,14 +2,17 @@
 //  OvernightCaution.swift
 //  Sentient OS macOS
 //
-//  The morning-after caution: when the UNATTENDED 3am cycle fails for one of the three reasons a
-//  user can actually act on or should simply know about — codex signed out · no internet · usage
-//  limit — the failure is classified here (at ProactiveCycle's catch sites, the one choke point
-//  every codex call already funnels typed errors through) and persisted, and the home renders it
-//  as a quiet amber capsule (HomeView.cautionBanner). Any later fully successful cycle clears it;
-//  so does the banner's ✕. Other failure kinds stay log/Sentry territory — no banner.
+//  Cycle-failure classification + the morning-after caution. `classify(_:)` turns a cycle failure
+//  into one of the three reasons a user can actually act on or should simply know about — codex
+//  signed out · no internet · usage limit — and serves BOTH failure surfaces: the UNATTENDED 3am
+//  run persists it via `record(_:)` (at ProactiveCycle's catch sites, the one choke point every
+//  codex call already funnels typed errors through) and the home renders it as a quiet amber
+//  capsule (HomeView.cautionBanner); the WATCHED processing takeover shows the same kind live on
+//  its failed screen (ProcessingView.failedView — "Codex isn't logged in" + a login button). Any
+//  later fully successful cycle clears the caution; so does the banner's ✕. Other failure kinds
+//  stay log/Sentry territory — no banner.
 //
-//  Key methods: note(_:) (classify + record) · latest() · clear()
+//  Key methods: classify(_:) · record(_:) (3am only) · latest() · clear()
 //
 
 import Foundation
@@ -51,19 +54,27 @@ enum OvernightCaution {
         UserDefaults.standard.removeObject(forKey: key)
     }
 
-    /// Classify a scheduled-cycle failure into one of the three user-facing kinds and persist it.
-    /// Anything unclassifiable records nothing (the banner only ever states what we verified).
-    static func note(_ error: Error) async {
-        let kind: Kind?
+    /// Classify a cycle failure into one of the three user-facing kinds (nil = unclassifiable —
+    /// the UI only ever states what was verified). Shared by the 3am run (record + banner) and
+    /// the watched takeover's failed screen.
+    static func classify(_ error: Error) async -> Kind? {
         if case CodexCLI.CLIError.usageLimit = error {
-            kind = .usageLimit                       // typed — certain, no probing needed
-        } else if await !CodexCLI.loginStatus() {    // local auth check — reliable even offline
-            kind = .loggedOut
-        } else if await !networkUp() {
-            kind = .noInternet
-        } else {
-            kind = nil
+            return .usageLimit                       // typed — certain, no probing needed
         }
+        // A 401 in codex's own output means the token died SERVER-side — auth.json still looks
+        // logged-in to the local probe below, so codex's stderr is the only tell (the exact
+        // failure of 2026-07-12: a token invalidated by a re-login elsewhere).
+        if case CodexCLI.CLIError.notAvailable(.notWorking(let detail)) = error,
+           detail.contains("401") || detail.localizedCaseInsensitiveContains("unauthorized") {
+            return .loggedOut
+        }
+        if await !CodexCLI.loginStatus() { return .loggedOut }   // local auth check — reliable even offline
+        if await !networkUp() { return .noInternet }
+        return nil
+    }
+
+    /// Persist a classified kind as the morning-after caution (3am runs only; nil records nothing).
+    static func record(_ kind: Kind?) {
         guard let kind else { return }
         if let data = try? JSONEncoder().encode(Record(kind: kind, date: Date())) {
             UserDefaults.standard.set(data, forKey: key)

--- a/Sentient OS macOS/Views/ProcessingView.swift
+++ b/Sentient OS macOS/Views/ProcessingView.swift
@@ -77,8 +77,13 @@ struct ProcessingView: View {
         self.onDone = onDone
     }
 
-    private enum UIState: Equatable { case loadingModel, processing, preparing, completed, failed(String) }
+    private enum UIState: Equatable { case loadingModel, processing, preparing, completed, failed(CycleFailure) }
     @State private var state: UIState = .loadingModel
+    /// The failed screen's inline codex login (the "Codex isn't logged in" fix) — same shared
+    /// engine Settings → Health drives; `loginStarted` scopes the auto-notice poll + auto-retry
+    /// to a login WE opened from that screen.
+    @State private var codex = CodexSetup.shared
+    @State private var loginStarted = false
     @State private var prepStatus = "Preparing your suggestions…"
     /// The 10-minute patience flip for the cloud tail's bottom line (see `patienceLine`).
     @State private var patienceLong = false
@@ -418,18 +423,66 @@ struct ProcessingView: View {
         }
     }
 
-    private func failedView(_ message: String) -> some View {
+    private func failedView(_ failure: CycleFailure) -> some View {
         VStack(spacing: 20) {
             Image(systemName: "exclamationmark.triangle.fill").font(.system(size: 46))
                 .foregroundStyle(.orange.opacity(0.85))
-            Text("Processing failed").font(.title3.weight(.semibold)).foregroundStyle(.white)
-            Text(message).font(.caption).foregroundStyle(.white.opacity(0.5))
+            Text(Self.failTitle(failure.kind)).font(.title3.weight(.semibold)).foregroundStyle(.white)
+            Text(Self.failBody(failure)).font(.caption).foregroundStyle(.white.opacity(0.5))
                 .multilineTextAlignment(.center).frame(maxWidth: 360)
             HStack(spacing: 12) {
                 Button("Back", action: onExitEarly ?? onDone).buttonStyle(.bordered).tint(.white)
-                Button("Retry") { Task { started = false; await startIfNeeded() } }
-                    .buttonStyle(.borderedProminent).tint(.white)
+                if failure.kind == .loggedOut {
+                    Button("Retry") { Task { started = false; await startIfNeeded() } }
+                        .buttonStyle(.bordered).tint(.white)
+                    Button("Log in to Codex") { loginStarted = true; codex.startLogin(force: true) }
+                        .buttonStyle(.borderedProminent).tint(.white)
+                        .disabled(codex.loggingIn)
+                } else {
+                    Button("Retry") { Task { started = false; await startIfNeeded() } }
+                        .buttonStyle(.borderedProminent).tint(.white)
+                }
             }
+            if loginStarted, codex.loggingIn {
+                Text("A browser window opened. Finish signing in there; I'll retry on my own.")
+                    .font(.caption).foregroundStyle(.white.opacity(0.4))
+            }
+        }
+        // The browser-login auto-notice, same as Settings → Health and onboarding: while our
+        // login is out, poll `codex login status` (the codex login process self-exits once
+        // auth.json lands, no confirm button); the moment it reads logged-in, retry the cycle
+        // on our own. Leaving the failed state cancels the poll.
+        .task(id: loginStarted) {
+            guard loginStarted else { return }
+            while !Task.isCancelled, !codex.loggedIn {
+                try? await Task.sleep(for: .seconds(1.5))
+                await codex.refreshLoginStatus()
+            }
+            guard !Task.isCancelled, codex.loggedIn else { return }
+            loginStarted = false
+            // Unstructured on purpose: the retry flips state out of .failed, which tears THIS
+            // task down — the run must survive that.
+            Task { started = false; await startIfNeeded() }
+        }
+    }
+
+    private static func failTitle(_ kind: OvernightCaution.Kind?) -> String {
+        switch kind {
+        case .loggedOut:  "Codex isn't logged in"
+        case .usageLimit: "We hit ChatGPT's usage limit"
+        case .noInternet: "No internet connection"
+        case nil:         "Processing failed"
+        }
+    }
+
+    /// Classified failures get a friendly, actionable line (the raw detail is in the log +
+    /// Sentry); unclassified ones show the step's own message, as before.
+    private static func failBody(_ failure: CycleFailure) -> String {
+        switch failure.kind {
+        case .loggedOut:  "Sentient runs on your own ChatGPT account through codex, and that login has stopped working. Log back in and I'll pick up right where we stopped."
+        case .usageLimit: "Your plan's window resets on its own. Everything so far is saved; retry in a while and I'll pick up right where we stopped."
+        case .noInternet: "This step runs in the cloud. Once you're back online, hit Retry; everything so far is saved."
+        case nil:         failure.message
         }
     }
 


### PR DESCRIPTION
## What

Root-caused from Friday night's Release-build failure (Sentry `SENTIENT-OS-24`): a server-side-invalidated codex token 401'd the vault-stage ping, the user fixed codex with a fresh `codex login` three minutes later, and every Retry still failed in 0ms — `CodexCLI.validate()` had cached the negative verdict for the whole app launch, so no retry ever spawned codex again. Only a relaunch recovered.

## Changes

- **`CodexCLI.validate()`** — only a good verdict is cached now; a failed probe re-checks on every call. Retry is honest in every case.
- **`OvernightCaution`** — the 3am classifier is extracted as `classify()` + `record()` and shared with watched runs. New tell: a `401`/`unauthorized` marker in codex's own output classifies as logged-out (a server-side-invalidated token still reads logged-in to the local `codex login status` probe — Friday's exact case would have classified as nothing).
- **`ProactiveCycle`** — failures return a classified `CycleFailure` (message + kind); one `fail()` helper replaces the three copy-pasted catch sites. Scheduled runs persist the caution exactly as before.
- **`ProcessingView`** — the failed screen now reads the kind: "Codex isn't logged in" gets a prominent **Log in to Codex** button (shared `CodexSetup` browser flow; auto-notices the finished sign-in and auto-retries the cycle, same pattern as Settings → Health), usage-limit and no-internet get honest progress-is-saved one-liners, unclassified failures look exactly as before.
- **Docs** — CodexCLI, Overnight Scheduler, and Home deep docs updated (including the scheduler doc's stale Sentry-vs-TelemetryDeck caution line).

## Verification

- Isolated `xcodebuild` (Debug, `/tmp/sentient-verify`) succeeds with no warnings in the changed files, re-verified after today's main fast-forward.
- The 0ms-retry diagnosis is receipt-backed: 8 Sentry `codex.failure` events (1 real 2825ms ping failure, 7 cached 0ms retries — 4 of them after the re-login), `~/.codex/log/codex-login.log`, and the ping's session rollout.

https://claude.ai/code/session_01Aj4BGbhUxSHRvrmA62LGpw