### PR TITLE
Sidekick voice (mic & speech) is optional, like screen recording

### DIFF
--- a/Sentient OS macOS/Ingestion/FactoryReset.swift
+++ b/Sentient OS macOS/Ingestion/FactoryReset.swift
@@ -31,7 +31,8 @@ enum FactoryReset {
         d.removeObject(forKey: "onboarding.step")
         d.removeObject(forKey: CodexAuth.kbOnlyKey)     // the crossroads re-detects the plan fresh
         d.removeObject(forKey: AppState.onboardingKey)
-        d.removeObject(forKey: ComputerUseGate.screenRecordingOfferedKey)   // re-offer Sentient's screen recording on rebuild
+        d.removeObject(forKey: ComputerUseGate.screenRecordingOfferedKey)   // re-offer Sentient's optional grants on rebuild
+        d.removeObject(forKey: ComputerUseGate.micSpeechOfferedKey)
         d.removeObject(forKey: HealthCaution.computerUseEverReadyKey)       // the home's computer-use banner re-arms at the rebuild's own gate
         // The overnight scheduler starts over too: the 14h clock re-stamps at the REBUILD's first
         // cycle (not the wiped one's), the auto-enable one-shot is re-armed, and the production

--- a/Sentient OS macOS/Notch Magic/CommandCoordinator.swift
+++ b/Sentient OS macOS/Notch Magic/CommandCoordinator.swift
@@ -196,6 +196,14 @@ final class CommandCoordinator {
 
     private func voiceHoldConfirmed() {
         guard phase == .opening else { return }
+        // Mic or speech DENIED → a hold can never work and no native prompt can re-appear, so the
+        // permission window rises as the fix surface (non-blocking — voice is optional; only a
+        // committed HOLD reaches this, taps and typed commands never do).
+        if !VoiceCapture.isAuthorized, ComputerUseGate.shared.presentVoiceFixIfDenied() {
+            setPhase(.hidden)
+            Log("hold answered with the permission window — mic/speech denied")
+            return
+        }
         // A genuine first-run model download → say so instead of pretending to listen (the mic tap
         // only installs after the model lands, so anything spoken now would be silently lost). Only
         // a committed HOLD gets this beat — tap-to-type stays fully alive during the download.

--- a/Sentient OS macOS/Views/Permissions/ComputerUseGate.swift
+++ b/Sentient OS macOS/Views/Permissions/ComputerUseGate.swift
@@ -4,14 +4,18 @@
 //
 //  The first-use permission gate for everything that acts on the Mac. Every computer-use surface
 //  (the home command bar, Sidekick's hotkey, a proactive card's fire) funnels through
-//  `intercept(_:)`: while any REQUIRED action grant is missing — Sentient's own Microphone &
-//  Speech, plus the Codex Computer Use helper's Accessibility and Screen Recording — it stashes
-//  the pending action, raises the one-time setup window (ComputerUseGateView), and fires the
-//  action when the user taps Continue. Sentient's own Screen Recording rides along as an
-//  OPTIONAL row (screen context for Sidekick; missing it never gates anything — no grant means
-//  commands simply run text-only). Closing the window instead cancels the pending action. Shown
-//  at most once per app session; all required grants green means it never appears at all. Status
-//  probes reuse Permissions/VoiceCapture (the helper's grants are system-TCC, read via our FDA).
+//  `intercept(_:)`: while any REQUIRED action grant is missing — the Codex Computer Use helper's
+//  Accessibility and Screen Recording — it stashes the pending action, raises the one-time setup
+//  window (ComputerUseGateView), and fires the action when the user taps Continue. Sentient's own
+//  grants ride along as OPTIONAL rows (Microphone & Speech — Sidekick's voice; Screen Recording —
+//  the screen-context snapshot): missing either never gates anything — no mic means hold-to-talk
+//  stays off (tap-to-type and typed commands still work), no screen grant means commands run
+//  text-only. Each optional grant is offered exactly once (persisted flags), and a voice HOLD
+//  against a DENIED mic re-raises the window as a non-blocking fix surface (presentVoiceFixIfDenied
+//  — a denied grant has no native prompt left to show). Closing the window instead cancels the
+//  pending action. All required grants green and both optionals offered means it never appears at
+//  all. Status probes reuse Permissions/VoiceCapture (the helper's grants are system-TCC, read via
+//  our FDA).
 //
 //  Key methods: intercept(_:) · refresh() · continueNow()
 //
@@ -30,7 +34,9 @@ final class ComputerUseGate {
 
     // MARK: Grant status (probed, not cached beyond the last refresh)
 
-    /// Sentient's mic + speech recognition — Sidekick's ears. Detail preserved for the fix action.
+    /// Sentient's mic + speech recognition — Sidekick's ears. OPTIONAL: without it, hold-to-talk
+    /// stays off (the first hold flashes the mic notice); tap-to-type and typed commands are
+    /// untouched. Detail preserved for the fix action.
     enum MicSpeechState { case granted, notAsked, denied }
     private(set) var micSpeech: MicSpeechState = .notAsked
 
@@ -43,23 +49,28 @@ final class ComputerUseGate {
     private(set) var helperAccessibility = false
     private(set) var helperScreen = false
 
-    /// The REQUIRED grants — what the gate holds actions for. Sentient's Screen Recording is
-    /// deliberately absent (optional row, shown but never blocking).
+    /// The REQUIRED grants — what the gate holds actions for. Sentient's own two (Microphone &
+    /// Speech, Screen Recording) are deliberately absent: optional rows, shown but never blocking.
     var allRequiredGranted: Bool {
-        micSpeech == .granted && helperAccessibility && helperScreen
+        helperAccessibility && helperScreen
     }
 
     // MARK: The gate
 
-    /// Persisted so Sentient's OPTIONAL Screen Recording is offered exactly once in the app's
-    /// lifetime. The gate blocks only on REQUIRED grants, so without this a user who already had
-    /// the Codex helper's grants (e.g. set up via the ChatGPT app) would sail straight past and
-    /// never be asked for Sentient's own screen recording. Cleared by FactoryReset so a rebuild
-    /// re-offers it.
+    /// Persisted so each of Sentient's OPTIONAL grants (Screen Recording · Microphone & Speech)
+    /// is offered exactly once in the app's lifetime. The gate blocks only on REQUIRED grants, so
+    /// without these a user who already had the Codex helper's grants (e.g. set up via the
+    /// ChatGPT app) would sail straight past and never be pitched Sentient's own two. Cleared by
+    /// FactoryReset so a rebuild re-offers them.
     static let screenRecordingOfferedKey = "computerUse.screenRecordingOffered"
+    static let micSpeechOfferedKey = "computerUse.micSpeechOffered"
     private static var screenRecordingOffered: Bool {
         get { UserDefaults.standard.bool(forKey: screenRecordingOfferedKey) }
         set { UserDefaults.standard.set(newValue, forKey: screenRecordingOfferedKey) }
+    }
+    private static var micSpeechOffered: Bool {
+        get { UserDefaults.standard.bool(forKey: micSpeechOfferedKey) }
+        set { UserDefaults.standard.set(newValue, forKey: micSpeechOfferedKey) }
     }
 
     private var pending: (@MainActor () -> Void)?
@@ -72,19 +83,24 @@ final class ComputerUseGate {
     ///   • a REQUIRED grant is missing → BLOCKING: always re-shows (or re-focuses) and re-holds the
     ///     action until every required grant is green — so a feature can never fire half-granted no
     ///     matter how many times the window was dismissed (Continue is disabled, close drops it).
-    ///   • all required are green but Sentient's OPTIONAL Screen Recording is missing and hasn't
-    ///     been offered yet → NON-BLOCKING, once ever: Continue is enabled immediately and closing
-    ///     still FIRES the held command, so an optional nudge never eats what the user fired.
+    ///   • all required are green but one of Sentient's OPTIONAL grants (Microphone & Speech ·
+    ///     Screen Recording) is missing and hasn't been offered yet → NON-BLOCKING, once ever:
+    ///     Continue is enabled immediately and closing still FIRES the held command, so an
+    ///     optional nudge never eats what the user fired.
     func intercept(_ action: @escaping @MainActor () -> Void) -> Bool {
         refresh()
         let blocking = !allRequiredGranted
         if !blocking {
             // Seen working — arm the home's regression banner (HealthCaution rung ③).
             HealthCaution.latchComputerUse()
-            // Nothing required is missing — the only reason to appear is the one-time optional offer.
-            guard !sentientScreen, !Self.screenRecordingOffered else { return false }
+            // Nothing required is missing — the only reason to appear is a one-time optional offer.
+            let offerScreen = !sentientScreen && !Self.screenRecordingOffered
+            let offerMic = micSpeech != .granted && !Self.micSpeechOffered
+            guard offerScreen || offerMic else { return false }
         }
-        if !sentientScreen { Self.screenRecordingOffered = true }   // the row is shown → they've now been offered it
+        // The rows are shown → they've now been offered them.
+        if !sentientScreen { Self.screenRecordingOffered = true }
+        if micSpeech != .granted { Self.micSpeechOffered = true }
         presentedBlocking = blocking
         let wasVisible = window?.isVisible ?? false
         pending = action
@@ -93,7 +109,7 @@ final class ComputerUseGate {
             Log("ComputerUseGate: re-intercepted — setup window already up, action re-held")
         } else {
             Analytics.signal("PermissionGate.shown", parameters: ["blocking": String(blocking)])
-            Log("ComputerUseGate: intercepted computer-use action — setup window up (\(blocking ? "required grants missing" : "optional screen-recording offer"))")
+            Log("ComputerUseGate: intercepted computer-use action — setup window up (\(blocking ? "required grants missing" : "optional-grants offer"))")
         }
         return true
     }
@@ -107,6 +123,22 @@ final class ComputerUseGate {
     @discardableResult
     func interceptBeforeStart() -> Bool {
         intercept({})
+    }
+
+    /// A voice HOLD against a DENIED mic/speech grant — an unambiguous "I want to talk" that can
+    /// never work and has no native prompt left to re-show (denied prompts appear once, ever). So
+    /// raise the setup window as a FIX SURFACE: non-blocking, nothing held, its Mic & Speech row
+    /// one Fix… away from the right System Settings pane. Voice stays optional — typed commands
+    /// and taps never reach this. Returns true when the window was raised (denied confirmed by a
+    /// fresh probe) and the caller should stand down; false means not denied — proceed to capture
+    /// (a not-asked-yet grant gets the native prompt instead).
+    func presentVoiceFixIfDenied() -> Bool {
+        refresh()
+        guard micSpeech == .denied else { return false }
+        presentedBlocking = false   // pending stays untouched — a held offer command still fires on close
+        present()
+        Log("ComputerUseGate: voice hold hit a denied mic/speech — setup window up as the fix surface")
+        return true
     }
 
     /// Re-probe all four grants (cheap; the TCC reads are two tiny indexed SELECTs).
@@ -188,15 +220,15 @@ final class ComputerUseGate {
     }
 
     /// The red button / X. A BLOCKING gate drops the held action (never fired blind — a required
-    /// grant is missing). The optional Screen-Recording offer is non-blocking, so dismissing it
-    /// still fires the command the user actually asked for.
+    /// grant is missing). The optional-grants offer is non-blocking, so dismissing it still fires
+    /// the command the user actually asked for.
     private func windowClosed() {
         if let action = pending {
             pending = nil
             if presentedBlocking {
                 Log("ComputerUseGate: setup window closed — held action dropped (required grant missing)")
             } else {
-                Log("ComputerUseGate: optional Screen-Recording offer dismissed — firing the held command")
+                Log("ComputerUseGate: optional-grants offer dismissed — firing the held command")
                 action()
             }
         }

--- a/Sentient OS macOS/Views/Permissions/ComputerUseGateView.swift
+++ b/Sentient OS macOS/Views/Permissions/ComputerUseGateView.swift
@@ -4,12 +4,12 @@
 //
 //  The one-time setup window's face (ComputerUseGate presents it): the four action grants as the
 //  same StatusLine rows Settings → Health uses, in two groups — SIDEKICK & PROACTIVE (Sentient's
-//  Microphone & Speech, plus its OPTIONAL Screen Recording — amber, never blocking) and CODEX
-//  PERMISSIONS (the helper's Accessibility, Screen Recording). Mic & Speech fix via the native
-//  system prompts; the other three fix via PermissionGuide's floating drag panel (they're
-//  system-TCC lists — only the user can flip them). Continue fires the held action whether or
-//  not everything is green; the rows re-probe when the app foregrounds (returning from System
-//  Settings).
+//  OPTIONAL Microphone & Speech and Screen Recording — amber, never blocking) and CODEX
+//  PERMISSIONS (the helper's Accessibility, Screen Recording — the REQUIRED pair). Mic & Speech
+//  fix via the native system prompts; the other three fix via PermissionGuide's floating drag
+//  panel (they're system-TCC lists — only the user can flip them). Continue fires the held action
+//  whether or not the optionals are green; the rows re-probe when the app foregrounds (returning
+//  from System Settings).
 //
 
 import SwiftUI
@@ -41,9 +41,9 @@ struct ComputerUseGateView: View {
                 SettingsGroup(label: "Sidekick & Proactive") {
                     VStack(alignment: .leading, spacing: 2) {
                         StatusLine(title: "Microphone & Speech",
-                                   health: micSpeechHealth,
+                                   health: gate.micSpeech == .granted ? .ok : .warn,   // optional — amber, never blocking
                                    note: micSpeechNote,
-                                   tip: "Lets Sidekick hear you and turn your words into text when you hold the shortcut key.\n\nYour voice is heard and transcribed on this Mac, never in the cloud.",
+                                   tip: "Optional but recommended.\nLets Sidekick hear you and turn your words into text when you hold the shortcut key.\n\nWithout it, hold-to-talk stays off — you can still tap the key (or click the notch) and type.\n\nYour voice is heard and transcribed on this Mac, never in the cloud.",
                                    fixTitle: gate.micSpeech == .notAsked ? "Allow…" : "Fix…") {
                             fixMicSpeech()
                         }
@@ -110,19 +110,11 @@ struct ComputerUseGateView: View {
 
     // MARK: Sentient's grants — native prompts first, the guide as the fallback
 
-    private var micSpeechHealth: StatusLine.Health {
-        switch gate.micSpeech {
-        case .granted:  return .ok
-        case .notAsked: return .bad   // compulsory here — this window exists to get them granted
-        case .denied:   return .bad
-        }
-    }
-
     private var micSpeechNote: String {
         switch gate.micSpeech {
         case .granted:  return "granted"
-        case .notAsked: return "not asked yet"
-        case .denied:   return "denied"
+        case .notAsked: return "recommended"
+        case .denied:   return "off"
         }
     }
 

--- a/Sentient OS macOS/Views/Settings/HealthPane.swift
+++ b/Sentient OS macOS/Views/Settings/HealthPane.swift
@@ -185,9 +185,9 @@ struct HealthPane: View {
         SettingsGroup(label: "Sidekick & Proactive") {
             VStack(alignment: .leading, spacing: 2) {
                 StatusLine(title: "Microphone & Speech",
-                           health: micSpeechHealth,
+                           health: micSpeech == .granted ? .ok : .warn,   // optional — Sidekick's voice; tap-to-type works without it
                            note: micSpeechNote,
-                           tip: "Lets Sidekick hear you and turn your words into text when you hold the shortcut key.\n\nYour voice is heard and transcribed on this Mac, never in the cloud.",
+                           tip: "Optional but recommended.\nLets Sidekick hear you and turn your words into text when you hold the shortcut key.\n\nWithout it, hold-to-talk stays off — you can still tap the key (or click the notch) and type.\n\nYour voice is heard and transcribed on this Mac, never in the cloud.",
                            fixTitle: micSpeech == .notAsked ? "Allow…" : "Fix…") {
                     fixMicSpeech()
                 }
@@ -256,21 +256,13 @@ struct HealthPane: View {
         }
     }
 
-    // MARK: Microphone & Speech (one row — one call asks for both)
-
-    private var micSpeechHealth: StatusLine.Health {
-        switch micSpeech {
-        case .granted:  return .ok
-        case .notAsked: return .warn
-        case .denied:   return .bad
-        }
-    }
+    // MARK: Microphone & Speech (one row — one call asks for both; optional, so yellow, never red)
 
     private var micSpeechNote: String {
         switch micSpeech {
         case .granted:  return "granted"
         case .notAsked: return "not asked yet"
-        case .denied:   return "denied"
+        case .denied:   return "off"
         }
     }
 


### PR DESCRIPTION
## What

Makes Sidekick's voice grants (Microphone & Speech) optional, mirroring the existing optional Screen Recording pattern — crossing off the "make sidekick voice (mic & speech rec perms) optional" todo.

## Why

The first-use permission gate treated Mic & Speech as REQUIRED, so it held every computer-use surface hostage (typed command bar, notch click, card fires — none of which need a mic) until voice was granted. A user who never wants voice couldn't use computer use at all.

## How

- **`ComputerUseGate`**: `allRequiredGranted` is now just the codex helper's Accessibility + Screen Recording. Mic & Speech gets the same one-time non-blocking offer as screen recording (`computerUse.micSpeechOffered`, cleared by `FactoryReset` so a rebuild re-offers it).
- **New `presentVoiceFixIfDenied()`**: a voice HOLD against a *denied* mic raises the gate window as a non-blocking fix surface — a denied grant has no native prompt left to show, so the old notch flash left the user with no door. Fix… deep-links to the actual blocker (mic first, then speech). Only a committed hold reaches this; taps and typed commands never do.
- **Gate window**: mic row is amber when missing ("recommended"/"off"), tip leads with "Optional but recommended" + what still works without it.
- **Settings → Health**: denied mic reads amber "off" per the pane's own rule (red = core capability broken, yellow = optional), like the Notifications row.

Behavior matrix: not-asked + hold → native prompt at the moment of intent · denied + hold → gate window with the fix path · granted → just works · no voice at all → typing and computer use fully unaffected. Screen rec missing + speech granted → voice Sidekick works with text-only screen context (unchanged).

## Testing

Isolated Debug build (`/tmp/sentient-verify`) compiles clean. The optionality itself (mic no longer in `allRequiredGranted`) was exercised live — the gate window correctly shows mic green/screen-rec amber as non-blocking with only the codex rows red. Still needs a hardware pass: the denied-mic HOLD → fix-surface window beat, and the one-time mic offer from a fresh `computerUse.micSpeechOffered` state. Docs (`Permission Guide (First-Use Grants).md` table, arch §7.5) update after that confirmation.

https://claude.ai/code/session_01H2LhZzEgi2b4wLTwGt5SCT