### PR TITLE
Card fires light the notch + one-task-at-a-time

### DIFF
--- a/Sentient OS macOS/Documentation/Home — Proactive Intelligence (For You).md
+++ b/Sentient OS macOS/Documentation/Home — Proactive Intelligence (For You).md
@@ -142,7 +142,18 @@ to the jesai deck — those devs were pitching), `.jesai` / `.launch` are the ha
   `Proactive Intelligence (Judge).md` §The welcome gift). **Firing is real:** `runReal` routes through
   `ProactiveExecutor.fire`, streams codex's live play-by-play into the card (`liveLines`, with a
   per-card **STOP** that terminates the codex process), flies the card away on success and removes it
-  from the persisted set; a failure returns it to the offer state for edit + retry. **Drafts are
+  from the persisted set; a failure returns it to the offer state for edit + retry. **A computer-use
+  fire also ADOPTS the notch (2026-07-17):** `runReal` opens with
+  `CommandCoordinator.beginExternalRun` — the shared `CommandRunModel` lights up with the card's
+  title, the raw lines tee into its cleaned `statusLine` (`externalPush`), and the ✓/■/✗ finishing
+  flourish plays on the bezel. `run.isRunning` is thereby the app-wide **one-task-at-a-time lock**:
+  while ANY task runs (Sidekick, the bar, a card), other computer cards' fire CTAs dim
+  (`fireDimmed`, card + letter) and `ForYouModel.run` refuses, with `beginExternalRun`'s refusal
+  doubling as the re-check for a gate-held fire; every STOP surface — the card's, the notch's, the
+  bar's, a fresh Sidekick press — cancels the one Task, and the adoption completes exactly once at
+  the fire's unwind (a stopped fire records NO scoreboard row and "stopped" analytics).
+  Gmail/Calendar and research fires are exempt by decision: quiet card-only, no notch, no lock,
+  concurrent is fine. (Doc: `Notch Magic/Notch Magic.md` §6.) **Drafts are
   editable, auto-saved:** every edit in the letter view's draft block (body, To:, Subject) commits on
   a 300ms debounce into `preparedContent`/`recipient` (both in-memory and in
   `ProactiveResearch.latest()`), so what the user edited is verbatim what fires — no Save button.
@@ -227,7 +238,8 @@ for `.system(design: .monospaced)` — that's why the bridge exists. Chat sends 
 `PromptBar` has a single mode — **Computer use**. `onSend` routes through
 `appState.commandCoordinator.submit(_:mode:source: .promptBar)` — the SAME shared run
 (`CommandRunModel` → `CodexCLI.runAgentCommand`) the right-⌘ Sidekick hotkey drives, so the bar and
-the notch are two views of one run: while running, the bar shows the cleaned codex `statusLine` with
+the notch are two views of one run — and a firing card makes it three (a computer-use card fire
+adopts the same run, above): while running, the bar shows the cleaned codex `statusLine` with
 a STOP button, and the notch glows alongside. (Doc: `Notch Magic/Notch Magic.md`.)
 
 ## The other windows

--- a/Sentient OS macOS/Documentation/Notch Magic/Notch Magic.md
+++ b/Sentient OS macOS/Documentation/Notch Magic/Notch Magic.md
@@ -10,16 +10,17 @@ Documentation for **Notch Magic** — Sentient OS's global hold-to-talk / tap-to
 
 ## 1. What Notch Magic is
 
