### PR TITLE
Analysis dropdown last/next run + synced stamp on the Connect AIs pill + connect veil

### DIFF
--- a/Sentient OS macOS/Cloud/MirrorClient.swift
+++ b/Sentient OS macOS/Cloud/MirrorClient.swift
@@ -200,7 +200,14 @@ actor MirrorClient {
         req.timeoutInterval = 120
         let (data, resp) = try await URLSession.shared.upload(for: req, from: blob)
         try Self.check(resp, data)
+        UserDefaults.standard.set(Date(), forKey: Self.lastPushKey)
         Analytics.signal("Mirror.pushed")
+    }
+
+    /// When the mirror last synced (the last successful push) — the Connect-AIs pill's stamp.
+    /// nil if never pushed, or since deleted.
+    nonisolated static var lastPush: Date? {
+        UserDefaults.standard.object(forKey: lastPushKey) as? Date
     }
 
     /// The one-click delete — removes the cloud copy (and its access log). The local vault
@@ -211,6 +218,7 @@ actor MirrorClient {
         req.httpMethod = "DELETE"
         let (data, resp) = try await URLSession.shared.data(for: req)
         try Self.check(resp, data)
+        UserDefaults.standard.removeObject(forKey: Self.lastPushKey)   // no cloud copy → no synced stamp
     }
 
     /// Opt out: flip mirroring OFF and delete the cloud copy, but KEEP the token so re-enabling
