### PR TITLE
Bottom-left model-download whisper card

### DIFF
--- a/Sentient OS macOS/Engine/ModelDownload.swift
+++ b/Sentient OS macOS/Engine/ModelDownload.swift
@@ -68,6 +68,10 @@ final class ModelDownload {
     private(set) var bytesDone: Int64 = 0
     let bytesTotal = ModelDownloadJob.production.bytes
 
+    /// True while onboarding's full-screen downloading view is up — the corner whisper
+    /// (ModelDownloadWhisper) yields so the signature bar never shows twice on one screen.
+    var fullScreenVisible = false
+
     private init() {}
 
     /// Start (or resume) the model download if this Mac actually needs one. Safe to call from

--- a/Sentient OS macOS/Views/ModelDownloadWhisper.swift
+++ b/Sentient OS macOS/Views/ModelDownloadWhisper.swift
@@ -1,0 +1,100 @@
+//
+//  ModelDownloadWhisper.swift
+//  Sentient OS macOS
+//
+//  The quiet bottom-left download card: while the on-device model lands in the background
+//  (ModelDownload), a small glass card with the signature GlowProgressBar + honest numbers rides
+//  RootView's bottom-leading overlay, over whatever screen is up. It yields while onboarding's
+//  full-screen downloading view shows the same bar big (ModelDownload.fullScreenVisible), fades
+//  away on .ready, and swaps to one quiet amber line on .failed (the full-screen view owns the
+//  Try Again flow).
+//
+
+import SwiftUI
+
+struct ModelDownloadWhisper: View {
+    let download: ModelDownload
+
+    /// Nothing renders when there's nothing worth whispering about (idle/ready), or while the
+    /// full-screen downloading view has the bar — the signature bar never shows twice on one screen.
+    private var visible: Bool {
+        if download.fullScreenVisible { return false }
+        switch download.phase {
+        case .downloading, .verifying, .failed: return true
+        case .idle, .ready: return false
+        }
+    }
+
+    private var fraction: Double {
+        download.bytesTotal > 0 ? Double(download.bytesDone) / Double(download.bytesTotal) : 0
+    }
+
+    /// "1.24 of 3.66 GB" — decimal GB, same voice as the full-screen downloading view.
+    private var gbLine: String {
+        String(format: "%.2f of %.2f GB",
+               Double(download.bytesDone) / 1_000_000_000,
+               Double(download.bytesTotal) / 1_000_000_000)
+    }
+
+    var body: some View {
+        if visible {
+            Group {
+                if case .failed = download.phase { paused } else { downloading }
+            }
+            .padding(.horizontal, 14).padding(.vertical, 12)
+            .background(Color.white.opacity(0.04), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .overlay(RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .strokeBorder(borderColor, lineWidth: 1))
+            .transition(.opacity)
+        }
+    }
+
+    private var borderColor: Color {
+        if case .failed = download.phase { return Theme.Ink.amber.opacity(0.28) }
+        return Theme.stroke
+    }
+
+    private var downloading: some View {
+        VStack(alignment: .leading, spacing: 9) {
+            MonoCaps("Downloading on-device model", size: 9, tracking: 2.0, color: Theme.Ink.label)
+            GlowProgressBar(value: fraction)
+            HStack {
+                Text(gbLine)
+                Spacer()
+                Text(download.phase == .verifying ? "verifying…" : "\(Int(fraction * 100))%")
+            }
+            .font(.system(size: 10.5)).monospacedDigit()
+            .foregroundStyle(Theme.secondary)
+        }
+        .frame(width: 212)
+    }
+
+    private var paused: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            MonoCaps("Model download paused", size: 9, tracking: 2.0, color: Theme.Ink.amber)
+            Text("It will resume when you continue.")
+                .font(.system(size: 11))
+                .foregroundStyle(Theme.faint)
+        }
+        .frame(width: 212, alignment: .leading)
+    }
+}
+
+// previewInstance is DEBUG-only, and #Preview bodies compile in Release too — so these must be guarded.
+#if DEBUG
+#Preview("Download whisper — states") {
+    ZStack(alignment: .bottomLeading) {
+        Color.black.ignoresSafeArea()
+        VStack(alignment: .leading, spacing: 18) {
+            ModelDownloadWhisper(download: .previewInstance(phase: .downloading, bytesDone: 310_000_000))
+            ModelDownloadWhisper(download: .previewInstance(phase: .downloading, bytesDone: 2_610_000_000))
+            ModelDownloadWhisper(download: .previewInstance(phase: .verifying, bytesDone: 3_659_530_240))
+            ModelDownloadWhisper(download: .previewInstance(
+                phase: .failed("Sentient could not reach the download server.")))
+        }
+        .padding(22)
+    }
+    .frame(width: 420, height: 480)
+    .preferredColorScheme(.dark)
+}
+#endif

--- a/Sentient OS macOS/Views/Onboarding/OnboardingModelDownloadView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingModelDownloadView.swift
@@ -77,7 +77,13 @@ struct OnboardingModelDownloadView: View {
         .animation(.easeInOut(duration: 0.3), value: download.phase)
         // The safety net: normally the post-FDA launch kick started this minutes ago, but if that
         // was missed (FDA granted without the relaunch), Start Analysis still gets a download.
-        .onAppear { download.kickIfNeeded() }
+        // fullScreenVisible hands the bar off from the corner whisper (ModelDownloadWhisper) —
+        // one signature bar on screen, never two.
+        .onAppear {
+            download.kickIfNeeded()
+            download.fullScreenVisible = true
+        }
+        .onDisappear { download.fullScreenVisible = false }
     }
 }
 

