### PR TITLE
Notch hover affordance: swell + haptic + click-to-type

### DIFF
--- a/Sentient OS macOS/Documentation/Notch Magic/Notch Magic.md
+++ b/Sentient OS macOS/Documentation/Notch Magic/Notch Magic.md
@@ -10,11 +10,12 @@ Documentation for **Notch Magic** — Sentient OS's global hold-to-talk / tap-to
 
 ## 1. What Notch Magic is
 
-**A global way to tell Sentient to *do something*, and a universal status surface for when it's working.** Three front doors, one backend, one notch:
+**A global way to tell Sentient to *do something*, and a universal status surface for when it's working.** Four front doors, one backend, one notch:
 
 1. **Press-and-hold the Sidekick key anywhere** → the notch *drops open the instant you press* (you're pulling it open); *speak* a task → release → it transcribes (on-device) and fires it as a **computer-use** command.
 2. **Tap the Sidekick key** (a quick press-release, no hold) → the open notch becomes a focused **text field** → type a task, hit ⏎ → same computer-use backend.
-3. **Type in the home command bar** (`PromptBar`) → same backend, same notch.
+3. **Click the notch itself** — mousing over the idle notch makes it *swell* under the cursor with a trackpad haptic tick and a drop shadow (the Dynamic-Island "press me" affordance); a click opens the same tap-to-type field. §7a.
+4. **Type in the home command bar** (`PromptBar`) → same backend, same notch.
 
 The **Sidekick key** is the user's choice in Settings → Proactive & Sidekick: **right ⌘** (default) or **right ⌥**. Both are right-side modifiers, so either works permission-free (§4); the rest of this doc says "right ⌘" as the default, but everything applies to whichever key is chosen.
 
@@ -54,12 +55,12 @@ Every command is **computer use** (the dedicated browser-use channel was removed
 | **`VoiceCapture.swift`** | Façade: mic + speech permissions, engine selection, `prewarm` / `start` / `stopAndTranscribe` / `cancel`. |
 | **`CommandRunModel.swift`** | Runs ONE codex task; **cleans codex's raw human-readable stream** into the bar's `statusLine` + the `remembering` state (§6); `stop()`, `onFinished(Outcome)`. Grabs + attaches the screen still at run start (§6a). |
 | **`ScreenCapture.swift`** | Grabs the screen to a temp JPEG for computer-use context (`/usr/sbin/screencapture`, main display). `grab() -> URL?` (nil if no Screen Recording grant) · `discard(_:)`. §6a. |
-| **`CommandCoordinator.swift`** | The brain: owns the run + hotkey + voice, drives `phase` (`NotchPhase`), the press→branch flow, `submit()` / `submitTyped()` / `dismissTyping()` / `cancelCurrent()` / `stop()`. |
+| **`CommandCoordinator.swift`** | The brain: owns the run + hotkey + voice, drives `phase` (`NotchPhase`), the press→branch flow, `submit()` / `submitTyped()` / `dismissTyping()` / `cancelCurrent()` / `stop()`. Also the hover affordance's seams: the `notchHovering` render state + `notchClicked()` (§7a). |
 | **`NotchSpace.swift`** | SkyLight private-API wrapper — pins the panel into a top-level window-server space so it's fixed over the notch on every Space. |
-| **`NotchWindowController.swift`** | The `NSPanel` host: a **fixed canvas** flush at the bezel; click-through by toggling `ignoresMouseEvents` per cursor position; all-Spaces; observers. Also `NotchPanel`, `NotchHostingView`, the `NSScreen.notchSize`/`displayID` extension. |
+| **`NotchWindowController.swift`** | The `NSPanel` host: a **fixed canvas** flush at the bezel; click-through by toggling `ignoresMouseEvents` per cursor position (two-tier poll, §7b); all-Spaces; observers. Also the hover affordance's mechanics (mouseMoved monitors → swell + haptic + click, §7a), `NotchPanel`, `NotchHostingView`, the `NSScreen.notchSize`/`displayID` extension. |
 | **`NotchShape.swift`** | The silhouette `Shape` (animatable corner radii) **+ `NotchSkirtShape`** — its open twin (sides + rounded bottom + concave top corners, no flat top edge) that the glow strokes. |
 | **`SpinningLogo.swift`** | The 2D spectrum-ring logo (matches the app icon). |
-| **`NotchView.swift`** | `NotchView` (binder) + `NotchContent` (the pure visual: morph, phases, layered edge glow, the read-back / Remembering / status captions) + `NotchMetrics` (per-phase sizing) + `NotchStopButton` + the `.blurDissolve` transition. |
+| **`NotchView.swift`** | `NotchView` (binder) + `NotchContent` (the pure visual: morph, phases, the depth-bed shadow, layered edge glow, the read-back / Remembering / status captions, the hover swell + its asymmetric springs) + `NotchMetrics` (per-phase + hover sizing) + `NotchStopButton` + the `.blurDissolve` transition. |
 
 Edits outside this folder: `AppState.swift` (owns/starts the two objects), `Views/HomeView.swift` (`PromptBar` drives `appState.commandCoordinator`), `Cloud/CodexCLI.swift` (`runAgentCommand` gained an optional `imagePath` → `codex exec -i`, §6a), `System/Permissions.swift` (`hasScreenRecording()`, already present), and the project's `INFOPLIST_KEY_NSMicrophoneUsageDescription` + `INFOPLIST_KEY_NSSpeechRecognitionUsageDescription` build settings.
 
@@ -177,7 +178,8 @@ This is where most of the hard bugs were fought and won. The window is a **FIXED
 **(a) Fixed canvas, top-flush, NEVER resized during a morph.** The panel is sized once to `canvasSize` — the biggest notch state + slack (`canvasHSlack 140`, `canvasVSlack 90`) for the bounce-overshoot and glow bloom — pinned with its top at the screen's edge. `applyPhase` just `placeCanvas()` + `reveal()`; on `.hidden` it `orderOut`s after `settleDelay` (idle = no window at all). Because the window never moves/resizes mid-animation, the notch **can't detach from the bezel**.
 > ⚠️ The OLD approach — resize the window to the notch on every phase change (grow-to-union, shrink-after-settle) — made the notch visibly **jump off the bezel** mid-morph (the AppKit frame and the SwiftUI animation fought, worse with a bouncy spring). Don't go back to per-state window resizing.
 
-**(b) Click-through = `ignoresMouseEvents` toggled by CURSOR POSITION.** macOS does per-pixel hit-testing: a click on ANY non-transparent pixel (incl. the glow bloom) is caught by the window *before* `hitTest` runs, and a nil `hitTest` then **swallows** it rather than passing through. So a static hitTest can't make the glow click-through. Instead a ~60 Hz cursor poll (`mouseTimer`, added in `.common` run-loop mode) sets `ignoresMouseEvents = false` **only while the cursor is over the actual notch silhouette** (`cursorOverSilhouette` — a `NotchShape` path test in screen coords); everywhere else the whole window ignores the mouse, so clicks (over the glow, the empty canvas, an inch away) sail straight through. `hitTest` then just returns `super ?? self`; `acceptsFirstMouse` so STOP/the field fire on the first click.
+**(b) Click-through = `ignoresMouseEvents` toggled by CURSOR POSITION.** macOS does per-pixel hit-testing: a click on ANY non-transparent pixel (incl. the glow bloom) is caught by the window *before* `hitTest` runs, and a nil `hitTest` then **swallows** it rather than passing through. So a static hitTest can't make the glow click-through. Instead a cursor poll (`mouseTimer`, added in `.common` run-loop mode) sets `ignoresMouseEvents = false` **only while the cursor is over the actual notch silhouette** (`cursorOverSilhouette` — a `NotchShape` path test in screen coords); everywhere else the whole window ignores the mouse, so clicks (over the glow, the empty canvas, an inch away) sail straight through. `hitTest` then just returns `super ?? self`; `acceptsFirstMouse` so STOP/the field fire on the first click.
+The poll is **two-tier by proximity** (`retuneMouseTimer`, 2026-07-13): 60 Hz while the cursor is inside the canvas, 10 Hz when it's far — the far tick is one rect test (the canvas box also gates the silhouette test, so a far cursor never pays for a Path build or the read-back text measurement), timer tolerance lets macOS coalesce wakeups, and the always-on hover monitors (§7a) bump far → near the instant the cursor re-approaches, so the lazy tier never delays a STOP click.
 > ⚠️ Don't gate click-through on a static `hitTest`/rect — the glow's drawn pixels are caught before hitTest, and a rect over-claims the area beside the rounded notch. Gate on **where the cursor is**, against the **shape path**.
 
 **(c) Present on ALL Spaces + no slide.** Both still needed: `collectionBehavior = [.canJoinAllSpaces, .stationary, .ignoresCycle, .fullScreenAuxiliary]`, **re-asserted on EVERY `reveal()`** (macOS drops `.canJoinAllSpaces` on re-order); and `NotchSpace.shared?.pin(panel)` (the SkyLight private API, level `Int32.max`) so it doesn't slide during the 3-finger Spaces swipe (`.stationary` is Exposé-only; best-effort, falls back to the public behaviour).
@@ -189,6 +191,17 @@ This is where most of the hard bugs were fought and won. The window is a **FIXED
 Other notes: `level = .mainMenu + 3`; `sharingType` **left at default** (the notch shows in screen recordings — Jesai chose recordability). Observers (`didChangeScreenParameters`, `activeSpaceDidChange`, `didWake`, `didActivateApplication`) re-place the canvas on the menu-bar display (`CGMainDisplayID`, not `NSScreen.main`) and re-`reveal()`; `host.update(metrics:)` re-renders on display change.
 
 ---
+
+## 7a. The notch as a button — hover swell + click-to-type  *(✅ built & verified on hardware 2026-07-13)*
+
+Mouse over the IDLE notch → a trackpad haptic tick (`NSHapticFeedbackManager`, `.alignment`) and the shell **swells** (`NotchMetrics.hoverSize`: +22pt wide, +3pt deep — the grow reads sideways; more depth looks like drooping) with a drop shadow and deliberately **NO glow** (the shadow alone says "solid, pressable"). Click → the same tap-to-type field as a hotkey tap, via `CommandCoordinator.notchClicked()` — the knowledge-base-only Plus aside and the first-use permission gate run first, mirroring the press beats. **Real-notch displays only** (a nil `notchSize` never arms it).
+
+The mechanics (all in `NotchWindowController`):
+- **Entry: zero-permission `.mouseMoved` NSEvent monitors** (global + local — mouse monitors are not keyboard-class, zero TCC contact; installed post-launch per lesson 14, with a retry tick). Idle costs NOTHING but the per-move callback: a couple of guards + ONE cached rect test (`hoverEntryRect`, recomputed on build + display changes) against the event's own screen coordinates (no `NSEvent.mouseLocation` round-trip).
+- **The window arrives invisibly:** the panel orders in with the shell at the EXACT hardware silhouette — black over the black cutout — then springs to the grown shape: the dismiss retract-merge trick (§8) played in reverse.
+- **Exit + click-through ride the §7b poll:** while hovering the poll detects the cursor leaving and flips `ignoresMouseEvents` over the swollen silhouette. Enter/exit have **hysteresis** (entry = the tight hardware cutout; exit = the grown box + 4pt) so the swollen lip can't flicker. Hover yields the instant a real phase opens the notch (`clearHover` — the phase owns the shape); `endHover`'s order-out waits **1.0s** (longer than `settleDelay`) because the exit glide outlives the phase retract.
+- **Asymmetric springs** (`NotchContent.hoverMorph`): entry `response 0.38 / damping 0.6` — quick, one tiny overshoot; exit `0.52 / 0.95` — a shrink's overshoot lands INSIDE the cutout where it's invisible, so a bouncy exit reads as a hard cut; the slower fully-damped glide is what *feels* symmetric. Tuned live on Jesai's bezel.
+- ⚠️ **The screen's top edge must stay clickable** — three separate boundary traps once made the notch's top row click-dead; see lesson 15 before touching any cursor-vs-top-edge math.
 
 ## 8. The notch visual — `NotchView` / `NotchContent` / `NotchShape` / `SpinningLogo`
 
@@ -202,6 +215,7 @@ Other notes: `level = .mainMenu + 3`; `sharingType` **left at default** (the not
 - **running/finishing:** `runningHeight(caption:) = baseHeight + caption + bottomPad` — `caption` is the read-back's measured height (grows to fit, below) or the tight one-line status (`captionHeight 18`). `topPad 0` + zero VStack spacing so the text sits right under the hardware notch; `bottomPad 4`.
 - **typing:** wider + one focusable field row.
 - **hidden (the dismiss RETRACT):** size collapses to the **exact hardware notch** (`hardwareNotch`, with the real notch radius), and the black shell stays **opaque** (`shellOpacity = 1`) while only the *content* fades. So on dismiss the shell morphs back into the real cutout and **merges with it** — a physical "suck back into the notch," then the window orders out invisibly (`settleDelay 0.6s`). No fade. (On a notch-less display there's nothing to merge into, so `shellOpacity` fades it instead.)
+- **hover (idle only):** `hoverSize` / `hoverRadii` — the hardware cutout +22pt wide, +3pt deep, the genuine radius scaled to the new depth. Rendered with the depth-bed shadow and zero glow (§7a).
 
 **Layout (camera-flanking):** a top row (`SpinningLogo` · `Spacer(centerGap 64)` · `rightControl`) at the camera band, then the caption / type-field row. `hPad 18` clearance. The logo AND every `rightControl` fill the **same `controlSlot` (17pt) square**, so the two flanks are twinned in size and on one optical center axis — no per-state drift. `rightControl` cross-fades between **the mic at 14pt** (opening calmer → listening "leans in") · spinner (transcribing) · the `TextField` (typing) · `NotchStopButton` (running) · outcome glyph (finishing).
 
@@ -211,6 +225,8 @@ Other notes: `level = .mainMenu + 3`; `sharingType` **left at default** (the not
 - **Status** — codex's work lines, mono, `.contentTransition(.interpolate)` so only the CHANGED glyphs morph in place (shared prefixes stay put — e.g. one tool line → the next).
 
 **The morph:** one spring `.spring(response: 0.52, dampingFraction: 0.72)` drives size/radii/content/glow together on `phase`, `readBack`, and `remembering` (reduced-motion → 0.24s ease) — fast-out, gentle settle, slight bounce.
+
+**The depth bed** (2026-07-13): a drop shadow (`0.55 / radius 9 / y+3`) cast by an identical silhouette at the very BOTTOM of the ZStack — **behind the glow layers**, so the spectrum reads against darkness instead of the user's wallpaper. Its fill never shows (the real shell covers it exactly); only the shadow escapes. Present in every visible state AND the hover swell; opacity-only fade so it rides whichever spring is driving and vanishes for the retract-merge. (It can't live on the main fill — that layer sits ABOVE the halo glows.)
 
 **The edge glow** (`glow` ×3 → `glowLayer`): a rotating `AngularGradient(GlowHalo.stops)` **masked by `NotchSkirtShape.stroke`** — the mask lives in the body so it morphs in LOCKSTEP with the black fill (no "separate entity" pop-in). Three layers (wide soft halo + dense halo behind the fill, crisp bright rim over it) make it thick + vivid. It's **always present**, fading via `.opacity(glowStrength)` so the edges light up in place; `glowStrength` is non-zero for **every visible state** (opening/listening/typing/running…), so the notch glows from the moment it's summoned. ⚠️ Each layer expands its gradient `(lineWidth/2 + blur + 6)` past every edge (`.padding(-m)` + `.mask(skirt.padding(m))`) so the BOTTOM edge isn't thinner than the sides (the gradient must reach beyond the stroke + blur on ALL sides, and the bottom edge sits at the frame edge).
 
@@ -239,6 +255,7 @@ Other notes: `level = .mainMenu + 3`; `sharingType` **left at default** (the not
 12. **The dismiss is a RETRACT, not a fade.** On `.hidden`, the black shell stays opaque and morphs to the *exact hardware-notch silhouette* (size + radius), so it merges into the real cutout and the window orders out invisibly — a physical "suck back in." Only the inner content fades. (Notch-less displays fade — there's nothing to merge into.) An earlier flat opacity fade read as cheap; don't go back.
 13. **Keyboard-class `CGEventTap`s are TCC-radioactive — Sidekick rides NSEvent monitors, permanently.** Two field-proven layers [both 2026-07-09]: (a) listen-only keyDown taps are Input-Monitoring-gated outright — the old global Esc landed Sentient in the pane with a stray request and the system disabled the tap every ~1.5s forever; (b) even a listen-only **flagsChanged-ONLY** tap fires a real `kTCCServiceListenEvent` access request at creation — fresh Mac → the "receive keystrokes from any application" dialog at first launch + a system-set denial (the app listed, unchecked, in the Input Monitoring pane) — while the tap *works anyway*, which is how it hid on never-pristine dev Macs. NSEvent global+local `flagsChanged` monitors deliver the same modifier stream with zero TCC contact (§4). The cancel story is the local Esc monitor + the hotkey press (§6).
 14. **NSEvent monitors must be installed AFTER the app finishes launching.** Registered during `AppState.init` (mid-`NSApplicationMain`, `NSApp` still nil) they wedge event routing for the life of the process — windows draw, the main thread idles, zero input is ever delivered ("AppleEvent activation suspension timed out"). Guard on `NSApp?.isRunning == true` and let the health tick install on its first post-launch pass (§4).
+15. **The screen's top edge must stay clickable (Fitts's law) — THREE boundary traps, all field-found 2026-07-13.** A cursor slammed against the top of the screen reports EXACTLY the boundary coordinate, and three independent layers each treat the boundary as "outside": (a) `Path.contains` excludes boundary points → the silhouette gate tests a point clamped 2pt INTO the shape; (b) SwiftUI shape hit-testing has the same exclusion → the shell's tap gesture rides a generous `contentShape(Rectangle().inset(by: -4))` (the window gate keeps it honest); (c) `NSRect.contains` is half-open (excludes the max edge) → every cursor rect touching the screen top (`hoverEntryRect`, `nearZone`) must overhang it by +2. Fixing one or two is not enough — the click dies at whichever layer still excludes the edge.
 
 ---
 
@@ -265,6 +282,7 @@ All of the below is **confirmed working on Jesai's bezel** (live screenshots/rec
 - **The logo** matches the app icon — twinned to the right control in a shared 17pt slot, the warm seam stop deepened to gold (no white spot), the white ring extra-fine, spinning 2× faster while processing.
 - **Dismiss & Esc:** the notch *retracts/merges into the cutout* on dismiss (no fade); Esc cancels globally (type field · listening · transcript), a hotkey tap closes the type field, and STOP/Esc dismiss the transcript instantly while still halting live computer use with the "Stopped" beat.
 - **The hotkey mechanism swap (2026-07-09):** the CGEventTap was replaced with NSEvent global+local `flagsChanged` monitors (lesson 13) with a post-launch install guard (lesson 14) — verified live on hardware: fresh TCC state (`tccutil reset`) → **no Keystroke Receiving dialog**, hold-to-talk + tap-to-type + Esc cancel all working, launch clean.
+- **The notch as a button (2026-07-13):** hover swell + haptic + depth-bed drop shadow + click-to-type (§7a), the asymmetric enter/exit springs, the two-tier proximity poll (§7b), and the top-edge Fitts fixes (lesson 15) — all verified on Jesai's bezel, including top-edge clicks across the notch's width and menu-bar click-through immediately beside it.
 - **Not yet done:** §12 polish backlog; productionization (§13). Reduced-motion + VoiceOver coded but unverified.
 
 ---
@@ -283,9 +301,11 @@ The morph is a longer, bouncier spring; the read-back→work swap is a blur-diss
 ### ✅ D. Dismiss everywhere (Esc · ⌘ · STOP) — **DONE**
 Esc cancels/dismisses via the window's LOCAL monitor whenever Sentient is frontmost — the type field, listening, transcribing, and the voice transcript; over other apps a fresh hotkey press is the cancel (transcribing bail + the instant transcript dismiss). A hotkey tap closes the type field; STOP and the cancels all route through `stop()`, dismissing the transcript INSTANTLY (no flourish) yet halting live computer use with the "Stopped" beat (§6). Esc over other apps is left entirely alone (no global keyDown tap — Input-Monitoring-gated, §4).
 
+### ✅ E1. Hover-haptic — **DONE and upgraded (2026-07-13)**
+Grew into the full notch-as-a-button affordance: hover swell + haptic + drop shadow + click-to-type. §7a.
+
 ### E. Deferred touches (each its own focused pass)
 - **Behind-mic color dance:** a small blurred colored glow *behind the mic icon* in the listening state (distinct from the edge glow — the `.opening`→`.listening` "lean in" is the hook).
-- **Hover-haptic:** a trackpad haptic (`NSHapticFeedbackManager`) when the cursor crosses the notch's boundary.
 - **2-line status:** the bar now shows a tight ONE status line (for compactness); if a 2-line codex narration matters, widen `captionHeight` / show the last 2.
 - **Multi-task "↓ N tasks":** today it's one run at a time; the future is a stack you pull down (per-task rows + STOPs). Big change to the coordinator (a list of runs) + the notch.
 

--- a/Sentient OS macOS/Notch Magic/CommandCoordinator.swift
+++ b/Sentient OS macOS/Notch Magic/CommandCoordinator.swift
@@ -46,6 +46,12 @@ final class CommandCoordinator {
     /// `readBack ?? run.statusLine` while running.
     private(set) var readBack: String?
 
+    /// True while the cursor hovers the IDLE notch — the click-to-type affordance (the shell swells
+    /// with a haptic tick; a click opens the type field). Set by NotchWindowController, which owns
+    /// the cursor geometry; read by NotchView for the grow + drop shadow. Idle-only by construction:
+    /// the controller clears it the instant the notch opens for real.
+    private(set) var notchHovering = false
+
     private let hotkey = SidekickHotkeyMonitor()
     private let voice = VoiceCapture()
     private var hotkeyChangeObserver: NSObjectProtocol?
@@ -302,6 +308,34 @@ final class CommandCoordinator {
         guard phase == .typing else { return }
         setPhase(.hidden)
         Log("notch typing dismissed")
+    }
+
+    // MARK: The notch as a button (the hover affordance)
+
+    /// NotchWindowController's seam for the hover state (it owns the cursor geometry; the view
+    /// renders the swell + shadow off this).
+    func setNotchHovering(_ hovering: Bool) {
+        guard notchHovering != hovering else { return }
+        notchHovering = hovering
+    }
+
+    /// A click on the idle, hover-swollen notch — the pointer's twin of a hotkey TAP: open the
+    /// tap-to-type field. Mirrors voicePressBegan's beats minus the voice branches (a click can only
+    /// mean typing): the knowledge-base-only aside, then the first-use permission gate, then the
+    /// field. The window controller makes the panel key on .typing, same as the hotkey path.
+    func notchClicked() {
+        guard phase == .hidden, !run.isRunning else { return }
+        if CodexAuth.knowledgeBaseOnly {
+            flash(Self.needsPlusNotice, for: 2.0)
+            Log("notch click blocked — knowledge-base-only plan (Sidekick needs Plus)")
+            return
+        }
+        if ComputerUseGate.shared.interceptBeforeStart() {
+            Log("notch click intercepted — computer-use permissions missing, gate up")
+            return
+        }
+        setPhase(.typing)
+        Log("notch clicked → typing")
     }
 
     /// Cancel — back out of whatever the notch is doing, mirroring the obvious one-tap action for each state:

--- a/Sentient OS macOS/Notch Magic/NotchView.swift
+++ b/Sentient OS macOS/Notch Magic/NotchView.swift
@@ -41,6 +41,24 @@ struct NotchMetrics: Equatable {
 
     var runningWidth: CGFloat { max(baseWidth + 160, 360) }
 
+    // MARK: Hover — the click-to-type affordance (the idle notch swells under the cursor)
+
+    /// The grown silhouette while the cursor hovers the IDLE notch: noticeably wider, only a touch
+    /// deeper than the hardware cutout — enough to read as "press me", small enough to stay a notch,
+    /// not a state. (Tuned on Jesai's bezel: the swell reads mostly sideways; too much depth looks
+    /// like the notch drooping.)
+    var hoverSize: CGSize {
+        let base = hardwareNotch ?? CGSize(width: baseWidth, height: baseHeight)
+        return CGSize(width: base.width + 22, height: base.height + 3)
+    }
+
+    /// The genuine notch radius (height / 3) scaled to the hover depth, so the swollen shape keeps
+    /// the real cutout's character instead of going balloon-round.
+    var hoverRadii: (top: CGFloat, bottom: CGFloat) {
+        let r = hoverSize.height / 3
+        return (top: max(r - 4, 0), bottom: r)
+    }
+
     /// The running/finishing notch height for a given caption-row height (the only variable bit). Kept as
     /// tight as possible — camera band + the text + a small bottom pad — so it eats minimally into apps.
     func runningHeight(caption: CGFloat) -> CGFloat { baseHeight + caption + bottomPad }
@@ -145,9 +163,11 @@ struct NotchView: View {
                      readBack: coordinator.readBack,
                      statusLine: coordinator.run.statusLine,
                      remembering: coordinator.run.remembering,
+                     hovering: coordinator.notchHovering,
                      metrics: metrics,
                      onStop: { coordinator.stop() },
-                     onSubmitText: { coordinator.submitTyped($0) })
+                     onSubmitText: { coordinator.submitTyped($0) },
+                     onNotchClick: { coordinator.notchClicked() })
     }
 }
 
@@ -158,28 +178,53 @@ struct NotchContent: View {
     let readBack: String?
     let statusLine: String
     var remembering: String? = nil
+    /// The cursor is over the IDLE notch (the click-to-type affordance): the shell swells with a
+    /// drop shadow — no glow, no content — and a click opens the type field. Honored only while
+    /// `.hidden`; any real phase owns the shape.
+    var hovering: Bool = false
     let metrics: NotchMetrics
     var onStop: () -> Void = {}
     var onSubmitText: (String) -> Void = { _ in }
+    var onNotchClick: () -> Void = {}
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var draft = ""
     @FocusState private var fieldFocused: Bool
 
     var body: some View {
-        let size = metrics.size(for: phase, readBack: readBack, remembering: remembering)
-        let radii = metrics.radii(for: phase)
+        let hoverIdle = hovering && phase == .hidden     // the swollen click affordance — idle only
+        let size = hoverIdle ? metrics.hoverSize
+                             : metrics.size(for: phase, readBack: readBack, remembering: remembering)
+        let radii = hoverIdle ? metrics.hoverRadii : metrics.radii(for: phase)
         let visible = phase != .hidden
         // The notch sits FLUSH at the screen's top edge — its concave top corners visible on the bezel
         // (the genuine-notch flare). The glow traces only the sides + bottom (NotchSkirtShape), so the
         // bezel line never lights up and there's no need to bleed the window off-screen to hide a top glow.
 
         ZStack(alignment: .top) {
+            // The depth bed — the silhouette's drop shadow, at the very BOTTOM of the stack so it
+            // sits BEHIND the color glow: the spectrum reads against darkness instead of the user's
+            // wallpaper, and the hover swell reads solid (hover deliberately has NO glow — the shadow
+            // alone says "pressable"). The bed's own fill never shows (the real shell covers it
+            // exactly); only its shadow escapes. Opacity-only fade, so it rides whichever morph is
+            // driving (the phase spring or the hover spring) and vanishes for the retract-merge.
+            NotchShape(topCornerRadius: radii.top, bottomCornerRadius: radii.bottom)
+                .fill(.black)
+                .shadow(color: .black.opacity(0.55), radius: 9, y: 3)
+                .opacity(visible || hoverIdle ? 1 : 0)
+                .allowsHitTesting(false)
             glow(radii, lineWidth: 13, blur: 17, strength: 0.75)   // wide soft outer halo (behind the fill)
             glow(radii, lineWidth: 6,  blur: 6,  strength: 0.95)   // denser halo hugging the edge
             NotchShape(topCornerRadius: radii.top, bottomCornerRadius: radii.bottom)
                 .fill(.black)
-                .allowsHitTesting(false)
+                // Clickable ONLY as the hover affordance — every other state keeps the shell
+                // hit-transparent (STOP / the type field stay the notch's only interactive elements).
+                // The generous contentShape makes a click pinned against the screen's top edge (a point
+                // ON the shape's boundary, which path hit-testing excludes) still land on the tap; the
+                // window only delivers clicks over the silhouette anyway, so this over-claims nothing.
+                .contentShape(Rectangle().inset(by: -4))
+                .onTapGesture(perform: onNotchClick)
+                .allowsHitTesting(hoverIdle)
             glow(radii, lineWidth: 3,  blur: 0.6, strength: 1.0)   // crisp bright rim, over the fill
             content(size: size)
                 .opacity(visible ? 1 : 0)              // icons + caption dissolve as the shell retracts into the cutout
@@ -188,12 +233,13 @@ struct NotchContent: View {
         .frame(width: size.width, height: size.height)
         .accessibilityElement(children: .combine)        // on the notch itself, never the full canvas
         .accessibilityLabel(a11yLabel)
-        .scaleEffect(visible ? 1 : 0.94, anchor: .top)
+        .scaleEffect(visible || hoverIdle ? 1 : 0.94, anchor: .top)
         .opacity(shellOpacity)                           // shell stays opaque & MERGES into a real notch on dismiss (fades only if there's none)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .animation(morph, value: phase)
         .animation(morph, value: readBack)               // grow/shrink the notch as the read-back appears/clears
         .animation(morph, value: remembering)            // shrink back to one line when "Remembering" takes over
+        .animation(hoverMorph, value: hovering)          // the hover swell/settle — snappier than the phase morph
         .onChange(of: phase) { _, newPhase in
             if newPhase == .typing {
                 draft = ""
@@ -208,6 +254,18 @@ struct NotchContent: View {
         // Longer + bouncier than a flat ease — fast out of the gate, then a gentle overshoot-and-settle
         // (the Dynamic Island "alive" curve). Lower damping = visible bounce; ~0.52 response = slightly slower.
         reduceMotion ? .easeInOut(duration: 0.24) : .spring(response: 0.52, dampingFraction: 0.72)
+    }
+
+    private var hoverMorph: Animation {
+        // The hover swell — a quick ease-out with one tiny overshoot at the end (the Dynamic Island
+        // "press me" bounce), snappier than the phase morph. The EXIT is slower and with the bounce
+        // damped out: a shrink's overshoot lands INSIDE the black cutout where it's invisible, and a
+        // fully-damped spring spends its tail creeping imperceptibly — so the exit needs extra time
+        // on paper for its VISIBLE portion to match the entry (tuned on Jesai's bezel).
+        // (`hovering` is already the new value when this is read, so it picks the right direction.)
+        if reduceMotion { return .easeOut(duration: 0.18) }
+        return hovering ? .spring(response: 0.38, dampingFraction: 0.6)
+                        : .spring(response: 0.52, dampingFraction: 0.95)
     }
 
     // MARK: Content
@@ -451,7 +509,7 @@ struct NotchContent: View {
 
     private var a11yLabel: String {
         switch phase {
-        case .hidden: return ""
+        case .hidden: return hovering ? "Sentient — click to type a task" : ""
         case .opening, .listening, .transcribing: return "Sentient is listening"
         case .typing: return "Type a task for Sentient"
         case .running: return "Sentient is working. \(statusLine)"
@@ -527,6 +585,9 @@ private struct NotchPreviewStage<Content: View>: View {
     }
 }
 
+#Preview("hover (click affordance)") {
+    NotchPreviewStage { NotchContent(phase: .hidden, readBack: nil, statusLine: "", hovering: true, metrics: .preview) }
+}
 #Preview("listening") {
     NotchPreviewStage { NotchContent(phase: .listening, readBack: nil, statusLine: "", metrics: .preview) }
 }

--- a/Sentient OS macOS/Notch Magic/NotchWindowController.swift
+++ b/Sentient OS macOS/Notch Magic/NotchWindowController.swift
@@ -9,10 +9,15 @@
 //  state, pinned with its top flush at the screen's edge. It NEVER resizes during a morph — the notch
 //  shape animates INSIDE it — so the notch can never detach from the bezel mid-animation. Click-through
 //  is guaranteed by toggling window-level `ignoresMouseEvents` by CURSOR POSITION: the window only stops
-//  ignoring the mouse while the cursor is over the actual notch SILHOUETTE (running/typing) — so every
-//  other point, INCLUDING the glow bloom's drawn pixels, passes straight through. (A static hitTest can't
-//  do this: macOS catches a click on ANY non-transparent pixel — the glow — before hitTest can pass it on,
-//  and a nil hitTest then SWALLOWS it rather than passing through.) Ordered OUT when idle.
+//  ignoring the mouse while the cursor is over the actual notch SILHOUETTE (running/typing/hovering) — so
+//  every other point, INCLUDING the glow bloom's drawn pixels, passes straight through. (A static hitTest
+//  can't do this: macOS catches a click on ANY non-transparent pixel — the glow — before hitTest can pass
+//  it on, and a nil hitTest then SWALLOWS it rather than passing through.) Ordered OUT when idle.
+//
+//  Also owns the HOVER affordance (the notch as a button): zero-permission `.mouseMoved` NSEvent
+//  monitors detect the cursor entering the hardware cutout while idle → haptic tick + the shell swells
+//  (rendered by NotchView off coordinator.notchHovering) → a click opens tap-to-type. Real-notch
+//  displays only. Exit + the swollen shape's click-through ride the same cursor poll as running/typing.
 //
 
 import SwiftUI
@@ -29,9 +34,24 @@ final class NotchWindowController {
     /// When the panel last became KEY for the type field — used to ignore the transient resign during focus setup.
     private var typingKeyAt = Date.distantPast
     /// Polls the cursor while interactive to toggle `ignoresMouseEvents` (silhouette-only click-through).
+    /// Two-tier rate — crisp near the notch, lazy when the cursor is far (see `retuneMouseTimer`).
     private var mouseTimer: Timer?
+    /// The live poll rate, so re-tuning only rebuilds the timer on an actual tier change.
+    private var mouseTimerInterval: TimeInterval = 0
     /// Local key monitor: Esc cancels the notch's pending input (type field / voice capture). See §4.
     private var keyMonitor: Any?
+    /// Hover entry detection: `.mouseMoved` NSEvent monitors, global + local — the same zero-permission
+    /// pattern as the hotkey (mouse monitors are not keyboard-class; zero TCC contact). They only ever
+    /// BEGIN a hover; exit + click-through are the cursor poll's job while the swell is up.
+    private var hoverMonitors: [Any] = []
+    /// Retries the hover-monitor install until the app has finished launching (lesson 14 — an NSEvent
+    /// monitor registered mid-NSApplicationMain wedges event routing for the life of the process).
+    private var hoverInstallTimer: Timer?
+    /// The cursor is over the idle notch — the shell is swollen and clickable.
+    private var hovering = false
+    /// The hardware notch cutout in screen coords — the hover ENTRY zone, cached so the per-mouse-move
+    /// idle check is a bare rect test (recomputed only on build + display changes). `.null` = no notch.
+    private var hoverEntryRect: NSRect = .null
 
     /// Extra room around the largest notch state so the morph's bounce-overshoot + the glow bloom never
     /// clip at the fixed window's edge. The notch is centered + top-anchored inside this canvas.
@@ -53,6 +73,7 @@ final class NotchWindowController {
             self?.build()
             self?.installObservers()
             self?.installKeyMonitor()
+            self?.installHoverMonitorsWhenReady()
             self?.observePhase()
             self?.applyPhase()          // sync the initial state (hidden → stays ordered out)
         }
@@ -79,6 +100,7 @@ final class NotchWindowController {
     private func build() {
         guard panel == nil, let screen = Self.menuBarScreen() else { return }
         metrics = Self.metrics(for: screen)
+        refreshHoverEntryRect(for: screen)
         let frame = windowFrame(for: canvasSize, on: screen)
         let panel = NotchPanel(contentRect: frame,
                                styleMask: [.borderless, .nonactivatingPanel],
@@ -121,10 +143,16 @@ final class NotchWindowController {
         sizeToken &+= 1
         let token = sizeToken
 
+        // The hover affordance is idle-only: the instant the notch opens for real (a hotkey press,
+        // a click landing in .typing, a notice), hover yields — the phase owns the shape now, and
+        // the window is already up so there's nothing to choreograph.
+        if coordinator.phase != .hidden, hovering { clearHover() }
+
         // Click-through: while interactive, a cursor poll lets the window receive clicks ONLY over the
         // notch silhouette (the glow + canvas always pass through); otherwise the whole window ignores
-        // the mouse so every click sails past.
-        if coordinator.phase == .running || coordinator.phase == .typing {
+        // the mouse so every click sails past. Hovering counts as interactive — the same poll also
+        // detects the cursor LEAVING the hover zone (updateMousePassthrough → endHover).
+        if coordinator.phase == .running || coordinator.phase == .typing || hovering {
             startMouseTracking()
         } else {
             stopMouseTracking()
@@ -134,11 +162,12 @@ final class NotchWindowController {
         if coordinator.phase != .hidden {
             placeCanvas()                                   // the fixed canvas — NEVER resized per morph
             reveal(makeKey: coordinator.phase == .typing)
-        } else {
+        } else if !hovering {
             // Order the window out only AFTER the SwiftUI retract animation has played.
             Task { @MainActor [weak self] in
                 try? await Task.sleep(for: .seconds(Self.settleDelay))
-                guard let self, self.sizeToken == token, self.coordinator.phase == .hidden else { return }
+                guard let self, self.sizeToken == token, self.coordinator.phase == .hidden,
+                      !self.hovering else { return }
                 self.panel?.orderOut(nil)                   // idle → no window at all
             }
         }
@@ -192,47 +221,226 @@ final class NotchWindowController {
 
     // MARK: Click-through (silhouette-only, by cursor position)
 
-    /// Poll the cursor (~60 Hz) while interactive so `ignoresMouseEvents` flips the instant the cursor
-    /// crosses into / out of the notch silhouette. Added in `.common` modes so it keeps ticking during
-    /// tracking loops. Idempotent.
+    /// Poll tiers: crisp while the cursor is anywhere near the notch (inside the canvas), lazy when
+    /// it's across the screen — the far tick is just "did they come back?" (one rect test), so timer
+    /// wakeups drop 6× during long computer-use runs. The always-on hover monitors bump far → near
+    /// the instant the cursor re-approaches, so the lazy tier never delays a real interaction.
+    private static let pollNear: TimeInterval = 1.0 / 60.0
+    private static let pollFar: TimeInterval = 1.0 / 10.0
+
+    /// Start (or keep) the cursor poll at the rate the cursor's position deserves. Idempotent.
     private func startMouseTracking() {
         updateMousePassthrough()
-        guard mouseTimer == nil else { return }
-        let timer = Timer(timeInterval: 1.0 / 60.0, repeats: true) { [weak self] _ in
-            MainActor.assumeIsolated { self?.updateMousePassthrough() }
-        }
-        RunLoop.main.add(timer, forMode: .common)
-        mouseTimer = timer
+        retuneMouseTimer()
     }
 
     private func stopMouseTracking() {
         mouseTimer?.invalidate()
         mouseTimer = nil
+        mouseTimerInterval = 0
+    }
+
+    /// Each tick re-checks passthrough, then re-tunes its own rate by proximity.
+    private func mouseTick() {
+        updateMousePassthrough()
+        if mouseTimer != nil { retuneMouseTimer() }   // a hover exit may have just stopped the poll
+    }
+
+    /// (Re)build the poll timer when the proximity tier changes. `.common` mode so it keeps ticking
+    /// during tracking loops; tolerance lets the system coalesce wakeups for energy.
+    private func retuneMouseTimer() {
+        let interval = cursorNearNotch() ? Self.pollNear : Self.pollFar
+        guard mouseTimerInterval != interval else { return }
+        mouseTimer?.invalidate()
+        let timer = Timer(timeInterval: interval, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated { self?.mouseTick() }
+        }
+        timer.tolerance = interval * 0.2
+        RunLoop.main.add(timer, forMode: .common)
+        mouseTimer = timer
+        mouseTimerInterval = interval
+    }
+
+    /// The "near" zone — the fixed canvas plus a hair ABOVE the screen's top edge. ⚠️ `NSRect.contains`
+    /// excludes the max edge, and a cursor slammed against the top of the screen reports EXACTLY that
+    /// boundary y — without the overhang, the proximity gate goes click-dead along the notch's top edge
+    /// (the same half-open trap the hover entry rect dodges with its own +2).
+    private var nearZone: NSRect {
+        guard let panel else { return .null }
+        var zone = panel.frame
+        zone.size.height += 2
+        return zone
+    }
+
+    /// Cheap proximity test — the canvas (biggest notch state + slack) IS the "near" zone.
+    private func cursorNearNotch() -> Bool {
+        nearZone.contains(NSEvent.mouseLocation)
     }
 
     /// The window receives the mouse ONLY while the cursor is over the live notch silhouette; everywhere
-    /// else (glow, canvas) it ignores the mouse, so those clicks pass straight through.
+    /// else (glow, canvas) it ignores the mouse, so those clicks pass straight through. While hovering,
+    /// the same tick doubles as the LEAVE detector (the mouseMoved monitors only ever begin a hover).
     private func updateMousePassthrough() {
         guard let panel else { return }
+        if hovering, coordinator.phase == .hidden, !cursorStillHovering() { endHover(); return }
         let interactive = coordinator.phase == .running || coordinator.phase == .typing
-        let receive = interactive && cursorOverSilhouette()
+            || (hovering && coordinator.phase == .hidden)
+        // The canvas box gates the EXPENSIVE silhouette test (a Path build + the read-back text
+        // measurement): a far cursor can't be over the silhouette, so it never pays for one.
+        let receive = interactive && cursorNearNotch() && cursorOverSilhouette()
         if panel.ignoresMouseEvents == receive { panel.ignoresMouseEvents = !receive }
     }
 
     /// Is the cursor over the actual notch shape right now? Works in screen coordinates (no view-flip
-    /// guesswork): a bounding-box early-out, then the exact `NotchShape` path test.
+    /// guesswork): a bounding-box early-out, then the exact `NotchShape` path test. During a hover the
+    /// live silhouette is the swollen hover shape, not the phase's.
     private func cursorOverSilhouette() -> Bool {
         guard let screen = Self.menuBarScreen() else { return false }
-        let s = metrics.size(for: coordinator.phase, readBack: coordinator.readBack,
-                             remembering: coordinator.run.remembering)
+        let hoverIdle = hovering && coordinator.phase == .hidden
+        let s = hoverIdle ? metrics.hoverSize
+                          : metrics.size(for: coordinator.phase, readBack: coordinator.readBack,
+                                         remembering: coordinator.run.remembering)
         let p = NSEvent.mouseLocation                        // screen coords, origin bottom-left
         let localX = p.x - (screen.frame.midX - s.width / 2)
         let depthFromTop = screen.frame.maxY - p.y           // 0 at the bezel, increasing downward
         guard localX >= 0, localX <= s.width, depthFromTop >= 0, depthFromTop <= s.height else { return false }
-        let radii = metrics.radii(for: coordinator.phase)
+        let radii = hoverIdle ? metrics.hoverRadii : metrics.radii(for: coordinator.phase)
+        // ⚠️ Fitts's law at the bezel: a cursor slammed against the screen's top edge reports depth ≈ 0 —
+        // a point ON the path's boundary, which `contains` excludes — so the top edge of the notch went
+        // click-dead. Test a couple of points INTO the shape instead: the screen edge itself is part of
+        // the notch (macOS's own menu bar works this way).
         return NotchShape(topCornerRadius: radii.top, bottomCornerRadius: radii.bottom)
             .path(in: CGRect(x: 0, y: 0, width: s.width, height: s.height))
-            .contains(CGPoint(x: localX, y: depthFromTop))
+            .contains(CGPoint(x: localX, y: max(depthFromTop, 2)))
+    }
+
+    // MARK: Hover — the notch as a button (swell + haptic; click opens tap-to-type)
+
+    /// Install now if the app is already running, else retry on a short tick. ⚠️ Lesson 14: an NSEvent
+    /// monitor registered during app init (NSApp can still be nil, mid-NSApplicationMain) wedges the
+    /// app's event routing for the LIFE of the process — and a Timer can only fire once the run loop
+    /// is pumping, i.e. post-launch by construction, so the tick path is safe by shape.
+    private func installHoverMonitorsWhenReady() {
+        installHoverMonitors()
+        guard hoverMonitors.isEmpty, hoverInstallTimer == nil else { return }
+        hoverInstallTimer = Timer.scheduledTimer(withTimeInterval: 1.5, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                self.installHoverMonitors()
+                if !self.hoverMonitors.isEmpty {
+                    self.hoverInstallTimer?.invalidate()
+                    self.hoverInstallTimer = nil
+                }
+            }
+        }
+    }
+
+    /// The `.mouseMoved` monitors — ENTRY detection only, so the idle cost is one rect test per mouse
+    /// move (no timers, no polling while idle). Global hears moves over other apps; local hears them
+    /// whenever Sentient itself is frontmost. Mouse monitors are not keyboard-class: zero TCC contact.
+    private func installHoverMonitors() {
+        guard hoverMonitors.isEmpty, NSApp?.isRunning == true else { return }
+        let global = NSEvent.addGlobalMonitorForEvents(matching: .mouseMoved, handler: { [weak self] event in
+            self?.hoverMouseMoved(at: Self.screenLocation(of: event))
+        })
+        if let global { hoverMonitors.append(global) }
+        let local = NSEvent.addLocalMonitorForEvents(matching: .mouseMoved, handler: { [weak self] event in
+            self?.hoverMouseMoved(at: Self.screenLocation(of: event))
+            return event
+        })
+        if let local { hoverMonitors.append(local) }
+        if !hoverMonitors.isEmpty {
+            Log("notch hover affordance armed (mouseMoved NSEvent monitors, zero-permission)")
+        }
+    }
+
+    /// The event's own screen-coord location — spares a per-move window-server query
+    /// (`NSEvent.mouseLocation`). Global-monitor events carry no window (already screen coords);
+    /// local ones convert from theirs.
+    private static func screenLocation(of event: NSEvent) -> NSPoint {
+        guard let window = event.window else { return event.locationInWindow }
+        return window.convertPoint(toScreen: event.locationInWindow)
+    }
+
+    /// Every mouse move funnels here — so the common case must stay a couple of guards and ONE cached
+    /// rect test. Begin the hover the moment the cursor enters the hardware cutout while the notch is
+    /// idle; and if the far-tier poll is watching an interactive notch, a re-approaching cursor bumps
+    /// it back to the crisp tier instantly (no tier lag before a STOP click must land).
+    private func hoverMouseMoved(at location: NSPoint) {
+        if mouseTimerInterval == Self.pollFar, nearZone.contains(location) {
+            retuneMouseTimer()
+        }
+        guard !hovering, coordinator.phase == .hidden, hoverEntryRect.contains(location) else { return }
+        beginHover()
+    }
+
+    /// Cache the hover ENTRY zone — the hardware notch cutout in screen coords. Notch-less displays
+    /// get `.null` (matches nothing): the affordance only exists on a real bezel. The rect extends
+    /// 2pt past the screen's top edge so a cursor pinned at the very top still counts.
+    private func refreshHoverEntryRect(for screen: NSScreen) {
+        guard let notch = screen.notchSize else { hoverEntryRect = .null; return }
+        hoverEntryRect = NSRect(x: screen.frame.midX - notch.width / 2,
+                                y: screen.frame.maxY - notch.height,
+                                width: notch.width, height: notch.height + 2)
+    }
+
+    /// LEAVE detection while hovering (polled): the swollen silhouette's box plus a small margin.
+    /// Entry is the tighter hardware cutout, exit is the grown box — that hysteresis keeps the swollen
+    /// lip from flickering enter/exit under a cursor resting right on the hardware boundary.
+    private func cursorStillHovering() -> Bool {
+        guard let screen = Self.menuBarScreen() else { return false }
+        let s = metrics.hoverSize
+        let m: CGFloat = 4
+        let rect = NSRect(x: screen.frame.midX - s.width / 2 - m,
+                          y: screen.frame.maxY - s.height - m,
+                          width: s.width + m * 2, height: s.height + m + 2)
+        return rect.contains(NSEvent.mouseLocation)
+    }
+
+    /// The cursor crossed into the idle notch: a trackpad haptic tick + the shell swells (NotchView
+    /// renders the grow + drop shadow off `coordinator.notchHovering`). The panel appears at the exact
+    /// hardware silhouette — black over the black cutout, so its arrival is invisible — then springs
+    /// to the grown shape: the dismiss retract-merge trick, played in reverse.
+    private func beginHover() {
+        guard panel != nil else { return }
+        hovering = true
+        sizeToken &+= 1                       // cancel any pending orderOut (a just-finished retract)
+        coordinator.setNotchHovering(true)
+        placeCanvas()
+        reveal()
+        startMouseTracking()                  // leave detection + click-through over the swollen shape
+        NSHapticFeedbackManager.defaultPerformer.perform(.alignment, performanceTime: .now)
+        Log("notch hover began")
+    }
+
+    /// The cursor left the hover zone: shrink back into the cutout, then order out after the settle —
+    /// token-guarded, so a re-hover mid-retract cleanly cancels the order-out. The wait is LONGER than
+    /// the phase retract's `settleDelay`: the hover exit glide (NotchContent.hoverMorph) is a slower,
+    /// fully-damped spring whose last few points are still outside the cutout at 0.6s — ordering out
+    /// then would visibly snip the tail.
+    private func endHover() {
+        guard hovering else { return }
+        hovering = false
+        coordinator.setNotchHovering(false)
+        Log("notch hover ended")
+        guard coordinator.phase == .hidden else { return }   // an open notch owns the window now
+        stopMouseTracking()
+        panel?.ignoresMouseEvents = true
+        sizeToken &+= 1
+        let token = sizeToken
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(1.0))
+            guard let self, self.sizeToken == token, self.coordinator.phase == .hidden,
+                  !self.hovering else { return }
+            self.panel?.orderOut(nil)
+        }
+    }
+
+    /// Hover yields to a real phase (the notch opened under the cursor) — just drop the flags; the
+    /// window is already up and applyPhase choreographs everything else.
+    private func clearHover() {
+        hovering = false
+        coordinator.setNotchHovering(false)
     }
 
     // MARK: Observers (display / Space / wake / app activation)
@@ -266,8 +474,10 @@ final class NotchWindowController {
     }
 
     private func reposition() {
-        guard let panel, let screen = Self.menuBarScreen() else { panel?.orderOut(nil); return }
+        guard panel != nil, let screen = Self.menuBarScreen() else { panel?.orderOut(nil); return }
+        if hovering { endHover() }                      // the display changed under the cursor — re-detect fresh
         metrics = Self.metrics(for: screen)
+        refreshHoverEntryRect(for: screen)
         host?.update(metrics: metrics)
         placeCanvas()                                   // re-size/re-center the canvas for the new display
         if coordinator.phase != .hidden { reveal(makeKey: coordinator.phase == .typing) }
@@ -276,6 +486,7 @@ final class NotchWindowController {
     deinit {
         observers.forEach { NotificationCenter.default.removeObserver($0) }
         if let keyMonitor { NSEvent.removeMonitor(keyMonitor) }
+        hoverMonitors.forEach { NSEvent.removeMonitor($0) }
     }
 
     // MARK: Screen helpers


### PR DESCRIPTION
## What
The notch is now a button — the fourth front door into Sidekick:

- **Hover** the idle notch → trackpad haptic tick + the shell swells (+22pt/+3pt) with a drop shadow, no glow — the Dynamic Island "press me" affordance
- **Click** → the same tap-to-type field as a hotkey tap (kb-only aside + permission gate beats mirrored)
- **Depth-bed shadow** behind the edge glow in every open state, so the spectrum reads against darkness
- **Asymmetric springs**: bouncy entry, fully-damped slower exit (a shrink's overshoot lands invisibly inside the cutout)

## Efficiency
- Idle = zero timers; entry via zero-permission mouseMoved monitors (one cached rect test per move, event's own coords)
- Cursor poll is now two-tier by proximity (60/10 Hz, tolerance for wakeup coalescing); silhouette test gated on the canvas box; monitors fast-lane the tier bump on approach

## Fitts fix (lesson 15 in the deep doc)
Top-edge clicks were dead: THREE layers each exclude the boundary coordinate a top-slammed cursor reports (Path.contains, SwiftUI shape hit-test, NSRect half-open contains). All three fixed.

## Docs
Notch Magic.md updated (§1, §3, §7a new, §7b, §8, lesson 15, §11, §12); context files updated in Our_Stuff.

Verified live on hardware: hover feel, click, top-edge clicks across the notch width, menu-bar click-through beside it, STOP-swoop mid-run for the tier bump.