### PR TITLE
Fix Knowledge sidebar not updating after deleting a nested note/folder

### DIFF
--- a/Sentient OS macOS/Views/Knowledge/VaultTree.swift
+++ b/Sentient OS macOS/Views/Knowledge/VaultTree.swift
@@ -23,10 +23,10 @@ struct VaultNode: Identifiable, Hashable {
 
     var id: URL { url }
 
-    // Identity is the URL alone — cheap hashing, and the recursive `children` never matter for
-    // equality (a node's URL fully determines it).
-    static func == (l: VaultNode, r: VaultNode) -> Bool { l.url == r.url }
-    func hash(into h: inout Hasher) { h.combine(url) }
+    // Equality is the synthesized full-value one — `children` included. SwiftUI decides whether to
+    // re-render by comparing old vs new values with ==, so a URL-only equality here made the sidebar
+    // ignore a reloaded tree whose top-level URLs hadn't changed (a note deleted inside a folder
+    // stayed visible until relaunch). The tree is tiny; recursive comparison is nothing.
 }
 
 /// A loaded snapshot of the vault: the tree (README pulled out and offered as the pinned


### PR DESCRIPTION
## What

Deleting a note or folder from the Knowledge reader view removed it on disk, but the sidebar kept showing it until relaunch.

## Why

`deleteItem` already re-scans the vault (`reloadVault()`), but `VaultNode` declared a custom Equatable/Hashable that compared **only the URL** and ignored `children`. SwiftUI decides whether to re-render by comparing old vs new values with `==`, so after a delete inside a folder the rebuilt tree's top-level nodes still compared equal (same URLs) and the sidebar update was skipped. Top-level deletes worked (array length changed); nested ones went stale.

## Fix

Dropped the custom conformance for the synthesized full-value one (children included), with a comment explaining why it must stay that way. Every existing refresh point — delete, new note, new folder — now lands in the UI. The tree is capped at ~120 notes, so recursive comparison costs nothing. Constellation view was already fine (rebuilds from the fresh vault on every sky entry).

## Verified

Full `xcodebuild` build succeeded (isolated DerivedData at `/tmp/sentient-verify`).

https://claude.ai/code/session_01E8VhA7LEFVG12BN5cd7THd