--- a/Sentient OS macOS/Views/RootView.swift
+++ b/Sentient OS macOS/Views/RootView.swift
@@ -40,6 +40,9 @@ struct RootView: View {
     /// Observed for the global "setting up computer use" whisper (the overlay below).
     @State private var codex = CodexSetup.shared
 
+    /// Observed for the bottom-left model-download whisper (same overlay slot).
+    @State private var download = ModelDownload.shared
+
     // Dev Tools → "Resizable analysis window (demo)": while the analysis takeover is up, the
     // window's min frame drops away entirely, so the website screen rec can shrink it to just
     // the analysis content. The home keeps its full canvas either way.
@@ -100,24 +103,32 @@ struct RootView: View {
             Analytics.signal("Home.opened",
                              parameters: ["trigger": sinceBoot < 5 ? "launch" : "reopen"], tier: .core)
         }
-        // The computer-use setup whisper — screen-agnostic on purpose: the bootstrap is an
-        // unstructured background task that outlives onboarding's processing takeover (knowledge
-        // base creation, even the home in rare cases), so as long as it's actually running, this
-        // quiet line rides the bottom of WHATEVER screen is up. Keyed to the live shared engine
-        // state, so dev/Settings-triggered setups surface it too.
+        // The bottom-left whispers — screen-agnostic on purpose, both keyed to live shared engine
+        // state so they ride the bottom of WHATEVER screen is up:
+        // · the model-download card (ModelDownloadWhisper) — the on-device model landing in the
+        //   background while the user is elsewhere (it hides itself when onboarding's full-screen
+        //   downloading view shows the same bar big);
+        // · the computer-use setup line — the bootstrap is an unstructured background task that
+        //   outlives onboarding's processing takeover (knowledge base creation, even the home in
+        //   rare cases), so as long as it's actually running, this quiet line shows.
         .overlay(alignment: .bottomLeading) {
-            if codex.settingUpComputerUse {
-                HStack(spacing: 7) {
-                    ProgressView().controlSize(.small).scaleEffect(0.6)
-                    Text("Setting up Codex computer use in the background.")
-                        .font(.system(size: 11))
-                        .foregroundStyle(Theme.faint)
+            VStack(alignment: .leading, spacing: 10) {
+                ModelDownloadWhisper(download: download)
+                if codex.settingUpComputerUse {
+                    HStack(spacing: 7) {
+                        ProgressView().controlSize(.small).scaleEffect(0.6)
+                        Text("Setting up Codex computer use in the background.")
+                            .font(.system(size: 11))
+                            .foregroundStyle(Theme.faint)
+                    }
+                    .transition(.opacity)
                 }
-                .padding(.leading, 22).padding(.bottom, 12)
-                .transition(.opacity)
             }
+            .padding(.leading, 22).padding(.bottom, 12)
         }
         .animation(.easeInOut(duration: 0.35), value: codex.settingUpComputerUse)
+        .animation(.easeInOut(duration: 0.35), value: download.phase)
+        .animation(.easeInOut(duration: 0.35), value: download.fullScreenVisible)
         // The mandatory update gate floats above everything (home, processing, dev sheet) — when a
         // required update is found it takes over; otherwise it draws nothing. (Updates/)
         .overlay { UpdateGateView(host: .home) }


### PR DESCRIPTION
## What

A small, quiet bottom-left card that shows the on-device model download while it runs in the background — so the user sees the 3.66 GB model landing during the codex-login / plan / ready stretch of onboarding instead of it happening invisibly.

- **New `Views/ModelDownloadWhisper.swift`**: glass card matching the CautionCapsule chrome, with the mono-caps whisper label `DOWNLOADING ON-DEVICE MODEL`, the signature `GlowProgressBar` (reused untouched, 212pt), and a `1.24 of 3.66 GB · 34%` line (`verifying…` during the SHA-256 pass). On terminal `.failed` it swaps to an amber-bordered `MODEL DOWNLOAD PAUSED` whisper; the full-screen download view keeps the Try Again flow.
- **`RootView`**: the card rides the existing screen-agnostic bottom-leading overlay, stacked in a VStack above the codex-setup whisper; 0.35s ease in/out.
- **`ModelDownload`**: new `fullScreenVisible` flag so the corner card yields while `OnboardingModelDownloadView` shows the same bar big — one signature bar per screen, never two.
- **`OnboardingModelDownloadView`**: sets/clears that flag in `onAppear`/`onDisappear`.

Disappears on its own the moment the model verifies (`.ready`); renders nothing on `.idle`.

## Testing

- Debug build green (isolated DerivedData, `xcodebuild`).
- DEBUG-guarded `#Preview` with four states (early / mid / verifying / failed).
- Note: on dev Macs the card never shows naturally (ModelLocator resolves the repo-root model, so the download short-circuits) — eyeball via the preview, or rename the repo-root `.litertlm` and run onboarding.

https://claude.ai/code/session_01SRKwgYgBDnLN1tGQPzRAQ4