### PR TITLE
Keep the display awake for the whole of onboarding

### DIFF
--- a/Sentient OS macOS/System/DisplayAwake.swift
+++ b/Sentient OS macOS/System/DisplayAwake.swift
@@ -2,10 +2,12 @@
 //  DisplayAwake.swift
 //  Sentient OS macOS
 //
-//  Keeps the SCREEN powered on for the lifetime of a foreground processing run, so the long
-//  first ingest isn't cut short by macOS dimming the display and idle-sleeping the Mac while
-//  real work is happening. This is the polite, no-root, no-entitlement path a video player
-//  uses: `ProcessInfo.beginActivity(.idleDisplaySleepDisabled)` → hold the token → `endActivity`.
+//  Keeps the SCREEN powered on while long foreground work is happening, so it isn't cut short
+//  by macOS dimming the display and idle-sleeping the Mac. Two holders: OnboardingView (the
+//  whole flow, slides through finale — the model download and first analysis run behind it)
+//  and ProcessingView (a home-launched initial ingest). This is the polite, no-root,
+//  no-entitlement path a video player uses:
+//  `ProcessInfo.beginActivity(.idleDisplaySleepDisabled)` → hold the token → `endActivity`.
 //  Keeping the display on implicitly blocks system idle-sleep too, so this covers both.
 //
 //  NB: this is intentionally NOT the WakeHelper's `pmset disablesleep` (that needs root, only

--- a/Sentient OS macOS/Views/Onboarding/OnboardingView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingView.swift
@@ -49,6 +49,11 @@ struct OnboardingView: View {
     /// screen renders it). Held here so this body observes its phase.
     @State private var download = ModelDownload.shared
 
+    /// Keeps the screen on for ALL of onboarding — the model download runs behind the slides
+    /// and the first analysis takes hours; idle-sleep would kill both. Held for this view's
+    /// whole lifetime (see body), released when the home replaces onboarding.
+    @State private var awake = DisplayAwake()
+
     /// Live model path (env → bundle → App Support → repo root); nil = not on this Mac YET.
     /// Reading the download phase first makes SwiftUI re-evaluate this body when the download
     /// verifies, so the path flips non-nil in place and the analysis takes over by itself (the
@@ -103,6 +108,13 @@ struct OnboardingView: View {
                 }
             }
         }
+        // The whole-onboarding display hold: slides → permissions → codex login → downloads →
+        // analysis → finale, pauses included. The FDA quit-and-relaunch re-begins on remount;
+        // the DEBUG skip and the real finish both release via onDisappear when RootView swaps
+        // to home. (ProcessingView's own hold covers home-launched first ingests; during
+        // onboarding the two overlap harmlessly — independent tokens.)
+        .onAppear { awake.begin(reason: "Onboarding — keeping the screen on") }
+        .onDisappear { awake.end() }
         // A quiet back door on every screen but the first (and never over the analysis takeover,
         // which owns its own pause/exit). One shared code path, so every step gets it for free.
         .overlay(alignment: .topLeading) {


### PR DESCRIPTION
## What

`OnboardingView` now owns a `DisplayAwake` hold for its entire lifetime — `begin()` on appear, `end()` on disappear. That covers every step: slides → permissions → codex login → plan crossroads → ready screen → the model-download wait → the first analysis + knowledge-base tail → completed/failed screens, **pauses included** (a deliberate change from the old release-on-pause). It releases exactly when RootView swaps to the home — both the real finale and the DEBUG skip — and the FDA quit-and-relaunch simply re-begins on remount.

## Why

Previously only `ProcessingView`'s ingest run held the screen awake, so on the early screens (where the model download runs in the background) the Mac could idle-sleep and stall everything. Todo item: "add keep display on for whole onboarding".

`ProcessingView`'s own hold stays as-is (it still covers home-launched first ingests); during onboarding the two overlap harmlessly — independent activity tokens.

## Verify

Get into onboarding, sit on any early screen, run `pmset -g assertions` — a `PreventUserIdleDisplaySleep` assertion with reason "Onboarding — keeping the screen on" should be present; reach home and it disappears.

Build verified (isolated DerivedData): **BUILD SUCCEEDED**.

https://claude.ai/code/session_01THgvyuCmHgFFy6SkGk4FYw