### PR TITLE
MCP sharing UI polish: cloud-MCP copy, Settings toggle removal, MCP ON switch, popover line

### DIFF
--- a/Sentient OS macOS/Views/ConnectAIsView.swift
+++ b/Sentient OS macOS/Views/ConnectAIsView.swift
@@ -6,12 +6,12 @@
 //  Your AIs and the home's Your AIs popover. Owns the whole story:
 //   · sharing OFF → the guide itself opens first (a 1-second crisp peek, inert), then blurs
 //     under a transparent veil carrying the consent ask: "Connect your AIs?", the trust pillars
-//     (E2E encryption, open-source server, delete anytime), a glowing "Yes, connect my AIs"
+//     (E2E encryption, open-source server, delete anytime), a glowing "Yes, use the cloud MCP"
 //     (enables the mirror + first push, blur releases in place) and a "Not now" that closes the
 //     window. No MCP pill while off.
-//   · sharing ON → per-AI tabs (ChatGPT · Claude · Other AIs), plus a quiet MCP ON pill
-//     top-right (carrying the last synced time) that flips sharing off behind the same
-//     confirm-and-delete alert Settings uses; turning off brings the veil straight back.
+//   · sharing ON → per-AI tabs (ChatGPT · Claude · Other AIs), plus a quiet MCP ON toggle
+//     top-right (carrying the last synced time) that flips sharing off behind the
+//     confirm-and-delete alert; turning off brings the veil straight back.
 //     ChatGPT/Claude show their
 //     GuideSpec's portrait video steps side by side (ChatGPT three: developer mode → paste the
 //     private MCP link → paste the system prompt; Claude two: link → prompt), each with a
