### PR TITLE
docs: PII backstop + second Sentry leak sweep

### DIFF
--- a/Sentient OS macOS/Documentation/Diagnostics (Sentry).md
+++ b/Sentient OS macOS/Documentation/Diagnostics (Sentry).md
@@ -62,11 +62,17 @@ Two defenses:
   (Log.swift), never `\(error)` / `localizedDescription`** — in Release it renders the enum case /
   type name only. Raw interpolation shipped codex stderr (`CLIError`'s description embeds up to
   300 chars of it — Gmail/calendar/screen content), note titles (Cocoa file errors carry the path),
-  and the mirror server's response body through ~22 error logs until the 2026-07-12 sweep.
+  and the mirror server's response body through ~22 error logs until the 2026-07-12 sweep. A second
+  sweep (2026-07-12) closed the last identifier-bearing sources: the on-device pipeline's error logs
+  logged only a bucketKey's **scheme prefix** (`CycleStore.scheme` — `whatsapp`/`file`/`notes`), never
+  the raw key (a chat's phone-number JID or a user file path); and the vault-swap failure became a
+  structured `vault_swap_failed` event (its Cocoa error embeds the failing note's path = a note title,
+  which the path scrubber can't fully strip from a spaced vault path).
 - **`beforeSend` / `beforeBreadcrumb` scrubber (backstop).** A pure closure set in `boot()` that
-  redacts free text on outgoing events + `Log()`-fed breadcrumbs: home-dir paths → `/Users/<redacted>`,
-  the mirror password path segment `/p_…` → `/p_<redacted>`, emails → `<email>`, phone runs →
-  `<phone>`, and **high-entropy** long tokens → `<token>`. Since 2026-07-12 the breadcrumb scrub
+  redacts free text on outgoing events + `Log()`-fed breadcrumbs: home-dir paths → `/Users/<redacted>`
+  (the WHOLE remainder — a folder/file name is PII, not just the username), external-volume paths →
+  `/Volumes/<redacted>`, the mirror password path segment `/p_…` → `/p_<redacted>`, emails → `<email>`,
+  phone runs → `<phone>`, and **high-entropy** long tokens → `<token>`. Since 2026-07-12 the breadcrumb scrub
   also walks `crumb.data` string values (SDK-authored crumbs carry their payload there, not in
   `message` — see §2.5).
   ⚠️ The token rule requires ≥1 uppercase/digit on purpose — a plain `{24,}` rule wrongly redacted our

--- a/Sentient OS macOS/Documentation/Iterative Core (Connectors).md
+++ b/Sentient OS macOS/Documentation/Iterative Core (Connectors).md
@@ -44,7 +44,10 @@ A connector is dumb: it lists keyed work-items per bucket and loads one. *All* p
   the rest up, all in one pass. (Home → `.auto`; the dev INITIAL/ITERATIVE buttons → `.initial`/
   `.iterative`; explicit `.initial` first clears the bucket = a full reset.) Reuses `Engine` + `Triage` +
   the GPU-wedge resilience (preemptive reload every ~40 items + reactive reload after a burst of
-  failures). Survivors → `CycleNote`; junk/sensitive store nothing.
+  failures). Survivors → `CycleNote`; junk/sensitive store nothing. A deterministic **PII backstop**
+(`Engine/PIIScan.swift`) runs on every would-be survivor's summary + title — a US SSN, a Luhn-valid
+credit-card number, or a passport number drops the whole item as `.sensitive` (zero trace), so a
+small on-device model slipping a raw identifier past the prompt can never send it to the cloud.
 
 ## The cycle (summaries are disposable)
 *on-device summarize → cloud (make/update KB) → cloud (proactive judge) → next cycle.*


### PR DESCRIPTION
Documents the security fixes merged in #186 — the deterministic PII backstop (Engine/PIIScan.swift) and the second Sentry identifier-leak sweep (widened path scrubber + /Volumes, bucketKey scheme prefix, structured vault_swap_failed). Deep docs only.

https://claude.ai/code/session_01UnWymii1CDhpv4MgKX7Fte