### PR TITLE
Settings → System: How We Protect Your Data group + Privacy Policy sheet

### DIFF
--- a/Sentient OS macOS/Views/Settings/PrivacyPolicyView.swift
+++ b/Sentient OS macOS/Views/Settings/PrivacyPolicyView.swift
@@ -1,0 +1,68 @@
+//
+//  PrivacyPolicyView.swift
+//  Sentient OS macOS
+//
+//  The Privacy Policy sheet (Settings → System → How We Protect Your Data → Read More).
+//  The whole policy is one screen: the one-line pledge, the two optional features that touch
+//  the cloud (the opt-in E2E MCP mirror, the opt-out crash reports & analytics), and the
+//  Codex CLI note. Static app-voice copy; Done or Esc closes it.
+//
+
+import SwiftUI
+
+struct PrivacyPolicyView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("Privacy Policy")
+                .display(24).foregroundStyle(.white)
+
+            prose("Unlike most privacy policies, ours can be summarized in one line:")
+                .padding(.top, 14)
+            Text("We don't collect your private info, ever.")
+                .font(.system(size: 15, weight: .medium)).foregroundStyle(.white)
+                .padding(.top, 8)
+
+            prose("Sentient has two optional features that let you get more out of it without compromising your privacy:")
+                .padding(.top, 16)
+            bullet("An optional, **opt-in**, end-to-end encrypted cloud MCP, if you want your ChatGPT and Claude to be able to access your knowledge base. Our E2E cloud MCP is open source, too!")
+                .padding(.top, 12)
+            bullet("Privacy-preserving crash logs and analytics, using open-source, privacy-focused libraries (Sentry and TelemetryDeck). You can opt out of crash logs completely, and opt out of analytics (except basic anonymous usage pings). Your personal summaries, knowledge base, and files never leave your device as part of these systems.")
+                .padding(.top, 10)
+
+            prose("When you use features that depend on your Codex CLI, OpenAI's privacy policy will apply.")
+                .padding(.top, 16)
+
+            SettingsPillButton(title: "Done") { dismiss() }
+                .frame(maxWidth: .infinity, alignment: .trailing)
+                .padding(.top, 22)
+        }
+        .padding(.horizontal, 34).padding(.top, 30).padding(.bottom, 24)
+        .frame(width: 470)
+        .background(Theme.bg)
+        .preferredColorScheme(.dark)
+    }
+
+    private func prose(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 12.5)).foregroundStyle(Theme.Ink.body)
+            .lineSpacing(3.5)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    /// A quiet bullet line; the text is a literal, so **bold** renders inline.
+    private func bullet(_ text: LocalizedStringKey) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 9) {
+            Text("•").font(.system(size: 12.5)).foregroundStyle(.white.opacity(0.42))
+            Text(text)
+                .font(.system(size: 12.5)).foregroundStyle(Theme.Ink.body)
+                .lineSpacing(3.5)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}
+
+#Preview("Privacy Policy") {
+    PrivacyPolicyView()
+}

--- a/Sentient OS macOS/Views/Settings/SystemPane.swift
+++ b/Sentient OS macOS/Views/Settings/SystemPane.swift
@@ -5,8 +5,9 @@
 //  Settings → System: how Sentient lives on this Mac. The overnight-intelligence story (prose,
 //  not a control — 3 AM is our taste, not a dial), the launch-at-login toggle (LoginItem.swift)
 //  with its keep-Sentient-alive confirm, the privacy pledge with the two anonymous-reporting
-//  switches (crash reports → CrashReporting/Sentry · analytics → Analytics/TelemetryDeck), and
-//  the danger-zone Reset (the shared FactoryReset wipe — a system-level act, so it lives here),
+//  switches (crash reports → CrashReporting/Sentry · analytics → Analytics/TelemetryDeck), the
+//  how-we-protect-your-data line with its Read More door to the PrivacyPolicyView sheet, the
+//  danger-zone Reset (the shared FactoryReset wipe — a system-level act, so it lives here),
 //  and the Uninstall group (the farewell sheet → the full System/Uninstall teardown).
 //  The updates group lands here once Sparkle ships.
 //
@@ -28,6 +29,7 @@ struct SystemPane: View {
     @State private var confirmReset = false
     @State private var resetting = false
     @State private var showUninstall = false
+    @State private var showPrivacyPolicy = false
     @State private var activity = PipelineActivity.shared   // Reset + Uninstall lock while a run is active
 
     var body: some View {
@@ -41,6 +43,7 @@ struct SystemPane: View {
                 SettingsHairline(opacity: 0.12)
                     .padding(.vertical, -8)
                 privacyGroup
+                protectionGroup
                 SettingsHairline(color: Theme.Ink.red, opacity: 0.25)
                     .padding(.vertical, -8)
                 dangerGroup
@@ -145,6 +148,19 @@ struct SystemPane: View {
         }
         .onChange(of: crashReportsEnabled) { _, _ in CrashReporting.applyEnabledChange() }
         .onChange(of: analyticsEnabled) { _, _ in Analytics.applyEnabledChange() }
+    }
+
+    // MARK: - How we protect your data (the door to the full policy)
+
+    private var protectionGroup: some View {
+        SettingsGroup(label: "How We Protect Your Data") {
+            HStack(spacing: 14) {
+                Text("We never collect your personal info.")
+                    .font(.system(size: 13, weight: .medium)).foregroundStyle(.white)
+                SettingsPillButton(title: "Read More") { showPrivacyPolicy = true }
+            }
+        }
+        .sheet(isPresented: $showPrivacyPolicy) { PrivacyPolicyView() }
     }
 
     // MARK: - Danger zone (the shared FactoryReset wipe)


### PR DESCRIPTION
## What

- New **HOW WE PROTECT YOUR DATA** group in Settings → System, right beneath the Privacy group (inside the privacy chapter, before the red hairline): the line "We never collect your personal info." with a **Read More** pill beside it.
- **Read More** opens the new Privacy Policy sheet (`Views/Settings/PrivacyPolicyView.swift`), matching the Uninstall farewell sheet's form (470pt, OLED black, display-voice title): the one-line pledge, the two optional cloud-touching features (opt-in E2E MCP mirror · opt-out Sentry/TelemetryDeck with the anonymous-pings exception), and the Codex CLI / OpenAI note. Done pill or Esc closes.

## Design notes

App-voice SF throughout (no serif: this is chrome, not the user's life), no em dashes, quiet bullets, **opt-in** bold inline.

## Verification

Isolated CLI build (`-derivedDataPath /tmp/sentient-verify`): BUILD SUCCEEDED. `#Preview` included in the new file.

https://claude.ai/code/session_011csCcGHUWVUWmvcUn1YmVd