### PR TITLE
Onboarding: hood-park telemetry consent + glow Continue, drop placeholder slides, kill right-click

### DIFF
--- a/Sentient OS macOS/Views/Onboarding/OnboardingFilmView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingFilmView.swift
@@ -158,13 +158,20 @@ struct OnboardingFilmView: View {
                     // exhibit's bottom chrome leaves only slack there on height-bound
                     // windows, so a centered button always rode the bottom clamp.
                     // Fallback = the old bottom-hug until the page answers.
+                    // The telemetry pill shares the Continue's row, bottom-left.
                     GeometryReader { geo in
-                        OnboardingNextButton(title: "Continue", action: advanceFromPark)
-                            .position(x: geo.size.width / 2,
-                                      y: min(hoodBandCenter ?? (geo.size.height - 68),
-                                             geo.size.height - 40))
-                            .onAppear { measureHoodBand() }
-                            .onChange(of: geo.size) { measureHoodBand() }
+                        let continueY = min(hoodBandCenter ?? (geo.size.height - 68),
+                                            geo.size.height - 40)
+                        ZStack {
+                            OnboardingTelemetryConsent(rowCenterY: continueY)
+                            // The exhibit's Continue wears the AI-gradient halo — a beat
+                            // brighter than the Analyze Now popover's 0.28.
+                            OnboardingNextButton(title: "Continue", glow: 0.4,
+                                                 action: advanceFromPark)
+                                .position(x: geo.size.width / 2, y: continueY)
+                        }
+                        .onAppear { measureHoodBand() }
+                        .onChange(of: geo.size) { measureHoodBand() }
                     }
                     .ignoresSafeArea()
                     .transition(.opacity)
@@ -342,7 +349,6 @@ struct OnboardingFilmView: View {
     private var fallbackSlide: some View {
         VStack(spacing: 40) {
             Spacer()
-            OnboardingWhisper("STEP 1 OF 3")
             Text("An AI that knows your life, and acts on it.")
                 .display(30)
             OnboardingNextButton(title: "Continue", action: exitStep)
@@ -467,6 +473,12 @@ private final class PassiveWebView: WKWebView {
         if popupOpen { super.scrollWheel(with: event) }
     }
     override var acceptsFirstResponder: Bool { false }
+
+    /// No browser context menu, ever — right-click/ctrl-click "Reload Page" would restart
+    /// the film and shatter the native-screen illusion. Emptying the menu shows nothing.
+    override func willOpenMenu(_ menu: NSMenu, with event: NSEvent) {
+        menu.removeAllItems()
+    }
 
     private func syncWheelGate() {
         if interactive, wheelGate == nil {

--- a/Sentient OS macOS/Views/Onboarding/OnboardingTelemetryConsent.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingTelemetryConsent.swift
@@ -1,0 +1,127 @@
+//
+//  OnboardingTelemetryConsent.swift
+//  Sentient OS macOS
+//
+//  The film's hood-park privacy block — "We never collect your personal info." over two
+//  capsules, bottom-left on the hood Continue's row: Read More (the Settings Privacy Policy
+//  sheet, PrivacyPolicyView, reused verbatim) and Configure Telemetry, which blooms a small
+//  anchored card with the two anonymous-telemetry toggles (crash reports → Sentry ·
+//  analytics → TelemetryDeck): the SAME @AppStorage keys as Settings → System, applied live
+//  through CrashReporting/Analytics.applyEnabledChange(), so the choice made here IS the
+//  Settings choice. Click anywhere outside dismisses; the film stays undimmed behind it.
+//
+
+import SwiftUI
+
+struct OnboardingTelemetryConsent: View {
+    /// The pill row's vertical center — the film view passes the hood Continue's
+    /// page-measured y, so the pill and Continue read as one composed footer row.
+    let rowCenterY: CGFloat
+
+    /// Same keys as Settings → System (SystemPane) — the original `diagnosticsEnabled` name
+    /// carries existing installs' crash-reports choice; analytics has its own key.
+    @AppStorage("diagnosticsEnabled") private var crashReportsEnabled = true
+    @AppStorage("analyticsEnabled") private var analyticsEnabled = true
+
+    @State private var open = false
+    @State private var showPrivacyPolicy = false
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack(alignment: .bottomLeading) {
+                // Click-outside dismiss: an invisible catcher over the film while the card
+                // is up. Sits UNDER the card/pill in this ZStack, so their controls keep
+                // their own clicks.
+                if open {
+                    Color.black.opacity(0.001)
+                        .contentShape(Rectangle())
+                        .onTapGesture { setOpen(false) }
+                }
+
+                VStack(alignment: .leading, spacing: 12) {
+                    if open {
+                        card
+                            .transition(.scale(scale: 0.96, anchor: .bottomLeading)
+                                .combined(with: .opacity))
+                    }
+                    pillBlock
+                }
+                .padding(.leading, 36)
+                // Center the ~52pt pill block on the Continue's y; the clamp keeps it
+                // on-screen if the page ever reports a band below the viewport.
+                .padding(.bottom, max(20, geo.size.height - rowCenterY - 26))
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
+        }
+        .onChange(of: crashReportsEnabled) { _, _ in CrashReporting.applyEnabledChange() }
+        .onChange(of: analyticsEnabled) { _, _ in Analytics.applyEnabledChange() }
+        .sheet(isPresented: $showPrivacyPolicy) { PrivacyPolicyView() }
+    }
+
+    // MARK: - The pill block (the Settings protection line over its two doors)
+
+    private var pillBlock: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("We never collect your personal info.")
+                .font(.system(size: 13, weight: .medium)).foregroundStyle(.white)
+            HStack(spacing: 10) {
+                SettingsPillButton(title: "Read More") { showPrivacyPolicy = true }
+                SettingsPillButton(title: "Configure Telemetry") { setOpen(!open) }
+            }
+        }
+    }
+
+    // MARK: - The anchored card (the two toggles, Settings dialect)
+
+    private var card: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            MonoCaps("Anonymous telemetry", size: 9.5, tracking: 2.4,
+                     color: .white.opacity(0.7), weight: .semibold)
+                .padding(.bottom, 8)
+            SettingToggleLine(title: "Crash reports · Sentry",
+                              sub: "Privacy-friendly, structure-only reports that help us fix your bugs; never your content.",
+                              isOn: $crashReportsEnabled)
+            SettingsHairline()
+            SettingToggleLine(title: "Analytics · TelemetryDeck",
+                              sub: "Anonymous usage signals through a privacy-first, open-source framework; never anything personal.",
+                              isOn: $analyticsEnabled)
+            if !analyticsEnabled {
+                // The core-tier disclosure — keeps the switch honest (Analytics.swift,
+                // Tier.core), same caption as Settings shows on opt-out.
+                Text("Even with this off, Sentient keeps a bare minimum of anonymous telemetry: simple counts of app opens and feature use that are core to building Sentient. Never your content, never anything personal.")
+                    .font(.system(size: 10.5))
+                    .foregroundStyle(Theme.Ink.deepMuted)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.top, 4)
+                    .transition(.opacity)
+            }
+        }
+        .animation(.easeInOut(duration: 0.2), value: analyticsEnabled)
+        .padding(18)
+        .frame(width: 330)
+        .background(Theme.Ink.cardBG,
+                    in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: 16, style: .continuous)
+            .strokeBorder(Color.white.opacity(0.12), lineWidth: 1))
+    }
+
+    private func setOpen(_ value: Bool) {
+        withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) { open = value }
+    }
+}
+
+#if DEBUG
+#Preview("Telemetry consent — pill + card") {
+    struct Host: View {
+        @State private var height: CGFloat = 820
+        var body: some View {
+            ZStack {
+                Theme.bg
+                OnboardingTelemetryConsent(rowCenterY: height - 60)
+            }
+            .frame(width: 1180, height: height)
+        }
+    }
+    return Host().preferredColorScheme(.dark)
+}
+#endif

