### PR TITLE
Fix Sidekick voice: model-check race, session teardown, and the CoreAudio input wedge

### DIFF
--- a/Sentient OS macOS/Notch Magic/CommandCoordinator.swift
+++ b/Sentient OS macOS/Notch Magic/CommandCoordinator.swift
@@ -172,7 +172,9 @@ final class CommandCoordinator {
             return
         }
         setPhase(.opening)                                // you're pulling it open — reveal the instant you press
-        if VoiceCapture.isAuthorized { startCapture() }   // never PROMPT on a press; defer to hold-confirm
+        // Never PROMPT on a press (defer to hold-confirm), and never capture into a model that's
+        // still downloading — the audio could never be transcribed.
+        if VoiceCapture.isAuthorized, !VoiceCapture.isModelDownloading { startCapture() }
     }
 
     /// Open the mic (idempotent). On first-ever use this is what prompts — so it's gated to a confirmed hold.
@@ -188,6 +190,14 @@ final class CommandCoordinator {
 
     private func voiceHoldConfirmed() {
         guard phase == .opening else { return }
+        // A genuine first-run model download → say so instead of pretending to listen (the mic tap
+        // only installs after the model lands, so anything spoken now would be silently lost). Only
+        // a committed HOLD gets this beat — tap-to-type stays fully alive during the download.
+        if VoiceCapture.isModelDownloading {
+            flash("still downloading the voice model", for: 2.0)
+            Log("hold answered with a download notice — speech model installing")
+            return
+        }
         setPhase(.listening)               // committed to voice — the "lean in" beat
         if !listening { startCapture() }   // perms weren't pre-granted → start now (the first-use prompt)
     }
@@ -213,11 +223,12 @@ final class CommandCoordinator {
         setPhase(.transcribing)
         let token = phaseToken
 
-        // Watchdog: transcription must resolve promptly (the finalize itself is <2s; the trap is
-        // voice.start() still parked on the on-device speech model DOWNLOAD, which has no bound of
-        // its own — seen in the field as a notch spinning forever with every new press "busy").
-        // Still transcribing after 15s → cancel the capture, keep the model download moving for
-        // the next attempt, and say so honestly. The notch must never wedge.
+        // Watchdog — the last-resort backstop: the finalize itself is <2s, and the old trap
+        // (voice.start() parked on the asset daemon EVERY press — assetInstallationRequest returns
+        // a request even when the model is installed) is gone now that readiness is memoized and
+        // gated on installedLocales. What's left is the rare genuine stall (a first-run download
+        // reaching a hold, a wedged finalize). Still transcribing after 15s → cancel the capture
+        // and say so honestly. The notch must never wedge.
         Task { [weak self] in
             try? await Task.sleep(for: .seconds(15))
             guard let self, self.phaseToken == token, self.phase == .transcribing else { return }
@@ -261,11 +272,17 @@ final class CommandCoordinator {
         listening = false
         voiceStartTask = nil
         voice.cancel()
+        if error is CancellationError { return }   // an intentional bail (tap-to-type / Esc / watchdog) — not a failure
         if case VoiceError.notAuthorized = error {
             flash("turn on the microphone to talk to Sentient")
         } else {
             Log("voice start failed — \(error.localizedDescription)")
-            setPhase(.hidden)
+            // Hide only if we're still in the voice moment — a late failure must never clobber a
+            // newer phase (the watchdog's notice, an open type field, a running task).
+            switch phase {
+            case .opening, .listening, .transcribing: setPhase(.hidden)
+            default: break
+            }
         }
     }
 

--- a/Sentient OS macOS/Notch Magic/CommandCoordinator.swift
+++ b/Sentient OS macOS/Notch Magic/CommandCoordinator.swift
@@ -232,12 +232,13 @@ final class CommandCoordinator {
         Task { [weak self] in
             try? await Task.sleep(for: .seconds(15))
             guard let self, self.phaseToken == token, self.phase == .transcribing else { return }
-            Log("✗ transcription timed out — cancelling the capture (speech model likely still downloading)")
+            let downloading = VoiceCapture.isModelDownloading
+            Log("✗ transcription timed out — cancelling the capture (\(downloading ? "model still downloading" : "capture stalled"))")
             self.listening = false
             self.voiceStartTask?.cancel(); self.voiceStartTask = nil
             self.voice.cancel()
-            self.voice.prewarm()   // best-effort: resume/continue the model install in the background
-            self.flash("voice isn’t ready yet, try again in a moment")
+            self.voice.prewarm()   // best-effort: keep a genuine model install moving (no-op when ready)
+            self.flash(downloading ? "voice isn’t ready yet, try again in a moment" : "voice got stuck — try again")
         }
 
         Task { [weak self] in

--- a/Sentient OS macOS/Notch Magic/SpeechAnalyzerEngine.swift
+++ b/Sentient OS macOS/Notch Magic/SpeechAnalyzerEngine.swift
@@ -24,12 +24,18 @@ final class SpeechAnalyzerEngine: QuickTranscriptionEngine {
     /// SpeechAnalyzer handles long-form audio; we cap a single spoken command at 3 minutes.
     static let maxUtteranceDuration: TimeInterval = 180
 
-    private let audioEngine = AVAudioEngine()
+    /// ONE audio engine for the process. A fresh AVAudioEngine per capture opens a new HAL IO proc
+    /// each press, and rapid press/cancel churn wedges CoreAudio input into delivering ZERO buffers
+    /// (field-proven: a 2.3s hold fed the analyzer nothing). Reuse the instance; only the tap and
+    /// start/stop cycle per capture.
+    private static let sharedAudioEngine = AVAudioEngine()
     private var analyzer: SpeechAnalyzer?
     private var inputContinuation: AsyncStream<AnalyzerInput>.Continuation?
     private var resultsTask: Task<String, Error>?
     private var tapInstalled = false
-    private var yieldedBuffers: OSAllocatedUnfairLock<Int>?   // shared with the audio-thread tap (diagnostic)
+    /// (tap callbacks, buffers fed to the analyzer) — shared with the audio-thread tap (diagnostic:
+    /// tap 0 = the mic never delivered; fed 0 with tap >0 = the format conversion failed).
+    private var tapCounts: OSAllocatedUnfairLock<(Int, Int)>?
 
     // MARK: Warm-up (best-effort, called when the hotkey arms so first use is instant)
 
@@ -78,21 +84,24 @@ final class SpeechAnalyzerEngine: QuickTranscriptionEngine {
 
         // Mic → convert to the analyzer's format → stream in. The tap runs on an audio thread and
         // touches only these locals (never the MainActor self), so there's no isolation violation.
-        let input = audioEngine.inputNode
+        let engine = Self.sharedAudioEngine
+        let input = engine.inputNode
         let inputFormat = input.outputFormat(forBus: 0)
         guard let converter = AVAudioConverter(from: inputFormat, to: analyzerFormat) else {
             throw VoiceError.modelUnavailable
         }
-        let yielded = OSAllocatedUnfairLock(initialState: 0)   // buffers fed to the analyzer (diagnostic)
-        self.yieldedBuffers = yielded
+        let counts = OSAllocatedUnfairLock(initialState: (0, 0))
+        self.tapCounts = counts
+        input.removeTap(onBus: 0)   // defensive: a stale tap from an interrupted capture must not linger
         input.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { buffer, _ in
+            counts.withLock { $0.0 += 1 }
             guard let converted = Self.convert(buffer, using: converter, to: analyzerFormat) else { return }
-            yielded.withLock { $0 += 1 }
+            counts.withLock { $0.1 += 1 }
             continuation.yield(AnalyzerInput(buffer: converted))
         }
         tapInstalled = true
-        audioEngine.prepare()
-        try audioEngine.start()
+        engine.prepare()
+        try engine.start()
         Log("voice: capture started (\(Self.msLabel(clock.now - started))ms)")
     }
 
@@ -101,9 +110,28 @@ final class SpeechAnalyzerEngine: QuickTranscriptionEngine {
         stopAudio()
         inputContinuation?.finish()
         inputContinuation = nil
-        // Bounded finalize: finalizeAndFinishThroughEndOfInput can park indefinitely inside the
-        // speech daemon (field-proven 15s+ — and cancelAndFinishNow unwedged it in ~16ms). Give
-        // the graceful path 5s, then force-close the session; whatever the results stream already
+        let (taps, fed) = tapCounts?.withLock { $0 } ?? (0, 0)
+
+        // No audio ever reached the analyzer (a dead/warming mic): there is nothing to transcribe,
+        // and an EMPTY session is exactly the one that parks — its finalize no-ops but its results
+        // stream never terminates (field-proven: Esc's resultsTask.cancel unwedged it in 2ms).
+        // Close the session immediately and answer honestly.
+        if fed == 0 {
+            resultsTask?.cancel()
+            if let analyzer {
+                let previous = Self.closingSession
+                Self.closingSession = Task {
+                    await previous?.value
+                    await analyzer.cancelAndFinishNow()
+                }
+            }
+            teardown()
+            Log("voice: finalized (\(Self.msLabel(clock.now - started))ms · tap \(taps) · fed 0 — no audio, session closed)")
+            return ""
+        }
+
+        // Bounded finalize: it can park inside the speech daemon; cancelAndFinishNow reliably
+        // unwedges it, so give the graceful path 5s then force-close. Whatever the results stream
         // produced still comes back below.
         if let analyzer {
             let finalize = Task { try await analyzer.finalizeAndFinishThroughEndOfInput() }
@@ -115,15 +143,21 @@ final class SpeechAnalyzerEngine: QuickTranscriptionEngine {
             _ = try? await finalize.value
             bound.cancel()
         }
+        // Bounded collection: the results stream is the OTHER half that can refuse to end.
         let transcript: String
         if let resultsTask {
+            let bound = Task {
+                try await Task.sleep(for: .seconds(2))
+                Log("voice: results stream parked — cancelling collection")
+                resultsTask.cancel()
+            }
             transcript = (try? await resultsTask.value) ?? ""
+            bound.cancel()
         } else {
             transcript = ""
         }
         teardown()
-        let buffers = yieldedBuffers?.withLock { $0 } ?? 0
-        Log("voice: finalized (\(Self.msLabel(clock.now - started))ms · \(buffers) buffers)")
+        Log("voice: finalized (\(Self.msLabel(clock.now - started))ms · tap \(taps) · fed \(fed))")
         return transcript.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
@@ -153,11 +187,12 @@ final class SpeechAnalyzerEngine: QuickTranscriptionEngine {
     // MARK: Internals
 
     private func stopAudio() {
+        let engine = Self.sharedAudioEngine
         if tapInstalled {
-            audioEngine.inputNode.removeTap(onBus: 0)
+            engine.inputNode.removeTap(onBus: 0)
             tapInstalled = false
         }
-        if audioEngine.isRunning { audioEngine.stop() }
+        if engine.isRunning { engine.stop() }
     }
 
     private func teardown() {

--- a/Sentient OS macOS/Notch Magic/SpeechAnalyzerEngine.swift
+++ b/Sentient OS macOS/Notch Magic/SpeechAnalyzerEngine.swift
@@ -16,6 +16,7 @@
 //
 
 import Speech
+import os
 @preconcurrency import AVFAudio
 
 @available(macOS 26, *)
@@ -28,6 +29,7 @@ final class SpeechAnalyzerEngine: QuickTranscriptionEngine {
     private var inputContinuation: AsyncStream<AnalyzerInput>.Continuation?
     private var resultsTask: Task<String, Error>?
     private var tapInstalled = false
+    private var yieldedBuffers: OSAllocatedUnfairLock<Int>?   // shared with the audio-thread tap (diagnostic)
 
     // MARK: Warm-up (best-effort, called when the hotkey arms so first use is instant)
 
@@ -81,8 +83,11 @@ final class SpeechAnalyzerEngine: QuickTranscriptionEngine {
         guard let converter = AVAudioConverter(from: inputFormat, to: analyzerFormat) else {
             throw VoiceError.modelUnavailable
         }
+        let yielded = OSAllocatedUnfairLock(initialState: 0)   // buffers fed to the analyzer (diagnostic)
+        self.yieldedBuffers = yielded
         input.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { buffer, _ in
             guard let converted = Self.convert(buffer, using: converter, to: analyzerFormat) else { return }
+            yielded.withLock { $0 += 1 }
             continuation.yield(AnalyzerInput(buffer: converted))
         }
         tapInstalled = true
@@ -96,7 +101,20 @@ final class SpeechAnalyzerEngine: QuickTranscriptionEngine {
         stopAudio()
         inputContinuation?.finish()
         inputContinuation = nil
-        try await analyzer?.finalizeAndFinishThroughEndOfInput()
+        // Bounded finalize: finalizeAndFinishThroughEndOfInput can park indefinitely inside the
+        // speech daemon (field-proven 15s+ — and cancelAndFinishNow unwedged it in ~16ms). Give
+        // the graceful path 5s, then force-close the session; whatever the results stream already
+        // produced still comes back below.
+        if let analyzer {
+            let finalize = Task { try await analyzer.finalizeAndFinishThroughEndOfInput() }
+            let bound = Task {
+                try await Task.sleep(for: .seconds(5))
+                Log("voice: finalize parked — force-closing the session")
+                await analyzer.cancelAndFinishNow()
+            }
+            _ = try? await finalize.value
+            bound.cancel()
+        }
         let transcript: String
         if let resultsTask {
             transcript = (try? await resultsTask.value) ?? ""
@@ -104,7 +122,8 @@ final class SpeechAnalyzerEngine: QuickTranscriptionEngine {
             transcript = ""
         }
         teardown()
-        Log("voice: finalized (\(Self.msLabel(clock.now - started))ms)")
+        let buffers = yieldedBuffers?.withLock { $0 } ?? 0
+        Log("voice: finalized (\(Self.msLabel(clock.now - started))ms · \(buffers) buffers)")
         return transcript.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 

--- a/Sentient OS macOS/Notch Magic/SpeechAnalyzerEngine.swift
+++ b/Sentient OS macOS/Notch Magic/SpeechAnalyzerEngine.swift
@@ -7,6 +7,11 @@
 //  Live mic buffers are converted to the analyzer's format and streamed in; on stop we finalize and
 //  return the single best transcript. No partials.
 //
+//  Model readiness is memoized + single-flight: SpeechTranscriber.installedLocales is the ONLY honest
+//  installed check (assetInstallationRequest hands back a request even when the model is fully
+//  installed — field-proven), and the one shared install task is shielded from caller cancellation
+//  (downloadAndInstall ignores cancellation, so a "cancelled" install keeps running in the daemon).
+//
 //  Key methods: prewarm() (install the model ahead of first use) · start() · stopAndTranscribe() · cancel().
 //
 
@@ -28,8 +33,7 @@ final class SpeechAnalyzerEngine: QuickTranscriptionEngine {
 
     static func prewarm() async {
         do {
-            let transcriber = SpeechTranscriber(locale: await resolvedLocale(), preset: .transcription)
-            try await ensureModelInstalled(for: transcriber)
+            try await ensureModelReady()
         } catch {
             Log("voice: prewarm skipped — \(error.localizedDescription)")
         }
@@ -38,9 +42,10 @@ final class SpeechAnalyzerEngine: QuickTranscriptionEngine {
     // MARK: Capture
 
     func start() async throws {
-        let transcriber = SpeechTranscriber(locale: await Self.resolvedLocale(), preset: .transcription)
-        try await Self.ensureModelInstalled(for: transcriber)
+        try await Self.ensureModelReady()
+        try Task.checkCancellation()   // a bailed start (watchdog / tap / Esc) must never open the mic late
 
+        let transcriber = SpeechTranscriber(locale: await Self.resolvedLocale(), preset: .transcription)
         guard let analyzerFormat = await SpeechAnalyzer.bestAvailableAudioFormat(compatibleWith: [transcriber]) else {
             throw VoiceError.modelUnavailable
         }
@@ -121,12 +126,60 @@ final class SpeechAnalyzerEngine: QuickTranscriptionEngine {
         return Locale(identifier: "en-US")
     }
 
-    /// Install the on-device model for the transcriber's locale if it isn't already (a no-op when present).
-    private static func ensureModelInstalled(for transcriber: SpeechTranscriber) async throws {
-        if let request = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) {
-            Log("voice: downloading on-device speech model…")
-            try await request.downloadAndInstall()
+    // MARK: Model readiness (memoized · single-flight · shielded from caller cancellation)
+
+    /// Session memo — once the model is verified installed, start() never touches the asset daemon again.
+    private static var modelReady = false
+
+    /// The ONE in-flight install. Unstructured on purpose: downloadAndInstall() ignores cooperative
+    /// cancellation, so a bailing caller (the 15s watchdog, a tap-to-type, Esc) must never cancel or
+    /// duplicate it — "cancelled" installs keep running in the daemon and stack up into the very
+    /// contention that parks the next attempt. Clears itself when it finishes, so a failure retries fresh.
+    private static var installTask: Task<Void, Error>?
+
+    /// True only while a genuine model download is in flight — the coordinator answers a voice hold
+    /// with an honest "still downloading" notice instead of listening into a model that isn't there.
+    static var isModelDownloading: Bool { installTask != nil && !modelReady }
+
+    /// Make sure the on-device model is installed. The installed-locales check is the ONLY honest one:
+    /// assetInstallationRequest returns a request even when the model is fully installed, so gating on
+    /// it (the old code) meant an asset-daemon round-trip on EVERY capture — usually a ~0.1s no-op,
+    /// occasionally a 15s+ park, and the park is what wedged Sidekick when the key lifted early.
+    private static func ensureModelReady() async throws {
+        if modelReady { return }
+        let locale = await resolvedLocale()
+        if await installed(locale) {
+            markReady(locale)
+            return
         }
+        let task = installTask ?? launchInstall(locale: locale)
+        installTask = task
+        try await task.value
+    }
+
+    private static func installed(_ locale: Locale) async -> Bool {
+        await SpeechTranscriber.installedLocales.contains { $0.identifier(.bcp47) == locale.identifier(.bcp47) }
+    }
+
+    /// The single shared install (a genuine first-run download, or a re-download after an OS purge).
+    private static func launchInstall(locale: Locale) -> Task<Void, Error> {
+        Task {
+            defer { installTask = nil }   // finished either way; markReady records a success
+            let transcriber = SpeechTranscriber(locale: locale, preset: .transcription)
+            if let request = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) {
+                Log("voice: downloading the on-device speech model…")
+                try await request.downloadAndInstall()
+            }
+            markReady(locale)
+        }
+    }
+
+    private static func markReady(_ locale: Locale) {
+        guard !modelReady else { return }
+        modelReady = true
+        Log("voice: speech model ready (\(locale.identifier))")
+        // Pin the asset so macOS keeps it for us (best-effort; 5 reservation slots per app, we use 1).
+        Task { try? await AssetInventory.reserve(locale: locale) }
     }
 
     /// Convert one mic buffer to the analyzer's format (sample-rate + layout). Pure → safe off-main.

--- a/Sentient OS macOS/Notch Magic/SpeechAnalyzerEngine.swift
+++ b/Sentient OS macOS/Notch Magic/SpeechAnalyzerEngine.swift
@@ -42,8 +42,15 @@ final class SpeechAnalyzerEngine: QuickTranscriptionEngine {
     // MARK: Capture
 
     func start() async throws {
+        let clock = ContinuousClock(); let started = clock.now
         try await Self.ensureModelReady()
         try Task.checkCancellation()   // a bailed start (watchdog / tap / Esc) must never open the mic late
+
+        // Let a just-cancelled session finish closing first — a fresh analyzer otherwise queues
+        // behind the zombie session inside the speech daemon (field-proven: an Esc mid-capture
+        // parked the very next press for 15s).
+        await Self.closingSession?.value
+        try Task.checkCancellation()
 
         let transcriber = SpeechTranscriber(locale: await Self.resolvedLocale(), preset: .transcription)
         guard let analyzerFormat = await SpeechAnalyzer.bestAvailableAudioFormat(compatibleWith: [transcriber]) else {
@@ -65,6 +72,7 @@ final class SpeechAnalyzerEngine: QuickTranscriptionEngine {
         let (stream, continuation) = AsyncStream<AnalyzerInput>.makeStream()
         self.inputContinuation = continuation
         try await analyzer.start(inputSequence: stream)
+        try Task.checkCancellation()   // cancelled during the session handoff → never touch the mic
 
         // Mic → convert to the analyzer's format → stream in. The tap runs on an audio thread and
         // touches only these locals (never the MainActor self), so there's no isolation violation.
@@ -80,9 +88,11 @@ final class SpeechAnalyzerEngine: QuickTranscriptionEngine {
         tapInstalled = true
         audioEngine.prepare()
         try audioEngine.start()
+        Log("voice: capture started (\(Self.msLabel(clock.now - started))ms)")
     }
 
     func stopAndTranscribe() async throws -> String {
+        let clock = ContinuousClock(); let started = clock.now
         stopAudio()
         inputContinuation?.finish()
         inputContinuation = nil
@@ -94,6 +104,7 @@ final class SpeechAnalyzerEngine: QuickTranscriptionEngine {
             transcript = ""
         }
         teardown()
+        Log("voice: finalized (\(Self.msLabel(clock.now - started))ms)")
         return transcript.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
@@ -102,8 +113,23 @@ final class SpeechAnalyzerEngine: QuickTranscriptionEngine {
         inputContinuation?.finish()
         inputContinuation = nil
         resultsTask?.cancel()
+        // Close the analyzer session FOR REAL. Dropping the object leaves a zombie session in the
+        // speech daemon that the next capture queues behind; cancelAndFinishNow is the documented
+        // immediate stop. Chained on the previous close so rapid bursts stay ordered; start() awaits
+        // the latest one.
+        if let analyzer {
+            let previous = Self.closingSession
+            Self.closingSession = Task {
+                await previous?.value
+                await analyzer.cancelAndFinishNow()
+            }
+        }
         teardown()
     }
+
+    /// The in-flight teardown of the most recently cancelled session (completed tasks linger —
+    /// awaiting one is then free). See cancel().
+    private static var closingSession: Task<Void, Never>?
 
     // MARK: Internals
 
@@ -180,6 +206,11 @@ final class SpeechAnalyzerEngine: QuickTranscriptionEngine {
         Log("voice: speech model ready (\(locale.identifier))")
         // Pin the asset so macOS keeps it for us (best-effort; 5 reservation slots per app, we use 1).
         Task { try? await AssetInventory.reserve(locale: locale) }
+    }
+
+    /// Whole milliseconds, for the terse capture-timing logs.
+    nonisolated private static func msLabel(_ duration: Duration) -> Int {
+        Int(duration.components.seconds) * 1000 + Int(duration.components.attoseconds / 1_000_000_000_000_000)
     }
 
     /// Convert one mic buffer to the analyzer's format (sample-rate + layout). Pure → safe off-main.

--- a/Sentient OS macOS/Notch Magic/VoiceCapture.swift
+++ b/Sentient OS macOS/Notch Magic/VoiceCapture.swift
@@ -34,6 +34,14 @@ final class VoiceCapture {
         return SFSpeechRecognizerEngine.maxUtteranceDuration
     }
 
+    /// True while the on-device speech model is genuinely downloading (first run / post-OS-purge) —
+    /// a voice hold is answered honestly instead of listening into a model that isn't there.
+    /// macOS 15's engine needs no model download.
+    static var isModelDownloading: Bool {
+        if #available(macOS 26, *) { return SpeechAnalyzerEngine.isModelDownloading }
+        return false
+    }
+
     /// Install the on-device speech model ahead of first use (best-effort, off-main).
     func prewarm() {
         if #available(macOS 26, *) {

--- a/Sentient OS macOS/Notch Magic/VoiceCapture.swift
+++ b/Sentient OS macOS/Notch Magic/VoiceCapture.swift
@@ -58,6 +58,7 @@ final class VoiceCapture {
         do {
             try await engine.start()
         } catch {
+            engine.cancel()   // a failed/bailed start still closes its analyzer session properly
             self.engine = nil
             throw error
         }


### PR DESCRIPTION
## The bug

Press the Sidekick key and lift right as the voice path spins up → the notch spinner parks for 15s, and repeated attempts wedge 'forever' (the original report + repro screenshots). Deep-dive found **three stacked bugs**, each masking the next:

### 1. The model 'installed' check lies (the original bug)
`AssetInventory.assetInstallationRequest(...) != nil` was our 'needs download' test — but on macOS 26 it returns a request **even when the model is fully installed** (probe-verified on real hardware: `installedLocales` contains en_US, status reads `.supported`, a second request is non-nil immediately after a successful install). So EVERY press did an asset-daemon round-trip (usually ~0.1s, sometimes 15s+ parks), and cancelling a parked one leaks — `downloadAndInstall()` ignores cooperative cancellation — so retries stacked concurrent installs into a permanent-looking wedge.

**Fix:** gate on `SpeechTranscriber.installedLocales` (Apple's canonical pattern), memoized per session; genuine first-run installs are ONE shared task shielded from caller cancellation; locale reserved so macOS keeps the asset.

### 2. Cancelled analyzer sessions were never closed
`cancel()` dropped the `SpeechAnalyzer` without `cancelAndFinishNow()` — a zombie session lingers in the speech daemon and the next capture's `analyzer.start()` queues behind it (field-proven: Esc mid-capture parked the very next press 15s).

**Fix:** every cancel/failed start closes its session for real (chained so bursts stay ordered); `start()` awaits the in-flight close; `checkCancellation` guards so a bailed start can never open the mic late.

### 3. Per-press AVAudioEngine churn wedges CoreAudio input
Each capture created a fresh `AVAudioEngine` (new HAL IO proc per press); rapid press/cancel churn wedged input into delivering **zero buffers** (counter-proven: a 2.3s hold fed the analyzer nothing) — and an EMPTY session is exactly the one that hangs: finalize no-ops but its results stream never terminates.

**Fix:** ONE process-wide `AVAudioEngine` (per capture: tap + start/stop only) · zero-audio captures skip finalize entirely (session force-closed, instant honest 'didn't catch that') · finalize AND results collection are bounded (5s/2s) with force-close · per-capture `tap N · fed M` timing logs.

## Verified on hardware (live log watch)
- Model verified ready at launch in <1s, zero daemon contact per press afterwards
- Capture starts in ~60ms; real utterances transcribe in 30–80ms finalize
- Aggressive hammering (rapid press/lift, Esc mid-capture, tap-to-type interleaved) — no parks, no zero-buffer captures, audio flowing on every attempt
- Watchdog copy now honest per cause ('voice got stuck' vs 'voice isn't ready yet')

https://claude.ai/code/session_01BDcxBLnDYq4LtjEWCYBzN6