### PR TITLE
Film step polish: per-park Continue placement + no STOP on the demo notch

### DIFF
--- a/Sentient OS macOS/Notch Magic/CommandRunModel.swift
+++ b/Sentient OS macOS/Notch Magic/CommandRunModel.swift
@@ -31,6 +31,10 @@ final class CommandRunModel {
     /// alone doesn't need it.
     var onFinished: ((Outcome) -> Void)?
 
+    /// True while the onboarding notch demo is performing — the notch hides STOP (scripted
+    /// theater has nothing to stop). Cleared the moment a REAL run starts.
+    private(set) var isDemo = false
+
     private var recent: [String] = []
     private var section = ""                      // codex's current output section (user/codex/exec/…) — for filtering the bar
     private var task: Task<Void, Never>?
@@ -45,6 +49,7 @@ final class CommandRunModel {
         self.mode = mode
         self.source = source
         self.runStarted = Date()
+        isDemo = false
         isRunning = true
         recent = []
         section = ""
@@ -114,6 +119,7 @@ final class CommandRunModel {
     func startOnboardingDemo() {
         guard !isRunning else { return }
         mode = .computer
+        isDemo = true
         isRunning = true
         recent = []; section = ""
         remembering = nil; rememberClear?.cancel()

--- a/Sentient OS macOS/Notch Magic/NotchView.swift
+++ b/Sentient OS macOS/Notch Magic/NotchView.swift
@@ -165,6 +165,7 @@ struct NotchView: View {
                      remembering: coordinator.run.remembering,
                      hovering: coordinator.notchHovering,
                      demoText: coordinator.demoDraft,
+                     showStop: !coordinator.run.isDemo,
                      metrics: metrics,
                      onStop: { coordinator.stop() },
                      onSubmitText: { coordinator.submitTyped($0) },
@@ -186,6 +187,8 @@ struct NotchContent: View {
     /// The onboarding demo's auto-typing: when set, the type field's draft mirrors it (the show
     /// runs through the REAL TextField). nil = the user owns the field.
     var demoText: String? = nil
+    /// False during the onboarding demo run — scripted theater has nothing to STOP.
+    var showStop: Bool = true
     let metrics: NotchMetrics
     var onStop: () -> Void = {}
     var onSubmitText: (String) -> Void = { _ in }
@@ -325,7 +328,8 @@ struct NotchContent: View {
                 .foregroundStyle(.white.opacity(draft.isEmpty ? 0.3 : 0.7))
                 .allowsHitTesting(false)
         case .running:
-            NotchStopButton(action: onStop)
+            // The onboarding demo is theater — nothing real to stop, so no STOP.
+            if showStop { NotchStopButton(action: onStop) } else { Color.clear.frame(width: 1, height: 18) }
         case .finishing(let outcome):
             Image(systemName: Self.outcomeSymbol(outcome))
                 .font(.system(size: 11, weight: .bold))

--- a/Sentient OS macOS/Views/Onboarding/OnboardingFilmView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingFilmView.swift
@@ -104,11 +104,22 @@ struct OnboardingFilmView: View {
                     .opacity(phase == .loading ? 0 : 1)
                     .allowsHitTesting(false)
 
-                // Continue blooms in whenever a leg parks. Hugs the window bottom — at
-                // the parked frames the Mac's chassis reaches low, and the button must
-                // sit in the black band BELOW the laptop, never on its base. The first
-                // Continue rides on into the Sidekick leg; the second leaves the film.
-                if phase == .parked || phase == .sidekickDone {
+                // Continue blooms in whenever a leg parks. On the MORNING park the laptop
+                // fills the window's lower half, so the button sits ABOVE it — in the black
+                // band between the "9:00 AM" whisper and the lid's top edge (~18.5% down;
+                // the film's frame scales with the window, so the gap does too). The film's
+                // FINAL park is a full-viewport stage, so that Continue hugs the bottom.
+                if phase == .parked {
+                    GeometryReader { geo in
+                        VStack {
+                            OnboardingNextButton(title: "Continue", action: advanceFromPark)
+                            Spacer()
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.top, geo.size.height * 0.185)
+                    }
+                    .transition(.opacity)
+                } else if phase == .sidekickDone {
                     VStack {
                         Spacer()
                         OnboardingNextButton(title: "Continue", action: advanceFromPark)

--- a/Sentient OS macOS/Views/Onboarding/OnboardingFilmView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingFilmView.swift
@@ -120,10 +120,12 @@ struct OnboardingFilmView: View {
                     }
                     .transition(.opacity)
                 } else if phase == .sidekickDone {
+                    // Lifted off the very edge — the full-viewport stage has breathing
+                    // room below the windows, and a bottom-hugging button read awkward.
                     VStack {
                         Spacer()
                         OnboardingNextButton(title: "Continue", action: advanceFromPark)
-                            .padding(.bottom, 14)
+                            .padding(.bottom, 44)
                     }
                     .transition(.opacity)
                 }


### PR DESCRIPTION
The morning park's Continue sits ABOVE the laptop (18.5% down, in the black band under the 9:00 AM whisper — the chassis fills the lower window there); the film-end park's Continue lifts off the window edge (14pt -> 44pt). And the onboarding notch demo hides STOP (scripted theater has nothing to stop; run.isDemo -> NotchContent.showStop, the ✓ flourish keeps its glyph, real runs untouched).

https://claude.ai/code/session_01PCtjNP5oAaBJcKRtyvBzx3