### PR TITLE
Hood-park polish: popup scrolls, SKIP TO HOME off the film step

### DIFF
--- a/Sentient OS macOS/Views/Onboarding/OnboardingFilmView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingFilmView.swift
@@ -330,12 +330,17 @@ final class FilmDriver {
 /// and refusing first-responder keeps keyboard scrolling (space, arrows) out too.
 ///
 /// One sanctioned exception: the hood park (`interactive`), where the exhibit's hover
-/// captions and Read More popup come alive. Even then the WHEEL stays swallowed — hit
-/// testing routes wheel straight to WebKit's own subviews (bypassing the stub above),
-/// and one scroll would drag the parked film toward the footer — via a local event
-/// monitor. The one wheel that passes is while the page reports its popup open
-/// (`popupOpen`): the popup's internal scroller needs it, and the page locks its own
-/// scroll then (Lenis stop), so the film can't move underneath.
+/// captions and Read More popup come alive. Even then the WHEEL stays swallowed — one
+/// scroll would drag the parked film toward the footer — via a local event monitor. The
+/// one wheel that passes is while the page reports its popup open (`popupOpen`): the
+/// popup's internal scroller needs it, and the page locks its own scroll then (Lenis
+/// stop), so the film can't move underneath.
+///
+/// ⚠️ Both halves must yield together. The monitor gates AppKit's dispatch, but a
+/// WKWebView usually hitTests to ITSELF, so the passed event lands right back on this
+/// override — an unconditional no-op here would eat the popup's wheel even after the
+/// monitor let it by (field-found 2026-07-17: the popup wouldn't scroll). So the
+/// override forwards to super under exactly the same `popupOpen` condition.
 private final class PassiveWebView: WKWebView {
     var interactive = false { didSet { syncWheelGate() } }
     /// Mirrors the page's popup state ("popup-open"/"popup-closed" bridge messages).
@@ -346,7 +351,9 @@ private final class PassiveWebView: WKWebView {
     override func hitTest(_ point: NSPoint) -> NSView? {
         interactive ? super.hitTest(point) : nil
     }
-    override func scrollWheel(with event: NSEvent) {}
+    override func scrollWheel(with event: NSEvent) {
+        if popupOpen { super.scrollWheel(with: event) }
+    }
     override var acceptsFirstResponder: Bool { false }
 
     private func syncWheelGate() {

--- a/Sentient OS macOS/Views/Onboarding/OnboardingView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingView.swift
@@ -133,10 +133,11 @@ struct OnboardingView: View {
         // DEV-ONLY: skip straight to the home (testing relaunches land back in onboarding until
         // a full first analysis flips the flag). Quietly marks onboarding complete — deliberately
         // NOT onFinished, so the Constellation finale stays reserved for the real finish.
-        // Compile-gated out of Release entirely.
+        // Compile-gated out of Release entirely. Hidden on step 0 (the film webview) — the film
+        // is meant to read as a native screen, not a page with dev chrome floating over it.
         #if DEBUG
         .overlay(alignment: .bottomTrailing) {
-            if !analyzing {
+            if !analyzing && step > 0 {
                 Button {
                     withAnimation(.easeInOut(duration: 0.3)) { appState.hasCompletedOnboarding = true }
                 } label: {


### PR DESCRIPTION
Two fixes on the onboarding film's interactive hood park:

- **Popup wouldn't scroll (app webview):** `PassiveWebView.scrollWheel` was an unconditional no-op. A WKWebView usually hitTests to itself, so even when the wheel monitor passed the event through on `popupOpen`, this override ate it. It now forwards to `super` under the same `popupOpen` condition — the Read More popup scrolls, the film stays locked when the popup is closed.
- **SKIP TO HOME on the film:** the DEBUG-only skip overlay is a global onboarding overlay shown on every non-analysis step, so it floated over the film. Scoped to `step > 0` — kept in debug builds on every other step, gone from the film webview (and from Release entirely, as before).

Pairs with website PR #5 (selection lock) which is deployed. Web side verified headless; the native wheel-forward is WKWebView-specific — please confirm the popup scroll on hardware.

https://claude.ai/code/session_01SGdXkKNELAwnjhquCxNrfj