### PR TITLE
Dev Tools: demo bar baseline (display-only recording knob)

### DIFF
--- a/Sentient OS macOS/Views/Dev/DevToolsView.swift
+++ b/Sentient OS macOS/Views/Dev/DevToolsView.swift
@@ -95,6 +95,10 @@ struct DevToolsView: View {
     // Demo: free-resize the home's analysis takeover (ProcessingView owns the key).
     @AppStorage(ProcessingView.resizableDemoKey) private var resizableAnalysisDemo = false
 
+    // Demo: start the analysis bar mid-run (ProcessingView owns the keys; total 0 = off).
+    @AppStorage(ProcessingView.demoBaseDoneKey) private var demoBaseDone = 0
+    @AppStorage(ProcessingView.demoBaseTotalKey) private var demoBaseTotal = 0
+
 
     // MCP mirror (the hosted Render copy). Local mirrors of MirrorClient's actor state, refreshed
     // when "More" opens and after each action.
@@ -174,6 +178,29 @@ struct DevToolsView: View {
         .background(.white.opacity(0.03), in: RoundedRectangle(cornerRadius: 12))
     }
 
+    /// Demo: the analysis bar opens as if this much were already done — "baseDone + real of
+    /// baseTotal", kept/junk tags seeded proportionally. Display-only; total 0 = off.
+    private var demoBarBaselineSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Demo bar baseline")
+                .font(.callout.weight(.medium)).foregroundStyle(.white)
+            HStack(spacing: 8) {
+                TextField("done", value: $demoBaseDone, format: .number)
+                    .textFieldStyle(.roundedBorder).frame(width: 72)
+                Text("of").font(.caption).foregroundStyle(Theme.faint)
+                TextField("total", value: $demoBaseTotal, format: .number)
+                    .textFieldStyle(.roundedBorder).frame(width: 72)
+                Spacer()
+            }
+            Text("Analysis opens as if this much were already done (290 of 416 ≈ 70%) and real items count up from there; kept/junk seed proportionally. Display-only — pipeline and stats untouched. Total 0 = off. For the website's screen rec.")
+                .font(.caption2).foregroundStyle(Theme.faint)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity)
+        .background(.white.opacity(0.03), in: RoundedRectangle(cornerRadius: 12))
+    }
+
     /// One deck segment — lit when it's the active mode.
     private func deckButton(_ mode: BriefingDeck, _ label: String) -> some View {
         let selected = (BriefingDeck(rawValue: deckRaw) ?? .real) == mode
@@ -227,6 +254,7 @@ struct DevToolsView: View {
                     executeButton
                     proactiveCardsSection
                     resizableAnalysisSection
+                    demoBarBaselineSection
                     HStack(spacing: 10) {
                         viewSummariesButton
                         viewActionItemsButton

--- a/Sentient OS macOS/Views/ProcessingView.swift
+++ b/Sentient OS macOS/Views/ProcessingView.swift
@@ -85,6 +85,22 @@ struct ProcessingView: View {
     static let resizableDemoKey = "dev.processing.resizableDemo"
     @AppStorage(ProcessingView.resizableDemoKey) private var resizableDemo = false
 
+    /// Dev Tools → "Demo bar baseline". While `total` > 0, the bar RENDERS as if a big run were
+    /// already mid-flight — `baseDone + real done` of `baseTotal`, with the kept/junk tags seeded
+    /// proportionally so a 70% bar never sits over "0 kept · 0 junk" — letting a website screen
+    /// recording open at "290 of 416" instead of 0. Display-only: the pipeline, marks, and
+    /// lifetime counters are untouched.
+    static let demoBaseDoneKey = "dev.processing.demoBaseDone"
+    static let demoBaseTotalKey = "dev.processing.demoBaseTotal"
+    @AppStorage(ProcessingView.demoBaseDoneKey) private var demoBaseDone = 0
+    @AppStorage(ProcessingView.demoBaseTotalKey) private var demoBaseTotal = 0
+
+    /// What the bar and count tags SHOW — real progress plus the demo baseline (when set).
+    private var shownDone: Int { progress.done + (demoBaseTotal > 0 ? demoBaseDone : 0) }
+    private var shownTotal: Int { demoBaseTotal > 0 ? demoBaseTotal : progress.total }
+    private var shownSurvivors: Int { progress.survivors + (demoBaseTotal > 0 ? demoBaseDone * 58 / 100 : 0) }
+    private var shownJunk: Int { progress.junk + (demoBaseTotal > 0 ? demoBaseDone * 36 / 100 : 0) }
+
     private enum UIState: Equatable { case loadingModel, processing, preparing, completed, failed(CycleFailure) }
     @State private var state: UIState = .loadingModel
     /// The failed screen's inline codex login (the "Codex isn't logged in" fix) — same shared
@@ -197,9 +213,9 @@ struct ProcessingView: View {
             AnalyzingTitle()
 
             VStack(spacing: 10) {
-                GlowProgressBar(value: progress.total > 0 ? Double(progress.done) / Double(progress.total) : 0)
+                GlowProgressBar(value: shownTotal > 0 ? Double(shownDone) / Double(shownTotal) : 0)
                 HStack {
-                    Text("\(progress.done) of \(progress.total)").fontWeight(.bold).monospacedDigit()
+                    Text("\(shownDone) of \(shownTotal)").fontWeight(.bold).monospacedDigit()
                     Spacer()
                     Text("\(percent)%").monospacedDigit()
                 }
@@ -243,8 +259,8 @@ struct ProcessingView: View {
 
     private var countsLine: some View {
         HStack(spacing: 16) {
-            countTag(progress.survivors, "kept", Theme.verdictColor(.survivor))
-            countTag(progress.junk, "junk", Theme.verdictColor(.junk))
+            countTag(shownSurvivors, "kept", Theme.verdictColor(.survivor))
+            countTag(shownJunk, "junk", Theme.verdictColor(.junk))
             if let last = progress.lastSeconds {
                 Text("· \(String(format: "%.1f", last))s/file")
                     .font(.caption).foregroundStyle(.white.opacity(0.4))
@@ -616,7 +632,7 @@ struct ProcessingView: View {
     }
 
     private var percent: Int {
-        progress.total > 0 ? Int(Double(progress.done) / Double(progress.total) * 100) : 0
+        shownTotal > 0 ? Int(Double(shownDone) / Double(shownTotal) * 100) : 0
     }
 
     // MARK: Run


### PR DESCRIPTION
## What
Two Dev Tools fields (\`done\` / \`total\`) that make the analysis takeover OPEN as if a big run were already mid-flight — bar, percent, and proportionally-seeded kept/junk tags — so a website screen recording starts at "290 of 416 · 70%" instead of 0. Real items count up from the baseline.

## Prod safety
- **Display-only by construction**: \`shown*\` computeds wrap rendering only — pipeline, high-water marks, and LifetimeStats are untouched.
- **Off by default**: \`total = 0\` (unset) short-circuits every computed back to real progress. Opt-in via Dev Tools only.
- Sibling of the existing \`resizableDemo\` recording toggle; keys owned by ProcessingView like that one.

Already battle-tested: this knob shot the website hero recording (the film's ProcessingWindow clip).