### PR TITLE
Capitalize the notch placeholder

### DIFF
--- a/Sentient OS macOS/Notch Magic/NotchView.swift
+++ b/Sentient OS macOS/Notch Magic/NotchView.swift
@@ -331,7 +331,7 @@ struct NotchContent: View {
     private var typingField: some View {
         ZStack(alignment: .leading) {
             if draft.isEmpty {
-                Text("what can I take over for you?")
+                Text("What can I take over for you?")
                     .font(.system(size: 13, design: .serif)).italic()
                     .foregroundStyle(.white.opacity(0.4))
                     .allowsHitTesting(false)


### PR DESCRIPTION
One character: "what can I take over for you?" → "What can I take over for you?" — Jesai's chosen casing (follow-up to #212, which landed lowercase from a parallel session).