### PR TITLE
Onboarding ready screen: run-it-overnight note replaces trust footer

### DIFF
--- a/Sentient OS macOS/Views/Onboarding/OnboardingReadyView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingReadyView.swift
@@ -114,7 +114,11 @@ struct OnboardingReadyView: View {
 
             Spacer()
 
-            OnboardingTrustFooter()
+            // This screen trades the trust footer for the one thing worth knowing before firing.
+            Text("This initial analysis can take a few hours. We recommend you run this overnight.")
+                .font(.system(size: 13))
+                .foregroundStyle(Theme.faint)
+                .padding(.bottom, 28)
         }
         .padding(40)
         .sheet(isPresented: $showWhatsAppPicker) {


### PR DESCRIPTION
On the onboarding ready-to-process screen only, the trust footer line is replaced with "This initial analysis can take a few hours. We recommend you run this overnight." — set one point larger (13pt) than the shared footer, same faint color and placement. Every other onboarding screen keeps `OnboardingTrustFooter` unchanged.

Verified with an incremental isolated build (`/tmp/sentient-verify`): BUILD SUCCEEDED.

https://claude.ai/code/session_01Uhev4vFXyCmvpXc5N54wLJ