### PR TITLE
Scheduler auto-enable: 18h → 14h after the first full cycle

### DIFF
--- a/Sentient OS macOS/App/AppState.swift
+++ b/Sentient OS macOS/App/AppState.swift
@@ -69,7 +69,7 @@ final class AppState {
         guard ProcessInfo.processInfo.environment["SENTIENT_SELFTEST"] == nil else { return }
 
         scheduler.reevaluate()   // arm if the dev setting was left on; otherwise a no-op
-        scheduler.maybeAutoEnable()   // 18h after initial: flip the overnight scheduler on (or arm the timer)
+        scheduler.maybeAutoEnable()   // 14h after initial: flip the overnight scheduler on (or arm the timer)
         // Always armed — knowledge-base-only (free/go) gating happens live at submit() inside
         // the coordinator: the notch experience still plays, the codex run just never fires.
         commandCoordinator.start()   // arm right-⌘ hold-to-talk + warm the speech model

--- a/Sentient OS macOS/App/Sentient_OS_macOSApp.swift
+++ b/Sentient OS macOS/App/Sentient_OS_macOSApp.swift
@@ -97,7 +97,7 @@ struct SentientOSApp: App {
         .restorationBehavior(.disabled)
 
         // Overnight Processing — the dev cockpit for the 3am scheduler (helper approval, launch-at-
-        // login, 18h auto-enable, manual arm). Opened from DEV TOOLS → "Overnight Processing…".
+        // login, 14h auto-enable, manual arm). Opened from DEV TOOLS → "Overnight Processing…".
         Window("Overnight Processing", id: OvernightDevView.windowID) {
             OvernightDevView()
                 .environment(appState)

--- a/Sentient OS macOS/Documentation/Overnight Scheduler (3am Wake).md
+++ b/Sentient OS macOS/Documentation/Overnight Scheduler (3am Wake).md
@@ -4,7 +4,7 @@ The overnight scheduler wakes the Mac at 3am (lid shut), runs the exact same pip
 Analyze Now (`IterativeRun .auto` + the Gmail/Calendar legs → `ProactiveCycle`), then sleeps — so a
 fresh "For You" briefing is waiting when you open the lid. This doc is the whole scheduler story:
 the proven wake mechanism, the root privilege model, the nightly run, and the production wiring
-(install · login item · enable flags · the 18h auto-enable).
+(install · login item · enable flags · the 14h auto-enable).
 
 The in-app scheduler lives in `Scheduling/OvernightScheduler.swift` (owned by `AppState`); it only
 runs while Sentient is open. Everything logs to `~/Library/Logs/SentientOS/scheduler.log`
@@ -103,31 +103,31 @@ record. *(The home's banner slot also carries a LIVE health ladder —
 attribution) — which silently excludes the DB sources. The arm-time `DETECTED …` / `FDA granted:`
 log lines surface it.
 
-## The 18h auto-enable — why, and how
+## The 14h auto-enable — why, and how
 
 Right after the first big **initial** processing run, everything is caught up — there's nothing new
 to chew on. If we armed the 3am wake immediately and initial finished at, say, 10pm, the run five
 hours later would find almost nothing → a wasted wake and an **empty morning briefing**. So we wait
-**18 hours after the first full cycle finishes**, by which point a full day of real life has piled up,
+**14 hours after the first full cycle finishes**, by which point a full day of real life has piled up,
 and *then* turn the scheduler on. The very first automatic overnight run has something worth surfacing.
 
 - **"Initial finished" = the first full `ProactiveCycle`.** `ProactiveCycle.run()` calls
   `OvernightScheduler.noteFirstCycleCompleted()` on its success path, which stamps
   `firstCycleCompletedAt` **once** (later calls are ignored, so the clock starts at the true first finish).
 - **The checker — `maybeAutoEnable()`** runs at launch (`AppState.init`), after every cycle
-  (`RootView`'s processing `onDone`), and from a one-shot timer it arms for the 18h mark (so it fires
+  (`RootView`'s processing `onDone`), and from a one-shot timer it arms for the 14h mark (so it fires
   even if the app just sits open). It is idempotent and:
   - **Latches** (`autoEnableFired`) so it acts at most once and never re-enables after a user turns it off.
   - **Never fights the user** — if the scheduler is already on (dev or prod flag), it just latches.
   - **Knowledge-base-only mode (free/go plans) early-returns before everything** — no timer, no
     production flag, no 3am runs (those plans have no quota for nightly codex work). Deliberately
-    NOT latched, so an upgrade + reset starts the 18h clock fresh. See `Plan Gate (CodexAuth &
+    NOT latched, so an upgrade + reset starts the 14h clock fresh. See `Plan Gate (CodexAuth &
     Knowledge-Base-Only).md`.
   - **Gates on prerequisites** — only flips production ON once the root helper is **approved** *and*
-    launch-at-login is on. If the 18h has elapsed but prerequisites aren't met, it sets
+    launch-at-login is on. If the 14h has elapsed but prerequisites aren't met, it sets
     `needsSchedulerSetup` (published, for the setup UX) and retries on the next tick — it never
     silently half-enables.
-- **The wait is 18h** (`defaultAutoEnableDelay`); a dev key (`autoEnableDelaySeconds`) shortens it for testing.
+- **The wait is 14h** (`defaultAutoEnableDelay`); a dev key (`autoEnableDelaySeconds`) shortens it for testing.
 
 ## A — Installing the root daemon
 
@@ -207,8 +207,8 @@ every 2s, so approving in System Settings updates without a refresh) sits above 
 - **① Approve the root helper** — one "Approve helper" button that registers the daemon *and* jumps to
   System Settings to flip it on; shows `enabled ✓` when done.
 - **② Launch at login** — a single toggle.
-- **③ Test the 18h auto-enable** — a plain-language readout of what will happen, a **Wait** picker
-  (18h real / 10s / 60s) to shorten the delay, and *Simulate first analyze done* / *Run check now* / *Reset*.
+- **③ Test the 14h auto-enable** — a plain-language readout of what will happen, a **Wait** picker
+  (14h real / 10s / 60s) to shorten the delay, and *Simulate first analyze done* / *Run check now* / *Reset*.
 - **④ Manual arm (bypass)** — the time picker + on/off for a direct end-to-end wake test.
 
 This is the dev cockpit; the shipping onboarding/Settings UX (Jesai) binds to the same seams
@@ -225,7 +225,7 @@ This is the dev cockpit; the shipping onboarding/Settings UX (Jesai) binds to th
 
 ## Files
 
-- `Scheduling/OvernightScheduler.swift` — the scheduler, the 18h auto-enable state machine, `ensureHelperReady`.
+- `Scheduling/OvernightScheduler.swift` — the scheduler, the 14h auto-enable state machine, `ensureHelperReady`.
 - `Scheduling/LoginItem.swift` — launch-at-login via `SMAppService.mainApp`.
 - `Scheduling/WakeHelperClient.swift` — daemon register/status/deep-link + the XPC ops + `isReachable()`/`healthProbe()` (the liveness ground truth).
 - `Scheduling/WakeHelperInstaller.swift` — the PRODUCTION admin-password installer (decided 2026-07-04); also the DEBUG fallback in `ensureHelperReady`.

--- a/Sentient OS macOS/Documentation/Plan Gate (CodexAuth & Knowledge-Base-Only).md
+++ b/Sentient OS macOS/Documentation/Plan Gate (CodexAuth & Knowledge-Base-Only).md
@@ -79,7 +79,7 @@ flips:
 
 | Surface | Behavior |
 |---|---|
-| `OvernightScheduler.maybeAutoEnable()` | Early-returns — no 18h auto-enable, no timer, no 3am runs. Deliberately NOT latched: upgrade + reset starts the clock fresh. |
+| `OvernightScheduler.maybeAutoEnable()` | Early-returns — no 14h auto-enable, no timer, no 3am runs. Deliberately NOT latched: upgrade + reset starts the clock fresh. |
 | `ProactiveCycle` | Skips decide + research (saves an empty ready-list — no stale cards). Still runs: read → KB build/update → mirror push → gift letter → wipe. |
 | Sidekick | Gated at **invoke**, not arming: the hotkey stays armed for everyone; on press the notch answers instantly with the 2s aside "get ChatGPT Plus to wake Sidekick" (the mic-notice pattern) and never opens for listening/typing. `submit()` carries a backstop for the command-bar path. Live-checked per press — no stale-launch-flag hole. |
 | Home | Command bar hidden. The **preview note** (orb + "This is a preview of Sentient." + feature rows + Get Plus glow + Reset Sentient… pill) is ALWAYS mounted; the gift envelope perches top-center above a compact version of it and the note blooms to full center when the letter is flung. Once the claim reads Plus (re-read every appearance), it becomes "You're on Plus. Time to go live." + a Reset & Rebuild glow. |

--- a/Sentient OS macOS/Documentation/Product Analytics (TelemetryDeck).md
+++ b/Sentient OS macOS/Documentation/Product Analytics (TelemetryDeck).md
@@ -60,7 +60,7 @@ existing B7 "length, not the command text" log — same discipline.
 | `Scheduler.overnightStarted` / `.overnightCompleted` | `Scheduling/OvernightScheduler.swift` | 3am run began / finished |
 | `Scheduler.gated` | `Scheduling/OvernightScheduler.swift` | Nightly run skipped (`reason`: battery/lowPower/thermal) |
 | `Scheduler.caution` | `Scheduling/OvernightCaution.swift` | An unattended run failed for a knowable reason (`kind`: usageLimit/loggedOut/noInternet) — was Sentry's `overnight.caution` until the 2026-07-12 curation |
-| `Scheduler.autoEnabled` | `Scheduling/OvernightScheduler.swift` | The 18h auto-enable flipped the scheduler on |
+| `Scheduler.autoEnabled` | `Scheduling/OvernightScheduler.swift` | The 14h auto-enable flipped the scheduler on |
 | `KnowledgeBase.built` / `.updated` / `.failed` | `Proactive/ProactiveCycle.swift` | First build / incremental update / error |
 | `KnowledgeBase.staleSwapAverted` | `Vault/VaultCloud.swift` | The freshness check aborted a swap over a mid-run editor save (working as designed — was Sentry's `vault.update.stale_swap_averted`) |
 | `Proactive.decided` | `Proactive/ProactiveCycle.swift` | # things-worth-doing found |

--- a/Sentient OS macOS/Ingestion/FactoryReset.swift
+++ b/Sentient OS macOS/Ingestion/FactoryReset.swift
@@ -33,7 +33,7 @@ enum FactoryReset {
         d.removeObject(forKey: AppState.onboardingKey)
         d.removeObject(forKey: ComputerUseGate.screenRecordingOfferedKey)   // re-offer Sentient's screen recording on rebuild
         d.removeObject(forKey: HealthCaution.computerUseEverReadyKey)       // the home's computer-use banner re-arms at the rebuild's own gate
-        // The overnight scheduler starts over too: the 18h clock re-stamps at the REBUILD's first
+        // The overnight scheduler starts over too: the 14h clock re-stamps at the REBUILD's first
         // cycle (not the wiped one's), the auto-enable one-shot is re-armed, and the production
         // flag comes off — otherwise a 3am run could fire mid-onboarding, racing the user's own
         // first analysis on an empty store. (The dev toggle and the installed helper survive —

--- a/Sentient OS macOS/Proactive/ProactiveCycle.swift
+++ b/Sentient OS macOS/Proactive/ProactiveCycle.swift
@@ -155,7 +155,7 @@ actor ProactiveCycle {
         await CycleStore.shared.wipeAllNotes()
         OvernightCaution.clear()                             // a full success retires any morning-after banner
         UserDefaults.standard.set(Date(), forKey: Self.lastCycleKey)
-        OvernightScheduler.noteFirstCycleCompleted()   // "initial processing ended" → start the 18h auto-enable clock (once)
+        OvernightScheduler.noteFirstCycleCompleted()   // "initial processing ended" → start the 14h auto-enable clock (once)
         progress(.done(ready: ProactiveResearch.latest()?.ready.count ?? 0))
         return nil
     }

--- a/Sentient OS macOS/Scheduling/OvernightScheduler.swift
+++ b/Sentient OS macOS/Scheduling/OvernightScheduler.swift
@@ -29,14 +29,14 @@ final class OvernightScheduler {
     /// One-line status for the dev UI ("off" / "armed for 4:00 PM" / "running…").
     var statusLine = "off"
 
-    /// Set true when the 18h auto-enable wants to arm but a prerequisite is missing: the root
+    /// Set true when the 14h auto-enable wants to arm but a prerequisite is missing: the root
     /// helper isn't installed (onboarding's permissions step and Settings → Health own the
     /// install), or launch-at-login is off. The setup UX reads this to prompt the user; it
     /// clears itself once auto-enable succeeds.
     var needsSchedulerSetup = false
 
     // The DEV toggle (testing) and the PRODUCTION flag are separate keys but either one runs the
-    // scheduler. The dev toggle is hand-flipped in DevToolsView; the production flag is what the 18h
+    // scheduler. The dev toggle is hand-flipped in DevToolsView; the production flag is what the 14h
     // auto-enable (and a future Settings switch) writes. Keeping them apart means a dev testing the
     // toggle never trips the production auto-enable latch, and vice-versa.
     static let enabledKey = "dbg.scheduler.enabled"        // DEV toggle
@@ -45,16 +45,16 @@ final class OvernightScheduler {
     static let defaultMinutes = 3 * 60                     // 3:00 AM — the production overnight time (the dev
                                                           // UI can override `minutesKey` for testing)
 
-    // 18h auto-enable state (all UserDefaults; survive restarts).
+    // 14h auto-enable state (all UserDefaults; survive restarts).
     static let firstCycleAtKey = "scheduler.firstCycleCompletedAt"   // Double epoch — set ONCE
     static let autoEnableFiredKey = "scheduler.autoEnableFired"      // latch — flip prod ON at most once
-    static let autoEnableDelayKey = "scheduler.autoEnableDelaySeconds"  // dev override of the 18h wait
-    static let defaultAutoEnableDelay: TimeInterval = 18 * 3600      // 18 hours after initial finishes
+    static let autoEnableDelayKey = "scheduler.autoEnableDelaySeconds"  // dev override of the 14h wait
+    static let defaultAutoEnableDelay: TimeInterval = 14 * 3600      // 14 hours after initial finishes
 
     /// The configured time-of-day in minutes since midnight (shared default so the UI and the loop agree).
     nonisolated static var configuredMinutes: Int { (UserDefaults.standard.object(forKey: minutesKey) as? Int) ?? defaultMinutes }
 
-    /// The auto-enable wait (default 18h; a dev key shortens it for testing). (Pure UserDefaults read.)
+    /// The auto-enable wait (default 14h; a dev key shortens it for testing). (Pure UserDefaults read.)
     nonisolated static var autoEnableDelay: TimeInterval {
         let v = UserDefaults.standard.double(forKey: autoEnableDelayKey)
         return v > 0 ? v : defaultAutoEnableDelay
@@ -71,12 +71,12 @@ final class OvernightScheduler {
 
     /// Stamp "initial processing finished" exactly once — called from ProactiveCycle on the first full,
     /// successful cycle (knowledge base now exists). Nonisolated: it's a single UserDefaults write, safe
-    /// from the cycle actor. Later calls are ignored, so the 18h clock starts at the TRUE first finish.
+    /// from the cycle actor. Later calls are ignored, so the 14h clock starts at the TRUE first finish.
     nonisolated static func noteFirstCycleCompleted() {
         let d = UserDefaults.standard
         guard d.double(forKey: firstCycleAtKey) == 0 else { return }
         d.set(Date().timeIntervalSince1970, forKey: firstCycleAtKey)
-        Log("Scheduler: first full cycle done — 18h auto-enable clock started (fires \(Date().addingTimeInterval(autoEnableDelay)))")
+        Log("Scheduler: first full cycle done — 14h auto-enable clock started (fires \(Date().addingTimeInterval(autoEnableDelay)))")
     }
 
     private var loopTask: Task<Void, Never>?
@@ -112,7 +112,7 @@ final class OvernightScheduler {
         // the scheduler ON even while it's currently off (that's the whole point of auto-enable).
     }
 
-    // MARK: - 18h auto-enable
+    // MARK: - 14h auto-enable
 
     /// Decide whether to auto-enable the production scheduler. Idempotent + safe to call repeatedly —
     /// from launch (AppState.init), right after any cycle finishes, and from the one-shot timer it arms.
@@ -121,7 +121,7 @@ final class OvernightScheduler {
     /// flags `needsSchedulerSetup` for the setup UX and retries on the next tick.
     func maybeAutoEnable() {
         // Free/go knowledge-base-only mode: no quota for nightly runs — auto-enable never fires.
-        // Deliberately NOT latched, so an upgrade (+ reset) later starts the 18h clock fresh.
+        // Deliberately NOT latched, so an upgrade (+ reset) later starts the 14h clock fresh.
         guard !CodexAuth.knowledgeBaseOnly else { return }
         let d = UserDefaults.standard
         guard !d.bool(forKey: Self.autoEnableFiredKey) else { return }      // already handled once
@@ -142,7 +142,7 @@ final class OvernightScheduler {
         // `isReady` is the dev cockpit's SMAppService approval path.
         guard WakeHelperInstaller.isInstalledAndCurrent() || WakeHelperClient.shared.isReady else {
             needsSchedulerSetup = true                                      // surface setup; retry next tick
-            Log("Scheduler: 18h elapsed but root helper not installed — awaiting setup")
+            Log("Scheduler: 14h elapsed but root helper not installed — awaiting setup")
             return
         }
         // The app must be alive at 3am to host the run — enable launch-at-login, and treat a
@@ -152,19 +152,19 @@ final class OvernightScheduler {
         LoginItem.enable()
         guard LoginItem.isEnabled else {
             needsSchedulerSetup = true
-            Log("Scheduler: 18h elapsed but launch-at-login is off (revoked?) — awaiting setup")
+            Log("Scheduler: 14h elapsed but launch-at-login is off (revoked?) — awaiting setup")
             return
         }
         d.set(true, forKey: Self.prodEnabledKey)
         d.set(true, forKey: Self.autoEnableFiredKey)
         needsSchedulerSetup = false
-        Log("Scheduler: 18h elapsed + prerequisites met — auto-enabled overnight processing")
+        Log("Scheduler: 14h elapsed + prerequisites met — auto-enabled overnight processing")
         Analytics.signal("Scheduler.autoEnabled")
         reevaluate()
     }
 
     /// Arm a one-shot wake-up for the auto-enable moment (so it fires even if the app just sits open
-    /// past the 18h mark). Replaces any pending timer; the timer just re-invokes maybeAutoEnable().
+    /// past the 14h mark). Replaces any pending timer; the timer just re-invokes maybeAutoEnable().
     private func armAutoEnableTimer(at fireAt: Date) {
         autoEnableTask?.cancel()
         let delay = max(1, fireAt.timeIntervalSinceNow)

--- a/Sentient OS macOS/Views/Dev/DevToolsView.swift
+++ b/Sentient OS macOS/Views/Dev/DevToolsView.swift
@@ -113,14 +113,14 @@ struct DevToolsView: View {
     // MARK: Overnight processing
 
     /// One door into the OVERNIGHT PROCESSING window — all the fiddly controls (helper approval,
-    /// launch-at-login, the 18h auto-enable, manual arm) live there (OvernightDevView), not inline.
+    /// launch-at-login, the 14h auto-enable, manual arm) live there (OvernightDevView), not inline.
     private var overnightSection: some View {
         Button { openWindow(id: OvernightDevView.windowID) } label: {
             HStack(spacing: 10) {
                 Image(systemName: "moon.stars")
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Overnight Processing…").font(.callout.weight(.medium)).foregroundStyle(.white)
-                    Text("Helper approval · launch-at-login · 18h auto-enable · manual arm")
+                    Text("Helper approval · launch-at-login · 14h auto-enable · manual arm")
                         .font(.caption2).foregroundStyle(Theme.faint)
                 }
                 Spacer()

--- a/Sentient OS macOS/Views/Dev/OvernightDevView.swift
+++ b/Sentient OS macOS/Views/Dev/OvernightDevView.swift
@@ -4,7 +4,7 @@
 //
 //  The dev cockpit for overnight processing, in its OWN window (opened from DEV TOOLS → "Overnight
 //  Processing…"). A simple top-to-bottom checklist to set up + test the 3am self-processing:
-//    ① approve the root wake helper  ② launch-at-login  ③ test the 18h auto-enable  ④ manual arm.
+//    ① approve the root wake helper  ② launch-at-login  ③ test the 14h auto-enable  ④ manual arm.
 //  A live status panel at the top mirrors reality (helper approval + login item are polled every 2s,
 //  so approving in System Settings updates here without a manual refresh). Dev-only; the shipping
 //  onboarding/Settings UX binds to the same seams (WakeHelperClient / LoginItem / OvernightScheduler).
@@ -108,11 +108,11 @@ struct OvernightDevView: View {
         }
     }
 
-    // MARK: - ③ Test the 18h auto-enable
+    // MARK: - ③ Test the 14h auto-enable
 
     private var autoEnableStep: some View {
-        stepCard("3", "Test the 18h auto-enable",
-                 "Normally the scheduler turns itself on 18h after your first full analyze — but only once steps 1 & 2 are done. Shorten the wait here to test it in seconds.") {
+        stepCard("3", "Test the 14h auto-enable",
+                 "Normally the scheduler turns itself on 14h after your first full analyze — but only once steps 1 & 2 are done. Shorten the wait here to test it in seconds.") {
             VStack(alignment: .leading, spacing: 12) {
                 Text(autoEnableSummary).font(.callout).foregroundStyle(.white.opacity(0.85))
                     .fixedSize(horizontal: false, vertical: true)
@@ -120,7 +120,7 @@ struct OvernightDevView: View {
                 HStack(spacing: 8) {
                     Text("Wait:").font(.caption).foregroundStyle(.secondary)
                     Picker("", selection: $delayOverride) {
-                        Text("18h (real)").tag(0.0)
+                        Text("14h (real)").tag(0.0)
                         Text("10s").tag(10.0)
                         Text("60s").tag(60.0)
                     }.pickerStyle(.segmented).frame(width: 240).labelsHidden()
@@ -138,11 +138,11 @@ struct OvernightDevView: View {
         }
     }
 
-    // MARK: - ④ Manual arm (bypass the 18h logic)
+    // MARK: - ④ Manual arm (bypass the 14h logic)
 
     private var manualStep: some View {
         stepCard("4", "Manual arm (bypass)",
-                 "Directly arm a wake at a set time, ignoring the 18h logic — the fastest end-to-end test.") {
+                 "Directly arm a wake at a set time, ignoring the 14h logic — the fastest end-to-end test.") {
             HStack(spacing: 12) {
                 Toggle("On", isOn: $schedEnabled).toggleStyle(.switch)
                     .onChange(of: schedEnabled) { _, _ in appState.scheduler.reevaluate() }

--- a/Sentient OS macOS/Views/ProcessingView.swift
+++ b/Sentient OS macOS/Views/ProcessingView.swift
@@ -625,7 +625,7 @@ struct ProcessingView: View {
     private func run() async {
         let generation = runGeneration   // this invocation's identity — stale once pause/stop bump it
         // Keep the display awake ONLY for the initial ingest — the long one. The home + 3am both run
-        // `.auto`, so the honest "is this the first-ever descent" signal is the flag the 18h auto-enable
+        // `.auto`, so the honest "is this the first-ever descent" signal is the flag the 14h auto-enable
         // uses (nil until the first full cycle completes). `defer` releases on completion, failure, or
         // cancellation; the 3am path never reaches here (it never presents this view).
         if mode == .initial || OvernightScheduler.firstCycleCompletedAt == nil {

--- a/Sentient OS macOS/Views/RootView.swift
+++ b/Sentient OS macOS/Views/RootView.swift
@@ -56,7 +56,7 @@ struct RootView: View {
                 OnboardingView {
                     modelPath = ModelLocator.resolve()   // the onboarding download may have just landed it
                     withAnimation(.easeInOut(duration: 0.3)) { appState.hasCompletedOnboarding = true }
-                    // The first full cycle just stamped "initial done" — arm the 18h clock NOW.
+                    // The first full cycle just stamped "initial done" — arm the 14h clock NOW.
                     // (The app lives in the menu bar and rarely relaunches, so waiting for the
                     // next launch tick could delay auto-enable by days.)
                     appState.scheduler.maybeAutoEnable()
@@ -76,7 +76,7 @@ struct RootView: View {
                                runCalendar: calendarConnected && runCalendar,
                                fullCycle: deck == .real) {   // real mode → read + knowledge base + proactive + wipe
                     withAnimation(.easeInOut(duration: 0.3)) { isProcessing = false }
-                    appState.scheduler.maybeAutoEnable()   // a full cycle may have just stamped "initial done" → arm the 18h clock
+                    appState.scheduler.maybeAutoEnable()   // a full cycle may have just stamped "initial done" → arm the 14h clock
                 }
                 .transition(.opacity)
             } else {

--- a/Sentient OS macOS/Views/Settings/HealthPane.swift
+++ b/Sentient OS macOS/Views/Settings/HealthPane.swift
@@ -239,7 +239,7 @@ struct HealthPane: View {
                 _ = await WakeHelperInstaller.installAsync()
                 try? await Task.sleep(for: .seconds(1))   // let launchd settle before the XPC probe
                 await refreshDaemon()
-                // A fresh install may be the last missing prerequisite — re-run the 18h check now
+                // A fresh install may be the last missing prerequisite — re-run the 14h check now
                 // instead of waiting for the next launch (this app rarely relaunches).
                 if daemon == .ready { appState?.scheduler.maybeAutoEnable() }
             }


### PR DESCRIPTION
Drops the production auto-enable wait from 18 hours to **14 hours** (`defaultAutoEnableDelay = 14 * 3600`) — a real production change, same in Debug and Release (no build gates; the temp-testing values are all gone as of #196).

Every stale "18h" mention rides along so nothing lies:
- Code comments in `OvernightScheduler`, `AppState`, `RootView`, `ProactiveCycle`, `FactoryReset`, `ProcessingView`, `HealthPane`, `Sentient_OS_macOSApp`
- Dev cockpit labels (`OvernightDevView` step ③ "Test the 14h auto-enable", the "14h (real)" wait picker, `DevToolsView` caption)
- Deep docs: `Overnight Scheduler (3am Wake).md`, `Plan Gate`, `Product Analytics`

The `Our_Stuff` context files were updated to match (outside this repo).

https://claude.ai/code/session_0193DEbN8X8ArmUUXMahpVJw