@@ -275,6 +283,7 @@ actor MirrorClient {
     private static let passwordKey = "mcp.mirror.password"  // Keychain: the root secret (persists)
     private static let legacyTokenKey = "mcp.mirror.token"  // pre-encryption single token — swept on enable
     private static let enabledKey = "mcp.mirror.enabled"    // UserDefaults: the on/off the toggle flips
+    private static let lastPushKey = "mcp.mirror.lastPush"  // UserDefaults: last successful push (Date)
 
     /// 18 random bytes → base64url (24 chars, no padding) — inside the server's [16,64] window
     /// and URL-safe, so it drops straight into the path. 144 bits: infeasible to brute-force,

--- a/Sentient OS macOS/Proactive/ProactiveCycle.swift
+++ b/Sentient OS macOS/Proactive/ProactiveCycle.swift
@@ -44,12 +44,13 @@ actor ProactiveCycle {
 
     static let shared = ProactiveCycle()
 
-    /// When the last full cycle finished (UserDefaults) — drives the home's real "Synced · …" stamp.
+    /// When the last full cycle finished (UserDefaults) — drives the Analysis popover's real
+    /// "Last run: …" stamp.
     static let lastCycleKey = "proactive.lastCycleAt"
 
     /// Wipe every persisted trace of the proactive layer — the decide-stage decisions, the prepared
-    /// cards, the welcome "gift", and the "Synced · …" stamp — so the home's "For You" deck comes back
-    /// empty. Used by the dev "Reset everything", alongside the cycle-store + knowledge-base wipe.
+    /// cards, the welcome "gift", and the "Last run: …" stamp — so the home's "For You" deck comes
+    /// back empty. Used by the dev "Reset everything", alongside the cycle-store + knowledge-base wipe.
     static func resetAll() {
         Proactive.clear()
         ProactiveResearch.clear()

--- a/Sentient OS macOS/Views/ConnectAIsView.swift
+++ b/Sentient OS macOS/Views/ConnectAIsView.swift
@@ -4,10 +4,13 @@
 //
 //  The "Connect your AIs" window — the guided setup, opened by the glow CTAs in Settings →
 //  Your AIs and the home's Your AIs popover. Owns the whole story:
-//   · sharing OFF → the single glowing "Connect your AIs" CTA (enables the mirror + first push,
-//     then the guide assembles in place); a quiet MCP ON/OFF pill top-right mirrors the state
-//     and flips it off behind the same confirm-and-delete alert Settings uses.
-//   · sharing ON → per-AI tabs (ChatGPT · Claude · Other AIs). ChatGPT/Claude show their
+//   · sharing OFF → the guide itself opens first (a 2-second crisp peek, inert), then blurs
+//     under a transparent veil carrying the glowing "Connect your AIs" CTA; pressing it enables
+//     the mirror + first push and the blur releases in place. No MCP pill while off.
+//   · sharing ON → per-AI tabs (ChatGPT · Claude · Other AIs), plus a quiet MCP ON pill
+//     top-right (carrying the last synced time) that flips sharing off behind the same
+//     confirm-and-delete alert Settings uses; turning off brings the veil straight back.
+//     ChatGPT/Claude show their
 //     GuideSpec's portrait video steps side by side (ChatGPT three: developer mode → paste the
 //     private MCP link → paste the system prompt; Claude two: link → prompt), each with a
 //     take-me-there deep link above the card. The masked link + Copy and the coached
@@ -34,6 +37,7 @@ struct ConnectAIsView: View {
 
     @State private var tab: AITab = .chatgpt
     @State private var enabled = false
+    @State private var veiled = false   // sharing off: the blur + CTA overlay (after the 2s peek)
     @State private var shareURL: String?
     @State private var loaded = false
     @State private var busy = false
@@ -47,15 +51,17 @@ struct ConnectAIsView: View {
             Theme.bg.ignoresSafeArea()
             VStack(spacing: 0) {
                 header
-                if loaded {
-                    if enabled { guide } else { connectPitch }
-                }
+                if loaded { guide }
             }
             .padding(.horizontal, 40).padding(.vertical, 36)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .blur(radius: veiled ? 34 : 0)
+            .saturation(veiled ? 0.7 : 1)   // mute the blurred cards so the veil reads calm
+            .allowsHitTesting(enabled)   // the peek is a teaser, not a playground
+            if veiled { connectVeil.transition(.opacity) }
         }
         .overlay(alignment: .topTrailing) {
-            if loaded { sharingPill.padding(16) }
+            if loaded && enabled { sharingPill.padding(16) }
         }
         .frame(minWidth: 1100, minHeight: 880)
         .task { await refresh() }
@@ -82,25 +88,34 @@ struct ConnectAIsView: View {
         }
     }
 
-    // MARK: - Sharing off: the one glowing object in the window
+    // MARK: - Sharing off: the veil — a translucent scrim over the blurred guide, carrying the
+    // one glowing object in the window. Connect releases the blur in place.
 
-    private var connectPitch: some View {
-        VStack(spacing: 0) {
-            GlowButton(title: busy ? "Connecting…" : "Connect your AIs",
-                       systemImage: "link", glowIntensity: 0.5) { connect() }
-                .frame(width: 280)
-                .padding(.top, 40)
-            MonoCaps("Private · no account · delete anytime",
-                     size: 8.5, tracking: 1.6, color: Theme.Ink.deepMuted)
-                .padding(.top, 22)
-            if let errorLine {
-                Text(errorLine)
-                    .font(.system(size: 11)).foregroundStyle(Theme.Ink.amber)
-                    .multilineTextAlignment(.center)
-                    .frame(maxWidth: 380)
-                    .padding(.top, 14)
+    private var connectVeil: some View {
+        ZStack {
+            // Deep enough that the inks (tuned for OLED black) sit right; the blurred guide
+            // survives as a faint glow, not a bright wall the grays melt into.
+            Color.black.opacity(0.82).ignoresSafeArea()
+            VStack(spacing: 0) {
+                header
+                GlowButton(title: busy ? "Connecting…" : "Connect your AIs",
+                           systemImage: "link", glowIntensity: 0.5) { connect() }
+                    .frame(width: 280)
+                    .padding(.top, 40)
+                MonoCaps("Private · no account · delete anytime",
+                         size: 8.5, tracking: 1.6, color: Theme.Ink.deepMuted)
+                    .padding(.top, 22)
+                if let errorLine {
+                    Text(errorLine)
+                        .font(.system(size: 11)).foregroundStyle(Theme.Ink.amber)
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: 380)
+                        .padding(.top, 14)
+                }
             }
+            .padding(.horizontal, 40)
         }
+        .contentShape(Rectangle())   // swallow clicks so the blurred guide stays inert
     }
 
     // MARK: - Sharing on: the per-AI guide
@@ -318,25 +333,31 @@ struct ConnectAIsView: View {
             .strokeBorder(.white.opacity(0.06), lineWidth: 1))
     }
 
-    // MARK: - The sharing pill (top-right): state at a glance, off behind the confirm
+    // MARK: - The sharing pill (top-right, sharing ON only): synced state at a glance, off
+    // behind the confirm. While sharing is off the window shows no pill — the veil IS the state.
 
     private var sharingPill: some View {
-        Button {
-            if enabled { confirmOff = true } else { connect() }
-        } label: {
+        Button { confirmOff = true } label: {
             HStack(spacing: 5) {
                 if busy { ProgressView().controlSize(.mini) }
-                else { Circle().fill(enabled ? Theme.Ink.green : Theme.Ink.deepMuted).frame(width: 6, height: 6) }
-                Text(enabled ? "MCP ON" : "MCP OFF")
+                else { Circle().fill(Theme.Ink.green).frame(width: 6, height: 6) }
+                Text(pillLabel)
             }
             .font(.system(size: 8.5, weight: .semibold, design: .monospaced)).tracking(1.4)
-            .foregroundStyle(enabled ? Theme.Ink.green : Theme.Ink.label)
+            .foregroundStyle(Theme.Ink.green)
             .padding(.horizontal, 9).padding(.vertical, 4)
-            .overlay(Capsule().strokeBorder((enabled ? Theme.Ink.green : Theme.Ink.label).opacity(0.3), lineWidth: 1))
+            .overlay(Capsule().strokeBorder(Theme.Ink.green.opacity(0.3), lineWidth: 1))
             .contentShape(Capsule())
         }
         .buttonStyle(.plain)
         .disabled(busy)
+    }
+
+    /// The synced stamp (the last successful push) answers "is my AIs' copy current?" at a
+    /// glance; no stamp = enabled but not yet pushed.
+    private var pillLabel: String {
+        guard let pushed = MirrorClient.lastPush else { return "MCP ON" }
+        return "MCP ON · SYNCED \(pushed.glanceStamp.uppercased())"
     }
 
     // MARK: - MirrorClient plumbing (the SAME path Settings + the popover drive)
@@ -345,6 +366,12 @@ struct ConnectAIsView: View {
         enabled = await MirrorClient.shared.isEnabled
         shareURL = await MirrorClient.shared.shareURL
         loaded = true
+        // Sharing off: let the guide land crisp for 2 seconds (the teaser), then draw the veil.
+        if !enabled {
+            try? await Task.sleep(for: .seconds(2))
+            guard !enabled, !veiled else { return }
+            withAnimation(.easeInOut(duration: 0.7)) { veiled = true }
+        }
     }
 
     private func connect() {
@@ -358,7 +385,7 @@ struct ConnectAIsView: View {
                 do { try await MirrorClient.shared.push(); VaultActivity.shared.vaultDirty = false }
                 catch {}
                 shareURL = await MirrorClient.shared.shareURL
-                withAnimation(.easeOut(duration: 0.35)) { enabled = true }
+                withAnimation(.easeOut(duration: 0.5)) { enabled = true; veiled = false }
             } catch {
                 errorLine = (error as? LocalizedError)?.errorDescription ?? "\(error)"
             }
@@ -371,7 +398,8 @@ struct ConnectAIsView: View {
         busy = true; errorLine = nil
         Task { @MainActor in
             await MirrorClient.shared.disable()
-            withAnimation(.easeOut(duration: 0.3)) { enabled = false }
+            // The veil returns immediately — no peek; the CTA is the off state's only exit.
+            withAnimation(.easeOut(duration: 0.4)) { enabled = false; veiled = true }
             busy = false
         }
     }

--- a/Sentient OS macOS/Views/HomePopovers.swift
+++ b/Sentient OS macOS/Views/HomePopovers.swift
@@ -4,13 +4,13 @@
 //
 //  The two glanceable dropdowns hung off the home's top-bar nav (HomeView). They keep status
 //  OFF the home itself — you open them only when curious:
-//   · AnalysisPopover — the work glance: things understood, vault size, the synced stamp, an
-//     Analyze Now control, and the source chips (sources are the INPUTS to analysis, so they
-//     live under "Analysis").
+//   · AnalysisPopover — the work glance: things understood, vault size, an Analyze Now control
+//     with the last/next-run footer, and the source chips (sources are the INPUTS to analysis,
+//     so they live under "Analysis").
 //   · ShareKnowledgePopover — the pitch + the glowing "Set up in 2 minutes" CTA that opens the guided
 //     setup window (ConnectAIsView owns sharing on/off, the link, and the prompt).
-//  Pure presentation; harvested from the retired Constellation home. Demo strings (synced
-//  stamp, access log) stand in until the real polls land; the vault counts ARE real (disk).
+//  Pure presentation; harvested from the retired Constellation home. The vault counts ARE real
+//  (disk); the demo deck substitutes its showcase last-run stamp.
 //
 
 import SwiftUI
@@ -31,8 +31,7 @@ struct AnalysisPopover: View {
     let thingsUnderstood: Int
     let sources: HomeSources               // for whatsappAvailable (hide the chip when WhatsApp isn't installed)
     let modelMissing: Bool
-    let syncedLabel: String
-    let pending: Int
+    let lastRun: String                    // last full cycle, pre-formatted by HomeView (deck-aware)
     var onAnalyze: () -> Void
     var onPickWhatsApp: () -> Void = {}    // tapping WhatsApp / iMessage opens the chat picker (in HomeView)
     var onPickIMessage: () -> Void = {}
@@ -64,13 +63,7 @@ struct AnalysisPopover: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            HStack {
-                MonoCaps("Analysis", size: 10, tracking: 2.4, color: Theme.Ink.label)
-                Spacer()
-                MonoCaps(syncedLabel, size: 8.5, tracking: 1.4, color: Theme.Ink.green)
-                    .padding(.horizontal, 9).padding(.vertical, 4)
-                    .overlay(Capsule().strokeBorder(Theme.Ink.green.opacity(0.3), lineWidth: 1))
-            }
+            MonoCaps("Analysis", size: 10, tracking: 2.4, color: Theme.Ink.label)
 
             Text(understoodLine)
                 .display(21).foregroundStyle(.white)
@@ -79,8 +72,7 @@ struct AnalysisPopover: View {
                 .padding(.top, 7)
 
             analyzeButton.padding(.top, 16)
-            MonoCaps(runHint, size: 9, tracking: 1.6, color: Theme.Ink.deepMuted)
-                .padding(.top, 11)
+            runFooter.padding(.top, 11)
 
             Rectangle().fill(.white.opacity(0.06)).frame(height: 1).padding(.vertical, 16)
 
@@ -131,9 +123,27 @@ struct AnalysisPopover: View {
         guard let v = vault, v.notes > 0 else { return "No vault yet · your first analysis builds it" }
         return "\(v.notes) notes · \(v.domains) domains in your knowledge"
     }
-    private var runHint: String {
-        if modelMissing { return "The on-device model is missing; see Dev Tools" }
-        return armed ? "\(pending) pending · runs when your Mac rests" : "No sources armed"
+    /// Under the button: last run + when the next one comes, or the reason nothing can run.
+    @ViewBuilder private var runFooter: some View {
+        if modelMissing {
+            MonoCaps("The on-device model is missing; see Dev Tools", size: 9, tracking: 1.6, color: Theme.Ink.deepMuted)
+        } else if !armed {
+            MonoCaps("No sources armed", size: 9, tracking: 1.6, color: Theme.Ink.deepMuted)
+        } else {
+            VStack(alignment: .leading, spacing: 5) {
+                MonoCaps("Last run: \(lastRun)", size: 9, tracking: 1.6, color: Theme.Ink.deepMuted)
+                MonoCaps("Next run: \(Self.overnightTime) if your Mac is plugged in", size: 9, tracking: 1.6, color: Theme.Ink.deepMuted)
+            }
+        }
+    }
+
+    /// The scheduler's configured time-of-day ("3 AM"; "3:15 AM" off the hour) — live, so a dev
+    /// override of the overnight time shows the truth.
+    private static var overnightTime: String {
+        let minutes = OvernightScheduler.configuredMinutes
+        var comps = DateComponents(); comps.hour = minutes / 60; comps.minute = minutes % 60
+        let f = DateFormatter(); f.dateFormat = minutes % 60 == 0 ? "h a" : "h:mm a"
+        return f.string(from: Calendar.current.date(from: comps) ?? Date())
     }
 
     private var analyzeButton: some View {
@@ -257,8 +267,7 @@ enum HomeStats {
 #Preview("Analysis") {
     ZStack { Theme.bg
         AnalysisPopover(thingsUnderstood: 3339, sources: .init(files: true, whatsapp: true, imessage: true, notes: true),
-                        modelMissing: false, syncedLabel: "Synced · 3:41 AM",
-                        pending: 214, onAnalyze: {})
+                        modelMissing: false, lastRun: "3:41 AM", onAnalyze: {})
     }.frame(width: 380, height: 460).preferredColorScheme(.dark)
 }
 

--- a/Sentient OS macOS/Views/HomeView.swift
+++ b/Sentient OS macOS/Views/HomeView.swift
@@ -270,7 +270,7 @@ struct HomeView: View {
     private var analysisPopover: some View {
         AnalysisPopover(thingsUnderstood: thingsUnderstood, sources: sources,
                         modelMissing: modelMissing,
-                        syncedLabel: syncedLabel, pending: deck == .real ? 0 : Demo.pending,
+                        lastRun: lastRunLabel,
                         onAnalyze: { showAnalysis = false; onAnalyze() },
                         onPickWhatsApp: { showAnalysis = false; showWhatsAppPicker = true },
                         onPickIMessage: { showAnalysis = false; showIMessagePicker = true },
@@ -280,14 +280,14 @@ struct HomeView: View {
             .preferredColorScheme(.dark)
     }
 
-    /// Real mode: the actual last-cycle stamp; demo mode: the showcase string.
-    private var syncedLabel: String {
-        guard deck == .real else { return Demo.synced }
+    /// The Analysis popover's "Last run:" value — the real last-cycle stamp (day spelled out once
+    /// it's no longer today's); demo mode: the showcase string.
+    private var lastRunLabel: String {
+        guard deck == .real else { return Demo.lastRun }
         guard let d = UserDefaults.standard.object(forKey: ProactiveCycle.lastCycleKey) as? Date else {
-            return "Not yet analyzed"
+            return "not yet"
         }
-        let f = DateFormatter(); f.dateFormat = "h:mm a"
-        return "Synced · \(f.string(from: d))"
+        return d.glanceStamp
     }
 
     private var shareKnowledgePopover: some View {
@@ -1097,8 +1097,7 @@ private struct LetterView: View {
 // MARK: - Demo data (the home's own showcase strings — cards live in Briefing.jesaiDemo/.launchDemo)
 
 private enum Demo {
-    static let synced = "Synced · 3:41 AM"
-    static let pending = 214
+    static let lastRun = "3:41 AM"
 }
 
 #Preview("Home — the suggestions") {

--- a/Sentient OS macOS/Views/Theme.swift
+++ b/Sentient OS macOS/Views/Theme.swift
@@ -103,6 +103,19 @@ struct MonoCaps: View {
     }
 }
 
+extension Date {
+    /// The whisper voice's glanceable time stamp — today → "3:18 AM" · yesterday →
+    /// "yesterday 3:18 AM" · older → "Jul 12". Rides the home's "Last run:" line and the
+    /// Connect-AIs pill's synced time (MonoCaps uppercases it in place).
+    var glanceStamp: String {
+        let f = DateFormatter()
+        if Calendar.current.isDateInToday(self) { f.dateFormat = "h:mm a"; return f.string(from: self) }
+        if Calendar.current.isDateInYesterday(self) { f.dateFormat = "h:mm a"; return "yesterday \(f.string(from: self))" }
+        f.dateFormat = "MMM d"
+        return f.string(from: self)
+    }
+}
+
 /// Subtle scale-on-press for custom (non-bordered) buttons across the app.
 struct PressScaleStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {


### PR DESCRIPTION
## What

**Analysis dropdown**
- The footer under Analyze Now now reads `LAST RUN: 3:18 AM` / `NEXT RUN: 3 AM IF YOUR MAC IS PLUGGED IN`, replacing `0 PENDING · RUNS WHEN YOUR MAC RESTS`. Last run is the real `ProactiveCycle.lastCycleKey` stamp (demo deck keeps its showcase string); the next-run hour reads `OvernightScheduler.configuredMinutes` live, so a dev override shows the truth.
- The green `SYNCED · <time>` capsule is gone from this popover.

**Connect AIs window**
- The `MCP ON` pill now carries the synced time: `MCP ON · SYNCED 3:18 AM`. The stamp is the mirror's **actual last successful push** — recorded in `MirrorClient.push()`, cleared when the cloud copy is deleted — not the analysis-cycle time, so it honestly answers "is my AIs' copy current?". Plain `MCP ON` until the first push lands (new key, no history).
- Sharing off: the guide opens as a 2-second inert peek, then blurs under a translucent veil carrying the glowing Connect CTA; pressing it enables the mirror + first push and the blur releases in place. No pill while off.

**Cleanup**
- Shared `Date.glanceStamp` (today → "3:18 AM" · yesterday → "yesterday 3:18 AM" · older → "Jul 12") in Theme, used by both the last-run line and the pill.
- Dead `syncedLabel` + `Demo.synced`/`Demo.pending` plumbing deleted; stale "Synced · …" comments in `ProactiveCycle` updated.

## Verification
- Isolated `xcodebuild` (Debug): **BUILD SUCCEEDED**, no new warnings.
- Deep docs (`MCP Mirror Client.md`, Home doc) still describe the old pill placement — updating them after the UI is confirmed on hardware, per doc practice.

https://claude.ai/code/session_01F8ejD9c881VuYYK8CxCb8e