@@ -114,13 +114,13 @@ struct ConnectAIsView: View {
                     .frame(maxWidth: 440)
                     .padding(.top, 20)
                 VStack(alignment: .leading, spacing: 10) {
-                    veilPillar("lock.fill", "End-to-end encrypted: sealed on this Mac with a key only your private link holds. On our server it's unreadable ciphertext; we can never read it.")
+                    veilPillar("lock.fill", "An end-to-end encrypted cloud MCP: sealed on this Mac with a key only your private link holds. On our server it's unreadable ciphertext; we can never read it.")
                     veilPillar("chevron.left.forwardslash.chevron.right", "The server in between is open source. Everything's verifiable.")
                     veilPillar("key.fill", "No account. Turn it off anytime and the cloud copy is deleted on the spot.")
                 }
                 .frame(width: 440)
                 .padding(.top, 28)
-                GlowButton(title: busy ? "Connecting…" : "Yes, connect my AIs",
+                GlowButton(title: busy ? "Connecting…" : "Yes, use the cloud MCP",
                            systemImage: "link", glowIntensity: 0.5) { connect() }
                     .frame(width: 280)
                     .padding(.top, 36)
@@ -379,24 +379,27 @@ struct ConnectAIsView: View {
             .strokeBorder(.white.opacity(0.06), lineWidth: 1))
     }
 
-    // MARK: - The sharing pill (top-right, sharing ON only): synced state at a glance, off
-    // behind the confirm. While sharing is off the window shows no pill — the veil IS the state.
+    // MARK: - The sharing toggle (top-right, sharing ON only): synced state at a glance, with a
+    // real switch — off goes through the confirm. While sharing is off the window shows no
+    // toggle — the veil IS the state.
 
     private var sharingPill: some View {
-        Button { confirmOff = true } label: {
-            HStack(spacing: 5) {
-                if busy { ProgressView().controlSize(.mini) }
-                else { Circle().fill(Theme.Ink.green).frame(width: 6, height: 6) }
-                Text(pillLabel)
-            }
-            .font(.system(size: 8.5, weight: .semibold, design: .monospaced)).tracking(1.4)
-            .foregroundStyle(Theme.Ink.green)
-            .padding(.horizontal, 9).padding(.vertical, 4)
-            .overlay(Capsule().strokeBorder(Theme.Ink.green.opacity(0.3), lineWidth: 1))
-            .contentShape(Capsule())
+        HStack(spacing: 8) {
+            if busy { ProgressView().controlSize(.mini) }
+            Text(pillLabel)
+                .font(.system(size: 8.5, weight: .semibold, design: .monospaced)).tracking(1.4)
+                .foregroundStyle(Theme.Ink.green)
+            // The setter never writes `enabled` itself — flipping off only raises the confirm,
+            // so "Keep Sharing" leaves the switch on; disconnect() is what actually turns it off.
+            Toggle("", isOn: Binding(
+                get: { enabled },
+                set: { requested in if !requested { confirmOff = true } }))
+                .labelsHidden().toggleStyle(.switch).controlSize(.mini)
+                .tint(Theme.Ink.green)
+                .disabled(busy)
         }
-        .buttonStyle(.plain)
-        .disabled(busy)
+        .padding(.horizontal, 9).padding(.vertical, 4)
+        .overlay(Capsule().strokeBorder(Theme.Ink.green.opacity(0.3), lineWidth: 1))
     }
 
     /// The synced stamp (the last successful push) answers "is my AIs' copy current?" at a

--- a/Sentient OS macOS/Views/HomePopovers.swift
+++ b/Sentient OS macOS/Views/HomePopovers.swift
@@ -133,6 +133,8 @@ struct AnalysisPopover: View {
             VStack(alignment: .leading, spacing: 5) {
                 MonoCaps("Last run: \(lastRun)", size: 9, tracking: 1.6, color: Theme.Ink.deepMuted)
                 MonoCaps("Next run: \(Self.overnightTime) if your Mac is plugged in", size: 9, tracking: 1.6, color: Theme.Ink.deepMuted)
+                MonoCaps("& Sentient is open in the menu bar", size: 9, tracking: 1.6, color: Theme.Ink.deepMuted)
+                    .frame(maxWidth: .infinity)   // this one line sits centered under the pair
             }
         }
     }

--- a/Sentient OS macOS/Views/Settings/ShareKnowledgePane.swift
+++ b/Sentient OS macOS/Views/Settings/ShareKnowledgePane.swift
@@ -2,12 +2,11 @@
 //  ShareKnowledgePane.swift
 //  Sentient OS macOS
 //
-//  Settings → Give AIs Knowledge: the value + privacy story up top, the share toggle (off =
-//  confirm, then the cloud copy is deleted; the token is kept so the link survives re-enabling),
-//  and the HERO: the glowing "Set up in 2 minutes" button → the real guided setup (ConnectAIsView),
-//  which owns the secret link + system prompt. Live activity from /stats below. Regenerate lives
-//  in MirrorClient only (a support/dev remediation; a UI button was a footgun that bricks every
-//  connector).
+//  Settings → Give AIs Knowledge: the value + privacy story up top, then the HERO: the glowing
+//  "Set up in 2 minutes" button → the real guided setup (ConnectAIsView), always visible — the
+//  window owns sharing on AND off (its consent veil / MCP pill), so this pane carries no toggle.
+//  Live activity from /stats below when sharing is on. Regenerate lives in MirrorClient only
+//  (a support/dev remediation; a UI button was a footgun that bricks every connector).
 //
 
 import SwiftUI
@@ -19,9 +18,6 @@ struct ShareKnowledgePane: View {
     @State private var enabled = false
     @State private var stats: MirrorClient.Stats?
     @State private var loaded = false
-    @State private var busy = false                // a network call is in flight — freeze the toggle
-    @State private var confirmOff = false
-    @State private var errorLine: String?
 
     var body: some View {
         SettingsPane(title: "ChatGPT & Claude",
@@ -31,21 +27,19 @@ struct ShareKnowledgePane: View {
                 cloudSyncGroup
                     .padding(.top, 10)    // same breath as before Activity — the blurb block stands alone
                 if enabled && loaded {
-                    heroButton
-                        .padding(.top, -14)   // belongs to the Cloud Sync group, not floating between groups
                     activityGroup
                         .padding(.top, 10)    // extra breath after the hero
                 } else if loaded {
                     localOnlyProse
                 }
-                if let errorLine {
-                    Text(errorLine)
-                        .font(.system(size: 11)).foregroundStyle(Theme.Ink.amber)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
             }
         }
         .task { await refresh() }
+        // Sharing flips inside the ConnectAIsView window now — re-probe when the user clicks
+        // back into Settings so Activity vs. local-only never shows a stale answer.
+        .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { _ in
+            Task { await refresh() }
+        }
     }
 
     // MARK: - The story (value first, then four scannable privacy pillars — never a wall of text)
@@ -78,61 +72,21 @@ struct ShareKnowledgePane: View {
         }
     }
 
-    // MARK: - The share toggle
+    // MARK: - Cloud Sync (no toggle — ConnectAIsView owns sharing on/off; the hero is the door)
 
     private var cloudSyncGroup: some View {
         SettingsGroup(label: "Cloud Sync") {
-            // A custom binding, NOT $enabled + onChange: the setter fires only when the USER flips
-            // the control, so programmatic `enabled =` writes can't re-trigger the confirm flow.
-            // (The old onChange guard checked `busy`, but turnOff() cleared `busy` in the same
-            // transaction as `enabled = false` — onChange then read busy == false, mistook the
-            // write for a user flip, and re-showed the dialog forever.)
-            SettingToggleLine(title: "Offer your knowledge base to your AIs",
-                              sub: "ChatGPT and Claude read it over MCP. No account, just a private link that only you hold.",
-                              isOn: Binding(
-                                  get: { enabled },
-                                  set: { requested in
-                                      if requested { turnOn() } else { confirmOff = true }
-                                  }))
-                .disabled(busy || !loaded)
-        }
-        .alert("Stop sharing your knowledge base?", isPresented: $confirmOff) {
-            Button("Keep Sharing", role: .cancel) {}       // switch never changed — stays on
-            Button("Stop & Delete Cloud Copy", role: .destructive) { turnOff() }
-        } message: {
-            Text("The cloud copy is deleted immediately and your AIs lose access. Your knowledge base stays safe on this Mac, and turning sharing back on restores the same link.")
-        }
-    }
-
-    private func turnOn() {
-        enabled = true                                     // optimistic — the switch answers instantly
-        busy = true; errorLine = nil
-        Task {
-            do {
-                _ = try await MirrorClient.shared.enable()
-                try? await MirrorClient.shared.push()      // best-effort first fill (no vault yet is fine)
-            } catch {
-                enabled = false
-                errorLine = (error as? LocalizedError)?.errorDescription ?? "\(error)"
+            VStack(alignment: .leading, spacing: 16) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Offer your knowledge base to your AIs")
+                        .font(.system(size: 13, weight: .medium)).foregroundStyle(.white)
+                    Text("ChatGPT and Claude read it over MCP. No account, just a private link that only you hold.")
+                        .font(.system(size: 11)).foregroundStyle(Theme.Ink.body)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                ConnectCTA { openWindow(id: ConnectAIsView.windowID) }
             }
-            busy = false
         }
-    }
-
-    private func turnOff() {
-        busy = true; errorLine = nil
-        Task {
-            await MirrorClient.shared.disable()
-            enabled = false
-            stats = nil
-            busy = false
-        }
-    }
-
-    // MARK: - The hero: the guided setup (settings-scale glow — a gradient ring, not the home's sun)
-
-    private var heroButton: some View {
-        ConnectCTA { openWindow(id: ConnectAIsView.windowID) }
     }
 
     // MARK: - Activity


### PR DESCRIPTION
Four small MCP-sharing UI changes:

- **ConnectAIsView consent veil:** the CTA now reads "Yes, use the cloud MCP", and the first trust pillar names the feature: "An end-to-end encrypted cloud MCP: sealed on this Mac…"
- **Settings → Give AIs Knowledge:** the Cloud Sync toggle is removed — ConnectAIsView (veil to enable, MCP pill to disable) is now the single owner of sharing on/off, so the pane's duplicate turnOn/turnOff plumbing + confirm alert are deleted with it. "Set up in 2 minutes" now shows always, MCP on or off. Since sharing flips in the other window, the pane re-probes on key-window change so Activity vs. the local-only prose never shows stale.
- **ConnectAIsView top-right:** the MCP ON pill is now a real mini switch (same green mono-caps label + synced stamp); flipping off raises the same confirm-and-delete alert, and a cancelled confirm leaves the switch on because the binding setter never writes state directly.
- **Analysis popover:** new centered whisper "& Sentient is open in the menu bar" under the "Next run: 3 AM if your Mac is plugged in" line.

Compile-verified via isolated-DerivedData xcodebuild after each change. Docs (Settings.md / architecture §8) intentionally not updated yet, pending a live-run check of the new flows.

https://claude.ai/code/session_01RhsmsabhsgKxnHJY1YQwxt