--- a/Sentient OS macOS/Views/Onboarding/OnboardingView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingView.swift
@@ -3,8 +3,8 @@
 //  Sentient OS macOS
 //
 //  First-launch onboarding: the film slide (OnboardingFilmView — the website's self-scrolling
-//  film in a webview, parking on the morning home) plus two placeholder slides (real design
-//  comes later), then permissions (OnboardingPermissionsView), then codex login (OnboardingCodexSteps),
+//  film in a webview, parking on the morning home),
+//  then permissions (OnboardingPermissionsView), then codex login (OnboardingCodexSteps),
 //  then the plan crossroads (OnboardingPlanView — free/go accounts only; full plans skip it),
 //  then the ready-to-process screen (OnboardingReadyView) whose Start Analysis presents the REAL
 //  ProcessingView takeover (pausable) — and only a finished run calls `onFinished` and reveals
@@ -13,8 +13,8 @@
 //  first and the analysis takes over by itself the moment the model verifies. The current step
 //  persists (UserDefaults "onboarding.step") so a quit-and-relaunch mid-onboarding — which
 //  granting Full Disk Access requires — resumes exactly where the user left. The background
-//  codex install is NOT here: AppState kicks it off 1s after launch while the user reads the
-//  slides. Computer use (codex step 3) IS here: the analysis takeover appearing arms a silent
+//  codex install is NOT here: AppState kicks it off 1s after launch while the film plays.
+//  Computer use (codex step 3) IS here: the analysis takeover appearing arms a silent
 //  one-shot that bootstraps it 2 minutes in (armComputerUseSetup) — armed at analysis start,
 //  not at Start Analysis, so its ~535 MB DMG never competes with the model download's tail.
 //
