### PR TITLE
Docs: Connect your AIs window, as shipped

### DIFF
--- a/Sentient OS macOS/Cloud/MirrorClient.swift
+++ b/Sentient OS macOS/Cloud/MirrorClient.swift
@@ -89,9 +89,9 @@ actor MirrorClient {
     }
 
     /// The coached system prompt the user pastes into ChatGPT/Claude/Gemini (custom instructions).
-    /// Naming the connector + "always call get_structure" is what reliably makes the client load and
-    /// use the tools — clients lazy-load connector tools behind a search gate (field lessons in
-    /// Documentation/MCP Mirror Client.md).
+    /// Naming the connector + coaching the get_structure-first habit is what reliably makes the
+    /// client load and use the tools — clients lazy-load connector tools behind a search gate
+    /// (field lessons in Documentation/MCP Mirror Client.md).
     /// Lives here (the MCP owner) so every surface that offers "Copy System Prompt" shares one copy.
     static let systemPrompt = """
         You have access to the user's personal knowledge base through the Sentient OS MCP: an \

--- a/Sentient OS macOS/Documentation/Home — Proactive Intelligence (For You).md
+++ b/Sentient OS macOS/Documentation/Home — Proactive Intelligence (For You).md
@@ -182,8 +182,12 @@ a STOP button, and the notch glows alongside. (Doc: `Notch Magic/Notch Magic.md`
   Settings: five live panes. Doc: `Settings.md`.
 - **`Views/Knowledge/KnowledgeView.swift`** (`windowID "knowledge"`) — the real Obsidian-style
   reader/editor/manager over the vault. Doc: `Knowledge Viewer.md`.
-- **`Views/ConnectAIsView.swift`** (`windowID "connect-ais"`) — the REAL two-step guided setup
-  (copy the masked MCP link → copy the system prompt → "ask it: what do you know about me?").
+- **`Views/ConnectAIsView.swift`** (`windowID "connect-ais"`) — the guided setup: per-AI tabs
+  (ChatGPT's three video steps · Claude's two · a text-only Other AIs) with bundled looping
+  tutorial clips, deep-link pills into each AI's own settings screens, the masked MCP link +
+  the system prompt to copy, and the sharing lifecycle itself (glow connect CTA when off; a
+  quiet MCP ON/OFF pill behind the confirm when on) — closing with "ask it: what do you know
+  about me?". Doc: the window section in `MCP Mirror Client.md`.
 - **`Views/Dev/ProactiveExecuteView.swift`** + **`Views/Dev/OvernightDevView.swift`** — dev windows
   (PART 3 fire bench · the overnight cockpit), opened from DEV TOOLS.
 

--- a/Sentient OS macOS/Documentation/MCP Mirror Client.md
+++ b/Sentient OS macOS/Documentation/MCP Mirror Client.md
@@ -101,10 +101,15 @@ is never marked clean.
 
 The user-facing opt-in is **Settings → Give AIs Knowledge** (`Views/Settings/ShareKnowledgePane.swift`,
 renamed 2026-07-13 from "Connect AIs to Knowledge"/`YourAIsPane`)
-and the guided **`ConnectAIsView`** window: the value/privacy story, the share toggle (ON =
-`enable()` + a first push; OFF = a confirm dialog, then `disable()`), the per-AI setup (masked link
-+ Copy · Copy-the-system-prompt · the "what do you know about me?" closer), and live `stats()`
-activity. The masked link (`MirrorClient.maskedURL`) shows the public userID but masks the password
+and the guided **`ConnectAIsView`** window (opened by the pane's CTA and the home popover's door).
+The pane: the value/privacy story, the share toggle (ON = `enable()` + a first push; OFF = a
+confirm dialog, then `disable()`), and live `stats()` activity. The window (rebuilt 2026-07-13):
+per-AI video tabs (ChatGPT's three steps: developer mode → New Plugin + link → instructions;
+Claude's two; a text-only Other AIs), deep-link pills straight into each AI's settings screens,
+the masked link + Copy, Copy-the-instructions (`MirrorClient.systemPrompt` — rewritten 2026-07-13
+to the softer get_structure/get_files coaching), the "what do you know about me?" closer — plus
+the same sharing lifecycle (a glowing connect CTA when off; an MCP ON/OFF pill behind the confirm
+when on). The masked link (`MirrorClient.maskedURL`) shows the public userID but masks the password
 to its first 4 chars. **Regenerate is backend-only** (`regenerateToken()` stays as the support
 remediation if a link leaks; there's no UI button — it bricks every connector the user set up).
 

--- a/Sentient OS macOS/Documentation/Settings.md
+++ b/Sentient OS macOS/Documentation/Settings.md
@@ -101,10 +101,15 @@ PII-stripped summaries only, E2E-encrypted, no accounts, the 30-day
 self-delete in plain words, open-source backend). Then the share toggle (OFF = confirm dialog →
 `disable()`, which deletes the cloud copy but keeps the token), and the pane's HERO: the glowing
 **Set up in 2 minutes** capsule (`ConnectCTA` — same label as the home popover's CTA) →
-**`ConnectAIsView`, the REAL guided setup**: step 1 =
-the masked link (`MirrorClient.maskedURL`) + Copy, step 2 = Copy the system prompt, closing with
-the magic line ("ask it: what do you know about me?"); a sharing-off state points back at
-Settings. Live `stats()` activity below; local-only story when sharing is off.
+**`ConnectAIsView`, the guided setup** (rebuilt 2026-07-13): per-AI tabs — ChatGPT's three video
+steps (developer mode → paste the link as a New Plugin → paste the instructions) · Claude's two ·
+a text-only Other AIs — each card a bundled looping clip (`Media/connect-<ai>-<n>.mp4`, per-AI
+aspect so fill never crops) with a deep-link pill above it, the masked link
+(`MirrorClient.maskedURL`) + Copy and Copy-the-instructions riding the cards, closing with the
+magic line ("ask it: what do you know about me?"). The window owns the sharing lifecycle too:
+off = one glowing connect CTA (enable + first push, the guide assembles in place); on = a quiet
+MCP ON/OFF pill behind the same confirm-and-delete as the pane's toggle.
+Live `stats()` activity below; local-only story when sharing is off.
 **Regenerate was removed from the UI** (a footgun that bricks every connector the user set up) —
 `MirrorClient.regenerateToken()` remains as a backend/support remediation.
 ⚠️ `maskedURL` must search "/mcp" BACKWARDS: the host `https://mcp.sentient-os.ai` itself


### PR DESCRIPTION
Doc sweep for the Connect your AIs work (PRs #155/#191/#192/#198):

- **Settings.md**: the Give AIs Knowledge pane's hero section now describes the rebuilt guided window (per-AI video tabs, Media/ clip convention, deep-link pills, the window owning sharing on/off) instead of the old two-step description.
- **MCP Mirror Client.md**: "Turning the mirror on" separates the pane's job from the window's, and notes the systemPrompt rewrite (softer get_structure/get_files coaching).
- **Home doc**: the ConnectAIsView entry in the windows list matches the shipped window.
- **MirrorClient.swift**: comment above systemPrompt no longer quotes the retired "always call get_structure" phrasing (comment-only change).

No code behavior changes.