### PR TITLE
UX polish: Give AIs Knowledge rename, speed slider, settings refinements

### DIFF
--- a/Sentient OS macOS/App/Sentient_OS_macOSApp.swift
+++ b/Sentient OS macOS/App/Sentient_OS_macOSApp.swift
@@ -86,7 +86,7 @@ struct SentientOSApp: App {
         .restorationBehavior(.disabled)
 
         // Connect your AIs — the guided setup (per-AI video steps + the sharing toggle), opened
-        // by the glow CTAs in the Your AIs popover and Settings → Your AIs.
+        // by the glow CTAs in the Give-AIs-Knowledge popover and Settings pane of the same name.
         Window("", id: ConnectAIsView.windowID) {
             ConnectAIsView()
                 .environment(appState)

--- a/Sentient OS macOS/Cloud/CodexCLI.swift
+++ b/Sentient OS macOS/Cloud/CodexCLI.swift
@@ -354,8 +354,9 @@ actor CodexCLI {
     /// The command bar's "Let me DO stuff for you" spine — computer use (the "computer use" phrase is
     /// built into the prompt by the caller, NOT a flag here). Runs a raw `codex exec` with the prompt
     /// passed as ARGV and the exact flag set verified to make Codex's computer use work via the CLI:
-    /// `--dangerously-bypass-approvals-and-sandbox -m gpt-5.6-sol -c model_reasoning_effort="low"
-    /// --skip-git-repo-check`, NO `--json` (human-readable output, not JSONL). Each output LINE is
+    /// `--dangerously-bypass-approvals-and-sandbox -m gpt-5.6-sol -c model_reasoning_effort=<the
+    /// user's ComputerUseSpeed slider; default low> --skip-git-repo-check`, NO `--json`
+    /// (human-readable output, not JSONL). Each output LINE is
     /// pumped to `onLine` AS it arrives, so the Xcode console shows codex's play-by-play live. Reuses
     /// the sanitized-env / PATH / watchdog plumbing; the binary comes from the same discovery
     /// (`~/.local/bin/codex` first). The user's ~/.codex config + MCP servers load by default (no
@@ -368,6 +369,9 @@ actor CodexCLI {
     func runAgentCommand(_ prompt: String, imagePath: String? = nil, timeout: TimeInterval = 1_800,
                          onLine: @escaping @Sendable (String) -> Void) async throws -> String {
         let t0 = Date()
+        // The user's speed-vs-intelligence slider (Settings → Proactive & Sidekick) — read fresh
+        // per run, so a change applies to the very next fire with no restart.
+        let effort = ComputerUseSpeed.current.effort
         do {
             guard let bin = Self.locateBinary() else { throw CLIError.notAvailable(.notInstalled) }
             // Self-heal the relaxed confirmation policy: a plugin update (desktop app or a
@@ -376,7 +380,7 @@ actor CodexCLI {
             ComputerUseSkillPatch.ensureApplied()
             var args = ["exec", "--dangerously-bypass-approvals-and-sandbox",
                         "-m", Model.gpt56sol.rawValue,
-                        "-c", "model_reasoning_effort=\"low\""]
+                        "-c", "model_reasoning_effort=\"\(effort.rawValue)\""]
             if let imagePath { args += ["-i", imagePath] }   // followed by a flag → variadic stops at one file
             args += ["--skip-git-repo-check", prompt]
             let out = try await Self.executeStreaming(binary: bin, args: args, timeout: timeout, onLine: onLine)
@@ -391,7 +395,7 @@ actor CodexCLI {
             // which is not a failure; field-found polluting Sentry 2026-07-12).
             if !Task.isCancelled {
                 Self.emitCodexFailure(event: "codex.agent_command", error, feature: "computer",
-                                      model: .gpt56sol, effort: .low, resumed: false,
+                                      model: .gpt56sol, effort: effort, resumed: false,
                                       durationMS: Int(Date().timeIntervalSince(t0) * 1000))
             }
             throw error

--- a/Sentient OS macOS/Cloud/ComputerUseSpeed.swift
+++ b/Sentient OS macOS/Cloud/ComputerUseSpeed.swift
@@ -1,0 +1,54 @@
+//
+//  ComputerUseSpeed.swift
+//  Sentient OS macOS
+//
+//  The speed-vs-intelligence dial for EVERY computer-use run — Sidekick, the command bar, and a
+//  card's fire all ride the same runAgentCommand spine, so one knob governs them all. The model
+//  never changes (gpt-5.6-sol); the tier only picks how hard it thinks. Read fresh at fire time,
+//  so the Settings slider is live with no restart. Default = .faster (low thinking — the shipped
+//  behavior before the slider existed).
+//  Producer: ProactivePane's slider · Consumer: CodexCLI.runAgentCommand.
+//
+
+import Foundation
+
+enum ComputerUseSpeed: String, CaseIterable, Sendable {
+    case faster, medium, smarter
+
+    /// The UserDefaults key the Settings slider writes.
+    static let key = "sidekick.speed"
+
+    /// The live setting.
+    static var current: ComputerUseSpeed {
+        ComputerUseSpeed(rawValue: UserDefaults.standard.string(forKey: key) ?? "") ?? .faster
+    }
+
+    /// The codex reasoning effort each tier buys on gpt-5.6-sol.
+    var effort: CodexCLI.Effort {
+        switch self {
+        case .faster: .low
+        case .medium: .medium
+        case .smarter: .high
+        }
+    }
+
+    /// The tier's display name (the slider's readout).
+    var label: String {
+        switch self {
+        case .faster: "Faster"
+        case .medium: "Medium"
+        case .smarter: "Smarter"
+        }
+    }
+
+    /// The honest spec line under the slider — the model named out loud. ("med", not the
+    /// effort's raw "medium" — the whisper reads tighter.)
+    var modelLine: String {
+        let thinking = switch self {
+        case .faster: "low"
+        case .medium: "med"
+        case .smarter: "high"
+        }
+        return "GPT-5.6 Sol · \(thinking) thinking"
+    }
+}

--- a/Sentient OS macOS/Documentation/CodexCLI (codex exec Compute Spine).md
+++ b/Sentient OS macOS/Documentation/CodexCLI (codex exec Compute Spine).md
@@ -41,8 +41,10 @@ plumbing).
 - `runAgentCommand(_:timeout:onLine:)` — **the computer-use spine** (the command bar, Sidekick, and
   the executor's `computer` channel): a raw `codex exec` with the exact flag set measured to make
   Codex's computer use work on the CLI (`--dangerously-bypass-approvals-and-sandbox`, gpt-5.6-sol,
-  `model_reasoning_effort=low`, NO `--json` — human-readable output, prompt in argv), streaming each
-  output line live. ⚠️ It runs with the FULL inherited environment + a rich PATH
+  `model_reasoning_effort=<the user's Speed vs Intelligence slider — `ComputerUseSpeed.current`,
+  Cloud/ComputerUseSpeed.swift: Faster/Medium/Smarter → low/medium/high, default low; read fresh
+  per run, so the Settings change is live>, NO `--json` — human-readable output, prompt in argv),
+  streaming each output line live. ⚠️ It runs with the FULL inherited environment + a rich PATH
   (`richEnvironment`) — computer use's helper IPC socket lives under the real `$TMPDIR`, so the
   sanitized env that's right for every other call would hang it at `list_apps`. `codex login` needs
   the same for its browser launch.

--- a/Sentient OS macOS/Documentation/Home — Proactive Intelligence (For You).md
+++ b/Sentient OS macOS/Documentation/Home — Proactive Intelligence (For You).md
@@ -13,8 +13,10 @@ stats were reused in this surface and its popovers. Arch §10.)*
 The main window's content (rendered by `RootView`). Layers, bottom-to-top:
 
 - **Chrome (on top, so the nav stays clickable):** a slim top bar — `OrbMark` + "Sentient OS"
-  wordmark on the left; on the right four **doors** — `Analysis ▾` and `Connect AIs ▾` (popovers) ·
-  `Knowledge` and `⚙ Settings` (their own windows). Below it, the editorial voice: an hour-aware
+  wordmark on the left; on the right four **doors** — `Analysis ▾` and `Give AIs Knowledge ▾`
+  (popovers; the latter renamed from "Connect AIs" 2026-07-13 — users read "connect" as the codex
+  plumbing they'd already done) · `Knowledge` and `⚙ Settings` (their own windows; the gear is
+  17pt **bold** since 2026-07-12 — user studies showed the old 14pt one got missed). Below it, the editorial voice: an hour-aware
   greeting in the SF display voice (`.display(27)` — "Good evening, Jesai.", the name from the
   macOS account, `macFirstName`) over a mono-caps read-line (the REAL lifetime count from
   `LifetimeStats`). Card titles stay upright serif — serif marks content about the user's life.
@@ -33,7 +35,9 @@ The main window's content (rendered by `RootView`). Layers, bottom-to-top:
   version of the note; flinging the letter blooms the note into the full center. Once the plan claim
   reads Plus (re-decoded every appearance), the note becomes *"You're on Plus. Time to go live."*
   with a *Reset & Rebuild* glow. See `Plan Gate (CodexAuth & Knowledge-Base-Only).md`.
-- **The dock:** the `PromptBar` command bar + the trust footer (the command bar is HIDDEN in
+- **The dock:** the `PromptBar` command bar + the trust footer — just "Private by design." here
+  since 2026-07-13; the full "Your files never leave this Mac." line is reserved for the surfaces
+  where files are the message (the command bar is HIDDEN in
   knowledge-base-only mode — computer use runs on quota those plans don't have). A small `DEV TOOLS`
   handle is pinned bottom-right (→ the `Views/Dev/DevToolsView.swift` sheet; `#if DEBUG` — compiled
   out of Release, and it's the sheet's only opener, so Dev Tools is unreachable there).
@@ -141,9 +145,11 @@ Status lives here, never cluttering the home:
   time), **Analyze Now**, and the **source chips** — live on the SAME `SourceSelection` keys as
   Settings/Dev Tools (folder chips toggle; WhatsApp/iMessage open the shared `ChatPicker`;
   Gmail/Calendar open their connect sheets; the WhatsApp chip hides when it isn't installed).
-- **`YourAIsPopover`** — the real MCP mirror control: an ON/OFF pill wired to `MirrorClient`
-  (enable + push / disable), live `stats()` ("Read 5 notes today"), Copy Link + Copy Prompt, and the
-  glowing **Connect your AIs** CTA when off.
+- **`ShareKnowledgePopover`** (renamed from `YourAIsPopover` with the door, 2026-07-13) — the MCP
+  door, deliberately control-free: the mono-caps "Give AIs Knowledge" header, the pitch ("Offer
+  your knowledge base to your ChatGPT or Claude."), the glowing **Set up in 2 minutes** CTA that
+  opens the guided `ConnectAIsView` (which owns sharing on/off, the link, and the prompt), and the
+  "Private · over MCP · two simple steps" whisper.
 
 ## The cards — `Briefing.swift` · `BriefingCard.swift`
 

--- a/Sentient OS macOS/Documentation/MCP Mirror Client.md
+++ b/Sentient OS macOS/Documentation/MCP Mirror Client.md
@@ -13,7 +13,7 @@ await mirror.isEnabled                 // is mirroring ON? (the toggle flag — 
 let url = try mirror.enable()          // opt in → mints the password if absent → returns the share URL
 await mirror.shareURL                  // the "Copy MCP Link" value, or nil
 try await mirror.push()                // zip + ENCRYPT the vault, replace the mirror (call after any change)
-let s = try await mirror.stats()       // {notesRead24h, toolCalls24h, lastAccess} for "Connect AIs"
+let s = try await mirror.stats()       // {notesRead24h, toolCalls24h, lastAccess} for "Give AIs Knowledge"
 try await mirror.deleteRemote()        // delete the cloud copy (keeps the password → stable URL)
 await mirror.disable()                 // opt out: flip OFF + delete remote, but KEEP the password (stable link)
 let u2 = try await mirror.regenerateToken()  // leak remediation: mint a NEW password, delete old copy, re-push
@@ -99,7 +99,8 @@ is never marked clean.
 
 ## Turning the mirror on (today)
 
-The user-facing opt-in is **Settings → Connect AIs to Knowledge** (`Views/Settings/YourAIsPane.swift`)
+The user-facing opt-in is **Settings → Give AIs Knowledge** (`Views/Settings/ShareKnowledgePane.swift`,
+renamed 2026-07-13 from "Connect AIs to Knowledge"/`YourAIsPane`)
 and the guided **`ConnectAIsView`** window: the value/privacy story, the share toggle (ON =
 `enable()` + a first push; OFF = a confirm dialog, then `disable()`), the per-AI setup (masked link
 + Copy · Copy-the-system-prompt · the "what do you know about me?" closer), and live `stats()`

--- a/Sentient OS macOS/Documentation/Settings.md
+++ b/Sentient OS macOS/Documentation/Settings.md
@@ -2,28 +2,28 @@
 
 The real Settings (shipped 2026-07-04, PRs #107 + #109): a modern two-pane window in the
 OLED-editorial design language. Sidebar of five sections on the left (plus the About footer:
-version, GitHub, report-an-issue), the selected pane on the right, the trust ribbon riding the
-foot. Opened from the home's top-bar gear (`windowID "settings"`, 940×660 default). Everything
-lives in `Views/Settings/`: the shell (`SettingsView.swift`), one file per pane, and the shared
-pieces (`SettingsComponents.swift`).
+version, GitHub, report-an-issue — the "Open source on GitHub" link + heart wear
+**`Theme.Ink.gold`**, the open-source pride mark, deliberately louder than the footer's whisper
+and distinct from the caution amber), the selected pane on the right, and the trust ribbon —
+since 2026-07-13 riding ONLY Knowledge Sources and Permissions & Health (the panes where the
+files story is the message), not every pane. Opened from the home's top-bar gear
+(`windowID "settings"`, 940×660 default). Everything lives in `Views/Settings/`: the shell
+(`SettingsView.swift`), one file per pane, and the shared pieces (`SettingsComponents.swift`).
 
 ## ⚠️ NOT wired up yet (read this first)
 
-1. **The E2E encryption claim front-runs the code** — the Connect-AIs privacy blurb says the cloud
-   copy is end-to-end encrypted and unreadable even by Sentient's devs. That is LAUNCH truth,
-   decided 2026-07-04: the mirror stores plaintext markdown today, and the "mcp encryption"
-   backlog item (Aditya) MUST ship before launch or the copy must change. Do not soften the copy;
-   ship the encryption.
-2. **The morning notification** — the Notifications permission row is real, and the permission ask
+*(Two former items are DONE and gone from this list: the mirror's encryption at rest shipped —
+AES-256-GCM before upload, see `MCP Mirror Client.md` — so the pane's E2E copy is now true; and
+the System pane's Updates group is live with Sparkle, see `Auto-Update (Sparkle).md`.)*
+
+1. **The morning notification** — the Notifications permission row is real, and the permission ask
    is now wired: onboarding's permissions screen fires `Notify.ask()` on appear, so the native
    macOS prompt happens once with no extra UI (`ask()` no-ops unless status is still
    `.notDetermined`). What's still dormant is the *sending* — `Notify.now()` has zero call sites;
    the "Proactive Intelligence is ready" morning note ships with the reminders/scheduler work.
-3. **The Updates group** (System pane) — doesn't exist until Sparkle lands; it brings its own
-   keep-it-on message.
-4. **Privacy toggles transmit only in RELEASE builds** — by design (Sentry/TelemetryDeck never
+2. **Privacy toggles transmit only in RELEASE builds** — by design (Sentry/TelemetryDeck never
    boot in DEBUG), so a Debug QA can verify persistence but not transmission.
-5. **Small known holes, accepted for now:** removing the LAST custom folder can bypass the
+3. **Small known holes, accepted for now:** removing the LAST custom folder can bypass the
    four-selection minimum (the guard covers chip toggle-offs only) · the reset-vs-run race has
    only the UI guard (see Reset below; the Layer-2 generation counter is deferred hardening) ·
    three Settings deep-link anchors (Speech Recognition, Accessibility, Screen Recording) are
@@ -80,13 +80,28 @@ feeds both proactive prompts (`Proactive.instructionsBlock` — PART 1 + PART 2)
 `sidekick.context` feeds the command/Sidekick prompt (`CommandRunModel.commandPrompt`, §6b of the
 Notch doc). Each is `""`-safe: no text → the prompt is unchanged.
 
-### Connect AIs to Knowledge (`YourAIsPane.swift`)
+**The Speed vs Intelligence slider (2026-07-13):** a compact custom three-detent slider
+(`SpeedIntelligenceSlider`, private to the pane — 300×24pt pill permanently wearing its own
+three-stop spectrum, `Theme.Ink.green` → cyan → purple, glow beneath; only the white thumb moves;
+the readout docks the tier name under the left edge and "GPT-5.6 SOL · LOW/MED/HIGH THINKING"
+under the right, live mid-drag). It writes `ComputerUseSpeed` (`Cloud/ComputerUseSpeed.swift` —
+the one source of truth: key `sidekick.speed`, tiers Faster/Medium/Smarter → gpt-5.6-sol effort
+low/medium/high, default Faster = the pre-slider behavior). **It governs EVERY computer-use run**
+— Sidekick, the command bar, and a card's fire all ride `runAgentCommand`, which reads the
+setting fresh per run (live, no restart). A brighter `SettingsHairline(opacity: 0.12)` splits the
+Proactive and Sidekick groups (same splitter as Health's codex divider).
+
+### Give AIs Knowledge (`ShareKnowledgePane.swift`)
+*(Renamed 2026-07-13 from "Connect AIs to Knowledge"/`YourAIsPane` — the whole surface family is
+now `ShareKnowledge*`: the pane, the home's `ShareKnowledgePopover`, `Pane.shareKnowledge`. The
+guided `ConnectAIsView` window keeps its name — in there "connect" is the literal action.)*
 The story leads: a value blurb (your ChatGPT/Claude, phone apps included, read the knowledge
 base and choose what's relevant) then the plain-language privacy explainer (local-first,
-PII-stripped summaries only, E2E-encrypted [see the NOT-wired list], no accounts, the 30-day
+PII-stripped summaries only, E2E-encrypted, no accounts, the 30-day
 self-delete in plain words, open-source backend). Then the share toggle (OFF = confirm dialog →
 `disable()`, which deletes the cloud copy but keeps the token), and the pane's HERO: the glowing
-**Connect your AIs** `GlowButton` → **`ConnectAIsView`, now the REAL guided setup**: step 1 =
+**Set up in 2 minutes** capsule (`ConnectCTA` — same label as the home popover's CTA) →
+**`ConnectAIsView`, the REAL guided setup**: step 1 =
 the masked link (`MirrorClient.maskedURL`) + Copy, step 2 = Copy the system prompt, closing with
 the magic line ("ask it: what do you know about me?"); a sharing-off state points back at
 Settings. Live `stats()` activity below; local-only story when sharing is off.
@@ -96,6 +111,10 @@ Settings. Live `stats()` activity below; local-only story when sharing is off.
 contains "/mcp", and a forward hit inverts the range (a shipped-then-fixed crash).
 
 ### System (`SystemPane.swift`)
+Reads as three chapters split by two dividers (2026-07-13): *how Sentient runs* (Overnight ·
+Startup · Updates), then a bright hairline; *privacy*; then a **red-tinted hairline**
+(`SettingsHairline(color: Theme.Ink.red, opacity: 0.25)` — the app's one semantic divider, the
+line you cross into destructive territory) guarding the exit door (Danger Zone · Uninstall).
 The overnight-intelligence story (prose; 3 AM is our taste, not a dial), launch-at-login
 (`LoginItem`) with a keep-Sentient-alive confirm on the way off, the privacy pledge with the two
 split consents (crash reports `diagnosticsEnabled` → Sentry · analytics `analyticsEnabled` →

--- a/Sentient OS macOS/Views/HomePopovers.swift
+++ b/Sentient OS macOS/Views/HomePopovers.swift
@@ -7,7 +7,7 @@
 //   · AnalysisPopover — the work glance: things understood, vault size, the synced stamp, an
 //     Analyze Now control, and the source chips (sources are the INPUTS to analysis, so they
 //     live under "Analysis").
-//   · YourAIsPopover — the pitch + the glowing "Connect your AIs" CTA that opens the guided
+//   · ShareKnowledgePopover — the pitch + the glowing "Set up in 2 minutes" CTA that opens the guided
 //     setup window (ConnectAIsView owns sharing on/off, the link, and the prompt).
 //  Pure presentation; harvested from the retired Constellation home. Demo strings (synced
 //  stamp, access log) stand in until the real polls land; the vault counts ARE real (disk).
@@ -155,28 +155,28 @@ struct AnalysisPopover: View {
     }
 }
 
-// MARK: - Your AIs
+// MARK: - Give AIs Knowledge
 
-/// The MCP door. One job: the glowing "Connect your AIs" CTA, always shown, opening the guided
+/// The MCP door. One job: the glowing "Set up in 2 minutes" CTA, always shown, opening the guided
 /// setup window — ConnectAIsView owns sharing on/off, the private link, and the system prompt,
 /// so the popover carries no state and no controls of its own.
-struct YourAIsPopover: View {
+struct ShareKnowledgePopover: View {
     @Environment(\.openWindow) private var openWindow
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            MonoCaps("Connect AIs", size: 10, tracking: 2.4, color: Theme.Ink.label)
+            MonoCaps("Give AIs Knowledge", size: 10, tracking: 2.4, color: Theme.Ink.label)
 
-            Text("Offer your knowledge to every AI.")
+            Text("Offer your knowledge base to your ChatGPT or Claude.")
                 .display(20).foregroundStyle(.white)
                 .padding(.top, 11)
 
-            GlowButton(title: "Connect your AIs", systemImage: "link", glowIntensity: 0.28) {
+            GlowButton(title: "Set up in 2 minutes", systemImage: "link", glowIntensity: 0.28) {
                 openWindow(id: ConnectAIsView.windowID)
             }
             .padding(.top, 18)
 
-            MonoCaps("Your whole knowledge · offered to every AI", size: 8.5, tracking: 1.6,
+            MonoCaps("Private · over MCP · two simple steps", size: 8.5, tracking: 1.6,
                      color: Theme.Ink.deepMuted)
                 .padding(.top, 13)
         }
@@ -262,8 +262,8 @@ enum HomeStats {
     }.frame(width: 380, height: 460).preferredColorScheme(.dark)
 }
 
-#Preview("Your AIs") {
+#Preview("Give AIs Knowledge") {
     ZStack { Theme.bg
-        YourAIsPopover()
+        ShareKnowledgePopover()
     }.frame(width: 360, height: 300).preferredColorScheme(.dark)
 }

--- a/Sentient OS macOS/Views/HomeView.swift
+++ b/Sentient OS macOS/Views/HomeView.swift
@@ -9,7 +9,7 @@
 //  bar at the foot lets you ask it to DO anything (computer use).
 //
 //  The chrome is deliberately quiet: a wordmark, and four doors at the top-right —
-//  Analysis ▾ and Connect AIs ▾ (glanceable popovers, HomePopovers.swift) · Knowledge and
+//  Analysis ▾ and Give AIs Knowledge ▾ (glanceable popovers, HomePopovers.swift) · Knowledge and
 //  Settings (their own windows). Status lives inside Analysis, never cluttering the home.
 //
 //  WHEN THERE ARE NO CARDS, the living Orb blooms into the vacated center with "I'm here to
@@ -60,7 +60,7 @@ struct HomeView: View {
     @State private var letter: Briefing?
     @State private var letterShown = false
     @State private var showAnalysis = false
-    @State private var showYourAIs = false
+    @State private var showShareKnowledge = false
     @State private var showWhatsAppPicker = false
     @State private var showIMessagePicker = false
     @State private var showGmailConnect = false
@@ -168,8 +168,8 @@ struct HomeView: View {
             NavItem(title: "Analysis", dot: Theme.Ink.green) { showAnalysis = true }
                 .popover(isPresented: $showAnalysis) { analysisPopover }
             NavItem(title: "Knowledge") { openWindow(id: KnowledgeView.windowID) }
-            NavItem(title: "Connect AIs") { showYourAIs = true }
-                .popover(isPresented: $showYourAIs) { yourAIsPopover }
+            NavItem(title: "Give AIs Knowledge") { showShareKnowledge = true }
+                .popover(isPresented: $showShareKnowledge) { shareKnowledgePopover }
             NavItem(icon: "gearshape") { openWindow(id: SettingsView.windowID) }
         }
         .padding(.horizontal, 30).padding(.top, 18)
@@ -290,8 +290,8 @@ struct HomeView: View {
         return "Synced · \(f.string(from: d))"
     }
 
-    private var yourAIsPopover: some View {
-        YourAIsPopover()   // self-contained: toggles the real MCP mirror + copies the link / system prompt
+    private var shareKnowledgePopover: some View {
+        ShareKnowledgePopover()   // self-contained: toggles the real MCP mirror + copies the link / system prompt
             .preferredColorScheme(.dark)
     }
 
@@ -480,7 +480,7 @@ struct HomeView: View {
             }
             HStack(spacing: 8) {
                 Image(systemName: "shield").font(.system(size: 11)).foregroundStyle(Theme.Ink.label)
-                Text("Private by design. Your files never leave this Mac.")
+                Text("Private by design.")
                     .font(.system(size: 12)).foregroundStyle(Theme.Ink.label)
             }
         }
@@ -608,7 +608,7 @@ private struct NavItem: View {
         Button(action: action) {
             HStack(spacing: 6) {
                 if let dot { Circle().fill(dot).frame(width: 5, height: 5).opacity(0.9) }
-                if let icon { Image(systemName: icon).font(.system(size: 14, weight: .medium)) }
+                if let icon { Image(systemName: icon).font(.system(size: 17, weight: .bold)) }
                 if let title { Text(title).font(.system(size: 13.5, weight: .medium)) }
             }
             .foregroundStyle(hover ? .white : Theme.Ink.bright)

--- a/Sentient OS macOS/Views/Settings/HealthPane.swift
+++ b/Sentient OS macOS/Views/Settings/HealthPane.swift
@@ -79,7 +79,8 @@ struct HealthPane: View {
                 VStack(alignment: .leading, spacing: 30) {
                     onDeviceGroup
                     sidekickGroup
-                    SettingsHairline()
+                    SettingsHairline(opacity: 0.12)
+                        .padding(.vertical, -7)   // the brighter, tighter group splitter (matches ProactivePane's)
                         .rise(6, revealed: revealed)
                     Group {
                         if codexAllGreen && !codexExpanded {

--- a/Sentient OS macOS/Views/Settings/ProactivePane.swift
+++ b/Sentient OS macOS/Views/Settings/ProactivePane.swift
@@ -3,12 +3,14 @@
 //  Sentient OS macOS
 //
 //  Settings → Proactive & Sidekick: the user's standing instructions for the proactive
-//  suggestion writer, and Sidekick's shortcut key + standing context. The strings persist and
-//  autosave. The hotkey choice (right ⌘ / right ⌥) is LIVE — toggling it posts `.sidekickHotkeyChanged`,
-//  which re-keys the running SidekickHotkeyMonitor with no restart. The two text fields are LIVE too:
-//  `proactive.instructions` feeds the proactive prompts (Proactive.instructionsBlock, PART 1 + 2) and
-//  `sidekick.context` feeds the command/Sidekick prompt (CommandRunModel.commandPrompt) — the two keys
-//  live in CustomInstructions so producer and consumers can't drift.
+//  suggestion writer, Sidekick's shortcut key + standing context, and the speed-vs-intelligence
+//  slider (ComputerUseSpeed — how hard gpt-5.6-sol thinks on EVERY computer-use run). The strings
+//  persist and autosave. The hotkey choice (right ⌘ / right ⌥) is LIVE — toggling it posts
+//  `.sidekickHotkeyChanged`, which re-keys the running SidekickHotkeyMonitor with no restart. The
+//  two text fields are LIVE too: `proactive.instructions` feeds the proactive prompts
+//  (Proactive.instructionsBlock, PART 1 + 2) and `sidekick.context` feeds the command/Sidekick
+//  prompt (CommandRunModel.commandPrompt) — the two keys live in CustomInstructions so producer
+//  and consumers can't drift. The slider is live the same way (read fresh per run).
 //
 
 import SwiftUI
@@ -17,6 +19,7 @@ struct ProactivePane: View {
     @AppStorage(CustomInstructions.proactiveKey) private var proactiveInstructions = ""
     @AppStorage("sidekick.hotkey") private var sidekickHotkey = "rightCommand"
     @AppStorage(CustomInstructions.sidekickKey) private var sidekickContext = ""
+    @AppStorage(ComputerUseSpeed.key) private var speedRaw = ComputerUseSpeed.faster.rawValue
 
     var body: some View {
         SettingsPane(title: "Proactive & Sidekick",
@@ -29,6 +32,8 @@ struct ProactivePane: View {
                                         text: $proactiveInstructions)
                     }
                 }
+                SettingsHairline(opacity: 0.12)
+                    .padding(.vertical, -7)   // sit tighter than the pane's 30pt group rhythm
                 SettingsGroup(label: "Sidekick") {
                     VStack(alignment: .leading, spacing: 14) {
                         SettingsProse("Hold the shortcut key and just talk (\u{201C}finish this for me\u{201D}), and Sidekick acts on whatever you're looking at.")
@@ -48,13 +53,127 @@ struct ProactivePane: View {
                                         text: $sidekickContext)
                     }
                 }
+                SettingsGroup(label: "Speed vs Intelligence") {
+                    VStack(alignment: .leading, spacing: 14) {
+                        SettingsProse("How hard your AI thinks when acting on your Mac: Sidekick, the command bar, and firing a card. Faster is right for most tasks; Smarter takes its time on the tricky ones.")
+                        SpeedIntelligenceSlider(selection: Binding(
+                            get: { ComputerUseSpeed(rawValue: speedRaw) ?? .faster },
+                            set: { speedRaw = $0.rawValue }))
+                    }
+                }
             }
         }
+    }
+}
+
+// MARK: - The speed-vs-intelligence slider
+
+/// A compact three-detent slider in the reference's proportions: a THICK pill permanently
+/// wearing its own three-stop spectrum (green → cyan → purple) at full strength, the detent
+/// dots living inside, and only the white circle moving. Drag or click; the readout underneath
+/// names the tier AND the honest spec (GPT-5.6 Sol · how hard it thinks) — live during a drag.
+private struct SpeedIntelligenceSlider: View {
+    @Binding var selection: ComputerUseSpeed
+
+    /// The pointer's live position while dragging (nil = resting on the selection's detent).
+    @State private var dragFraction: CGFloat?
+
+    private static let width: CGFloat = 300
+    private static let trackHeight: CGFloat = 24
+    private static let thumb: CGFloat = 28          // slightly proud of the track, like the reference
+    /// The slider's own three-stop spectrum: the app green → cyan → purple.
+    private static let spectrum = [Theme.Ink.green,
+                                   Color(red: 0.13, green: 0.83, blue: 0.93),
+                                   Color(red: 0.66, green: 0.33, blue: 0.97)]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            track
+                .frame(width: Self.width, height: Self.thumb)
+            // One line under the pill: the landed tier under the left edge, the honest
+            // model spec under the right — both live during a drag.
+            HStack(alignment: .firstTextBaseline) {
+                Text(hovered.label)
+                    .font(.system(size: 12.5, weight: .semibold))
+                    .foregroundStyle(.white)
+                Spacer()
+                MonoCaps(hovered.modelLine, size: 8.5, tracking: 1.6, color: Theme.Ink.deepMuted)
+            }
+            .frame(width: Self.width)
+        }
+    }
+
+    private var fraction: CGFloat { dragFraction ?? Self.fraction(of: selection) }
+    /// The tier the thumb is nearest RIGHT NOW — previews in the readout mid-drag.
+    private var hovered: ComputerUseSpeed { Self.tier(nearest: fraction) }
+
+    private static func fraction(of tier: ComputerUseSpeed) -> CGFloat {
+        switch tier {
+        case .faster: 0
+        case .medium: 0.5
+        case .smarter: 1
+        }
+    }
+
+    private static func tier(nearest f: CGFloat) -> ComputerUseSpeed {
+        f < 0.25 ? .faster : (f < 0.75 ? .medium : .smarter)
+    }
+
+    private var track: some View {
+        let usable = Self.width - Self.thumb
+        let center = fraction * usable + Self.thumb / 2
+        let gradient = LinearGradient(colors: Self.spectrum,
+                                      startPoint: .leading, endPoint: .trailing)
+
+        return ZStack(alignment: .leading) {
+            // The permanent spectrum: the whole gradient always dresses the pill at full
+            // strength, its glow breathing underneath.
+            gradient
+                .frame(width: Self.width, height: Self.trackHeight)
+                .clipShape(Capsule())
+                .blur(radius: 10)
+                .opacity(0.4)
+            gradient
+                .frame(width: Self.width, height: Self.trackHeight)
+                .clipShape(Capsule())
+
+            // The detents, living INSIDE the pill.
+            ForEach([CGFloat](arrayLiteral: 0, 0.5, 1), id: \.self) { f in
+                Circle()
+                    .fill(.white.opacity(0.4))
+                    .frame(width: 4, height: 4)
+                    .offset(x: f * usable + Self.thumb / 2 - 2)
+            }
+
+            // The one moving thing.
+            Circle()
+                .fill(.white)
+                .frame(width: Self.thumb, height: Self.thumb)
+                .shadow(color: .black.opacity(0.45), radius: 4, y: 1)
+                .offset(x: center - Self.thumb / 2)
+        }
+        .contentShape(Rectangle())
+        .gesture(
+            DragGesture(minimumDistance: 0)
+                .onChanged { g in
+                    let f = min(max((g.location.x - Self.thumb / 2) / usable, 0), 1)
+                    withAnimation(.interactiveSpring(response: 0.15, dampingFraction: 0.85)) {
+                        dragFraction = f
+                    }
+                }
+                .onEnded { _ in
+                    let landed = hovered
+                    withAnimation(.spring(response: 0.32, dampingFraction: 0.78)) {
+                        selection = landed
+                        dragFraction = nil
+                    }
+                }
+        )
     }
 }
 
 #Preview("Proactive & Sidekick pane") {
     ProactivePane()
         .background(Theme.bg)
-        .frame(width: 720, height: 640)
+        .frame(width: 720, height: 760)
 }

--- a/Sentient OS macOS/Views/Settings/SettingsComponents.swift
+++ b/Sentient OS macOS/Views/Settings/SettingsComponents.swift
@@ -367,9 +367,13 @@ struct SettingsTextBox: View {
     }
 }
 
-/// The hairline that separates lines inside a group.
+/// The hairline that separates lines inside a group — or, a touch brighter, whole groups.
+/// `color` is for the one semantic exception: the red line guarding System's destructive tail.
 struct SettingsHairline: View {
+    var color: Color = .white
+    var opacity: Double = 0.06
+
     var body: some View {
-        Rectangle().fill(.white.opacity(0.06)).frame(height: 1)
+        Rectangle().fill(color.opacity(opacity)).frame(height: 1)
     }
 }

--- a/Sentient OS macOS/Views/Settings/SettingsView.swift
+++ b/Sentient OS macOS/Views/Settings/SettingsView.swift
@@ -5,7 +5,7 @@
 //  The Settings window — a modern two-pane layout: a quiet sidebar of sections on the left
 //  (with the About footer: version + the open-source link), the selected pane on the right,
 //  and the trust ribbon riding the foot. Every pane is real and lives beside this file:
-//  SourcesPane · ProactivePane · YourAIsPane · SystemPane · HealthPane.
+//  SourcesPane · ProactivePane · ShareKnowledgePane · SystemPane · HealthPane.
 //
 
 import SwiftUI
@@ -16,14 +16,14 @@ struct SettingsView: View {
 
     /// The five sections, in sidebar order.
     enum Pane: CaseIterable, Identifiable {
-        case sources, proactive, yourAIs, system, health
+        case sources, proactive, shareKnowledge, system, health
 
         var id: Self { self }
         var title: String {
             switch self {
             case .sources:   return "Knowledge Sources"
             case .proactive: return "Proactive & Sidekick"
-            case .yourAIs:   return "Connect AIs to Knowledge"
+            case .shareKnowledge: return "Give AIs Knowledge"
             case .system:    return "System"
             case .health:    return "Permissions & Health"
             }
@@ -32,7 +32,7 @@ struct SettingsView: View {
             switch self {
             case .sources:   return "tray.full"
             case .proactive: return "sparkles"
-            case .yourAIs:   return "antenna.radiowaves.left.and.right"
+            case .shareKnowledge: return "antenna.radiowaves.left.and.right"
             case .system:    return "gearshape"
             case .health:    return "checkmark.shield"
             }
@@ -95,14 +95,16 @@ struct SettingsView: View {
         VStack(alignment: .leading, spacing: 9) {
             MonoCaps("Sentient OS · v\(UpdateController.currentVersionString)", size: 8, tracking: 1.6, color: Theme.Ink.deepMuted)
             footerLink("Open source on GitHub", icon: "heart.fill",
-                       url: "https://github.com/Sentient-OS-Labs/sentient-os")
+                       url: "https://github.com/Sentient-OS-Labs/sentient-os",
+                       color: Theme.Ink.gold)   // the pride mark — gold, deliberately louder than the footer's whisper
             footerLink("Report an issue", icon: "ladybug",
                        url: "https://github.com/Sentient-OS-Labs/sentient-os/issues")
         }
         .padding(.horizontal, 10)
     }
 
-    private func footerLink(_ title: String, icon: String, url: String) -> some View {
+    private func footerLink(_ title: String, icon: String, url: String,
+                            color: Color = Theme.Ink.label) -> some View {
         Button {
             if let u = URL(string: url) { NSWorkspace.shared.open(u) }
         } label: {
@@ -110,7 +112,7 @@ struct SettingsView: View {
                 Image(systemName: icon).font(.system(size: 8.5))
                 Text(title).font(.system(size: 10.5))
             }
-            .foregroundStyle(Theme.Ink.label)
+            .foregroundStyle(color)
         }
         .buttonStyle(PressScaleStyle())
     }
@@ -123,18 +125,20 @@ struct SettingsView: View {
                 switch selection {
                 case .sources:   SourcesPane()
                 case .proactive: ProactivePane()
-                case .yourAIs:   YourAIsPane()
+                case .shareKnowledge: ShareKnowledgePane()
                 case .system:    SystemPane()
                 case .health:    HealthPane()
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
 
-            trustFooter
+            if selection == .sources || selection == .health { trustFooter }
         }
     }
 
-    /// The trust ribbon — rides every surface, Settings included.
+    /// The trust ribbon — in Settings it rides ONLY Knowledge Sources and Permissions & Health,
+    /// the panes where the files story is the message (what we read · what the grants allow);
+    /// boilerplate on every pane would cheapen it.
     private var trustFooter: some View {
         HStack(spacing: 8) {
             Image(systemName: "shield").font(.system(size: 10.5)).foregroundStyle(Theme.Ink.label)

--- a/Sentient OS macOS/Views/Settings/ShareKnowledgePane.swift
+++ b/Sentient OS macOS/Views/Settings/ShareKnowledgePane.swift
@@ -1,18 +1,19 @@
 //
-//  YourAIsPane.swift
+//  ShareKnowledgePane.swift
 //  Sentient OS macOS
 //
-//  Settings → Your AIs: the value + privacy story up top, the share toggle (off = confirm, then
-//  the cloud copy is deleted; the token is kept so the link survives re-enabling), and the HERO:
-//  the glowing "Connect your AIs" button → the real guided setup (ConnectAIsView), which owns the
-//  secret link + system prompt. Live activity from /stats below. Regenerate lives in MirrorClient
-//  only (a support/dev remediation; a UI button was a footgun that bricks every connector).
+//  Settings → Give AIs Knowledge: the value + privacy story up top, the share toggle (off =
+//  confirm, then the cloud copy is deleted; the token is kept so the link survives re-enabling),
+//  and the HERO: the glowing "Set up in 2 minutes" button → the real guided setup (ConnectAIsView),
+//  which owns the secret link + system prompt. Live activity from /stats below. Regenerate lives
+//  in MirrorClient only (a support/dev remediation; a UI button was a footgun that bricks every
+//  connector).
 //
 
 import SwiftUI
 import AppKit
 
-struct YourAIsPane: View {
+struct ShareKnowledgePane: View {
     @Environment(\.openWindow) private var openWindow
 
     @State private var enabled = false
@@ -186,7 +187,7 @@ private struct ConnectCTA: View {
         Button(action: action) {
             HStack(spacing: 8) {
                 Image(systemName: "sparkles").font(.system(size: 12, weight: .semibold))
-                Text("Connect your AIs").font(.system(size: 13, weight: .semibold))
+                Text("Set up in 2 minutes").font(.system(size: 13, weight: .semibold))
             }
             .foregroundStyle(.white)
             .padding(.horizontal, 22).padding(.vertical, 10)
@@ -199,8 +200,8 @@ private struct ConnectCTA: View {
     }
 }
 
-#Preview("Your AIs pane") {
-    YourAIsPane()
+#Preview("Give AIs Knowledge pane") {
+    ShareKnowledgePane()
         .background(Theme.bg)
         .frame(width: 720, height: 640)
 }

--- a/Sentient OS macOS/Views/Settings/SystemPane.swift
+++ b/Sentient OS macOS/Views/Settings/SystemPane.swift
@@ -33,10 +33,16 @@ struct SystemPane: View {
     var body: some View {
         SettingsPane(title: "System", whisper: "How Sentient lives on this Mac.") {
             VStack(alignment: .leading, spacing: 34) {
+                // Three chapters, two dividers: how Sentient runs · privacy · the exit door —
+                // the second line is red on purpose (you cross it into destructive territory).
                 overnightGroup
                 startupGroup
                 updatesGroup
+                SettingsHairline(opacity: 0.12)
+                    .padding(.vertical, -8)
                 privacyGroup
+                SettingsHairline(color: Theme.Ink.red, opacity: 0.25)
+                    .padding(.vertical, -8)
                 dangerGroup
                 uninstallGroup
             }

--- a/Sentient OS macOS/Views/Theme.swift
+++ b/Sentient OS macOS/Views/Theme.swift
@@ -72,6 +72,7 @@ enum Theme {
         static let bright = Color(red: 0.812, green: 0.804, blue: 0.839)       // #cfcdd6
         static let green = Color(red: 0.290, green: 0.871, blue: 0.502)        // #4ade80 (was mint #47d7ac — too seafoam)
         static let amber = Color(red: 1.0, green: 0.765, blue: 0.443)          // #ffc371
+        static let gold = Color(red: 0.851, green: 0.702, blue: 0.294)         // #d9b34b — the open-source pride mark (Settings footer); NOT the caution amber
         static let red = Color(red: 1.0, green: 0.36, blue: 0.36)              // status-LED red (StatusLine .bad · the home's live caution)
         static let chipInk = Color(red: 0.541, green: 0.537, blue: 0.565)      // #8a8990
         static let chipBorder = Color(red: 0.114, green: 0.114, blue: 0.133)   // #1d1d22


### PR DESCRIPTION
## What's in here (one UX-polish session, all verified in the running app)

### Home
- Settings gear enlarged to 17pt bold (user studies: the 14pt one got missed)
- Trust footer trimmed to just "Private by design." (the full line is reserved for surfaces where files are the message)
- The "Connect AIs" door renamed **"Give AIs Knowledge"** — users read "connect" as the codex plumbing they'd already done

### The ShareKnowledge* surface family (renamed from YourAIs*)
- `ShareKnowledgePopover`: new pitch ("Offer your knowledge base to your ChatGPT or Claude."), **Set up in 2 minutes** CTA, "Private · over MCP · two simple steps" whisper
- `ShareKnowledgePane` (file git-mv'd from `YourAIsPane.swift`), `Pane.shareKnowledge`; the guided `ConnectAIsView` keeps its name (there, connecting is the literal action)

### Speed vs Intelligence slider (Settings → Proactive & Sidekick)
- New `Cloud/ComputerUseSpeed.swift`: Faster/Medium/Smarter → gpt-5.6-sol low/med/high thinking, default Faster (pre-slider behavior), key `sidekick.speed`
- `runAgentCommand` reads it fresh per run — governs Sidekick, the command bar, AND card fires, live with no restart; Sentry failure tag now reports the real effort
- Custom 3-detent slider: 300×24 pill wearing a permanent green→cyan→purple gradient, only the white thumb moves, readout docks tier left / "GPT-5.6 SOL · x THINKING" right

### Settings chrome
- "Open source on GitHub" + heart in new `Theme.Ink.gold` (distinct from caution amber)
- Trust ribbon now only on Knowledge Sources + Permissions & Health
- Brighter group splitters (`SettingsHairline` gained color/opacity) in Proactive & Sidekick and Health's codex divider; System pane reads as three chapters with a **red hairline** guarding the destructive tail

### Docs
Settings.md (incl. dropping two shipped items from the NOT-wired list), Home, MCP Mirror Client, CodexCLI docs updated to match.