-**A global way to tell Sentient to *do something*, and a universal status surface for when it's working.** Four front doors, one backend, one notch:
+**A global way to tell Sentient to *do something*, and a universal status surface for when it's working.** Five front doors, one run, one notch:
 
 1. **Press-and-hold the Sidekick key anywhere** → the notch *drops open the instant you press* (you're pulling it open); *speak* a task → release → it transcribes (on-device) and fires it as a **computer-use** command.
 2. **Tap the Sidekick key** (a quick press-release, no hold) → the open notch becomes a focused **text field** → type a task, hit ⏎ → same computer-use backend.
 3. **Click the notch itself** — mousing over the idle notch makes it *swell* under the cursor with a trackpad haptic tick and a drop shadow (the Dynamic-Island "press me" affordance); a click opens the same tap-to-type field. Works even when an external display is primary — the whole click session anchors to the built-in bezel (§7f). §7a.
 4. **Type in the home command bar** (`PromptBar`) → same backend, same notch.
+5. **Fire a proactive card** on the home → the fire **ADOPTS the same run** (`beginExternalRun`, 2026-07-17): the notch rises in `.running` with the card's title and streams the work — the card, the bar, and the notch are three views of one task. §6.
 
 The **Sidekick key** is the user's choice in Settings → Proactive & Sidekick: **right ⌘** (default) or **right ⌥**. Both are right-side modifiers, so either works permission-free (§4); the rest of this doc says "right ⌘" as the default, but everything applies to whichever key is chosen.
 
-All funnel through **`CommandCoordinator` → `CommandRunModel` → `CodexCLI.runAgentCommand`**, and the notch is a live view of `coordinator.phase` (+ `coordinator.run`). The notch is the Mac's "face" coming alive — it descends from the bezel **glowing**, shows what it heard (or lets you type), then streams the work — *Thinking through your task*, **Remembering** the notes it reads from your knowledge base, the actions — with a STOP button, and retracts.
+Doors 1–4 funnel through **`CommandCoordinator` → `CommandRunModel` → `CodexCLI.runAgentCommand`**; a card fire keeps its own executor spine (`ProactiveExecutor` → `runAgentCommand`) but adopts the same `CommandRunModel` — so **`run.isRunning` is the app-wide ONE-task-at-a-time lock** (while anything runs, every other entry point is locked out, and a fresh hotkey press is the universal STOP; gmail/calendar connector fires are exempt — quiet, card-only). The notch is a live view of `coordinator.phase` (+ `coordinator.run`). The notch is the Mac's "face" coming alive — it descends from the bezel **glowing**, shows what it heard (or lets you type), then streams the work — *Thinking through your task*, **Remembering** the notes it reads from your knowledge base, the actions — with a STOP button, and retracts.
 
 Every command is **computer use** (the dedicated browser-use channel was removed — see the root architecture doc §7), and the notch shows for all of them.
 
@@ -33,6 +34,8 @@ Every command is **computer use** (the dedicated browser-use channel was removed
  ⌘/⌥ key hold ──► SidekickHotkeyMonitor ─┐
                                         ├─► CommandCoordinator ──► CommandRunModel ──► CodexCLI (computer use)
  home PromptBar ──► coordinator.submit ─┘        │  owns phase (NotchPhase)
+ card fire ──► coordinator.beginExternalRun ─────┤  (ADOPTS the run — the work itself stays in the
+   (ForYouModel.runReal → ProactiveExecutor)     │   card's Task; lines tee in via externalPush)
                                                  │  owns VoiceCapture (mic → on-device transcript)
                                                  ▼
                                   coordinator.phase  ◄── observed by ──  NotchWindowController (NSPanel host)
@@ -53,16 +56,16 @@ Every command is **computer use** (the dedicated browser-use channel was removed
 | **`SpeechAnalyzerEngine.swift`** | macOS **26+** speech-to-text (`SpeechAnalyzer` + `SpeechTranscriber`, on-device, in-memory). |
 | **`SFSpeechRecognizerEngine.swift`** | macOS **15** fallback (`SFSpeechRecognizer`, server-capable). |
 | **`VoiceCapture.swift`** | Façade: mic + speech permissions, engine selection, `prewarm` / `start` / `stopAndTranscribe` / `cancel`. |
-| **`CommandRunModel.swift`** | Runs ONE codex task; **cleans codex's raw human-readable stream** into the bar's `statusLine` + the `remembering` state (§6); `stop()`, `onFinished(Outcome)`. Grabs + attaches the per-display screen stills at run start (§6a). |
+| **`CommandRunModel.swift`** | Runs ONE codex task; **cleans codex's raw human-readable stream** into the bar's `statusLine` + the `remembering` state (§6); `stop()`, `onFinished(Outcome)`. Grabs + attaches the per-display screen stills at run start (§6a). Also the adoption seams — `adoptExternal` / `externalPush` / `completeExternal` — for a proactive card's fire (§6); `isRunning` doubles as the app-wide one-task lock. |
 | **`ScreenCapture.swift`** | Grabs EVERY display to temp JPEGs for computer-use context (`/usr/sbin/screencapture -D <n>`, main display always first). `grab() -> [URL]` (empty if no Screen Recording grant) · `discard(_:)`. §6a. |
-| **`CommandCoordinator.swift`** | The brain: owns the run + hotkey + voice, drives `phase` (`NotchPhase`), the press→branch flow, `submit()` / `submitTyped()` / `dismissTyping()` / `cancelCurrent()` / `stop()`. Also the hover affordance's seams: the `notchHovering` render state + `notchClicked()` (§7a), and the per-interaction `notchAnchor` — which display owns the session (§7f). |
+| **`CommandCoordinator.swift`** | The brain: owns the run + hotkey + voice, drives `phase` (`NotchPhase`), the press→branch flow, `submit()` / `submitTyped()` / `dismissTyping()` / `cancelCurrent()` / `stop()` / `beginExternalRun()` (the card-fire door, §6). Also the hover affordance's seams: the `notchHovering` render state + `notchClicked()` (§7a), and the per-interaction `notchAnchor` — which display owns the session (§7f). |
 | **`NotchSpace.swift`** | SkyLight private-API wrapper — pins the panel into a top-level window-server space so it's fixed over the notch on every Space. |
 | **`NotchWindowController.swift`** | The `NSPanel` host: a **fixed canvas** flush at the bezel of the anchor's display (§7f); click-through by toggling `ignoresMouseEvents` per cursor position (two-tier poll, §7b); all-Spaces; observers. Also the hover affordance's mechanics (mouseMoved monitors → swell + haptic + click, §7a), `NotchPanel`, `NotchHostingView`, the `NSScreen.notchSize`/`displayID` extension. |
 | **`NotchShape.swift`** | The silhouette `Shape` (animatable corner radii) **+ `NotchSkirtShape`** — its open twin (sides + rounded bottom + concave top corners, no flat top edge) that the glow strokes. |
 | **`SpinningLogo.swift`** | The 2D spectrum-ring logo (matches the app icon). |
 | **`NotchView.swift`** | `NotchView` (binder) + `NotchContent` (the pure visual: morph, phases, the depth-bed shadow, layered edge glow, the read-back / Remembering / status captions, the hover swell + its asymmetric springs) + `NotchMetrics` (per-phase + hover sizing) + `NotchStopButton` + the `.blurDissolve` transition. |
 
-Edits outside this folder: `AppState.swift` (owns/starts the two objects), `Views/HomeView.swift` (`PromptBar` drives `appState.commandCoordinator`), `Cloud/CodexCLI.swift` (`runAgentCommand` gained an optional `imagePath` → `codex exec -i`, §6a), `System/Permissions.swift` (`hasScreenRecording()`, already present), and the project's `INFOPLIST_KEY_NSMicrophoneUsageDescription` + `INFOPLIST_KEY_NSSpeechRecognitionUsageDescription` build settings.
+Edits outside this folder: `AppState.swift` (owns/starts the two objects), `Views/HomeView.swift` (`PromptBar` drives `appState.commandCoordinator`; `ForYouModel.runReal` adopts the run for a card's computer-use fire, §6), `Cloud/CodexCLI.swift` (`runAgentCommand` gained an optional `imagePath` → `codex exec -i`, §6a), `System/Permissions.swift` (`hasScreenRecording()`, already present), and the project's `INFOPLIST_KEY_NSMicrophoneUsageDescription` + `INFOPLIST_KEY_NSSpeechRecognitionUsageDescription` build settings.
 
 There is still a **DEV bench** `Views/Dev/HotkeyLabView.swift` (DEV TOOLS → HOTKEY LAB) — the original proof of the permission-free hotkey (now on NSEvent monitors, same mechanism as the real thing). It's superseded by `SidekickHotkeyMonitor`; **retire it** once you're confident (see §13).
 
@@ -124,8 +127,26 @@ command-bar path, which has no press) and the **first-use permission gate**
 takes over and HOLDS the command: Continue fires the stashed `launch`, closing drops it; the notch
 steps aside with `.hidden`. See `Permission Guide (First-Use Grants).md`).
 
+**Adopted external runs — a proactive card's fire lights the same notch (2026-07-17).**
+`beginExternalRun(caption:onStopRequest:)` is the card-fire door: `ForYouModel.runReal`
+(computer-method cards only) adopts THE run — `run.adoptExternal` flips `isRunning`, seeds
+`statusLine` with the card's title, and the notch rises in `.running` on the main display. The work
+itself stays in the card's own Task (`ProactiveExecutor.fire`); its raw codex lines tee through
+`run.externalPush` (the same stream cleaning below, "Remembering" included), and every exit
+completes the adoption exactly once via `run.completeExternal` — which **skips the scoreboard +
+analytics** (the executor records every card fire itself) and rides the normal `onFinished` →
+finishing flourish. `stop()` on an adopted run delegates to `onStopRequest` (the card's own
+cancel), so the notch STOP, the bar STOP, Esc, and the hotkey press all reach it — and the card's
+own STOP ends the notch identically, from the fire's unwind. **`run.isRunning` is therefore the
+app-wide ONE-task-at-a-time lock:** the existing guards lock every other entry point while a card
+fires, `beginExternalRun` returns `false` while anything runs (doubling as the re-check for a fire
+the permission gate held for minutes), and the home dims other computer cards' CTAs. By decision
+(2026-07-17): **gmail/calendar connector fires and research cards are fully EXEMPT** — quiet,
+card-only, no lock, concurrent is fine. Home-side wiring:
+`Home — Proactive Intelligence (For You).md`.
+
 **The hotkey flow — press OPENS, then it branches to voice or type:**
-- `voicePressBegan()` (onPress): first the CANCEL beats (below), then — from idle only, `isInteracting` blocks a fresh press mid-interaction — **knowledge-base-only plans get answered RIGHT HERE** — a 2s `flash("get ChatGPT Plus to wake Sidekick")`, the same instant beat as the mic notice, and the notch never opens for listening or typing (live-checked per press, so it can never go stale; the run costs codex quota those plans don't have). Otherwise: `setPhase(.opening)` *immediately* (the "pull it open" feel). Start the mic **only if `VoiceCapture.isAuthorized`** — never PROMPT on a press.
+- `voicePressBegan()` (onPress): **first the UNIVERSAL STOP (2026-07-17) — a press while ANY real task is running (hotkey-, command-bar-, or card-launched) cancels it via `stop()`** (one task, one notch, one key; hoisted above the voice gate so a Mac with no speech model still gets the cancel; the onboarding demo is exempt — the film narrates through it). Then the transcribing bail, then — from idle only, `isInteracting` blocks a fresh press mid-interaction — **knowledge-base-only plans get answered RIGHT HERE** — a 2s `flash("get ChatGPT Plus to wake Sidekick")`, the same instant beat as the mic notice, and the notch never opens for listening or typing (live-checked per press, so it can never go stale; the run costs codex quota those plans don't have). Otherwise: `setPhase(.opening)` *immediately* (the "pull it open" feel). Start the mic **only if `VoiceCapture.isAuthorized`** — never PROMPT on a press.
 - `voiceHoldConfirmed()` (@250ms): `setPhase(.listening)` — committed to voice (the "lean in"); start the mic now if perms weren't pre-granted (the only first-use prompt path).
 - `voiceReleased(held:)` from `.opening`/`.listening`: `held ≥ 0.25` → `finalizeVoice()` (→ `.transcribing` → `stopAndTranscribe()` → empty? `flash` : `submit(.voice)`); else `beginTyping()` (cancel the mic → `setPhase(.typing)`).
 - **`finalizeVoice` carries a 15s WATCHDOG** — the finalize itself is <2s, but `voice.start()` can park on the on-device speech-model DOWNLOAD (unbounded; seen in the field as a notch spinning forever with every new press "busy"). Still `.transcribing` at 15s → cancel the capture, re-kick `prewarm()` so the download keeps moving, and `flash("voice isn't ready yet, try again in a moment")`. Both resolution paths re-check `phaseToken` so a timed-out/cancelled finalize can never double-speak. The notch must never wedge.
@@ -140,8 +161,9 @@ Two routes feed the cancel (there is NO global Esc — a keyDown tap is Input-Mo
 the window's **local** Esc monitor (§7) covers every state **whenever Sentient is frontmost** — the
 typing field (where it consumes Esc before the text field so dismissing never beeps) and any notch
 state over the app's own windows; over OTHER apps, a **fresh hotkey press IS the cancel** —
-`voicePressBegan` routes a press during `.transcribing` to `cancelCurrent()`, and a press while the
-transcript is still shown to `stop()` (instant dismiss), before any new interaction can begin.
+`voicePressBegan` routes a press during ANY real run to `stop()` (the universal stop above — the
+transcript beat keeps its instant no-flourish dismiss inside `stop()` itself) and a press during
+`.transcribing` to `cancelCurrent()`, before any new interaction can begin.
 
 **STOP is transcript-aware too — `stop()` unifies both.** A STOP click (or a cancel) *while the transcript shows* dismisses instantly: it sets `.hidden` first, so `runFinished` sees a non-running phase and skips the flourish — while the run is still cancelled underneath. Once computer use is working, STOP halts it with the honest "Stopped" beat. The STOP button (`onStop`), Esc, and the hotkey press all route through `stop()`, so they behave identically.
 
@@ -288,6 +310,7 @@ All of the below is **confirmed working on Jesai's bezel** (live screenshots/rec
 - **The hotkey mechanism swap (2026-07-09):** the CGEventTap was replaced with NSEvent global+local `flagsChanged` monitors (lesson 13) with a post-launch install guard (lesson 14) — verified live on hardware: fresh TCC state (`tccutil reset`) → **no Keystroke Receiving dialog**, hold-to-talk + tap-to-type + Esc cancel all working, launch clean.
 - **The notch as a button (2026-07-13):** hover swell + haptic + depth-bed drop shadow + click-to-type (§7a), the asymmetric enter/exit springs, the two-tier proximity poll (§7b), and the top-edge Fitts fixes (lesson 15) — all verified on Jesai's bezel, including top-edge clicks across the notch's width and menu-bar click-through immediately beside it.
 - **External-primary anchoring + all-display screenshots (2026-07-14):** [VERIFIED live, external display as primary] hover → swell → click → type → run all landed on the built-in bezel (`NotchAnchor`, §7f) with the live status streaming there, while the hotkey kept the main display; and the same run attached BOTH displays' frames (log: `📸 2 display screenshots captured`), main display first, with the both-displays prompt line — confirmed by dumping the exact codex inputs (prompt + frames) via temp scaffolding, since deleted.
+- **Adopted card fires + the universal stop (2026-07-17):** [verified live on hardware] a proactive card's computer-use fire raises the notch with the card's title + the cleaned live stream + the ✓/■/✗ flourish; `run.isRunning` locks every entry point app-wide (other computer cards dim); every STOP surface — card, notch, bar, a fresh hotkey press — cancels the one task; gmail/calendar fires stay quiet + exempt (§6).
 - **Not yet done:** §12 polish backlog; productionization (§13). Reduced-motion + VoiceOver coded but unverified. The SkyLight pin during a Spaces swipe on the *built-in-as-secondary* display is untested (best-effort with a public fallback either way).
 
 ---
@@ -312,7 +335,7 @@ Grew into the full notch-as-a-button affordance: hover swell + haptic + drop sha
 ### E. Deferred touches (each its own focused pass)
 - **Behind-mic color dance:** a small blurred colored glow *behind the mic icon* in the listening state (distinct from the edge glow — the `.opening`→`.listening` "lean in" is the hook).
 - **2-line status:** the bar now shows a tight ONE status line (for compactness); if a 2-line codex narration matters, widen `captionHeight` / show the last 2.
-- **Multi-task "↓ N tasks":** today it's one run at a time; the future is a stack you pull down (per-task rows + STOPs). Big change to the coordinator (a list of runs) + the notch.
+- **Multi-task "↓ N tasks":** today it's one run at a time — now formalized app-wide (card fires adopt the same run, §6); the future is a stack you pull down (per-task rows + STOPs). Big change to the coordinator (a list of runs) + the notch.
 
 ---
 

--- a/Sentient OS macOS/Documentation/Proactive Intelligence (Judge).md
+++ b/Sentient OS macOS/Documentation/Proactive Intelligence (Judge).md
@@ -196,7 +196,12 @@ verified live — a real give-up parses clean with its reason extracted). Sideki
 now demand and parse the SAME sentinel (`Notch Magic/Notch Magic.md` §6). The verdict feeds
 `ExecutorScoreboard` (`Diagnostics/ExecutorScoreboard.swift`, §7.19) — one structured event per fire;
 "fired" means codex *claimed* done, and a missing sentinel is tracked as the false-success risk.
-Cancellation is real: the awaiting Task's cancel (a card's STOP) terminates the codex process.
+Cancellation is real: the awaiting Task's cancel terminates the codex process — reachable from the
+card's STOP and, since a computer-use fire ADOPTS the shared `CommandRunModel` (2026-07-17, one task
+at a time app-wide — `Notch Magic/Notch Magic.md` §6), from the notch's STOP, the bar's, and a fresh
+Sidekick press too. A stopped fire records NO scoreboard row (a user cancel is not a health outcome)
+and its `Proactive.actionFired` analytics outcome says "stopped" — the same exit semantics as
+`CommandRunModel`, so the shared dashboards stay comparable.
 
 ## Where it surfaces
 
@@ -204,7 +209,9 @@ Cancellation is real: the awaiting Task's cancel (a card's STOP) terminates the 
   `ProactiveResearch.latest()` (`dev.proactive.realCards`, ON by default) — the
   welcome `GiftLetter` envelope first, then one card per `PreparedAction` (method accent + kicker,
   editable draft, the LLM-written fire button). Firing streams codex's live play-by-play into the
-  card with a per-card STOP; success flies the card away and removes it from the persisted set.
+  card with a per-card STOP — and a computer-use fire lights the notch with the same stream (the
+  adopted run, one task at a time; gmail/calendar fires stay quiet); success flies the card away
+  and removes it from the persisted set.
   The dev toggle OFF = the hard-coded investor demo deck (pitch mode; scrubbed pre-launch). See
   `Home — Proactive Intelligence (For You).md`.
 - **The dev cockpit:** DEV TOOLS → "proactive system" (PART 1) → "proactive RESEARCH + PREPARE"

--- a/Sentient OS macOS/Notch Magic/CommandCoordinator.swift
+++ b/Sentient OS macOS/Notch Magic/CommandCoordinator.swift
@@ -11,8 +11,10 @@
 //
 //  Hotkey path: press → notch OPENS + mic (if already authorized) · still-held @250ms → committed
 //  listening · release(hold) → transcribe → submit(.voice) · release(tap) → a focused TYPE field →
-//  submit. Prompt-bar path: submit(.promptBar). Every command is computer use, which raises the notch.
-//  Doc: Documentation/Notch Magic/.
+//  submit. Prompt-bar path: submit(.promptBar). Card-fire path: beginExternalRun (a proactive card's
+//  computer-use fire adopts the same run — ONE task at a time, app-wide, and the notch shows it).
+//  Every command is computer use, which raises the notch. A hotkey press during any real run is the
+//  universal STOP. Doc: Documentation/Notch Magic/.
 //
 
 import Foundation
@@ -164,10 +166,30 @@ final class CommandCoordinator {
 
     /// Cancel the running task. A STOP (or Esc) WHILE THE TRANSCRIPT IS SHOWN means "you misheard me — redo":
     /// dismiss INSTANTLY with no "Stopped" flourish (hiding first makes `runFinished` skip it). Once computer
-    /// use is actually working, STOP halts it with the honest "Stopped" beat. Either way the run is cancelled.
+    /// use is actually working, STOP halts it with the honest "Stopped" beat. Either way the run is cancelled
+    /// (an adopted card fire included — run.stop() routes to the card's own cancel).
     func stop() {
         if phase == .running, readBack != nil, run.remembering == nil { setPhase(.hidden) }
         run.stop()
+    }
+
+    // MARK: Adopted external runs (a proactive card's computer-use fire)
+
+    /// A proactive card's computer-use fire adopting the notch: the run model lights up — locking
+    /// out every other entry point — and the notch rises in `.running`, exactly like a command-bar
+    /// launch. Returns false when a task already owns the run (the ONE-task-at-a-time lock): the
+    /// caller must not fire. Doubles as the gate-held re-check — a fire the permission gate held
+    /// for minutes re-answers the lock here. Completion needs no coordinator API: the card's
+    /// completeExternal rides onFinished → runFinished → the normal finishing flourish.
+    @discardableResult
+    func beginExternalRun(caption: String, onStopRequest: @escaping @MainActor () -> Void) -> Bool {
+        guard !run.isRunning else { return false }
+        clearReadBack()
+        notchAnchor = .mainDisplay        // card fires live on the home's display, like the prompt bar
+        run.adoptExternal(caption: caption, onStopRequest: onStopRequest)
+        setPhase(.running)
+        Log("▶︎ external run adopted (proactive card)")
+        return true
     }
 
     // MARK: Voice + tap-to-type (hotkey) path
@@ -221,19 +243,23 @@ final class CommandCoordinator {
     }
 
     private func voicePressBegan() {
+        // One task, one notch, one key: a press while ANY real task is running STOPS it —
+        // hotkey-, command-bar-, or card-launched alike (decided 2026-07-17). Hoisted above the
+        // voice gate so a Mac with no speech model still gets the cancel. stop() keeps the
+        // transcript beat's instant no-flourish dismiss ("you misheard me"); every other running
+        // moment gets the honest "Stopped" beat. The onboarding demo is exempt (scripted
+        // theater — the film narrates through it; those presses fall to the guards below).
+        if run.isRunning, !run.isDemo {
+            stop()
+            Log("hotkey → STOP (universal cancel, \(hotkey.key.label))")
+            return
+        }
         guard VoiceCapture.isAvailable else { return }
         // A hotkey tap while the type field is open toggles it closed (no action) — a quick way to back out.
         if phase == .typing { dismissTyping(); return }
-        // The hotkey doubles as the GLOBAL cancel (there is no global Esc — keyDown taps are what
-        // Input Monitoring gates): a press while a stuck finalize is spinning, or while the
-        // just-fired transcript is still shown ("you misheard me"), backs out — the beats the
-        // global Esc used to cover.
+        // The press also bails a stuck finalize (there is no global Esc — keyDown taps are what
+        // Input Monitoring gates).
         if phase == .transcribing { cancelCurrent(); return }
-        if phase == .running, readBack != nil, run.remembering == nil {
-            stop()                        // transcript shown → instant dismiss, run cancelled
-            Log("notch transcript cancelled (\(hotkey.key.label))")
-            return
-        }
         guard !run.isRunning, !isInteracting else { Log("hotkey ignored — busy"); return }
         notchAnchor = .mainDisplay        // the hotkey always lives on the main display (incl. the asides below)
         // Before the home screen, Sidekick doesn't exist yet (the onboarding policy above) —

--- a/Sentient OS macOS/Notch Magic/CommandRunModel.swift
+++ b/Sentient OS macOS/Notch Magic/CommandRunModel.swift
@@ -5,12 +5,15 @@
 //  Runs ONE "do this for me" task through the user's codex (computer use), streaming codex's latest
 //  output line(s) into `statusLine`. `stop()` cancels the run (CodexCLI terminates codex). One run at a time.
 //
-//  Both ways to start a task — the home command bar AND the right-⌘ hotkey — drive the SAME instance
-//  (owned by CommandCoordinator), so the prompt bar and the notch are two views of one run. `onFinished`
-//  lets the coordinator move the notch from running → finishing. Everything also tees to Log()
+//  Every way to start a task — the home command bar, the right-⌘ hotkey, AND a proactive card's
+//  computer-use fire (which ADOPTS this run via adoptExternal/externalPush/completeExternal) — drives
+//  the SAME instance (owned by CommandCoordinator), so the prompt bar, the notch, and the card are all
+//  views of one run, and `isRunning` is the app-wide one-task-at-a-time lock. `onFinished` lets the
+//  coordinator move the notch from running → finishing. Everything also tees to Log()
 //  (tail /tmp/sentient-dev.log). Doc: Documentation/Notch Magic/.
 //
-//  Key methods: start(_:mode:) · stop() · commandPrompt(task:mode:screenshots:spoken:).
+//  Key methods: start(_:mode:) · stop() · adoptExternal(caption:onStopRequest:) ·
+//  commandPrompt(task:mode:screenshots:spoken:).
 //
 
 import Foundation
@@ -35,6 +38,14 @@ final class CommandRunModel {
     /// theater has nothing to stop). Cleared the moment a REAL run starts.
     private(set) var isDemo = false
 
+    /// True while this run is an ADOPTED external one — a proactive card's computer-use fire.
+    /// The work lives in ForYouModel's Task (not `task`), so stop() delegates to `externalStop`
+    /// (which cancels that Task) and completion arrives via completeExternal, exactly once, when
+    /// the fire unwinds. External ends never touch the scoreboard/analytics — ProactiveExecutor
+    /// records every card fire itself.
+    private(set) var isExternal = false
+    private var externalStop: (@MainActor () -> Void)?
+
     private var recent: [String] = []
     private var section = ""                      // codex's current output section (user/codex/exec/…) — for filtering the bar
     private var task: Task<Void, Never>?
@@ -50,6 +61,8 @@ final class CommandRunModel {
         self.source = source
         self.runStarted = Date()
         isDemo = false
+        isExternal = false
+        externalStop = nil
         isRunning = true
         recent = []
         section = ""
@@ -122,7 +135,46 @@ final class CommandRunModel {
         guard isRunning else { return }
         clearRemembering()
         statusLine = "Stopping…"
-        task?.cancel()
+        // An adopted run's Task lives in ForYouModel — ask IT to cancel (which kills codex the
+        // same way); completion still arrives once, from the fire's unwind. Never both paths.
+        if let externalStop { externalStop() } else { task?.cancel() }
+    }
+
+    // MARK: Adopted external runs (a proactive card's computer-use fire)
+
+    /// Adopt a proactive card's fire as THE one run: `isRunning` + `statusLine` light the notch
+    /// and the prompt bar, and every other entry point — hotkey, submits, other cards — is locked
+    /// out until it ends. The work itself stays in the caller's Task; `onStopRequest` is how any
+    /// STOP surface (notch, bar, hotkey) reaches it. Silently refuses while a run is live — the
+    /// caller checks the coordinator's `beginExternalRun` return.
+    func adoptExternal(caption: String, onStopRequest: @escaping @MainActor () -> Void) {
+        guard !isRunning else { return }
+        mode = .computer
+        source = "proactive_card"        // log/analytics honesty only — external ends never reach complete()
+        runStarted = Date()
+        isDemo = false
+        isExternal = true
+        externalStop = onStopRequest
+        isRunning = true
+        recent = []
+        section = ""
+        remembering = nil
+        rememberClear?.cancel()
+        statusLine = caption
+    }
+
+    /// One raw codex line from the adopted run, through the same cleaning a native run gets
+    /// (stderr strip, section tracking, the "Remembering" bloom, the bar filter).
+    func externalPush(_ line: String) {
+        guard isExternal else { return }
+        push(line)
+    }
+
+    /// End the adopted run — no scoreboard, no analytics (ProactiveExecutor already recorded the
+    /// fire); just the shared epilogue. Idempotent: a late second arrival no-ops.
+    func completeExternal(_ outcome: Outcome, line: String) {
+        guard isRunning, isExternal else { return }
+        finish(outcome, line: line)
     }
 
     // MARK: The onboarding notch demo
@@ -164,24 +216,30 @@ final class CommandRunModel {
                 try await Task.sleep(for: .seconds(1.7))
                 guard let self, self.isRunning else { return }
                 Log("──────── 🤖 ✓ NOTCH DEMO done ────────")
-                self.demoFinish(.success, line: "✓ done")
+                self.finish(.success, line: "✓ done")
             } catch {   // cancelled — a STOP mid-demo gets the honest beat, same as a real run
                 guard let self, self.isRunning else { return }
                 Log("──────── 🤖 ■ NOTCH DEMO stopped ────────")
-                self.demoFinish(.stopped, line: "■ stopped")
+                self.finish(.stopped, line: "■ stopped")
             }
         }
     }
 
-    /// The demo's exit — complete() minus the scoreboard + analytics a fake run must never feed.
-    private func demoFinish(_ outcome: Outcome, line: String) {
+    /// The shared run epilogue — every ending funnels here: complete() (native runs, after their
+    /// scoreboard + analytics), the demo's theater exit, and completeExternal. Sets the final
+    /// status line, releases the run, tells the coordinator, and lets the line linger.
+    private func finish(_ outcome: Outcome, line: String) {
         clearRemembering()
         statusLine = line
         isRunning = false
+        isExternal = false
+        externalStop = nil
         task = nil
         onFinished?(outcome)
-        Task { [weak self] in
-            try? await Task.sleep(for: .seconds(outcome == .success ? 2.5 : 4.5))
+        Task { [weak self] in            // let the final status linger a moment, then clear the bar
+            // Failures hold longest — the ✗ line carries the give-up REASON and must be readable.
+            let linger: Double = outcome == .success ? 2.5 : (outcome == .failed ? 6.0 : 4.5)
+            try? await Task.sleep(for: .seconds(linger))
             if let self, !self.isRunning { self.statusLine = "" }
         }
     }
@@ -291,17 +349,7 @@ final class CommandRunModel {
         Analytics.signal("ComputerUse.finished",
                          parameters: ["source": source, "method": mode.rawValue, "outcome": outcomeTag],
                          floatValue: Date().timeIntervalSince(runStarted), tier: .core)
-        clearRemembering()
-        statusLine = line
-        isRunning = false
-        task = nil
-        onFinished?(outcome)
-        Task { [weak self] in            // let the final status linger a moment, then clear the bar
-            // Failures hold longest — the ✗ line carries the give-up REASON and must be readable.
-            let linger: Double = outcome == .success ? 2.5 : (outcome == .failed ? 6.0 : 4.5)
-            try? await Task.sleep(for: .seconds(linger))
-            if let self, !self.isRunning { self.statusLine = "" }
-        }
+        finish(outcome, line: line)
     }
 
     private static func short(_ error: Error) -> String {

--- a/Sentient OS macOS/Proactive/ProactiveExecutor.swift
+++ b/Sentient OS macOS/Proactive/ProactiveExecutor.swift
@@ -73,17 +73,27 @@ actor ProactiveExecutor {
             r = .notFireable("This is a briefing to read; there's nothing to fire.")
         }
         // §7.19: one scoreboard record per fire (source is always a proactive card here; the command
-        // bar / voice records separately from CommandRunModel).
-        ExecutorScoreboard.record(method: action.method.rawValue, source: "proactive_card",
-            outcome: r.board, durationS: Date().timeIntervalSince(t0),
-            statusPresent: r.statusPresent, errorClass: r.errorClass)
+        // bar / voice records separately from CommandRunModel). A user STOP — the awaiting Task was
+        // cancelled by the card's STOP, the notch's, or the hotkey — is a cancel, not a health
+        // outcome: no scoreboard row, and the analytics say "stopped" (CommandRunModel's exact exit
+        // semantics, so the shared dashboards stay comparable).
+        let stopped = Task.isCancelled
+        if !stopped {
+            ExecutorScoreboard.record(method: action.method.rawValue, source: "proactive_card",
+                outcome: r.board, durationS: Date().timeIntervalSince(t0),
+                statusPresent: r.statusPresent, errorClass: r.errorClass)
+        }
         // The single most important number: a user fired a real action — which channel, did it land.
         // Core tier — the proactive-click count is always-on telemetry (disclosed in Settings).
         let landed: String
-        switch r.outcome {
-        case .fired:       landed = "fired"
-        case .notFireable: landed = "not_fireable"
-        case .failed:      landed = "failed"
+        if stopped {
+            landed = "stopped"
+        } else {
+            switch r.outcome {
+            case .fired:       landed = "fired"
+            case .notFireable: landed = "not_fireable"
+            case .failed:      landed = "failed"
+            }
         }
         Analytics.signal("Proactive.actionFired", parameters: ["method": action.method.rawValue, "outcome": landed], tier: .core)
         // Core tier: agent working time for this fire, but only when a channel actually ran (the

--- a/Sentient OS macOS/Views/BriefingCard.swift
+++ b/Sentient OS macOS/Views/BriefingCard.swift
@@ -26,6 +26,7 @@ struct BriefingCard: View {
     var onOpenEnvelope: () -> Void
     var liveLines: [String] = []       // real cards: codex's live play-by-play (empty → demo theater)
     var onStop: (() -> Void)? = nil    // real cards: the per-card STOP
+    var fireDimmed = false             // one task at a time: another task is running → the CTA waits
 
     @State private var hovering = false
 
@@ -83,6 +84,9 @@ struct BriefingCard: View {
             HStack(spacing: 12) {
                 if let offer = briefing.offer {
                     OfferButton(label: offer, accent: briefing.accent, action: onOffer)
+                        .disabled(fireDimmed)
+                        .opacity(fireDimmed ? 0.45 : 1)
+                        .animation(.easeInOut(duration: 0.25), value: fireDimmed)
                 }
                 if let detail = briefing.detailLabel {
                     Button(action: onDetail) {

--- a/Sentient OS macOS/Views/HomeView.swift
+++ b/Sentient OS macOS/Views/HomeView.swift
@@ -110,6 +110,7 @@ struct HomeView: View {
         .onAppear {                        // every appearance starts fresh: sealed envelope, full deal
             letter = nil
             letterShown = false
+            model.coordinator = appState.commandCoordinator
             if !appState.isUninstalling { model.beginVisit(deck: deck) }
             planUpgraded = previewUpgraded ?? (kbOnly && CodexAuth.currentPlan()?.tier == .full)
             caution = OvernightCaution.latest()
@@ -309,6 +310,8 @@ struct HomeView: View {
                     entry: item.element,
                     slot: slots[min(item.offset, slots.count - 1)],
                     dealFrom: CGPoint(x: geo.size.width / 2, y: -160),
+                    fireDimmed: appState.commandCoordinator.run.isRunning
+                        && item.element.action?.method == .computer,
                     onOffer: { model.run(item.element.id) },
                     onDetail: { openLetter(item.element.b) },
                     onOpenEnvelope: {
@@ -503,6 +506,8 @@ struct HomeView: View {
                            // per briefing so a reused letter view never shows the previous card's draft.
                            liveDraft: model.entry(b.id)?.action?.preparedContent ?? b.draft ?? "",
                            liveRecipient: model.entry(b.id)?.action?.recipient ?? "",
+                           fireDimmed: appState.commandCoordinator.run.isRunning
+                               && model.entry(b.id)?.action?.method == .computer,
                            onCommitEdit: { model.applyEdit(b.id, content: $0, recipient: $1) },
                            onOffer: {
                                closeLetter()
@@ -636,6 +641,10 @@ final class ForYouModel {
     }
 
     var entries: [Entry] = []
+    /// The app-lifetime command coordinator (HomeView sets it on appear) — the notch and the
+    /// app-wide one-task lock. A computer-use card fire ADOPTS its run (lighting the notch and
+    /// locking out Sidekick/the bar/other cards); gmail/calendar/research fires ignore it.
+    weak var coordinator: CommandCoordinator?
     /// Bumped per appearance — in-flight Tasks from a previous visit check it and bail,
     /// so a re-deal can never be mutated by stale theater/dismiss timers.
     private var visit = 0
@@ -707,6 +716,14 @@ final class ForYouModel {
     func run(_ id: String) {
         guard let e = entry(id), e.phase == .offer, e.b.offer != nil else { return }
         if let action = e.action {   // real card → fire for real (behind the first-use permission gate)
+            // The app-wide one-task lock (computer use only): while ANY task owns the run — a
+            // Sidekick/command-bar run or another card — a new fire can't start (the CTA is
+            // dimmed; this is the backstop for a click that lands anyway). Gmail/Calendar
+            // connector writes and research are exempt: quiet card-only, concurrent is fine.
+            if action.method == .computer, coordinator?.run.isRunning == true {
+                Log("card fire blocked — a task is already running (one at a time)")
+                return
+            }
             if ComputerUseGate.shared.intercept({ [weak self] in self?.runReal(id, action) }) { return }
             runReal(id, action)
             return
@@ -734,20 +751,40 @@ final class ForYouModel {
     /// card (replacing the demo theater), and on success fly it away + drop it from the persisted set
     /// so a re-deal won't show it again. `ProactiveExecutor.fire` reads `action.preparedContent`, so a
     /// draft the user edited in the letter is exactly what gets sent.
+    ///
+    /// A computer-use fire is also ADOPTED by the notch (`beginExternalRun`): the shared run lights
+    /// up (the one-task lock engages), the card's lines tee into it, and every exit — success,
+    /// failure, ANY stop — completes the adoption exactly once, here, when `fire` unwinds (it
+    /// always returns, even cancelled). `beginExternalRun`'s refusal doubles as the re-check for a
+    /// fire the permission gate held while another task started.
     private func runReal(_ id: String, _ action: PreparedAction) {
         let v = visit
+        let external = action.method == .computer
+        if external {
+            guard let coordinator,
+                  coordinator.beginExternalRun(
+                      caption: entry(id)?.b.title ?? "Working on your Mac…",
+                      onStopRequest: { [weak self] in self?.stopRun(id) })
+            else { Log("card fire blocked at launch — a task already owns the run"); return }
+        }
         update(id) { $0.phase = .working(0); $0.liveLines = [] }
         let task = Task {
             let progress: @Sendable (String) -> Void = { line in
                 Task { @MainActor in
                     guard self.visit == v else { return }
-                    self.appendLine(id, line)
+                    self.appendLine(id, line)                                  // the card (raw)
+                    if external { self.coordinator?.run.externalPush(line) }   // the notch (cleaned)
                 }
             }
             let outcome = await ProactiveExecutor.shared.fire(action, progress: progress)
-            guard self.visit == v, !Task.isCancelled else { return }
+            let adopted = external ? self.coordinator?.run : nil
+            guard self.visit == v, !Task.isCancelled else {
+                adopted?.completeExternal(.stopped, line: "■ stopped")   // any stop/re-deal lands here
+                return
+            }
             switch outcome {
             case .fired:
+                adopted?.completeExternal(.success, line: "✓ done")
                 withAnimation(.spring(response: 0.5, dampingFraction: 0.8)) { self.update(id) { $0.phase = .done } }
                 self.removeFromLatest(id)
                 try? await Task.sleep(for: .seconds(2.6))
@@ -755,6 +792,7 @@ final class ForYouModel {
                 self.dismiss(id, toward: CGSize(width: CGFloat.random(in: 250...520),
                                                 height: -CGFloat.random(in: 350...560)))
             case .notFireable(let m), .failed(let m):
+                adopted?.completeExternal(.failed, line: "✗ \(String(m.prefix(160)))")
                 self.appendLine(id, "✗ \(m)")
                 try? await Task.sleep(for: .seconds(1.4))
                 guard self.visit == v else { return }
@@ -766,8 +804,12 @@ final class ForYouModel {
     }
 
     /// STOP a live real-card run: cancel the codex process (CodexCLI honors it) and return to offer.
+    /// Reached from the card's STOP directly and, for an adopted run, from the notch/bar/hotkey via
+    /// `onStopRequest` — the guard makes a second arrival a no-op (one cancel is enough; the
+    /// adoption completes from the fire's unwind in runReal, never here).
     func stopRun(_ id: String) {
-        runTasks[id]?.cancel(); runTasks[id] = nil
+        guard let task = runTasks[id] else { return }
+        task.cancel(); runTasks[id] = nil
         withAnimation { update(id) { $0.liveLines.append("■ stopped"); $0.phase = .offer } }
     }
 
@@ -835,6 +877,7 @@ private struct DealtCard: View {
     let entry: ForYouModel.Entry
     let slot: CGPoint
     let dealFrom: CGPoint
+    var fireDimmed: Bool = false       // one task at a time: another task is running → the CTA waits
     var onOffer: () -> Void
     var onDetail: () -> Void
     var onOpenEnvelope: () -> Void
@@ -847,7 +890,8 @@ private struct DealtCard: View {
         let j = Self.jitter(entry.id)
         BriefingCard(briefing: entry.b, phase: entry.phase,
                      onOffer: onOffer, onDetail: onDetail, onOpenEnvelope: onOpenEnvelope,
-                     liveLines: entry.liveLines, onStop: entry.action != nil ? onStop : nil)
+                     liveLines: entry.liveLines, onStop: entry.action != nil ? onStop : nil,
+                     fireDimmed: fireDimmed)
             .rotationEffect(.degrees(j.rot + drag.width / 24))
             .scaleEffect(entry.dealt ? 1 : 0.7)
             .position(entry.dealt ? CGPoint(x: slot.x + j.dx, y: slot.y + j.dy) : dealFrom)
@@ -887,6 +931,7 @@ private struct LetterView: View {
     var editable: Bool = false                       // real card with a draft → the draft is editable
     var liveDraft: String = ""                       // THIS card's current content (seeds the editor)
     var liveRecipient: String = ""                   // THIS card's "To:" (seeds the recipient field); "" = no recipient
+    var fireDimmed: Bool = false                     // one task at a time: another task is running → the CTA waits
     var onCommitEdit: (String, String) -> Void = { _, _ in }   // persist (edited draft, edited recipient) → what fires
     var onOffer: () -> Void
     var onClose: () -> Void
@@ -974,6 +1019,9 @@ private struct LetterView: View {
                     if editable { commitEdit() }   // fire what's shown — commit any unsaved edit first
                     onOffer()
                 })
+                    .disabled(fireDimmed)
+                    .opacity(fireDimmed ? 0.45 : 1)
+                    .animation(.easeInOut(duration: 0.25), value: fireDimmed)
                     .padding(.top, 16)
             }
             if briefing.kind == .welcome { giftFooter.padding(.top, 16) }


### PR DESCRIPTION
## What

Firing a proactive card's **computer-use** action now ADOPTS the one Sidekick run — the notch rises with the card's title, streams the same cleaned live status (card + notch + prompt bar are three views of one task), and plays the ✓/■/✗ finishing flourish. `CommandRunModel.isRunning` becomes the app-wide **one-task-at-a-time lock**.

## How

- **CommandRunModel**: `adoptExternal(caption:onStopRequest:)` / `externalPush` / `completeExternal` — external runs reuse `push()`'s stream cleaning and the shared `finish` epilogue, but skip the scoreboard/analytics (ProactiveExecutor records every card fire itself). `stop()` on an adopted run delegates to the card's own cancel.
- **CommandCoordinator**: `beginExternalRun` (the card-fire door — refuses while anything runs, doubling as the gate-held re-check) + the **universal right-⌘ stop**: a press during ANY real run cancels it (replacing "hotkey ignored — busy"; onboarding demo exempt).
- **ForYouModel/HomeView/BriefingCard**: computer-method fires check the lock, adopt the run, tee lines to card + notch, and complete the adoption exactly once at the fire's unwind; other computer cards' CTAs dim (`fireDimmed`) while a task runs. `stopRun` is idempotent (all STOP surfaces converge on one cancel).
- **ProactiveExecutor**: a stopped fire records NO scoreboard row and "stopped" analytics (CommandRunModel's exit semantics).
- **Exempt by decision:** gmail/calendar connector fires + research — quiet card-only, no lock, concurrent fine.

Docs updated: Notch Magic §1/§2/§3/§6/§11/§12 · Home (For You) · Judge (executor).

## Testing

Verified live on hardware (Jesai): notch lights for card fires with live stream; right-⌘/notch-STOP/card-STOP all stop the one task; CTAs dim while running; success/failure flourishes honest; gmail fires stay quiet. Build clean via Xcode MCP.