### PR TITLE
Tell computer-use codex runs they can't ask follow-up questions

### DIFF
--- a/Sentient OS macOS/Notch Magic/CommandRunModel.swift
+++ b/Sentient OS macOS/Notch Magic/CommandRunModel.swift
@@ -238,6 +238,8 @@ final class CommandRunModel {
         Using \(mode.promptPhrase), \(task)
         \(voiceLine)\(screenLine)
         Carry out the task itself with \(mode.promptPhrase) — drive the real apps and websites directly (open them, click, type, navigate). Do NOT fake it with AppleScript, osascript, or other GUI-scripting shortcuts.
+
+        You will not be able to ask me follow-up questions to clarify: in this harness, the moment you stop responding I see the task attempt as completed. So don't stop to ask trivial follow-up questions. Either do the task, or if it's genuinely too ambiguous to act on, just don't — say what was unclear instead. No follow-up questions.
         \(contextLine)
         For context about me, my knowledge base is a folder of markdown files at '\(VaultGenerator.vaultRoot.path)'. When you need it, read it directly with your shell/file tools — `ls`, `cat`, and `grep` the .md files. Do NOT open it in Obsidian or any GUI app to read it.
         """

--- a/Sentient OS macOS/Proactive/ProactiveExecutor.swift
+++ b/Sentient OS macOS/Proactive/ProactiveExecutor.swift
@@ -269,8 +269,9 @@ actor ProactiveExecutor {
 
         NEVER use AppleScript, osascript, the Terminal, or any shell automation — use COMPUTER USE \
         only. Do not take screenshots via the shell, do not run unrelated commands, and do not touch \
-        unrelated apps or files. If you cannot complete the task with computer use, STOP and reply with \
-        `STATUS: COULD_NOT — <reason>`.
+        unrelated apps or files. You cannot ask the user follow-up questions — the moment you stop \
+        responding, the attempt is over. If you cannot complete the task with computer use, STOP and \
+        reply with `STATUS: COULD_NOT — <reason>`.
 
         <<<CONTENT
         \(content)


### PR DESCRIPTION
## What

Codex sometimes stops mid-computer-use to ask the user a clarifying question — but in our one-shot `codex exec` harness there's no way to answer: the run just ends and looks like a completed attempt. Both computer-use prompts now tell it so up front.

- **`CommandRunModel.commandPrompt`** (the shared command bar + Sidekick prompt): a standing paragraph — you can't ask me follow-up questions; either do the task, or if it's genuinely too ambiguous, don't — say what was unclear instead.
- **`ProactiveExecutor.computerWrapper`** (card fires): one sentence folded into the existing STOP rule. Same failure mode, but sneakier there: a clarifying question comes back with no `STATUS:` sentinel, which the scoreboard counts as an optimistic "fired" (a false success). This nudges it to a proper `STATUS: COULD_NOT` instead.

The "(due to speech to text fail)" nuance from the todo draft is handled by the existing `voiceLine`, which only rides in on spoken runs — the new paragraph serves typed commands too.

## Test

Fire a deliberately vague Sidekick command that previously made codex stop and ask; it should now either push through or end with a clear "couldn't do it".

https://claude.ai/code/session_01D6YkTZ5gUNSTCb4zqapz5p