### PR TITLE
Onboarding step 1+2: the website film in a webview, with the hardware notch beat

### DIFF
--- a/Sentient OS macOS/Notch Magic/CommandCoordinator.swift
+++ b/Sentient OS macOS/Notch Magic/CommandCoordinator.swift
@@ -64,6 +64,20 @@ final class CommandCoordinator {
     /// until the next interaction starts.
     private(set) var notchAnchor: NotchAnchor = .mainDisplay
 
+    /// Onboarding's film step arms this while the film is parked on "Click the notch": the next
+    /// notch click plays the scripted Sidekick demo on the user's real bezel — the real type field,
+    /// the task typing itself, the run model's scripted story — with the two real-world doors (the
+    /// Plus aside, the first-use permission gate) deliberately bypassed: nothing real can fire, so
+    /// there is nothing to gate. One-shot: consumed at fire, restored by a dismissed field,
+    /// disarmed when the film step leaves.
+    private(set) var onboardingDemoArmed = false
+    private var onboardingDemoFired: (() -> Void)?
+    private var demoTask: Task<Void, Never>?
+
+    /// What the demo is currently "typing" — NotchContent mirrors it into the field's draft, so
+    /// the show runs through the REAL TextField. nil = the user owns the field.
+    private(set) var demoDraft: String?
+
     private let hotkey = SidekickHotkeyMonitor()
     private let voice = VoiceCapture()
     private var hotkeyChangeObserver: NSObjectProtocol?
@@ -324,6 +338,9 @@ final class CommandCoordinator {
     /// ⏎ from the notch field — fire it as a computer-use task (empty just closes).
     func submitTyped(_ text: String) {
         guard phase == .typing else { return }
+        // While the onboarding demo owns the field, a stray user ⏎ must never reach the real
+        // submit path (the script fires the demo itself).
+        guard !onboardingDemoArmed else { return }
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { dismissTyping(); return }
         submit(trimmed, mode: .computer, source: .notchTyped)   // typed → no read-back
@@ -352,6 +369,7 @@ final class CommandCoordinator {
     func notchClicked() {
         guard phase == .hidden, !run.isRunning else { return }
         notchAnchor = .builtInNotch       // the whole session lives on the bezel that was clicked
+        if onboardingDemoArmed { beginNotchDemo(); return }
         if CodexAuth.knowledgeBaseOnly {
             flash(Self.needsPlusNotice, for: 2.0)
             Log("notch click blocked — knowledge-base-only plan (Sidekick needs Plus)")
@@ -363,6 +381,61 @@ final class CommandCoordinator {
         }
         setPhase(.typing)
         Log("notch clicked → typing")
+    }
+
+    // MARK: The onboarding notch demo (the film step's "click the notch" beat)
+
+    /// Arm the one-shot demo. `onFired` is the film step's cue to resume the webview ride the
+    /// moment the demo "presses ⏎" — the film's browser windows play the shopping run while the
+    /// real notch narrates.
+    func armOnboardingNotchDemo(onFired: @escaping () -> Void) {
+        onboardingDemoArmed = true
+        onboardingDemoFired = onFired
+        Log("onboarding notch demo ARMED")
+    }
+
+    /// Disarm + cancel any in-flight typing script (the film step left, or SKIP). A demo RUN
+    /// already in flight is left to finish on its own — it's pure theater and self-retracts.
+    func disarmOnboardingNotchDemo() {
+        guard onboardingDemoArmed || demoTask != nil else { return }
+        onboardingDemoArmed = false
+        onboardingDemoFired = nil
+        demoTask?.cancel(); demoTask = nil
+        demoDraft = nil
+        Log("onboarding notch demo disarmed")
+    }
+
+    /// The demo click: the REAL type field opens (no Plus aside, no permission gate — nothing real
+    /// can fire), the film's task types itself, then the run model performs the scripted story.
+    /// A dismissed field (Esc / click-away / hotkey tap) bails the script and re-arms for another
+    /// click; the arm is consumed only when the demo actually fires.
+    private func beginNotchDemo() {
+        setPhase(.typing)
+        Log("notch clicked → onboarding demo (typing)")
+        demoTask = Task { [weak self] in
+            do {
+                try await Task.sleep(for: .seconds(0.7))          // the field's bloom + focus settle
+                let task = "order this stuff"
+                for i in 1...task.count {
+                    guard let self, self.phase == .typing else { self?.demoDraft = nil; return }
+                    self.demoDraft = String(task.prefix(i))
+                    try await Task.sleep(for: .seconds(0.07))
+                }
+                try await Task.sleep(for: .seconds(0.4))          // the beat before ⏎
+                guard let self, self.phase == .typing else { self?.demoDraft = nil; return }
+                self.demoDraft = nil
+                self.onboardingDemoArmed = false                  // consumed — later clicks are real
+                let fired = self.onboardingDemoFired
+                self.onboardingDemoFired = nil
+                self.demoTask = nil
+                self.run.startOnboardingDemo()
+                self.setPhase(.running)
+                Log("▶︎ onboarding notch demo fired")
+                fired?()
+            } catch {
+                self?.demoDraft = nil                             // cancelled by disarm — nothing to restore
+            }
+        }
     }
 
     /// Cancel — back out of whatever the notch is doing, mirroring the obvious one-tap action for each state:

--- a/Sentient OS macOS/Notch Magic/CommandCoordinator.swift
+++ b/Sentient OS macOS/Notch Magic/CommandCoordinator.swift
@@ -125,6 +125,10 @@ final class CommandCoordinator {
         // notch-anchored one to the main display the moment ⏎ lands.
         if source == .promptBar { notchAnchor = .mainDisplay }
 
+        // The onboarding backstop: no run — and therefore no permission gate — can EVER fire
+        // before the home screen (the press doors are already guarded; this covers everything).
+        if interceptForOnboarding() { return }
+
         // Knowledge-base-only backstop (the hotkey path already flashed at press) — covers the
         // home command bar, which submits without a press. The run must never fire on free/go.
         if CodexAuth.knowledgeBaseOnly {
@@ -177,6 +181,45 @@ final class CommandCoordinator {
     /// notice: [do X] to [get Y], in the living-machine voice ("wake", not "unlock").
     private static let needsPlusNotice = "get ChatGPT Plus to wake Sidekick"
 
+    // MARK: Sidekick before the home screen (the onboarding policy)
+
+    /// Sidekick is HOME-ONLY. Until onboarding completes, a press can never open the notch, fire
+    /// a run, or raise the first-use permission gate — before the film's notch beat a press does
+    /// NOTHING (silence; the hover swell is off too, via notchButtonAvailable); after the beat it
+    /// answers with the honest aside. Live-checked per press so it can never go stale.
+    private static var hasCompletedOnboarding: Bool {
+        UserDefaults.standard.bool(forKey: AppState.onboardingKey)
+    }
+
+    /// Flipped the moment the film's notch beat is behind the user (the demo fired, or the film
+    /// step was skipped/advanced) — from here presses get the aside instead of silence.
+    /// FactoryReset wipes it with the rest of the defaults (the onboarding rewind).
+    static let notchDemoPlayedKey = "onboarding.notchDemoPlayed"
+
+    private static let finishOnboardingNotice = "finish onboarding to use Sidekick"
+
+    /// The window controller's gate for the hover affordance: no swell for a button that would
+    /// do nothing (pre-beat silence); during the beat and after it, the swell is honest.
+    var notchButtonAvailable: Bool {
+        Self.hasCompletedOnboarding || onboardingDemoArmed
+            || UserDefaults.standard.bool(forKey: Self.notchDemoPlayedKey)
+    }
+
+    /// True = the press was consumed by the onboarding policy (silence, or the aside). The
+    /// armed demo exempts only the notch CLICK — the film says "click the notch", so a hotkey
+    /// press stays quiet even during the beat.
+    private func interceptForOnboarding(demoEligible: Bool = false) -> Bool {
+        guard !Self.hasCompletedOnboarding else { return false }
+        if demoEligible, onboardingDemoArmed { return false }
+        if UserDefaults.standard.bool(forKey: Self.notchDemoPlayedKey) {
+            flash(Self.finishOnboardingNotice, for: 2.0)
+            Log("sidekick press during onboarding — the finish-onboarding aside")
+        } else {
+            Log("sidekick press during onboarding — silent (pre notch beat)")
+        }
+        return true
+    }
+
     private func voicePressBegan() {
         guard VoiceCapture.isAvailable else { return }
         // A hotkey tap while the type field is open toggles it closed (no action) — a quick way to back out.
@@ -193,6 +236,9 @@ final class CommandCoordinator {
         }
         guard !run.isRunning, !isInteracting else { Log("hotkey ignored — busy"); return }
         notchAnchor = .mainDisplay        // the hotkey always lives on the main display (incl. the asides below)
+        // Before the home screen, Sidekick doesn't exist yet (the onboarding policy above) —
+        // and the permission gate below can therefore never rise during onboarding.
+        if interceptForOnboarding() { return }
         // Knowledge-base-only plan (free/go): the notch answers the press INSTANTLY with the
         // Plus aside — same immediate beat as the mic-perms notice — and never opens for
         // listening or typing. Checked live per press, so it can never go stale.
@@ -370,6 +416,8 @@ final class CommandCoordinator {
         guard phase == .hidden, !run.isRunning else { return }
         notchAnchor = .builtInNotch       // the whole session lives on the bezel that was clicked
         if onboardingDemoArmed { beginNotchDemo(); return }
+        // Before home: silence pre-beat (the swell is off then anyway), the aside after.
+        if interceptForOnboarding(demoEligible: true) { return }
         if CodexAuth.knowledgeBaseOnly {
             flash(Self.needsPlusNotice, for: 2.0)
             Log("notch click blocked — knowledge-base-only plan (Sidekick needs Plus)")
@@ -425,6 +473,7 @@ final class CommandCoordinator {
                 guard let self, self.phase == .typing else { self?.demoDraft = nil; return }
                 self.demoDraft = nil
                 self.onboardingDemoArmed = false                  // consumed — later clicks are real
+                UserDefaults.standard.set(true, forKey: Self.notchDemoPlayedKey)   // beat done → presses get the aside
                 let fired = self.onboardingDemoFired
                 self.onboardingDemoFired = nil
                 self.demoTask = nil

--- a/Sentient OS macOS/Notch Magic/CommandRunModel.swift
+++ b/Sentient OS macOS/Notch Magic/CommandRunModel.swift
@@ -103,6 +103,66 @@ final class CommandRunModel {
         task?.cancel()
     }
 
+    // MARK: The onboarding notch demo
+
+    /// The film step's scripted run — the notch performs the film's shopping story on the user's
+    /// real bezel with NOTHING real underneath: no codex, no screenshots, and deliberately no
+    /// scoreboard or analytics (a demo is not a health signal, so complete() is bypassed). The
+    /// lines are codex-SHAPED and replay through the real push() cleaner, so the status bar and
+    /// the "Remembering" bloom render exactly as a live run does. Same finishing contract
+    /// (onFinished → the coordinator's ✓ flourish + retract); stop() cancels it like any run.
+    func startOnboardingDemo() {
+        guard !isRunning else { return }
+        mode = .computer
+        isRunning = true
+        recent = []; section = ""
+        remembering = nil; rememberClear?.cancel()
+        statusLine = "Starting computer use…"
+        Log("──────── 🤖 NOTCH DEMO (onboarding, scripted) ────────")
+        let vault = VaultGenerator.vaultRoot.path
+        // (pause-before-line, line) — paced to the film's background beat (~9s to ✓).
+        let script: [(Double, String)] = [
+            (0.8, "codex"),
+            (0.0, "Thinking through your task"),
+            (1.6, "exec"),
+            (0.0, "cat '\(vault)/Kitchen/Pantry & Fridge.md'"),
+            (2.1, "codex"),
+            (0.0, "You already have arborio rice, butter, and lemons"),
+            (2.2, "Opening amazing in a background window"),
+            (1.9, "Adding the missing ingredients to the cart"),
+        ]
+        task = Task { [weak self] in
+            do {
+                for (pause, line) in script {
+                    try await Task.sleep(for: .seconds(pause))
+                    guard let self, self.isRunning else { return }
+                    self.push(line)
+                }
+                try await Task.sleep(for: .seconds(1.7))
+                guard let self, self.isRunning else { return }
+                Log("──────── 🤖 ✓ NOTCH DEMO done ────────")
+                self.demoFinish(.success, line: "✓ done")
+            } catch {   // cancelled — a STOP mid-demo gets the honest beat, same as a real run
+                guard let self, self.isRunning else { return }
+                Log("──────── 🤖 ■ NOTCH DEMO stopped ────────")
+                self.demoFinish(.stopped, line: "■ stopped")
+            }
+        }
+    }
+
+    /// The demo's exit — complete() minus the scoreboard + analytics a fake run must never feed.
+    private func demoFinish(_ outcome: Outcome, line: String) {
+        clearRemembering()
+        statusLine = line
+        isRunning = false
+        task = nil
+        onFinished?(outcome)
+        Task { [weak self] in
+            try? await Task.sleep(for: .seconds(outcome == .success ? 2.5 : 4.5))
+            if let self, !self.isRunning { self.statusLine = "" }
+        }
+    }
+
     private func push(_ line: String) {
         guard isRunning else { return }
 

--- a/Sentient OS macOS/Notch Magic/NotchView.swift
+++ b/Sentient OS macOS/Notch Magic/NotchView.swift
@@ -164,6 +164,7 @@ struct NotchView: View {
                      statusLine: coordinator.run.statusLine,
                      remembering: coordinator.run.remembering,
                      hovering: coordinator.notchHovering,
+                     demoText: coordinator.demoDraft,
                      metrics: metrics,
                      onStop: { coordinator.stop() },
                      onSubmitText: { coordinator.submitTyped($0) },
@@ -182,6 +183,9 @@ struct NotchContent: View {
     /// drop shadow — no glow, no content — and a click opens the type field. Honored only while
     /// `.hidden`; any real phase owns the shape.
     var hovering: Bool = false
+    /// The onboarding demo's auto-typing: when set, the type field's draft mirrors it (the show
+    /// runs through the REAL TextField). nil = the user owns the field.
+    var demoText: String? = nil
     let metrics: NotchMetrics
     var onStop: () -> Void = {}
     var onSubmitText: (String) -> Void = { _ in }
@@ -247,6 +251,11 @@ struct NotchContent: View {
             } else {
                 fieldFocused = false
             }
+        }
+        // The onboarding demo types through the real field: the draft mirrors the scripted text
+        // while it's set (the field renders + measures exactly as if the user typed it).
+        .onChange(of: demoText) { _, text in
+            if let text { draft = text }
         }
     }
 

--- a/Sentient OS macOS/Notch Magic/NotchWindowController.swift
+++ b/Sentient OS macOS/Notch Magic/NotchWindowController.swift
@@ -389,7 +389,10 @@ final class NotchWindowController {
         if mouseTimerInterval == Self.pollFar, nearZone.contains(location) {
             retuneMouseTimer()
         }
-        guard !hovering, coordinator.phase == .hidden, hoverEntryRect.contains(location) else { return }
+        // notchButtonAvailable: during onboarding, before the film's notch beat, a click would do
+        // NOTHING — so the swell stays off too (a button must never tease a dead click).
+        guard !hovering, coordinator.phase == .hidden, coordinator.notchButtonAvailable,
+              hoverEntryRect.contains(location) else { return }
         beginHover()
     }
 

--- a/Sentient OS macOS/Views/Onboarding/OnboardingFilmView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingFilmView.swift
@@ -66,11 +66,14 @@ struct OnboardingFilmView: View {
                     .allowsHitTesting(false)
 
                 // Continue blooms in the moment the film parks on the morning home.
+                // Hugs the window bottom — at the parked frame the Mac's chassis reaches
+                // low, and the button must sit in the black band BELOW the laptop, never
+                // on its base.
                 if phase == .parked {
                     VStack {
                         Spacer()
                         OnboardingNextButton(title: "Continue", action: onContinue)
-                            .padding(.bottom, 42)
+                            .padding(.bottom, 14)
                     }
                     .transition(.opacity)
                 }

--- a/Sentient OS macOS/Views/Onboarding/OnboardingFilmView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingFilmView.swift
@@ -1,0 +1,222 @@
+//
+//  OnboardingFilmView.swift
+//  Sentient OS macOS
+//
+//  Onboarding slide 1 — the website's film (sentient-os.ai/onboarding) playing inside a
+//  WKWebView. The page drives itself (its Autopilot scrolls the film) and parks at the
+//  morning-home rest (?end=0.54 in film progress); at the park it posts "parked" to the
+//  `autopilot` message handler and the native Continue button blooms in. The webview is a
+//  movie, not a page: hit-testing returns nil (no scrolling, no clicks), navigation off our
+//  host is blocked, and the view fades in black-on-black only after the page loads (no
+//  flash). Offline or a failed load falls back to a quiet branded slide, so onboarding is
+//  never blocked on the network. Watchdogs bound every wait: 12s to load, 40s to park.
+//  DEBUG: `defaults write` the string `dev.film.url` to point the step at a local dev
+//  server (e.g. http://localhost:3100/onboarding?end=0.54).
+//
+
+import SwiftUI
+import WebKit
+
+struct OnboardingFilmView: View {
+    let onContinue: () -> Void
+
+    /// The step's phases: black until the page loads → the ride → parked (Continue up).
+    /// `unavailable` is the offline fallback slide.
+    private enum Phase { case loading, playing, parked, unavailable }
+    @State private var phase: Phase = .loading
+
+    /// The production cut: the film to the morning-home rest (film p 0.54, just before
+    /// Scene III's turn). Pace rides the page's own defaults.
+    private static let productionURL = URL(string: "https://sentient-os.ai/onboarding?end=0.54")!
+
+    private static var filmURL: URL {
+        #if DEBUG
+        if let raw = UserDefaults.standard.string(forKey: "dev.film.url"),
+           let url = URL(string: raw) { return url }
+        #endif
+        return productionURL
+    }
+
+    var body: some View {
+        ZStack {
+            Theme.bg.ignoresSafeArea()
+
+            if phase == .unavailable {
+                fallbackSlide.transition(.opacity)
+            } else {
+                FilmWebView(url: Self.filmURL,
+                            onLoaded: { setPhase(.playing) },
+                            onParked: { setPhase(.parked) },
+                            onFailed: { if phase != .parked { setPhase(.unavailable) } })
+                    .ignoresSafeArea()
+                    .opacity(phase == .loading ? 0 : 1)
+                    .allowsHitTesting(false)
+
+                // Continue blooms in the moment the film parks on the morning home.
+                if phase == .parked {
+                    VStack {
+                        Spacer()
+                        OnboardingNextButton(title: "Continue", action: onContinue)
+                            .padding(.bottom, 42)
+                    }
+                    .transition(.opacity)
+                }
+            }
+        }
+        // A quiet skip for the impatient, gone once Continue is up.
+        .overlay(alignment: .bottomLeading) {
+            if phase == .loading || phase == .playing {
+                FilmSkipButton(action: onContinue)
+                    .padding(.leading, 22).padding(.bottom, 13)
+                    .transition(.opacity)
+            }
+        }
+        // Load watchdog: a first launch with no internet lands on the fallback, never a void.
+        .task {
+            try? await Task.sleep(for: .seconds(12))
+            if phase == .loading { setPhase(.unavailable) }
+        }
+        // Park watchdog: the ride to p 0.54 takes ~15s after load; if the park signal never
+        // arrives (old deploy without ?end, JS hiccup), Continue blooms anyway.
+        .task(id: phase == .playing) {
+            guard phase == .playing else { return }
+            try? await Task.sleep(for: .seconds(40))
+            if phase == .playing { setPhase(.parked) }
+        }
+    }
+
+    private func setPhase(_ new: Phase) {
+        withAnimation(.easeInOut(duration: 0.45)) { phase = new }
+    }
+
+    /// The no-internet stand-in: the promise in one line, and onboarding moves on.
+    private var fallbackSlide: some View {
+        VStack(spacing: 40) {
+            Spacer()
+            OnboardingWhisper("STEP 1 OF 3")
+            Text("An AI that knows your life, and acts on it.")
+                .display(30)
+            OnboardingNextButton(title: "Continue", action: onContinue)
+            Spacer()
+            OnboardingTrustFooter()
+        }
+        .padding(40)
+    }
+}
+
+/// The corner skip — a mono whisper, quiet until hovered.
+private struct FilmSkipButton: View {
+    let action: () -> Void
+    @State private var hovering = false
+
+    var body: some View {
+        Button(action: action) {
+            Text("SKIP")
+                .font(.system(size: 9, weight: .medium, design: .monospaced))
+                .tracking(1.6)
+                .foregroundStyle(hovering ? Theme.secondary : Theme.Ink.deepMuted)
+                .padding(.horizontal, 10).padding(.vertical, 5)
+                .overlay(Capsule().strokeBorder(Color.white.opacity(0.07), lineWidth: 1))
+                .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .opacity(0.6)
+        .onHover { hovering = $0 }
+        .animation(.easeInOut(duration: 0.15), value: hovering)
+    }
+}
+
+// MARK: - The webview
+
+/// A WKWebView that can never be interacted with, so the film can't be scrolled off its
+/// autopilot or clicked away: hitTest nil keeps the whole subtree out of event routing,
+/// the scrollWheel stub swallows anything that arrives some other way (responder chain),
+/// and refusing first-responder keeps keyboard scrolling (space, arrows) out too.
+private final class PassiveWebView: WKWebView {
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+    override func scrollWheel(with event: NSEvent) {}
+    override var acceptsFirstResponder: Bool { false }
+}
+
+private struct FilmWebView: NSViewRepresentable {
+    let url: URL
+    let onLoaded: () -> Void
+    let onParked: () -> Void
+    let onFailed: () -> Void
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    func makeNSView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        // Onboarding runs once — no cookies or cache worth keeping.
+        config.websiteDataStore = .nonPersistent()
+        config.userContentController.add(context.coordinator, name: "autopilot")
+
+        let webView = PassiveWebView(frame: .zero, configuration: config)
+        webView.navigationDelegate = context.coordinator
+        webView.underPageBackgroundColor = .black   // never a white flash behind the film
+        webView.allowsMagnification = false
+        webView.allowsBackForwardNavigationGestures = false
+        webView.load(URLRequest(url: url))
+        return webView
+    }
+
+    func updateNSView(_ webView: WKWebView, context: Context) {}
+
+    static func dismantleNSView(_ webView: WKWebView, coordinator: Coordinator) {
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: "autopilot")
+        webView.stopLoading()
+    }
+
+    final class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
+        private let parent: FilmWebView
+        init(_ parent: FilmWebView) { self.parent = parent }
+
+        func userContentController(_ userContentController: WKUserContentController,
+                                   didReceive message: WKScriptMessage) {
+            if message.name == "autopilot", message.body as? String == "parked" {
+                parent.onParked()
+            }
+        }
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            parent.onLoaded()
+        }
+
+        func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+            Log("Onboarding film: load failed — \(ErrorLabel(error))")
+            parent.onFailed()
+        }
+
+        func webView(_ webView: WKWebView,
+                     didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+            Log("Onboarding film: provisional load failed — \(ErrorLabel(error))")
+            parent.onFailed()
+        }
+
+        /// The film is the only thing this view will ever show — same-host loads only.
+        func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction,
+                     decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+            decisionHandler(navigationAction.request.url?.host == parent.url.host ? .allow : .cancel)
+        }
+
+        /// An HTTP error page (404 before the site route deploys, a server incident) is a
+        /// failed load, not a film — cancel it so the fallback slide shows instead.
+        func webView(_ webView: WKWebView, decidePolicyFor navigationResponse: WKNavigationResponse,
+                     decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void) {
+            if navigationResponse.isForMainFrame,
+               let http = navigationResponse.response as? HTTPURLResponse, http.statusCode >= 400 {
+                Log("Onboarding film: HTTP \(http.statusCode) — falling back")
+                decisionHandler(.cancel)
+                return
+            }
+            decisionHandler(.allow)
+        }
+    }
+}
+
+#Preview("Onboarding — film slide") {
+    OnboardingFilmView(onContinue: {})
+        .frame(width: 1180, height: 880)
+        .preferredColorScheme(.dark)
+}

--- a/Sentient OS macOS/Views/Onboarding/OnboardingFilmView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingFilmView.swift
@@ -199,9 +199,12 @@ final class FilmDriver {
     weak var webView: WKWebView?
 
     /// Resume the parked ride to a new film-p address (leg 2: the Sidekick scene).
-    func continueTo(_ end: Double) {
-        Log("Onboarding film: continueTo(\(end))")
-        webView?.evaluateJavaScript("window.__sentientAutopilot?.continueTo(\(end))")
+    /// delay = the breath before motion; pace = full-film-pace seconds for this leg
+    /// (lower = faster; the Sidekick leg rides brisker than the site default).
+    func continueTo(_ end: Double, delay: Double = 0.1, pace: Double = 20) {
+        Log("Onboarding film: continueTo(\(end), delay: \(delay), pace: \(pace))")
+        webView?.evaluateJavaScript(
+            "window.__sentientAutopilot?.continueTo(\(end), \(delay), \(pace))")
     }
 }
 

--- a/Sentient OS macOS/Views/Onboarding/OnboardingFilmView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingFilmView.swift
@@ -20,6 +20,10 @@ import WebKit
 struct OnboardingFilmView: View {
     let onContinue: () -> Void
 
+    /// For the notch demo: the film step arms the coordinator's one-shot scripted Sidekick
+    /// performance while the film is parked on "Click the notch".
+    @Environment(AppState.self) private var appState
+
     /// The step's phases, two film legs in one webview: black until the film is really
     /// rendering → leg 1 (night → the morning park; Continue up) → on Continue, leg 2
     /// (the turn, "One more thing. Meet Sidekick.", the dive, the whole Sidekick scene;
@@ -29,7 +33,14 @@ struct OnboardingFilmView: View {
     /// post-hydration, as the entrance starts) — WKWebView's didFinish fires long before
     /// first paint, so fading on it pops content into an already-visible view; didFinish
     /// survives only as a grace-period fallback for a page that never posts.
-    private enum Phase { case loading, playing, parked, ridingSidekick, sidekickDone, unavailable }
+    /// With a real notch, the Sidekick leg splits around the hardware beat: ride to the
+    /// "Click the notch" whisper (.ridingToInvitation) → wait for the user's REAL bezel click
+    /// (.awaitingNotch — the coordinator's armed demo answers it) → the demo fires and the film
+    /// rides on (.ridingSidekick). Notch-less Macs skip straight from .parked to .ridingSidekick.
+    private enum Phase {
+        case loading, playing, parked, ridingToInvitation, awaitingNotch,
+             ridingSidekick, sidekickDone, unavailable
+    }
     @State private var phase: Phase = .loading
 
     /// didFinish fired — arms the fallback fade for a "ready"-less page (older deploy).
@@ -50,12 +61,30 @@ struct OnboardingFilmView: View {
     private static let productionURL = URL(string: "https://sentient-os.ai/onboarding?end=0.42")!
     private static let sidekickEndP = 0.999
 
+    /// The "Click the notch" park — pDay 0.44 (the invitation whisper holds 0.42–0.47), in
+    /// master p: 0.4773 + 0.44 × 0.5227. Only used when a real notch exists.
+    private static let invitationEndP = 0.707
+
+    /// A Mac with a real notch gets the hardware beat: the film hides its DOM notch
+    /// (?notch=real) and the user's own bezel performs the Sidekick show.
+    private static var realNotchAvailable: Bool {
+        NotchWindowController.builtInNotchScreen() != nil
+    }
+
     private static var filmURL: URL {
+        var base = productionURL
         #if DEBUG
         if let raw = UserDefaults.standard.string(forKey: "dev.film.url"),
-           let url = URL(string: raw) { return url }
+           let url = URL(string: raw) { base = url }
         #endif
-        return productionURL
+        guard realNotchAvailable,
+              var comps = URLComponents(url: base, resolvingAgainstBaseURL: false) else { return base }
+        var items = comps.queryItems ?? []
+        if !items.contains(where: { $0.name == "notch" }) {
+            items.append(URLQueryItem(name: "notch", value: "real"))
+            comps.queryItems = items
+        }
+        return comps.url ?? base
     }
 
     var body: some View {
@@ -89,14 +118,19 @@ struct OnboardingFilmView: View {
                 }
             }
         }
-        // A quiet skip for the impatient, gone whenever Continue is up.
+        // A quiet skip for the impatient, gone whenever Continue is up. (Also the only exit
+        // from .awaitingNotch besides clicking the bezel — the park is a calm rest state.)
         .overlay(alignment: .bottomLeading) {
-            if phase == .loading || phase == .playing || phase == .ridingSidekick {
+            if phase == .loading || phase == .playing || phase == .ridingToInvitation
+                || phase == .awaitingNotch || phase == .ridingSidekick {
                 FilmSkipButton(action: onContinue)
                     .padding(.leading, 22).padding(.bottom, 13)
                     .transition(.opacity)
             }
         }
+        // The film step leaving (SKIP, Continue, back) must never strand an armed demo — the
+        // notch goes back to its real behavior the moment onboarding moves on.
+        .onDisappear { appState.commandCoordinator.disarmOnboardingNotchDemo() }
         // Load watchdog: a first launch with no internet lands on the fallback, never a void.
         .task {
             try? await Task.sleep(for: .seconds(12))
@@ -120,6 +154,11 @@ struct OnboardingFilmView: View {
             try? await Task.sleep(for: .seconds(45))
             if phase == .ridingSidekick { setPhase(.sidekickDone) }
         }
+        .task(id: phase == .ridingToInvitation) {
+            guard phase == .ridingToInvitation else { return }
+            try? await Task.sleep(for: .seconds(30))
+            if phase == .ridingToInvitation { armNotchBeat() }
+        }
     }
 
     private func setPhase(_ new: Phase) {
@@ -129,21 +168,38 @@ struct OnboardingFilmView: View {
     /// A leg landed — route the page's "parked" by which leg was riding.
     private func legParked() {
         switch phase {
-        case .loading, .playing:  setPhase(.parked)
-        case .ridingSidekick:     setPhase(.sidekickDone)
+        case .loading, .playing:    setPhase(.parked)
+        case .ridingToInvitation:   armNotchBeat()
+        case .ridingSidekick:       setPhase(.sidekickDone)
         default: break
         }
     }
 
-    /// The parked Continue: first park rides on into the Sidekick leg (same page, no
-    /// reload); the Sidekick park hands onboarding to the next step.
+    /// The parked Continue: the first park rides on — to the hardware notch beat when the Mac
+    /// has one, else straight through the whole Sidekick scene. The final park's Continue hands
+    /// onboarding to the next step.
     private func advanceFromPark() {
         switch phase {
+        case .parked where Self.realNotchAvailable:
+            setPhase(.ridingToInvitation)
+            driver.continueTo(Self.invitationEndP)
         case .parked:
             setPhase(.ridingSidekick)
             driver.continueTo(Self.sidekickEndP)
         default:
             onContinue()
+        }
+    }
+
+    /// Parked on "Click the notch": arm the coordinator's one-shot demo. The user's real bezel
+    /// click opens the real type field, the task types itself, and the moment the demo fires,
+    /// the film rides on — the webview's windows play the shopping run while the hardware notch
+    /// narrates. Disarmed on SKIP/step-exit via onDisappear.
+    private func armNotchBeat() {
+        setPhase(.awaitingNotch)
+        appState.commandCoordinator.armOnboardingNotchDemo { [self] in
+            driver.continueTo(Self.sidekickEndP)
+            setPhase(.ridingSidekick)
         }
     }
 

--- a/Sentient OS macOS/Views/Onboarding/OnboardingFilmView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingFilmView.swift
@@ -199,12 +199,13 @@ final class FilmDriver {
     weak var webView: WKWebView?
 
     /// Resume the parked ride to a new film-p address (leg 2: the Sidekick scene).
-    /// delay = the breath before motion; pace = full-film-pace seconds for this leg
-    /// (lower = faster; the Sidekick leg rides brisker than the site default).
-    func continueTo(_ end: Double, delay: Double = 0.1, pace: Double = 20) {
-        Log("Onboarding film: continueTo(\(end), delay: \(delay), pace: \(pace))")
+    /// delay = the breath before motion. Pace stays the site's: the film's own beat
+    /// profile makes the turn + dive transition brisk while the Sidekick scene rides
+    /// base speed — the app doesn't second-guess the film's timing.
+    func continueTo(_ end: Double, delay: Double = 0.1) {
+        Log("Onboarding film: continueTo(\(end), delay: \(delay))")
         webView?.evaluateJavaScript(
-            "window.__sentientAutopilot?.continueTo(\(end), \(delay), \(pace))")
+            "window.__sentientAutopilot?.continueTo(\(end), \(delay))")
     }
 }
 

--- a/Sentient OS macOS/Views/Onboarding/OnboardingFilmView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingFilmView.swift
@@ -20,10 +20,17 @@ import WebKit
 struct OnboardingFilmView: View {
     let onContinue: () -> Void
 
-    /// The step's phases: black until the page loads → the ride → parked (Continue up).
-    /// `unavailable` is the offline fallback slide.
+    /// The step's phases: black until the film is really rendering → the ride → parked
+    /// (Continue up). `unavailable` is the offline fallback slide. The loading → playing
+    /// fade keys on the page's "ready" message (posted post-hydration, as the entrance
+    /// starts) — WKWebView's didFinish fires long before first paint, so fading on it pops
+    /// content into an already-visible view; didFinish survives only as a grace-period
+    /// fallback for a page that never posts.
     private enum Phase { case loading, playing, parked, unavailable }
     @State private var phase: Phase = .loading
+
+    /// didFinish fired — arms the fallback fade for a "ready"-less page (older deploy).
+    @State private var finishedLoad = false
 
     /// The production cut: the film to the morning-home rest — p 0.42 (pNight 0.76: home
     /// settled, wake line up, before the zoom at 0.477 and the turn/dive after it). The turn
@@ -50,7 +57,8 @@ struct OnboardingFilmView: View {
                 fallbackSlide.transition(.opacity)
             } else {
                 FilmWebView(url: Self.filmURL,
-                            onLoaded: { setPhase(.playing) },
+                            onLoaded: { finishedLoad = true },
+                            onReady: { fadeIn() },
                             onParked: { setPhase(.parked) },
                             onFailed: { if phase != .parked { setPhase(.unavailable) } })
                     .ignoresSafeArea()
@@ -81,6 +89,12 @@ struct OnboardingFilmView: View {
             try? await Task.sleep(for: .seconds(12))
             if phase == .loading { setPhase(.unavailable) }
         }
+        // The "ready"-less fallback: didFinish + a grace beat, for a page that never posts.
+        .task(id: finishedLoad) {
+            guard finishedLoad else { return }
+            try? await Task.sleep(for: .seconds(1.2))
+            fadeIn()
+        }
         // Park watchdog: the ride to p 0.54 takes ~15s after load; if the park signal never
         // arrives (old deploy without ?end, JS hiccup), Continue blooms anyway.
         .task(id: phase == .playing) {
@@ -92,6 +106,13 @@ struct OnboardingFilmView: View {
 
     private func setPhase(_ new: Phase) {
         withAnimation(.easeInOut(duration: 0.45)) { phase = new }
+    }
+
+    /// The webview's entrance — a long, gentle rise from black (the film's entrance is
+    /// already playing underneath it). Idempotent: ready + the didFinish fallback can race.
+    private func fadeIn() {
+        guard phase == .loading else { return }
+        withAnimation(.easeInOut(duration: 1.2)) { phase = .playing }
     }
 
     /// The no-internet stand-in: the promise in one line, and onboarding moves on.
@@ -146,6 +167,7 @@ private final class PassiveWebView: WKWebView {
 private struct FilmWebView: NSViewRepresentable {
     let url: URL
     let onLoaded: () -> Void
+    let onReady: () -> Void
     let onParked: () -> Void
     let onFailed: () -> Void
 
@@ -190,8 +212,11 @@ private struct FilmWebView: NSViewRepresentable {
 
         func userContentController(_ userContentController: WKUserContentController,
                                    didReceive message: WKScriptMessage) {
-            if message.name == "autopilot", message.body as? String == "parked" {
-                parent.onParked()
+            guard message.name == "autopilot" else { return }
+            switch message.body as? String {
+            case "ready":  parent.onReady()
+            case "parked": parent.onParked()
+            default: break
             }
         }
 

--- a/Sentient OS macOS/Views/Onboarding/OnboardingFilmView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingFilmView.swift
@@ -195,6 +195,7 @@ private struct FilmWebView: NSViewRepresentable {
         webView.underPageBackgroundColor = .black   // never a white flash behind the film
         webView.allowsMagnification = false
         webView.allowsBackForwardNavigationGestures = false
+        Log("Onboarding film: loading \(url.absoluteString)")
         webView.load(URLRequest(url: url))
         return webView
     }
@@ -213,6 +214,7 @@ private struct FilmWebView: NSViewRepresentable {
         func userContentController(_ userContentController: WKUserContentController,
                                    didReceive message: WKScriptMessage) {
             guard message.name == "autopilot" else { return }
+            Log("Onboarding film: page says '\(message.body as? String ?? "?")'")
             switch message.body as? String {
             case "ready":  parent.onReady()
             case "parked": parent.onParked()
@@ -221,6 +223,7 @@ private struct FilmWebView: NSViewRepresentable {
         }
 
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            Log("Onboarding film: didFinish")
             parent.onLoaded()
         }
 

--- a/Sentient OS macOS/Views/Onboarding/OnboardingFilmView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingFilmView.swift
@@ -25,9 +25,11 @@ struct OnboardingFilmView: View {
     private enum Phase { case loading, playing, parked, unavailable }
     @State private var phase: Phase = .loading
 
-    /// The production cut: the film to the morning-home rest (film p 0.54, just before
-    /// Scene III's turn). Pace rides the page's own defaults.
-    private static let productionURL = URL(string: "https://sentient-os.ai/onboarding?end=0.54")!
+    /// The production cut: the film to the morning-home rest. p 0.50 = cards dealt (done
+    /// 0.426), camera settled (0.493), morning line up (0.347), with a full 0.08p of margin
+    /// before Scene III's turn text at 0.58 — the turn must never be seen in onboarding.
+    /// Pace rides the page's own defaults.
+    private static let productionURL = URL(string: "https://sentient-os.ai/onboarding?end=0.50")!
 
     private static var filmURL: URL {
         #if DEBUG
@@ -151,6 +153,17 @@ private struct FilmWebView: NSViewRepresentable {
         // Onboarding runs once — no cookies or cache worth keeping.
         config.websiteDataStore = .nonPersistent()
         config.userContentController.add(context.coordinator, name: "autopilot")
+
+        // No scrollbar over the film — it's a movie, not a page. Injected at document
+        // start so the thumb never flashes even on the first scrolled frame.
+        let hideScrollbars = WKUserScript(
+            source: """
+            const style = document.createElement('style');
+            style.textContent = '::-webkit-scrollbar{display:none!important} html{scrollbar-width:none}';
+            document.documentElement.appendChild(style);
+            """,
+            injectionTime: .atDocumentStart, forMainFrameOnly: true)
+        config.userContentController.addUserScript(hideScrollbars)
 
         let webView = PassiveWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = context.coordinator

--- a/Sentient OS macOS/Views/Onboarding/OnboardingFilmView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingFilmView.swift
@@ -20,26 +20,35 @@ import WebKit
 struct OnboardingFilmView: View {
     let onContinue: () -> Void
 
-    /// The step's phases: black until the film is really rendering → the ride → parked
-    /// (Continue up). `unavailable` is the offline fallback slide. The loading → playing
-    /// fade keys on the page's "ready" message (posted post-hydration, as the entrance
-    /// starts) — WKWebView's didFinish fires long before first paint, so fading on it pops
-    /// content into an already-visible view; didFinish survives only as a grace-period
-    /// fallback for a page that never posts.
-    private enum Phase { case loading, playing, parked, unavailable }
+    /// The step's phases, two film legs in one webview: black until the film is really
+    /// rendering → leg 1 (night → the morning park; Continue up) → on Continue, leg 2
+    /// (the turn, "One more thing. Meet Sidekick.", the dive, the whole Sidekick scene;
+    /// same page instance, `continueTo` over evaluateJavaScript) → parked again → the
+    /// final Continue advances onboarding. `unavailable` is the offline fallback slide.
+    /// The loading → playing fade keys on the page's "ready" message (posted
+    /// post-hydration, as the entrance starts) — WKWebView's didFinish fires long before
+    /// first paint, so fading on it pops content into an already-visible view; didFinish
+    /// survives only as a grace-period fallback for a page that never posts.
+    private enum Phase { case loading, playing, parked, ridingSidekick, sidekickDone, unavailable }
     @State private var phase: Phase = .loading
 
     /// didFinish fired — arms the fallback fade for a "ready"-less page (older deploy).
     @State private var finishedLoad = false
 
-    /// The production cut: the film to the morning-home rest — p 0.42 (pNight 0.76: home
-    /// settled, wake line up, before the zoom at 0.477 and the turn/dive after it). The turn
-    /// ("One more thing. Meet Sidekick.") must never be seen in onboarding.
+    /// The bridge for driving the page's autopilot (leg 2's continueTo).
+    @State private var driver = FilmDriver()
+
+    /// Leg 1: the film to the morning-home rest — p 0.42 (pNight 0.76: home settled, wake
+    /// line up, before the zoom at 0.477 and the turn/dive after it). The turn ("One more
+    /// thing. Meet Sidekick.") belongs to LEG 2, which rides from the park to the film's
+    /// final frame (0.999 — never 1.0: p ≥ 1 means the page bottom, and the site's tail +
+    /// footer must never scroll into the webview).
     /// ⚠️ Parked beats are ADDRESSES into the film's scroll timeline: whenever the website
-    /// re-budgets FilmHero's per-scene _VH constants, this value must be re-derived in
-    /// lockstep (the contract lives in the site's Autopilot.tsx header; p = beat vh /
-    /// SCROLL_VH — 0.42 = the 2026-07-16 pacing). Pace rides the page's own defaults.
+    /// re-budgets FilmHero's per-scene _VH constants, these must be re-derived in lockstep
+    /// (the contract lives in the site's Autopilot.tsx header; p = beat vh / SCROLL_VH —
+    /// 0.42 = the 2026-07-16 pacing). Pace rides the page's own defaults.
     private static let productionURL = URL(string: "https://sentient-os.ai/onboarding?end=0.42")!
+    private static let sidekickEndP = 0.999
 
     private static var filmURL: URL {
         #if DEBUG
@@ -57,31 +66,32 @@ struct OnboardingFilmView: View {
                 fallbackSlide.transition(.opacity)
             } else {
                 FilmWebView(url: Self.filmURL,
+                            driver: driver,
                             onLoaded: { finishedLoad = true },
                             onReady: { fadeIn() },
-                            onParked: { setPhase(.parked) },
-                            onFailed: { if phase != .parked { setPhase(.unavailable) } })
+                            onParked: { legParked() },
+                            onFailed: { if phase == .loading { setPhase(.unavailable) } })
                     .ignoresSafeArea()
                     .opacity(phase == .loading ? 0 : 1)
                     .allowsHitTesting(false)
 
-                // Continue blooms in the moment the film parks on the morning home.
-                // Hugs the window bottom — at the parked frame the Mac's chassis reaches
-                // low, and the button must sit in the black band BELOW the laptop, never
-                // on its base.
-                if phase == .parked {
+                // Continue blooms in whenever a leg parks. Hugs the window bottom — at
+                // the parked frames the Mac's chassis reaches low, and the button must
+                // sit in the black band BELOW the laptop, never on its base. The first
+                // Continue rides on into the Sidekick leg; the second leaves the film.
+                if phase == .parked || phase == .sidekickDone {
                     VStack {
                         Spacer()
-                        OnboardingNextButton(title: "Continue", action: onContinue)
+                        OnboardingNextButton(title: "Continue", action: advanceFromPark)
                             .padding(.bottom, 14)
                     }
                     .transition(.opacity)
                 }
             }
         }
-        // A quiet skip for the impatient, gone once Continue is up.
+        // A quiet skip for the impatient, gone whenever Continue is up.
         .overlay(alignment: .bottomLeading) {
-            if phase == .loading || phase == .playing {
+            if phase == .loading || phase == .playing || phase == .ridingSidekick {
                 FilmSkipButton(action: onContinue)
                     .padding(.leading, 22).padding(.bottom, 13)
                     .transition(.opacity)
@@ -98,17 +108,43 @@ struct OnboardingFilmView: View {
             try? await Task.sleep(for: .seconds(1.2))
             fadeIn()
         }
-        // Park watchdog: the ride to p 0.54 takes ~15s after load; if the park signal never
-        // arrives (old deploy without ?end, JS hiccup), Continue blooms anyway.
+        // Park watchdogs, one per leg: if the park signal never arrives (older deploy,
+        // JS hiccup), Continue blooms anyway. Leg 1 rides ~15s, leg 2 ~17s — both bounded.
         .task(id: phase == .playing) {
             guard phase == .playing else { return }
             try? await Task.sleep(for: .seconds(40))
             if phase == .playing { setPhase(.parked) }
         }
+        .task(id: phase == .ridingSidekick) {
+            guard phase == .ridingSidekick else { return }
+            try? await Task.sleep(for: .seconds(45))
+            if phase == .ridingSidekick { setPhase(.sidekickDone) }
+        }
     }
 
     private func setPhase(_ new: Phase) {
         withAnimation(.easeInOut(duration: 0.45)) { phase = new }
+    }
+
+    /// A leg landed — route the page's "parked" by which leg was riding.
+    private func legParked() {
+        switch phase {
+        case .loading, .playing:  setPhase(.parked)
+        case .ridingSidekick:     setPhase(.sidekickDone)
+        default: break
+        }
+    }
+
+    /// The parked Continue: first park rides on into the Sidekick leg (same page, no
+    /// reload); the Sidekick park hands onboarding to the next step.
+    private func advanceFromPark() {
+        switch phase {
+        case .parked:
+            setPhase(.ridingSidekick)
+            driver.continueTo(Self.sidekickEndP)
+        default:
+            onContinue()
+        }
     }
 
     /// The webview's entrance — a long, gentle rise from black (the film's entrance is
@@ -157,6 +193,18 @@ private struct FilmSkipButton: View {
 
 // MARK: - The webview
 
+/// The native → page bridge: holds the webview so the step can drive the page's
+/// autopilot (window.__sentientAutopilot, installed by the site on mount).
+final class FilmDriver {
+    weak var webView: WKWebView?
+
+    /// Resume the parked ride to a new film-p address (leg 2: the Sidekick scene).
+    func continueTo(_ end: Double) {
+        Log("Onboarding film: continueTo(\(end))")
+        webView?.evaluateJavaScript("window.__sentientAutopilot?.continueTo(\(end))")
+    }
+}
+
 /// A WKWebView that can never be interacted with, so the film can't be scrolled off its
 /// autopilot or clicked away: hitTest nil keeps the whole subtree out of event routing,
 /// the scrollWheel stub swallows anything that arrives some other way (responder chain),
@@ -169,6 +217,7 @@ private final class PassiveWebView: WKWebView {
 
 private struct FilmWebView: NSViewRepresentable {
     let url: URL
+    let driver: FilmDriver
     let onLoaded: () -> Void
     let onReady: () -> Void
     let onParked: () -> Void
@@ -198,6 +247,7 @@ private struct FilmWebView: NSViewRepresentable {
         webView.underPageBackgroundColor = .black   // never a white flash behind the film
         webView.allowsMagnification = false
         webView.allowsBackForwardNavigationGestures = false
+        driver.webView = webView
         Log("Onboarding film: loading \(url.absoluteString)")
         webView.load(URLRequest(url: url))
         return webView

--- a/Sentient OS macOS/Views/Onboarding/OnboardingFilmView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingFilmView.swift
@@ -25,11 +25,14 @@ struct OnboardingFilmView: View {
     private enum Phase { case loading, playing, parked, unavailable }
     @State private var phase: Phase = .loading
 
-    /// The production cut: the film to the morning-home rest. p 0.50 = cards dealt (done
-    /// 0.426), camera settled (0.493), morning line up (0.347), with a full 0.08p of margin
-    /// before Scene III's turn text at 0.58 — the turn must never be seen in onboarding.
-    /// Pace rides the page's own defaults.
-    private static let productionURL = URL(string: "https://sentient-os.ai/onboarding?end=0.50")!
+    /// The production cut: the film to the morning-home rest — p 0.42 (pNight 0.76: home
+    /// settled, wake line up, before the zoom at 0.477 and the turn/dive after it). The turn
+    /// ("One more thing. Meet Sidekick.") must never be seen in onboarding.
+    /// ⚠️ Parked beats are ADDRESSES into the film's scroll timeline: whenever the website
+    /// re-budgets FilmHero's per-scene _VH constants, this value must be re-derived in
+    /// lockstep (the contract lives in the site's Autopilot.tsx header; p = beat vh /
+    /// SCROLL_VH — 0.42 = the 2026-07-16 pacing). Pace rides the page's own defaults.
+    private static let productionURL = URL(string: "https://sentient-os.ai/onboarding?end=0.42")!
 
     private static var filmURL: URL {
         #if DEBUG

--- a/Sentient OS macOS/Views/Onboarding/OnboardingFilmView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingFilmView.swift
@@ -123,7 +123,7 @@ struct OnboardingFilmView: View {
         .overlay(alignment: .bottomLeading) {
             if phase == .loading || phase == .playing || phase == .ridingToInvitation
                 || phase == .awaitingNotch || phase == .ridingSidekick {
-                FilmSkipButton(action: onContinue)
+                FilmSkipButton(action: exitStep)
                     .padding(.leading, 22).padding(.bottom, 13)
                     .transition(.opacity)
             }
@@ -187,8 +187,16 @@ struct OnboardingFilmView: View {
             setPhase(.ridingSidekick)
             driver.continueTo(Self.sidekickEndP)
         default:
-            onContinue()
+            exitStep()
         }
+    }
+
+    /// Leaving the film step (Continue, SKIP, the fallback slide): the notch beat is behind the
+    /// user now — from here to the home screen, a notch/hotkey press answers with the
+    /// "finish onboarding" aside instead of pre-beat silence (the coordinator's policy).
+    private func exitStep() {
+        UserDefaults.standard.set(true, forKey: CommandCoordinator.notchDemoPlayedKey)
+        onContinue()
     }
 
     /// Parked on "Click the notch": arm the coordinator's one-shot demo. The user's real bezel
@@ -217,7 +225,7 @@ struct OnboardingFilmView: View {
             OnboardingWhisper("STEP 1 OF 3")
             Text("An AI that knows your life, and acts on it.")
                 .display(30)
-            OnboardingNextButton(title: "Continue", action: onContinue)
+            OnboardingNextButton(title: "Continue", action: exitStep)
             Spacer()
             OnboardingTrustFooter()
         }

--- a/Sentient OS macOS/Views/Onboarding/OnboardingView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingView.swift
@@ -2,8 +2,9 @@
 //  OnboardingView.swift
 //  Sentient OS macOS
 //
-//  First-launch onboarding: three intro slides (placeholder boxes for now — real design comes
-//  later), then permissions (OnboardingPermissionsView), then codex login (OnboardingCodexSteps),
+//  First-launch onboarding: the film slide (OnboardingFilmView — the website's self-scrolling
+//  film in a webview, parking on the morning home) plus two placeholder slides (real design
+//  comes later), then permissions (OnboardingPermissionsView), then codex login (OnboardingCodexSteps),
 //  then the plan crossroads (OnboardingPlanView — free/go accounts only; full plans skip it),
 //  then the ready-to-process screen (OnboardingReadyView) whose Start Analysis presents the REAL
 //  ProcessingView takeover (pausable) — and only a finished run calls `onFinished` and reveals
@@ -68,6 +69,10 @@ struct OnboardingView: View {
             Theme.bg.ignoresSafeArea()
 
             switch step {
+            case 0:
+                // Slide 1 is the website's film in a webview — it plays to the morning-home
+                // rest and blooms its own Continue (OnboardingFilmView owns the choreography).
+                OnboardingFilmView(onContinue: advance).transition(.opacity)
             case ..<Self.slideCount:
                 slides.transition(.opacity)
             case Self.slideCount:


### PR DESCRIPTION
The film slide: onboarding opens with the site's /onboarding film in a non-interactive WKWebView (autopilot-driven, parks at the morning home, Continue blooms on the page's 'parked' signal; offline/HTTP-error fallback slide, load/park watchdogs, no-flash fade-in keyed to the page's post-hydration 'ready').

Step 2 rides the SAME webview into the Sidekick scene — and on Macs with a real notch, the film parks on 'Click the notch' and the USER'S OWN bezel performs the show: the coordinator's one-shot demo opens the real type field, auto-types 'order this stuff', and replays a codex-shaped script through the real stream cleaner (status lines + the Remembering bloom). Nothing real fires: no codex, no screenshots, no scoreboard/analytics.

Sidekick is now HOME-ONLY: before the film's notch beat a press does nothing (hover swell off too); after it, every press answers 'finish onboarding to use Sidekick'; the first-use permission gate can never rise before the home screen (all three doors guarded).

Website counterpart is live: /onboarding + Autopilot (?end, ?delay, ?notch=real, multi-leg continueTo, the hinge-curve beat easing).

https://claude.ai/code/session_01PCtjNP5oAaBJcKRtyvBzx3