### PR TITLE
Dev Tools: resizable analysis takeover for the website screen rec

### DIFF
--- a/Sentient OS macOS/Documentation/Home — Proactive Intelligence (For You).md
+++ b/Sentient OS macOS/Documentation/Home — Proactive Intelligence (For You).md
@@ -98,7 +98,12 @@ their knowledge base, whatever their plan. ProcessingView's "Analysis complete" 
 **auto-advances after 5s** (the Done button stays as a skip; a cancellation check stops a manual
 Done from double-firing the finale) — so someone who left the first run going overnight wakes up
 to the Constellation + cards, never a stale complete screen. Dev runs (`showPrompt`) keep the
-manual Done so final counts can be inspected. `RootView` also mounts the screen-agnostic
+manual Done so final counts can be inspected. **Demo toggle** (Dev Tools → "Resizable analysis
+window for demo", key `ProcessingView.resizableDemoKey`): while ON, the home's takeover drops
+RootView's 1040×800 min frame (the window shrinks to the content's own floor — resizes freely for
+the website's screen rec) and hides the Stop Analysis button + caption; home runs only — onboarding
+keeps Pause, dev runs keep Stop, and the min frame snaps back when the takeover ends.
+`RootView` also mounts the screen-agnostic
 **computer-use setup whisper** — a small spinner + "Setting up Codex computer use in the
 background." bottom-left, keyed to the live `CodexSetup.settingUpComputerUse` flag, so it rides
 onboarding's takeover, the knowledge-base phase, and (rarely) the home for exactly as long as the

--- a/Sentient OS macOS/Views/Dev/DevToolsView.swift
+++ b/Sentient OS macOS/Views/Dev/DevToolsView.swift
@@ -92,6 +92,9 @@ struct DevToolsView: View {
     // The 3-way card mode (which deck the home deals) — see BriefingDeck (Briefing.swift).
     @AppStorage(BriefingDeck.key) private var deckRaw = BriefingDeck.defaultRaw
 
+    // Demo: free-resize the home's analysis takeover (ProcessingView owns the key).
+    @AppStorage(ProcessingView.resizableDemoKey) private var resizableAnalysisDemo = false
+
 
     // MCP mirror (the hosted Render copy). Local mirrors of MirrorClient's actor state, refreshed
     // when "More" opens and after each action.
@@ -151,6 +154,26 @@ struct DevToolsView: View {
         .background(.white.opacity(0.03), in: RoundedRectangle(cornerRadius: 12))
     }
 
+    /// Demo: while ON, the home's analysis takeover drops its window min size AND the Stop
+    /// Analysis footer, so the website's screen recording can frame just the analysis content.
+    /// Onboarding's Pause and the dev prompt-pane runs are untouched.
+    private var resizableAnalysisSection: some View {
+        Toggle(isOn: $resizableAnalysisDemo) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Resizable analysis window for demo")
+                    .font(.callout.weight(.medium)).foregroundStyle(.white)
+                Text("Home → Analyze Now resizes freely (no min size) and hides the Stop Analysis footer — for the website's screen rec.")
+                    .font(.caption2).foregroundStyle(Theme.faint)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .toggleStyle(.switch)
+        .controlSize(.small)
+        .padding(12)
+        .frame(maxWidth: .infinity)
+        .background(.white.opacity(0.03), in: RoundedRectangle(cornerRadius: 12))
+    }
+
     /// One deck segment — lit when it's the active mode.
     private func deckButton(_ mode: BriefingDeck, _ label: String) -> some View {
         let selected = (BriefingDeck(rawValue: deckRaw) ?? .real) == mode
@@ -203,6 +226,7 @@ struct DevToolsView: View {
                     }
                     executeButton
                     proactiveCardsSection
+                    resizableAnalysisSection
                     HStack(spacing: 10) {
                         viewSummariesButton
                         viewActionItemsButton

--- a/Sentient OS macOS/Views/ProcessingView.swift
+++ b/Sentient OS macOS/Views/ProcessingView.swift
@@ -78,6 +78,13 @@ struct ProcessingView: View {
         self.onDone = onDone
     }
 
+    /// Dev Tools → "Resizable analysis window (demo)". While ON, the home's takeover loses its
+    /// window min size (RootView reads this same key) and this footer's Stop control, so a website
+    /// screen recording can frame just the analysis content. Home runs only — onboarding keeps
+    /// Pause, dev prompt-pane runs keep Stop.
+    static let resizableDemoKey = "dev.processing.resizableDemo"
+    @AppStorage(ProcessingView.resizableDemoKey) private var resizableDemo = false
+
     private enum UIState: Equatable { case loadingModel, processing, preparing, completed, failed(CycleFailure) }
     @State private var state: UIState = .loadingModel
     /// The failed screen's inline codex login (the "Codex isn't logged in" fix) — same shared
@@ -517,18 +524,21 @@ struct ProcessingView: View {
 
     private var footer: some View {
         VStack(spacing: 18) {
-            VStack(spacing: 6) {
-                Button(action: pausable ? (paused ? resume : pause) : stop) {
-                    Text(pausable ? (paused ? "Resume Analysis" : "Pause Analysis") : "Stop Analysis")
-                        .font(.subheadline.weight(.medium)).foregroundStyle(.white.opacity(0.9))
-                        .padding(.horizontal, 24).padding(.vertical, 10)
-                        .background(Capsule().fill(.white.opacity(0.08)))
-                        .overlay(Capsule().strokeBorder(.white.opacity(0.18)))
+            // Demo mode drops the Stop control (home runs only) — the recording wants a clean frame.
+            if !(resizableDemo && !pausable && !showPrompt) {
+                VStack(spacing: 6) {
+                    Button(action: pausable ? (paused ? resume : pause) : stop) {
+                        Text(pausable ? (paused ? "Resume Analysis" : "Pause Analysis") : "Stop Analysis")
+                            .font(.subheadline.weight(.medium)).foregroundStyle(.white.opacity(0.9))
+                            .padding(.horizontal, 24).padding(.vertical, 10)
+                            .background(Capsule().fill(.white.opacity(0.08)))
+                            .overlay(Capsule().strokeBorder(.white.opacity(0.18)))
+                    }
+                    .buttonStyle(.plain)
+                    Text(pausable ? (paused ? "Paused. It picks up exactly where it stopped." : "Pausing keeps your progress.")
+                                  : "Analysis can always resume later.")
+                        .font(.caption).foregroundStyle(.white.opacity(0.4))
                 }
-                .buttonStyle(.plain)
-                Text(pausable ? (paused ? "Paused. It picks up exactly where it stopped." : "Pausing keeps your progress.")
-                              : "Analysis can always resume later.")
-                    .font(.caption).foregroundStyle(.white.opacity(0.4))
             }
             if showPrompt {
                 // Dev: the current item being processed (replaces the trust footer).

--- a/Sentient OS macOS/Views/RootView.swift
+++ b/Sentient OS macOS/Views/RootView.swift
@@ -40,6 +40,11 @@ struct RootView: View {
     /// Observed for the global "setting up computer use" whisper (the overlay below).
     @State private var codex = CodexSetup.shared
 
+    // Dev Tools → "Resizable analysis window (demo)": while the analysis takeover is up, the
+    // window's min frame drops away entirely, so the website screen rec can shrink it to just
+    // the analysis content. The home keeps its full canvas either way.
+    @AppStorage(ProcessingView.resizableDemoKey) private var resizableAnalysisDemo = false
+
     /// The sources Analyze Now will process — the shared selection (folders + DB sources).
     private var selectedSources: [RunSource] {
         SourceSelection.current(fdaGranted: fdaGranted)
@@ -83,7 +88,8 @@ struct RootView: View {
                 home.transition(.opacity)
             }
         }
-        .frame(minWidth: 1040, minHeight: 800)
+        .frame(minWidth: resizableAnalysisDemo && isProcessing ? nil : 1040,
+               minHeight: resizableAnalysisDemo && isProcessing ? nil : 800)
         // Core tier: the home window came up (fires once per window instantiation — launch opens it
         // automatically; anything later is a deliberate menu-bar/Dock reopen, hence the trigger
         // param). Sidekick-only users who never look at home are exactly who this measures.


### PR DESCRIPTION
## What
New **dev.processing.resizableDemo** toggle in Dev Tools ("Resizable analysis window for demo", under the Proactive Cards section).

While ON:
- The home's analysis takeover drops RootView's 1040×800 min frame — the window resizes freely down to the content's own floor, so the website screen rec can frame just the analysis content.
- The Stop Analysis button + "Analysis can always resume later." caption are hidden (trust footer stays).

Scoped to home runs only: onboarding keeps Pause/Resume, dev prompt-pane runs keep Stop. The min frame snaps back the moment the takeover ends. The key lives on ProcessingView (`resizableDemoKey`), read by RootView + DevToolsView.

Doc: one paragraph added to `Home — Proactive Intelligence (For You).md`.

## Verified
Builds green via Xcode MCP; behavior confirmed by Jesai on a real run.