### PR TITLE
Onboarding Sidekick beat for notchless/external-display Macs (press right ⌘)

### DIFF
--- a/Sentient OS macOS/Notch Magic/CommandCoordinator.swift
+++ b/Sentient OS macOS/Notch Magic/CommandCoordinator.swift
@@ -64,8 +64,9 @@ final class CommandCoordinator {
     /// until the next interaction starts.
     private(set) var notchAnchor: NotchAnchor = .mainDisplay
 
-    /// Onboarding's film step arms this while the film is parked on "Click the notch": the next
-    /// notch click plays the scripted Sidekick demo on the user's real bezel — the real type field,
+    /// Onboarding's film step arms this while the film is parked on its invitation: the next
+    /// notch click OR hotkey press plays the scripted Sidekick demo on the user's real notch
+    /// (the hardware bezel, or the main display's software overlay) — the real type field,
     /// the task typing itself, the run model's scripted story — with the two real-world doors (the
     /// Plus aside, the first-use permission gate) deliberately bypassed: nothing real can fire, so
     /// there is nothing to gate. One-shot: consumed at fire, restored by a dismissed field,
@@ -206,11 +207,10 @@ final class CommandCoordinator {
     }
 
     /// True = the press was consumed by the onboarding policy (silence, or the aside). The
-    /// armed demo exempts only the notch CLICK — the film says "click the notch", so a hotkey
-    /// press stays quiet even during the beat.
-    private func interceptForOnboarding(demoEligible: Bool = false) -> Bool {
+    /// armed demo never reaches here — both its doors (the notch click, the hotkey press)
+    /// answer before their intercept.
+    private func interceptForOnboarding() -> Bool {
         guard !Self.hasCompletedOnboarding else { return false }
-        if demoEligible, onboardingDemoArmed { return false }
         if UserDefaults.standard.bool(forKey: Self.notchDemoPlayedKey) {
             flash(Self.finishOnboardingNotice, for: 2.0)
             Log("sidekick press during onboarding — the finish-onboarding aside")
@@ -221,6 +221,16 @@ final class CommandCoordinator {
     }
 
     private func voicePressBegan() {
+        // The armed onboarding beat answers the hotkey too — the key variant's NAMED door
+        // ("press the right ⌘ key" on iMacs / external displays / clamshell), and a forgiving
+        // one during the click beat. Ahead of the voice guard on purpose (the demo is typing
+        // theater, no mic involved), and fired on press-DOWN so a user who holds, expecting
+        // hold-to-talk, still gets the show — the release lands on .typing and does nothing.
+        if onboardingDemoArmed, phase == .hidden, !run.isRunning {
+            notchAnchor = .mainDisplay    // hardware notch when it's main; software notch otherwise
+            beginNotchDemo(door: "hotkey press")
+            return
+        }
         guard VoiceCapture.isAvailable else { return }
         // A hotkey tap while the type field is open toggles it closed (no action) — a quick way to back out.
         if phase == .typing { dismissTyping(); return }
@@ -415,9 +425,9 @@ final class CommandCoordinator {
     func notchClicked() {
         guard phase == .hidden, !run.isRunning else { return }
         notchAnchor = .builtInNotch       // the whole session lives on the bezel that was clicked
-        if onboardingDemoArmed { beginNotchDemo(); return }
+        if onboardingDemoArmed { beginNotchDemo(door: "notch click"); return }
         // Before home: silence pre-beat (the swell is off then anyway), the aside after.
-        if interceptForOnboarding(demoEligible: true) { return }
+        if interceptForOnboarding() { return }
         if CodexAuth.knowledgeBaseOnly {
             flash(Self.needsPlusNotice, for: 2.0)
             Log("notch click blocked — knowledge-base-only plan (Sidekick needs Plus)")
@@ -431,7 +441,7 @@ final class CommandCoordinator {
         Log("notch clicked → typing")
     }
 
-    // MARK: The onboarding notch demo (the film step's "click the notch" beat)
+    // MARK: The onboarding notch demo (the film step's invitation beat — click or hotkey)
 
     /// Arm the one-shot demo. `onFired` is the film step's cue to resume the webview ride the
     /// moment the demo "presses ⏎" — the film's browser windows play the shopping run while the
@@ -453,13 +463,14 @@ final class CommandCoordinator {
         Log("onboarding notch demo disarmed")
     }
 
-    /// The demo click: the REAL type field opens (no Plus aside, no permission gate — nothing real
-    /// can fire), the film's task types itself, then the run model performs the scripted story.
-    /// A dismissed field (Esc / click-away / hotkey tap) bails the script and re-arms for another
-    /// click; the arm is consumed only when the demo actually fires.
-    private func beginNotchDemo() {
+    /// The demo (a notch click or a hotkey press — `door` labels the log): the REAL type field
+    /// opens (no Plus aside, no permission gate — nothing real can fire), the film's task types
+    /// itself, then the run model performs the scripted story. A dismissed field (Esc /
+    /// click-away / hotkey tap) bails the script and re-arms for another answer; the arm is
+    /// consumed only when the demo actually fires.
+    private func beginNotchDemo(door: String) {
         setPhase(.typing)
-        Log("notch clicked → onboarding demo (typing)")
+        Log("\(door) → onboarding demo (typing)")
         demoTask = Task { [weak self] in
             do {
                 try await Task.sleep(for: .seconds(0.7))          // the field's bloom + focus settle

--- a/Sentient OS macOS/Views/Onboarding/OnboardingFilmView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingFilmView.swift
@@ -17,6 +17,7 @@
 //  server (e.g. http://localhost:3100/onboarding?end=0.42).
 //
 
+import AppKit
 import SwiftUI
 import WebKit
 
@@ -24,7 +25,7 @@ struct OnboardingFilmView: View {
     let onContinue: () -> Void
 
     /// For the notch demo: the film step arms the coordinator's one-shot scripted Sidekick
-    /// performance while the film is parked on "Click the notch".
+    /// performance while the film is parked on the invitation (click the notch / press right ⌘).
     @Environment(AppState.self) private var appState
 
     /// The step's phases, three film legs in one webview: black until the film is really
@@ -39,10 +40,11 @@ struct OnboardingFilmView: View {
     /// post-hydration, as the entrance starts) — WKWebView's didFinish fires long before
     /// first paint, so fading on it pops content into an already-visible view; didFinish
     /// survives only as a grace-period fallback for a page that never posts.
-    /// With a real notch, the Sidekick leg splits around the hardware beat: ride to the
-    /// "Click the notch" whisper (.ridingToInvitation) → wait for the user's REAL bezel click
-    /// (.awaitingNotch — the coordinator's armed demo answers it) → the demo fires and the film
-    /// rides on (.ridingSidekick). Notch-less Macs skip straight from .parked to .ridingSidekick.
+    /// The Sidekick leg splits around the hardware beat on EVERY Mac: ride to the invitation
+    /// whisper (.ridingToInvitation — "Click the notch" on a lone notch display, "Press the
+    /// right ⌘ key" otherwise) → wait for the user's real answer (.awaitingNotch — the
+    /// coordinator's armed demo takes a bezel click or a hotkey press alike) → the demo fires
+    /// and the film rides on (.ridingSidekick).
     private enum Phase {
         case loading, playing, parked, ridingToInvitation, awaitingNotch,
              ridingSidekick, sidekickDone, ridingToHood, hoodParked, unavailable
@@ -77,14 +79,22 @@ struct OnboardingFilmView: View {
     private static let productionURL = URL(string: "https://sentient-os.ai/onboarding?end=0.42")!
     private static let sidekickEndP = 0.999
 
-    /// The "Click the notch" park — pDay 0.44 (the invitation whisper holds 0.42–0.47), in
-    /// master p: 0.4773 + 0.44 × 0.5227. Only used when a real notch exists.
+    /// The invitation park — pDay 0.44 (the invitation whisper holds 0.42–0.47), in
+    /// master p: 0.4773 + 0.44 × 0.5227. Every Mac rides here.
     private static let invitationEndP = 0.707
 
-    /// A Mac with a real notch gets the hardware beat: the film hides its DOM notch
-    /// (?notch=real) and the user's own bezel performs the Sidekick show.
-    private static var realNotchAvailable: Bool {
-        NotchWindowController.builtInNotchScreen() != nil
+    /// Which door the film's invitation names (the ?notch= query value). "real" = a lone
+    /// built-in notch display — "Click the notch", the bezel moment. "key" = everything else
+    /// (external display connected, iMac, clamshell, a notch-less MacBook) — "Press the
+    /// right ⌘ key": the press drops the overlay on the main display, a software notch when
+    /// there's no cutout (the hotkey path's shipped rendering). Either way the film hides its
+    /// DOM notch and the user's own notch performs the Sidekick show. During the beat BOTH
+    /// doors answer (the coordinator arms click and hotkey alike), so the variant only picks
+    /// the whisper — baked once at film load; a mid-film display change just means the
+    /// whisper names the other door, which still works.
+    private static var notchBeat: String {
+        NotchWindowController.builtInNotchScreen() != nil && NSScreen.screens.count == 1
+            ? "real" : "key"
     }
 
     private static var filmURL: URL {
@@ -93,11 +103,10 @@ struct OnboardingFilmView: View {
         if let raw = UserDefaults.standard.string(forKey: "dev.film.url"),
            let url = URL(string: raw) { base = url }
         #endif
-        guard realNotchAvailable,
-              var comps = URLComponents(url: base, resolvingAgainstBaseURL: false) else { return base }
+        guard var comps = URLComponents(url: base, resolvingAgainstBaseURL: false) else { return base }
         var items = comps.queryItems ?? []
         if !items.contains(where: { $0.name == "notch" }) {
-            items.append(URLQueryItem(name: "notch", value: "real"))
+            items.append(URLQueryItem(name: "notch", value: notchBeat))
             comps.queryItems = items
         }
         return comps.url ?? base
@@ -211,8 +220,8 @@ struct OnboardingFilmView: View {
             if phase == .ridingToHood { setPhase(.hoodParked) }
         }
         // The notch invitation was the one wait without a watchdog — the corner SKIP
-        // used to be its manual exit (removed 2026-07-17). If the bezel never gets
-        // clicked, the film rides on by itself, exactly as answering it would.
+        // used to be its manual exit (removed 2026-07-17). If the invitation is never
+        // answered, the film rides on by itself, exactly as answering it would.
         .task(id: phase == .awaitingNotch) {
             guard phase == .awaitingNotch else { return }
             try? await Task.sleep(for: .seconds(60))
@@ -247,18 +256,14 @@ struct OnboardingFilmView: View {
         }
     }
 
-    /// The parked Continue: the first park rides on — to the hardware notch beat when the Mac
-    /// has one, else straight through the whole Sidekick scene. The Sidekick park's Continue
-    /// rides leg 3 down to the Under-the-hood exhibit; the hood park's Continue hands
+    /// The parked Continue: the first park rides on to the invitation beat. The Sidekick park's
+    /// Continue rides leg 3 down to the Under-the-hood exhibit; the hood park's Continue hands
     /// onboarding to the next step.
     private func advanceFromPark() {
         switch phase {
-        case .parked where Self.realNotchAvailable:
+        case .parked:
             setPhase(.ridingToInvitation)
             driver.continueTo(Self.invitationEndP)
-        case .parked:
-            setPhase(.ridingSidekick)
-            driver.continueTo(Self.sidekickEndP)
         case .sidekickDone:
             setPhase(.ridingToHood)
             // A deploy without the hood anchor (older site) reports unsupported —
@@ -282,10 +287,10 @@ struct OnboardingFilmView: View {
         onContinue()
     }
 
-    /// Parked on "Click the notch": arm the coordinator's one-shot demo. The user's real bezel
-    /// click opens the real type field, the task types itself, and the moment the demo fires,
-    /// the film rides on — the webview's windows play the shopping run while the hardware notch
-    /// narrates. Disarmed on step-exit via onDisappear.
+    /// Parked on the invitation: arm the coordinator's one-shot demo. The user's answer — a
+    /// bezel click or a hotkey press — opens the real type field, the task types itself, and
+    /// the moment the demo fires, the film rides on — the webview's windows play the shopping
+    /// run while the real notch narrates. Disarmed on step-exit via onDisappear.
     private func armNotchBeat() {
         setPhase(.awaitingNotch)
         appState.commandCoordinator.armOnboardingNotchDemo { [self] in


### PR DESCRIPTION
## What

The onboarding film's hardware Sidekick beat assumed a clickable notch. External displays, iMacs, clamshell mode, and notch-less MacBooks either got a misleading "Click the notch" instruction or (notchless) no hardware beat at all — just the DOM-notch movie.

Now every Mac gets the beat:

- **`OnboardingFilmView`**: `realNotchAvailable` → `notchBeat` — `?notch=real` (click beat, unchanged) only when the built-in notch display is the *only* screen; `?notch=key` (press right ⌘) for everything else. The first park always rides to the invitation now; the film-only fallback path is deleted. The existing 60s unanswered-invitation watchdog covers all variants.
- **`CommandCoordinator`**: the armed beat answers the hotkey too — press-down fires the same scripted demo the bezel click does, anchored `.mainDisplay` (the shipped software-notch rendering when there's no cutout). Sits ahead of the voice guard (demo is typing theater, no mic); a hold-expecting user still gets the show. Removed the now-dead `demoEligible:` intercept param; `beginNotchDemo(door:)` labels which door fired.

## Deploy coupling

⚠️ The site must learn `?notch=key` (`SidekickScene.tsx`: treat like `real`, whisper "Press the right ⌘ key", no chevron) — until that deploys, the key variant parks on a visible DOM notch with the wrong whisper (the ⌘ press still works). Site change ships from the website repo separately.

## Verification

- Isolated `xcodebuild` (`/tmp/sentient-verify`): BUILD SUCCEEDED.
- Hardware smoke test still owed: (1) lone notch MacBook — unchanged click beat; (2) notch MacBook + external — key beat; (3) iMac/clamshell — key beat, software notch.

https://claude.ai/code/session_01Eg6Ar4BeP34Sv4Q561CYb7