### PR TITLE
Orb: 60fps lock when unfocused + Login Items guide copy fix

### DIFF
--- a/Sentient OS macOS/Documentation/Home — Proactive Intelligence (For You).md
+++ b/Sentient OS macOS/Documentation/Home — Proactive Intelligence (For You).md
@@ -26,7 +26,11 @@ The main window's content (rendered by `RootView`). Layers, bottom-to-top:
   drag physics, or tapped to expand into a full typeset letter.
 - **The empty state — the orb's ONE home:** when there are no cards, the living **`Orb`** rises into
   the center with *"I'm here to help."* The orb appears **only** here (plus the ProcessingView
-  takeover); Settings and Connect use the static `OrbMark` glyph instead.
+  takeover); Settings and Connect use the static `OrbMark` glyph instead. The orb's clock is
+  focus-aware (`FocusThrottledTimeline` in `Orb.swift`): window focused = the display-link schedule
+  (up to 120fps on ProMotion), unfocused = a fixed timer hard-locked to 60fps (halo 30) — so a
+  background window (overnight runs especially) never burns 120Hz frames. Full performance rules
+  live in `Orb.swift`'s header comment.
 - **Knowledge-base-only mode (free/go plans, `CodexAuth.knowledgeBaseOnly`):** cards never come, so
   the empty state is replaced by the ALWAYS-mounted **preview note** — orb + "This is a preview of
   Sentient." + the three feature rows + the *Get ChatGPT Plus* glow CTA + a *Reset Sentient…*

--- a/Sentient OS macOS/Documentation/Permission Guide (First-Use Grants).md
+++ b/Sentient OS macOS/Documentation/Permission Guide (First-Use Grants).md
@@ -68,7 +68,7 @@ window and follows it live. Two modes:
   string) — the exact mix System Settings accepts into its privacy lists. While dragging, the
   panel goes mouse-transparent so the drop lands in Settings.
 - **Instruction** (`appURL` nil): toggle-only panes with no drag target — Login Items approval
-  ("Flip Sentient OS on under Allow in the Background").
+  ("Flip Sentient OS on under App Background Activity" — matches the pane's section header).
 
 Panes: `.fullDiskAccess` (onboarding + Health, Sentient as card) · `.accessibility` /
 `.screenRecording` (the helper, or Sentient for its own screen recording) · `.loginItems`

--- a/Sentient OS macOS/Views/Orb.swift
+++ b/Sentient OS macOS/Views/Orb.swift
@@ -18,6 +18,9 @@
 //   · One Canvas glow pass per side, not two.
 //   · The planet's diameter is FIXED (vector-crisp); breathing lives in the heart's glow,
 //     the halo, and the ring — never in a scaleEffect over the whole orb (bitmap fuzz).
+//   · Focus-aware clock (FocusThrottledTimeline): an unfocused window swaps the display-link
+//     schedule for a fixed timer, hard-locking the orb to 60fps (halo 30) — otherwise a
+//     ProMotion Mac renders a background orb at 120fps.
 //
 
 import SwiftUI
@@ -32,8 +35,7 @@ struct Orb: View {
     var body: some View {
         ZStack {
             haloLayer
-            TimelineView(.animation(minimumInterval: 1.0 / 60.0)) { ctx in
-                let t = ctx.date.timeIntervalSinceReferenceDate
+            FocusThrottledTimeline(minimumInterval: 1.0 / 60.0) { t in
                 let breath = (sin(t * 2 * .pi / 5.5) + 1) / 2     // 0…1, the 5.5s heartbeat
                 ZStack {
                     ringCanvas(front: false, t: t, breath: breath)
@@ -49,8 +51,7 @@ struct Orb: View {
     // MARK: Ambient halo — a cached texture, spun and breathed (never re-blurred)
 
     private var haloLayer: some View {
-        TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { ctx in
-            let t = ctx.date.timeIntervalSinceReferenceDate
+        FocusThrottledTimeline(minimumInterval: 1.0 / 30.0) { t in
             let breath = (sin(t * 2 * .pi / 5.5) + 1) / 2
             HaloTexture(size: size, mode: mode)
                 .rotationEffect(.radians(t * 2 * .pi / 18))
@@ -375,6 +376,30 @@ struct Orb: View {
                 twinkleSpeed: .random(in: 0.4...1.5, using: &rng))
         }
     }()
+}
+
+/// The orb's frame clock, focus-aware. While the window is active it rides the display-link
+/// `.animation` schedule (a ProMotion Mac may render at up to 120fps); the moment the window
+/// loses focus it swaps to a fixed timer cadence, hard-locking the rate to `minimumInterval` —
+/// `.animation(minimumInterval:)` alone doesn't reliably cap a 120Hz panel, and a background
+/// orb has no business burning frames. Motion never jumps across the swap: every phase is a
+/// pure function of wall time.
+private struct FocusThrottledTimeline<Content: View>: View {
+    @Environment(\.appearsActive) private var appearsActive
+    let minimumInterval: TimeInterval
+    @ViewBuilder let content: (_ t: TimeInterval) -> Content
+
+    var body: some View {
+        if appearsActive {
+            TimelineView(.animation(minimumInterval: minimumInterval)) { ctx in
+                content(ctx.date.timeIntervalSinceReferenceDate)
+            }
+        } else {
+            TimelineView(.periodic(from: .now, by: minimumInterval)) { ctx in
+                content(ctx.date.timeIntervalSinceReferenceDate)
+            }
+        }
+    }
 }
 
 /// The tiny static orb glyph (header scale): the logo's ring + dot with a soft glow.

--- a/Sentient OS macOS/Views/Permissions/PermissionGuide.swift
+++ b/Sentient OS macOS/Views/Permissions/PermissionGuide.swift
@@ -78,7 +78,7 @@ final class PermissionGuide {
         if job.appURL != nil {
             markdown = "Drag **\(appName)** into the list, then flip its switch on."
         } else if job.pane == .loginItems {
-            markdown = "Flip **Sentient OS** on under \"Allow in the Background\"."
+            markdown = "Flip **Sentient OS** on under \"App Background Activity\"."
         } else {
             markdown = "Flip **Sentient OS** on in the list."
         }


### PR DESCRIPTION
## What

- **Orb (`Views/Orb.swift`):** the orb's two clocks (ring 60fps, halo 30fps) now run through a focus-aware `FocusThrottledTimeline`. Focused window = unchanged display-link `.animation` schedule (up to 120fps on ProMotion); unfocused = a fixed `.periodic` timer hard-locked to the same intervals, so a background window (overnight/processing runs especially) can't render at 120Hz. Focus via `@Environment(\.appearsActive)`; no visual jump on the swap since every orb phase is a pure function of wall time. Rule added to the file's PERFORMANCE RULES header.
- **PermissionGuide (`Views/Permissions/PermissionGuide.swift`):** Login Items instruction now reads "App Background Activity" — System Settings' actual section header (was "Allow in the Background").
- Docs updated: Home deep doc + Permission Guide deep doc.

## Verified

Builds clean via Xcode's own build system (MCP `BuildProject`); orb throttle confirmed by Jesai on hardware.