@@ -29,7 +29,6 @@ struct OnboardingView: View {
 
     /// Persisted so a relaunch mid-onboarding (the FDA grant needs one) resumes at the same step.
     @AppStorage("onboarding.step") private var step = 0
-    private static let slideCount = 3
 
     /// Start Analysis pressed — the ProcessingView takeover is up. Not persisted: a quit
     /// mid-run relaunches to the ready screen, and the durable marks resume the analysis.
@@ -70,16 +69,14 @@ struct OnboardingView: View {
 
             switch step {
             case 0:
-                // Slide 1 is the website's film in a webview — it plays to the morning-home
+                // Step 1 is the website's film in a webview — it plays to the morning-home
                 // rest and blooms its own Continue (OnboardingFilmView owns the choreography).
                 OnboardingFilmView(onContinue: advance).transition(.opacity)
-            case ..<Self.slideCount:
-                slides.transition(.opacity)
-            case Self.slideCount:
+            case 1:
                 OnboardingPermissionsView(onContinue: advance).transition(.opacity)
-            case Self.slideCount + 1:
+            case 2:
                 OnboardingCodexLoginView(onContinue: advance).transition(.opacity)
-            case Self.slideCount + 2:
+            case 3:
                 // The plan crossroads — free/go accounts decide here; full plans skip it
                 // before it renders (OnboardingPlanView auto-advances).
                 OnboardingPlanView(onContinue: advance).transition(.opacity)
@@ -120,6 +117,10 @@ struct OnboardingView: View {
         // onboarding the two overlap harmlessly — independent tokens.)
         .onAppear { awake.begin(reason: "Onboarding — keeping the screen on") }
         .onDisappear { awake.end() }
+        // No right-clicks anywhere in onboarding — the film's webview would offer a browser
+        // context menu (Reload…), and no onboarding surface has a legitimate right-click.
+        // Window-scoped, gone with this view.
+        .background(RightClickBlocker())
         // A quiet back door on every screen but the first (and never over the analysis takeover,
         // which owns its own pause/exit). One shared code path, so every step gets it for free.
         .overlay(alignment: .topLeading) {
@@ -186,43 +187,19 @@ struct OnboardingView: View {
         var target = step - 1
         // The crossroads only exists for free/go accounts — never strand a full plan on an
         // auto-advancing screen (back would visibly bounce forward again).
-        if target == Self.slideCount + 2 && !CodexAuth.isLimited() { target -= 1 }
+        if target == 3 && !CodexAuth.isLimited() { target -= 1 }
         withAnimation(.easeInOut(duration: 0.25)) { step = max(0, target) }
     }
 
-    // MARK: The three intro slides (placeholders)
-
-    private var slides: some View {
-        VStack(spacing: 40) {
-            Spacer()
-
-            OnboardingWhisper("STEP \(step + 1) OF \(Self.slideCount)")
-
-            // Placeholder for the real slide design.
-            RoundedRectangle(cornerRadius: 20, style: .continuous)
-                .fill(Theme.panel)
-                .overlay(RoundedRectangle(cornerRadius: 20, style: .continuous)
-                    .stroke(Theme.stroke, lineWidth: 1))
-                .overlay(
-                    Text("Intro slide \(step + 1)")
-                        .font(.system(size: 15))
-                        .foregroundStyle(Theme.secondary))
-                .frame(maxWidth: 560, maxHeight: 360)
-
-            OnboardingNextButton(title: "Next", action: advance)
-
-            Spacer()
-
-            OnboardingTrustFooter()
-        }
-        .padding(40)
-    }
 }
 
-/// The onboarding CTA — a quiet white capsule, shared by the slides and the permissions screen.
+/// The onboarding CTA — a quiet white capsule, shared across the onboarding screens.
+/// `glow` adds the rotating AI-gradient halo (GlowHalo intensity) — off by default, reserved
+/// for the one deliberate jewelry moment (the film's hood-park Continue).
 struct OnboardingNextButton: View {
     let title: String
     var enabled: Bool = true
+    var glow: Double = 0
     let action: () -> Void
 
     var body: some View {
@@ -236,6 +213,7 @@ struct OnboardingNextButton: View {
                     .fill(enabled ? Color.white : Color.white.opacity(0.08)))
         }
         .buttonStyle(.plain)
+        .background { if glow > 0 { GlowHalo(active: enabled, intensity: glow) } }
         .disabled(!enabled)
         .animation(.easeInOut(duration: 0.3), value: enabled)
     }
@@ -266,6 +244,36 @@ struct OnboardingBackButton: View {
     }
 }
 
+/// Swallows right-clicks in the window hosting onboarding, for onboarding's whole lifetime.
+/// The film's webview serves WebKit's context menu (Reload Page restarts the film), and no
+/// onboarding screen has a legitimate right-click — so the event is eaten at the door.
+/// Window-scoped on purpose: other windows (dev tools, the notch) keep theirs. The local
+/// monitor installs on view-did-move-to-window (post-launch — never during app init, the
+/// notch lesson) and dies with the view. Ctrl-click menus are covered separately by
+/// PassiveWebView's willOpenMenu override.
+private struct RightClickBlocker: NSViewRepresentable {
+    func makeNSView(context: Context) -> Blocker { Blocker() }
+    func updateNSView(_ view: Blocker, context: Context) {}
+
+    final class Blocker: NSView {
+        private var monitor: Any?
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            if let monitor { NSEvent.removeMonitor(monitor); self.monitor = nil }
+            guard window != nil else { return }
+            monitor = NSEvent.addLocalMonitorForEvents(
+                matching: [.rightMouseDown, .rightMouseUp]) { [weak self] event in
+                event.window === self?.window ? nil : event
+            }
+        }
+
+        deinit {
+            if let monitor { NSEvent.removeMonitor(monitor) }
+        }
+    }
+}
+
 /// The trust footer — on every onboarding surface, like everywhere else in the app.
 struct OnboardingTrustFooter: View {
     var body: some View {
@@ -276,7 +284,7 @@ struct OnboardingTrustFooter: View {
     }
 }
 
-#Preview("Onboarding — intro slides") {
+#Preview("Onboarding") {
     OnboardingView(onFinished: {})
         .frame(width: 1180, height: 880)
         .preferredColorScheme(.dark)


### PR DESCRIPTION
Four onboarding changes, all around the film step:

## Telemetry consent on the hood park
New `OnboardingTelemetryConsent` (native overlay, same pattern as the hood Continue): bottom-left privacy block — "We never collect your personal info." over two capsules, **Read More** (presents the Settings `PrivacyPolicyView` sheet verbatim) and **Configure Telemetry**, which blooms a subtle anchored card (no scrim, click-outside dismisses) with the two anonymous-telemetry toggles:

- Crash reports · Sentry
- Analytics · TelemetryDeck (with the core-tier disclosure caption when switched off)

Both ride the same `@AppStorage` keys as Settings → System and apply live via `CrashReporting`/`Analytics.applyEnabledChange()` — the choice made here IS the Settings choice.

## Glowing hood Continue
`OnboardingNextButton` gains an optional `glow` (default 0 = unchanged everywhere else); the hood park's Continue wears the shared `GlowHalo` at 0.4, a beat brighter than the Analyze Now popover's 0.28.

## Placeholder intro slides removed
Step machine is now film → permissions → codex login → crossroads → ready. The `slides` placeholder view, `slideCount`, and the film fallback's stale "STEP 1 OF 3" whisper are gone. Note: persisted `onboarding.step` values shift meaning on dev Macs mid-onboarding (no migration — pre-launch, Reset rewinds).

## Right-click disabled across onboarding
`PassiveWebView` empties WebKit's context menu (kills right-click AND ctrl-click "Reload Page", which restarted the film), and a window-scoped `RightClickBlocker` local monitor swallows right-clicks in the onboarding window for onboarding's lifetime (other windows unaffected; installs post-launch, never during app init).

Verified with isolated CLI builds throughout. Visual pass on real hardware still pending — hood-park footer layout, card bloom, glow intensity.

https://claude.ai/code/session_01F67AnP7zxWPbgDLqqvnz3B