### PR TITLE
Notch placeholder: "what can I take over for you?"

### DIFF
--- a/Sentient OS macOS/Notch Magic/NotchView.swift
+++ b/Sentient OS macOS/Notch Magic/NotchView.swift
@@ -331,7 +331,7 @@ struct NotchContent: View {
     private var typingField: some View {
         ZStack(alignment: .leading) {
             if draft.isEmpty {
-                Text("type a task…")
+                Text("what can I take over for you?")
                     .font(.system(size: 13, design: .serif)).italic()
                     .foregroundStyle(.white.opacity(0.4))
                     .allowsHitTesting(false)


### PR DESCRIPTION
One-string copy change (NotchView.swift:334): the tap-to-type placeholder now speaks in the living-machine voice — "what can I take over for you?" — instead of the instructional "type a task…". VoiceOver labels untouched (instructional wording is correct for the affordance). Builds clean.