### PR TITLE
Proactive: editable To: recipient on message-sending cards

### DIFF
--- a/Sentient OS macOS/Proactive/ProactiveExecutor.swift
+++ b/Sentient OS macOS/Proactive/ProactiveExecutor.swift
@@ -52,17 +52,21 @@ actor ProactiveExecutor {
     func fire(_ action: PreparedAction, progress: @escaping @Sendable (String) -> Void) async -> Outcome {
         let recipe = action.executionRecipe.trimmingCharacters(in: .whitespacesAndNewlines)
         let content = action.preparedContent     // the VERBATIM, possibly user-edited artifact to send
+        // The routing the message channels act on: the (possibly user-EDITED) "To:" recipient first,
+        // as the authoritative destination, then the model's recipe for the how. So correcting the
+        // card's To: actually re-targets the send. Empty recipient (calendar / form-fill) ⇒ bare recipe.
+        let routing = Self.authoritativeRouting(recipient: action.recipient, recipe: recipe)
         let t0 = Date()
         let r: FireResult
         switch action.method {
         case .gmail:
-            r = hasRecipe(recipe) ? await fireGmail(routing: recipe, content: content, progress: progress)
+            r = hasRecipe(recipe) ? await fireGmail(routing: routing, content: content, progress: progress)
                                   : .notFireable("No email recipe to fire.")
         case .calendar:
             r = hasRecipe(recipe) ? await fireCalendar(routing: recipe, content: content, progress: progress)
                                   : .notFireable("No calendar recipe to fire.")
         case .computer:
-            r = hasRecipe(recipe) ? await fireComputer(routing: recipe, content: content, progress: progress)
+            r = hasRecipe(recipe) ? await fireComputer(routing: routing, content: content, progress: progress)
                                   : .notFireable("No computer-use recipe to fire.")
         case .research:
             r = .notFireable("This is a briefing to read; there's nothing to fire.")
@@ -94,6 +98,17 @@ actor ProactiveExecutor {
 
     private func hasRecipe(_ recipe: String) -> Bool {
         !recipe.isEmpty && recipe.lowercased() != "none"
+    }
+
+    /// The routing a message channel acts on. When the card carries a `recipient` (the user-visible,
+    /// user-editable "To:"), it goes FIRST as the authoritative destination — so an edit to the To:
+    /// re-targets the send and beats any address the model left in the recipe. No recipient ⇒ the bare
+    /// recipe (calendar events, form-fill tasks). The value rides in the wrapper's ROUTING data block.
+    private static func authoritativeRouting(recipient: String, recipe: String) -> String {
+        let to = recipient.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !to.isEmpty else { return recipe }
+        return "Send to EXACTLY this recipient, confirmed by the user (if the routing below names a "
+            + "different address/person, THIS one wins): \(to)\n\(recipe)"
     }
 
     /// Internal fire result — the public `Outcome` for the UI PLUS the finer scoreboard fields.

--- a/Sentient OS macOS/Proactive/ProactiveResearch.swift
+++ b/Sentient OS macOS/Proactive/ProactiveResearch.swift
@@ -50,6 +50,12 @@ struct PreparedAction: Sendable, Identifiable, Codable {
     let executionRecipe: String    // ROUTING ONLY: which thread/recipient/chat/app/URL + which field
                                    // takes which content. References preparedContent, never duplicates
                                    // the body. "none" for research.
+    var recipient: String = ""     // WHO a message-send goes to — display name + handle/email
+                                   // ("Serena Saxena · serena@anthos.com"). Shown + EDITABLE as the
+                                   // card's "To:"; "" for cards that send to nobody (calendar / a
+                                   // form-fill task / research). Authoritative: the executor routes to
+                                   // exactly this, so a user edit re-targets the actual send. `var`
+                                   // (not `let`) so a memberwise init keeps compiling everywhere.
     let buttonText: String         // LLM-written fire CTA ("Should I send it for you?"); "" = no fire (research)
     let detailLabel: String        // LLM-written "read the …" link ("read the draft", "read the brief")
     let sources: [String]          // grounding receipts (vault notes, the thread, web results)
@@ -199,11 +205,12 @@ actor ProactiveResearch {
     "card_summary":{"type":"string"},\
     "prepared_content":{"type":"string"},\
     "execution_recipe":{"type":"string"},\
+    "recipient":{"type":"string"},\
     "button_text":{"type":"string"},\
     "detail_label":{"type":"string"},\
     "sources":{"type":"array","items":{"type":"string"}},\
     "review_note":{"type":"string"}},\
-    "required":["title","method","target","urgency","due_date","status","verification","card_summary","prepared_content","execution_recipe","button_text","detail_label","sources","review_note"]}},\
+    "required":["title","method","target","urgency","due_date","status","verification","card_summary","prepared_content","execution_recipe","recipient","button_text","detail_label","sources","review_note"]}},\
     "dropped":{"type":"array","items":{"type":"object","additionalProperties":false,"properties":{\
     "title":{"type":"string"},\
     "reason":{"type":"string"}},\
@@ -237,6 +244,7 @@ actor ProactiveResearch {
                 cardSummary: (d["card_summary"] as? String) ?? "",
                 preparedContent: (d["prepared_content"] as? String) ?? "",
                 executionRecipe: (d["execution_recipe"] as? String) ?? "",
+                recipient: ((d["recipient"] as? String) ?? "").trimmingCharacters(in: .whitespacesAndNewlines),
                 buttonText: ((d["button_text"] as? String) ?? "").trimmingCharacters(in: .whitespacesAndNewlines),
                 detailLabel: ((d["detail_label"] as? String) ?? "").trimmingCharacters(in: .whitespacesAndNewlines),
                 sources: (d["sources"] as? [String]) ?? [],
@@ -376,6 +384,12 @@ actor ProactiveResearch {
         fires exactly as written — in the user's own voice wherever it's something they'd say.
         - Write `execution_recipe`: ROUTING only (where the action goes), referencing `prepared_content` \
         — never restate the message body in the recipe.
+        - Set `recipient`: WHO the message goes TO — the person's display name plus their handle/email \
+        when you have it (e.g. "Priya Sharma · priya@example.com"). Fill it for any action that sends a \
+        message to a person (a gmail reply/new email; a chat message via computer); leave it "" for \
+        actions that send to nobody (calendar, a form-fill/registration task, research). The user sees \
+        and can EDIT this as the card's "To:", and the executor sends to EXACTLY it — so name the real \
+        intended recipient, and keep it consistent with the recipient in `execution_recipe`. \
         - If something irreversible genuinely can't be resolved (an unknown recipient, a real either/or \
         choice), prepare everything else and put exactly what the user must check/decide in \
         `review_note` — never guess on the irreversible specifics.

--- a/Sentient OS macOS/Views/HomeView.swift
+++ b/Sentient OS macOS/Views/HomeView.swift
@@ -502,7 +502,8 @@ struct HomeView: View {
                            // The LIVE content for THIS card (reflects any prior edit) — seeds the editor
                            // per briefing so a reused letter view never shows the previous card's draft.
                            liveDraft: model.entry(b.id)?.action?.preparedContent ?? b.draft ?? "",
-                           onCommitEdit: { model.applyEdit(b.id, content: $0) },
+                           liveRecipient: model.entry(b.id)?.action?.recipient ?? "",
+                           onCommitEdit: { model.applyEdit(b.id, content: $0, recipient: $1) },
                            onOffer: {
                                closeLetter()
                                model.run(b.id)   // real card → fires for real; demo → theater
@@ -775,16 +776,17 @@ final class ForYouModel {
         }
     }
 
-    /// Apply an edited draft to a card (its `preparedContent`) and persist it, so the fire sends it.
-    func applyEdit(_ id: String, content: String) {
+    /// Apply an edited draft + recipient to a card and persist them, so the fire sends exactly this
+    /// content to exactly this "To:".
+    func applyEdit(_ id: String, content: String, recipient: String) {
         update(id) {
             guard let old = $0.action else { return }
-            $0.action = Self.replacingContent(old, with: content)
+            $0.action = Self.replacing(old, content: content, recipient: recipient)
         }
-        guard var result = ProactiveResearch.latest() else { return }
-        result = ReadyResult(ready: result.ready.map { $0.id == id ? Self.replacingContent($0, with: content) : $0 },
-                             dropped: result.dropped)
-        ProactiveResearch.saveLatest(result)
+        guard let result = ProactiveResearch.latest() else { return }
+        ProactiveResearch.saveLatest(ReadyResult(
+            ready: result.ready.map { $0.id == id ? Self.replacing($0, content: content, recipient: recipient) : $0 },
+            dropped: result.dropped))
     }
 
     /// Drop a fired card from the persisted `latest` so a re-deal (next visit) won't show it again.
@@ -794,11 +796,12 @@ final class ForYouModel {
                                                  dropped: result.dropped))
     }
 
-    /// A copy of a PreparedAction with new `preparedContent` (the rest unchanged).
-    private static func replacingContent(_ a: PreparedAction, with content: String) -> PreparedAction {
+    /// A copy of a PreparedAction with new `preparedContent` + `recipient` (the rest unchanged).
+    private static func replacing(_ a: PreparedAction, content: String, recipient: String) -> PreparedAction {
         PreparedAction(title: a.title, method: a.method, target: a.target, urgency: a.urgency,
                        dueDate: a.dueDate, status: a.status, verification: a.verification,
                        cardSummary: a.cardSummary, preparedContent: content, executionRecipe: a.executionRecipe,
+                       recipient: recipient,
                        buttonText: a.buttonText, detailLabel: a.detailLabel, sources: a.sources,
                        reviewNote: a.reviewNote)
     }
@@ -877,24 +880,31 @@ private struct LetterView: View {
     let phase: BriefingPhase
     var editable: Bool = false                       // real card with a draft → the draft is editable
     var liveDraft: String = ""                       // THIS card's current content (seeds the editor)
-    var onCommitEdit: (String) -> Void = { _ in }    // persist the edited draft (so it's what fires)
+    var liveRecipient: String = ""                   // THIS card's "To:" (seeds the recipient field); "" = no recipient
+    var onCommitEdit: (String, String) -> Void = { _, _ in }   // persist (edited draft, edited recipient) → what fires
     var onOffer: () -> Void
     var onClose: () -> Void
 
     @State private var copied = false
     @State private var editedDraft = ""        // the live editor text
     @State private var savedDraft = ""         // the last COMMITTED text — drift from editedDraft = unsaved edits
+    @State private var editedRecipient = ""    // the live "To:" text
+    @State private var savedRecipient = ""     // the last COMMITTED "To:"
     @State private var saveTask: Task<Void, Never>?   // in-flight debounced auto-save
     @State private var giftSaved = false       // the welcome letter's keepsake PNG landed on the Desktop
 
-    /// Auto-save is pending (unsaved edits still settling). Drives the ambient "Saving…" status.
-    private var isDirty: Bool { editable && editedDraft != savedDraft }
+    /// This card sends a message to someone, so it shows an editable "To:" (the model filled a recipient).
+    private var hasRecipient: Bool { !liveRecipient.isEmpty }
 
-    /// Commit the current draft so it persists + is what fires. Cancels any pending debounce.
+    /// Auto-save is pending (unsaved edits still settling). Drives the ambient "Saving…" status.
+    private var isDirty: Bool { editable && (editedDraft != savedDraft || editedRecipient != savedRecipient) }
+
+    /// Commit the current draft + recipient so they persist + are what fires. Cancels any pending debounce.
     private func commitEdit() {
         saveTask?.cancel()
-        onCommitEdit(editedDraft)
+        onCommitEdit(editedDraft, editedRecipient)
         savedDraft = editedDraft
+        savedRecipient = editedRecipient
     }
 
     /// Debounced auto-save: commit ~0.6s after the user stops typing.
@@ -956,15 +966,17 @@ private struct LetterView: View {
         // briefing opens. The letter layer is always-mounted and REUSED across cards (stable identity),
         // so .onAppear fires only once; without the .onChange a second card would show the first card's
         // draft. editedDraft + savedDraft start equal (a freshly-opened card has no unsaved edits).
-        .onAppear { editedDraft = liveDraft; savedDraft = liveDraft }
+        .onAppear { editedDraft = liveDraft; savedDraft = liveDraft; editedRecipient = liveRecipient; savedRecipient = liveRecipient }
         // A different card opened: cancel any pending auto-save (it belongs to the OLD card's closure)
-        // and reseed. editedDraft + savedDraft start equal — a freshly-opened card has no unsaved edits.
+        // and reseed. edited + saved start equal — a freshly-opened card has no unsaved edits.
         .onChange(of: briefing.id) { _, _ in
-            saveTask?.cancel(); editedDraft = liveDraft; savedDraft = liveDraft; copied = false
+            saveTask?.cancel(); editedDraft = liveDraft; savedDraft = liveDraft
+            editedRecipient = liveRecipient; savedRecipient = liveRecipient; copied = false
             giftSaved = false
         }
-        // Every keystroke reschedules the debounced commit, so edits persist without a Save click.
+        // Every keystroke (draft OR recipient) reschedules the debounced commit, so edits persist without a Save click.
         .onChange(of: editedDraft) { _, _ in if isDirty { scheduleAutoSave() } }
+        .onChange(of: editedRecipient) { _, _ in if isDirty { scheduleAutoSave() } }
         .onDisappear { saveTask?.cancel() }
     }
 
@@ -1043,6 +1055,24 @@ private struct LetterView: View {
                         .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
+                }
+                // "To:" — WHO this message goes to. Shown only for cards that send to a person; editable
+                // (the executor sends to exactly this), so a wrong recipient is visible and correctable.
+                if hasRecipient {
+                    HStack(alignment: .firstTextBaseline, spacing: 10) {
+                        MonoCaps("To", size: 9, tracking: 2.0, color: Theme.Ink.label)
+                        if editable {
+                            TextField("", text: $editedRecipient)
+                                .textFieldStyle(.plain)
+                                .font(.system(size: 13)).foregroundStyle(.white.opacity(0.92))
+                                .tint(briefing.accent)
+                        } else {
+                            Text(editedRecipient.isEmpty ? liveRecipient : editedRecipient)
+                                .font(.system(size: 13)).foregroundStyle(.white.opacity(0.92))
+                                .textSelection(.enabled)
+                        }
+                    }
+                    Rectangle().fill(.white.opacity(0.07)).frame(height: 1)   // hairline between "who" and "what"
                 }
                 if editable {
                     TextEditor(text: $editedDraft)


### PR DESCRIPTION
A card that sends a message never showed **who** it was going to — the recipient lived only in the model's free-text `execution_recipe` and was dropped before the card rendered. This makes it a first-class, visible, **editable** field.

## Changes
- **`PreparedAction.recipient`** (new): display name + handle/email. The prepare step's output schema + prompt fill it for message sends (gmail; a chat via computer use), `""` otherwise.
- **`LetterView`**: an editable `To:` row in the card's edit section, shown only when the card sends to someone — mono-caps `TO` label + name/email, auto-saved on the same debounce as the draft.
- **`ProactiveExecutor.fire()`**: puts the (possibly user-edited) recipient FIRST in the routing as the user-confirmed destination, overriding any address the model left in the recipe — so correcting the `To:` actually re-targets the send.

This is also the F2 audit fix (the hidden-recipient risk): the destination is now visible and correctable before you fire.

## Notes
- Backward-compatible: `recipient` defaults to `""` (memberwise init unaffected); old persisted decks decode-fail gracefully (`latest()` → nil → regenerate).
- Debug + Release both build.
- **Runtime checks still pending** (merging ahead of them per request): a screenshot to confirm the `To:` row against the design bar, and a real cycle to confirm the model fills `recipient` well.

https://claude.ai/code/session_01UnWymii1CDhpv4MgKX7Fte