### PR TITLE
Security: on-device PII backstop + stop identifier/error leaks into Sentry

### DIFF
--- a/Sentient OS macOS/Diagnostics/CrashReporting.swift
+++ b/Sentient OS macOS/Diagnostics/CrashReporting.swift
@@ -255,7 +255,10 @@ enum CrashReporting {
     private static let scrubbers: [(NSRegularExpression, String)] = {
         func re(_ p: String) -> NSRegularExpression { try! NSRegularExpression(pattern: p) }
         return [
-            (re("/Users/[^/\\s\"']+"), "/Users/<redacted>"),                 // home-dir paths
+            // Home-dir paths — redact the WHOLE remainder, not just the username: a folder name
+            // ("…/Divorce lawyer/…") or filename ("…/Lab results.pdf") is exactly the PII we can't ship.
+            (re("/Users/[^\\s\"']+"), "/Users/<redacted>"),
+            (re("/Volumes/[^\\s\"']+"), "/Volumes/<redacted>"),              // custom roots on external volumes
             // The mirror password's URL path segment (/u_<id>/p_<password>/…) — the §8 invariant.
             // Network breadcrumbs are off, but ANY future surface that logs the share URL is
             // covered here by construction.

--- a/Sentient OS macOS/Engine/PIIScan.swift
+++ b/Sentient OS macOS/Engine/PIIScan.swift
@@ -1,0 +1,64 @@
+//
+//  PIIScan.swift
+//  Sentient OS macOS  ·  Engine/
+//
+//  Deterministic PII backstop for on-device triage. The triage prompt tells the model to omit
+//  high-risk identifiers from summaries, but a small on-device model can slip — so `Triage.decide()`
+//  runs this over any would-be survivor and, on a hit, drops the whole item as `.sensitive` (nothing
+//  stored, zero trace, never sent to the cloud). Tuned to favour catching the three the prompt names
+//  — US SSN · credit-card number (Luhn-checked) · passport number — over sparing a summary: dropping
+//  a good summary is cheap, leaking a card number is not. Patterns verified against a positive/
+//  negative suite before shipping.
+//
+//  Key method: `containsHighRiskPII(_:)`.
+//
+
+import Foundation
+
+enum PIIScan {
+
+    /// True if the text contains a US SSN, a Luhn-valid card number, or a passport number.
+    static func containsHighRiskPII(_ text: String) -> Bool {
+        guard !text.isEmpty else { return false }
+        return matches(ssn, text) || containsCardNumber(text) || matches(passport, text)
+    }
+
+    // 3-2-4 digits with a dash/space separator, skipping the invalid SSN ranges (area 000/666/9xx,
+    // group 00, serial 0000). Requires separators — a bare 9-digit run is too false-positive-prone.
+    private static let ssn = re(#"\b(?!000|666|9\d\d)\d{3}[ -](?!00)\d{2}[ -](?!0000)\d{4}\b"#)
+
+    // A 13–19 digit run (single space/dash separators allowed), then validated by Luhn below —
+    // random 13–19 digit strings almost never pass Luhn, so this rarely fires on a real order number.
+    private static let cardCandidate = re(#"\b\d(?:[ -]?\d){12,18}\b"#)
+
+    // "passport" followed within a short gap by a 6–9 char alphanumeric code containing a digit.
+    // Context-gated so it never nukes a summary that merely mentions a passport with no number.
+    private static let passport = re(#"(?i)passport\b.{0,24}?\b(?=[A-Za-z0-9]*\d)[A-Za-z0-9]{6,9}\b"#)
+
+    private static func containsCardNumber(_ text: String) -> Bool {
+        let ns = text as NSString
+        for m in cardCandidate.matches(in: text, range: NSRange(location: 0, length: ns.length)) {
+            let digits = ns.substring(with: m.range).filter(\.isNumber)
+            if (13...19).contains(digits.count), luhnValid(digits) { return true }
+        }
+        return false
+    }
+
+    private static func luhnValid(_ digits: String) -> Bool {
+        var sum = 0, alt = false
+        for ch in digits.reversed() {
+            guard let d = ch.wholeNumberValue else { return false }
+            let v = alt ? (d * 2 > 9 ? d * 2 - 9 : d * 2) : d
+            sum += v
+            alt.toggle()
+        }
+        return sum % 10 == 0
+    }
+
+    private static func matches(_ re: NSRegularExpression, _ text: String) -> Bool {
+        let ns = text as NSString
+        return re.firstMatch(in: text, range: NSRange(location: 0, length: ns.length)) != nil
+    }
+
+    private static func re(_ p: String) -> NSRegularExpression { try! NSRegularExpression(pattern: p) }
+}

--- a/Sentient OS macOS/Engine/Triage.swift
+++ b/Sentient OS macOS/Engine/Triage.swift
@@ -164,6 +164,13 @@ enum Triage {
         if summary.isEmpty {
             return Outcome(verdict: .junk, title: title, summary: summary, reason: .emptySummary)
         }
+        // Backstop behind the model: if a high-risk identifier (US SSN, Luhn-valid card number, or
+        // passport number) slipped into a would-be survivor despite the prompt, drop the whole item
+        // as sensitive — nothing stored, zero trace, never sent to the cloud (drop the summary/title
+        // too so the PII isn't even carried in the Outcome).
+        if PIIScan.containsHighRiskPII(summary) || PIIScan.containsHighRiskPII(title ?? "") {
+            return Outcome(verdict: .sensitive, title: nil, summary: "", reason: .sensitive)
+        }
         return Outcome(verdict: .survivor, title: title, summary: summary, reason: .survivor)
     }
 

--- a/Sentient OS macOS/Ingestion/CycleStore.swift
+++ b/Sentient OS macOS/Ingestion/CycleStore.swift
@@ -185,12 +185,17 @@ actor CycleStore {
         ).first
     }
 
+    /// The scheme prefix of a bucketKey ("whatsapp" / "imessage" / "file" / "notes") — the only part
+    /// safe to log: the full key carries a chat's phone-number JID or a user file path, and every
+    /// Log() line ships to Sentry as a Release breadcrumb.
+    nonisolated static func scheme(_ bucketKey: String) -> Substring { bucketKey.prefix(while: { $0 != ":" }) }
+
     /// Read-only convenience (pointer / pointerState). A failed fetch degrades to nil (re-listing),
     /// but is now surfaced instead of silently swallowed.
     private func row(_ bucketKey: String) -> BucketPointer? {
         do { return try fetchRow(bucketKey) }
         catch {
-            Log("CycleStore.row(\(bucketKey)) fetch failed: \(error)")
+            Log("CycleStore.row(\(Self.scheme(bucketKey))) fetch failed: \(ErrorLabel(error))")
             CrashReporting.capture(error)
             return nil
         }
@@ -210,7 +215,7 @@ actor CycleStore {
         }
         do { try attempt() }
         catch {
-            Log("CycleStore.commit(\(bucketKey)) failed: \(error) — rolling back, retrying as update")
+            Log("CycleStore.commit(\(Self.scheme(bucketKey))) failed: \(ErrorLabel(error)) — rolling back, retrying as update")
             CrashReporting.capture(error)
             modelContext.rollback()
             do {
@@ -220,7 +225,7 @@ actor CycleStore {
                 try modelContext.save()
             } catch {
                 modelContext.rollback()
-                Log("CycleStore.commit(\(bucketKey)) recovery failed: \(error) — mark NOT persisted this item")
+                Log("CycleStore.commit(\(Self.scheme(bucketKey))) recovery failed: \(ErrorLabel(error)) — mark NOT persisted this item")
                 CrashReporting.capture(error)
             }
         }
@@ -277,7 +282,7 @@ actor CycleStore {
             if let r = try fetchRow(bucketKey) { r.floorOrder = nil; r.floorTiebreak = nil; r.updatedAt = Date() }
             try modelContext.save()
         } catch {
-            Log("CycleStore.collapseFloor(\(bucketKey)) failed: \(error)")
+            Log("CycleStore.collapseFloor(\(Self.scheme(bucketKey))) failed: \(ErrorLabel(error))")
             CrashReporting.capture(error)
         }
     }

--- a/Sentient OS macOS/Ingestion/IterativeRun.swift
+++ b/Sentient OS macOS/Ingestion/IterativeRun.swift
@@ -255,7 +255,7 @@ struct IterativeRun {
                         .sorted { $0.key > $1.key }                      // newest → oldest (top-down)
                 case .iterative:
                     guard let s = state, s.floor == nil else {
-                        Log("IterativeRun: \(bucket.key) — \(state == nil ? "no pointer" : "first run unfinished"); run initial first; skipping.")
+                        Log("IterativeRun: \(CycleStore.scheme(bucket.key)) — \(state == nil ? "no pointer" : "first run unfinished"); run initial first; skipping.")
                         continue
                     }
                     top = nil

--- a/Sentient OS macOS/Proactive/ProactiveCycle.swift
+++ b/Sentient OS macOS/Proactive/ProactiveCycle.swift
@@ -105,7 +105,7 @@ actor ProactiveCycle {
         if !giftPreexisted {
             progress(.knowledgeBase("Writing your welcome…"))
             do { _ = try await GiftLetter.shared.generate(onLine: onLine) }
-            catch { Log("GiftLetter: welcome skipped — \(Self.msg(error))") }
+            catch { Log("GiftLetter: welcome skipped — \(ErrorLabel(error))") }   // type only: msg() embeds raw codex output → Sentry breadcrumb
         }
 
         // 3) Proactive — decide, then research + prepare. Inject the live calendar when connected.

--- a/Sentient OS macOS/Vault/VaultGenerator.swift
+++ b/Sentient OS macOS/Vault/VaultGenerator.swift
@@ -242,7 +242,9 @@ actor VaultGenerator {
             try Self.swapStagingIntoVault(staging)
         } catch {
             Log("VaultGenerator: ❌ swap failed, vault left intact — \(ErrorLabel(error))")
-            CrashReporting.capture(error)                            // TODO(P2): structured `vault_swap_failed`
+            // Structured event, not capture(error): a Cocoa move error embeds the failing note's
+            // PATH (i.e. a note title) which the scrubber can't fully strip from a spaced vault path.
+            CrashReporting.captureEvent("vault_swap_failed", tags: ["error": ErrorLabel(error)])
             throw error
         }
         Log("VaultGenerator: ✅ vault swapped into place — \(notes) notes at \(Self.vaultRoot.path)")


### PR DESCRIPTION
Audit batch 2. Two commits.

## #5 — code-level PII backstop (F5)
The "PII-stripped summaries" promise was prompt-only. Added a deterministic checker so a small-model slip can't send a raw identifier to the cloud.
- `Engine/PIIScan.swift` (new): US SSN · Luhn-valid credit-card number · passport number. Verified against a positive/negative suite before shipping.
- `Triage.decide()`: runs it over any would-be survivor's summary+title; a hit drops the whole item as `.sensitive` (nothing stored, zero trace).

## #6 — stop identifiers + raw error text reaching Sentry (F9, F23, bucketKey)
Every `Log()` line ships as a Release breadcrumb.
- **F9** `ProactiveCycle`: gift-letter failure logged `msg(error)` (embeds raw codex output) → `ErrorLabel(error)`.
- **F23** scrubber: home-path rule redacted only the username, keeping folder/filename → redact the whole `/Users/…` remainder + add `/Volumes/…`.
- **bucketKey**: `CycleStore` (×4) + `IterativeRun` error logs interpolated the raw bucketKey (chat phone-number JID / user file path) + `\(error)` → scheme prefix only (`CycleStore.scheme`) + `ErrorLabel`.
- **VaultGenerator**: vault-swap `capture(error)` embeds the failing note's path (a note title) the scrubber can't fully strip → structured `vault_swap_failed` event.

## Verification
- PIIScan detection: 8/8 positives caught, 8/8 negatives clean.
- Scrubber: confirmed whole-path + `/Volumes` redaction at runtime.
- Debug + Release both build (incl. after rebase onto #185).

https://claude.ai/code/session_01UnWymii1CDhpv4MgKX7Fte