### PR TITLE
Fix create note/folder prompt focus landing on Cancel instead of the name field

### DIFF
--- a/Sentient OS macOS/Documentation/Knowledge Viewer.md
+++ b/Sentient OS macOS/Documentation/Knowledge Viewer.md
@@ -73,7 +73,11 @@ Cancel (all sidebar clicks, wikilinks, Back, AND sky-mode switches funnel throug
 
 **Create / delete:** three creation affordances — the header "+", a hover "+" on folder rows,
 and right-click menus. New notes are seeded `# Title` and open straight into edit mode; names
-are sanitized + uniqued. Delete = **move to macOS Trash** (recoverable, no confirm) for notes
+are sanitized + uniqued. ⚠️ The name prompt is a system `.alert` whose initial key view lands on
+the BUTTON row, not its TextField (macOS 26) — `claimCreateFieldFocus()` claims the field a beat
+after presentation: a FocusState claim plus an AppKit first-responder walk matched by the field's
+placeholder (SwiftUI can strip `.focused` inside alert content; the placeholder match keeps it
+off the sidebar's search box). Delete = **move to macOS Trash** (recoverable, no confirm) for notes
 AND folders — the toolbar trash icon (reading mode; hidden for the README/Overview, which can't
 be deleted) or right-click. Trashing the folder that contained the open note lands back on
 Overview.

--- a/Sentient OS macOS/Views/Knowledge/KnowledgeView.swift
+++ b/Sentient OS macOS/Views/Knowledge/KnowledgeView.swift
@@ -50,6 +50,7 @@ struct KnowledgeView: View {
     @State private var showDiscardPrompt = false
     @FocusState private var editorFocused: Bool
     @FocusState private var searchFocused: Bool
+    @FocusState private var createFieldFocused: Bool
 
     // The new-note / new-folder name prompt (raised by the right-click menus).
     @State private var showCreatePrompt = false
@@ -92,8 +93,12 @@ struct KnowledgeView: View {
         }
         .alert(createIsFolder ? "New folder" : "New note", isPresented: $showCreatePrompt) {
             TextField(createIsFolder ? "Folder name" : "Note name", text: $createName)
+                .focused($createFieldFocused)
             Button("Create") { performCreate() }
             Button("Cancel", role: .cancel) {}
+        }
+        .onChange(of: showCreatePrompt) { _, shown in
+            if shown { claimCreateFieldFocus() }
         }
     }
 
@@ -304,6 +309,40 @@ struct KnowledgeView: View {
     /// Raise the name prompt for a new note/folder inside `parent` (nil = the vault root).
     private func promptCreate(folder: Bool, in parent: URL?) {
         createIsFolder = folder; createParent = parent; createName = ""; showCreatePrompt = true
+    }
+
+    /// The create alert opens with its initial key view on the button row, not the TextField —
+    /// so typing lands nowhere until the user clicks the field. Claim it a beat after
+    /// presentation (same delayed-claim pattern as PromptBar's launch focus): the FocusState
+    /// claim for when SwiftUI honors `.focused` inside alert content, and an AppKit
+    /// first-responder walk as the backstop — matched by the field's placeholder, so it can
+    /// never grab the sidebar's search box or any other field.
+    private func claimCreateFieldFocus() {
+        let placeholder = createIsFolder ? "Folder name" : "Note name"
+        for delay: TimeInterval in [0.1, 0.35] {
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                guard showCreatePrompt else { return }
+                createFieldFocused = true
+                for window in NSApp.windows where window.isVisible {
+                    guard let field = Self.editableField(in: window.contentView,
+                                                         placeholder: placeholder) else { continue }
+                    if field.currentEditor() == nil { window.makeFirstResponder(field) }
+                    return
+                }
+            }
+        }
+    }
+
+    /// Depth-first hunt for an editable NSTextField identified by its placeholder.
+    private static func editableField(in view: NSView?, placeholder: String) -> NSTextField? {
+        guard let view else { return nil }
+        if let field = view as? NSTextField, field.isEditable, field.placeholderString == placeholder {
+            return field
+        }
+        for sub in view.subviews {
+            if let field = editableField(in: sub, placeholder: placeholder) { return field }
+        }
+        return nil
     }
 
     private func performCreate() {


### PR DESCRIPTION
## What
The Knowledge editor's New note / New folder prompt opened with keyboard focus on the **Cancel button** instead of the name TextField — typing went nowhere until you clicked the field.

## Why
The prompt is a SwiftUI `.alert` with a `TextField`, and macOS 26's alert style hands the initial key view to the button row.

## Fix (`KnowledgeView.swift`)
- `claimCreateFieldFocus()` claims the field a beat after presentation (0.1s + 0.35s backup) — same delayed-claim idiom as PromptBar's launch focus.
- Two-pronged: a `createFieldFocused` FocusState claim, plus an AppKit first-responder walk as backstop (SwiftUI can strip `.focused` inside alert content). The walk matches the field **by placeholder** ("Note name" / "Folder name"), so it can never grab the sidebar's search box; it no-ops if the field is already focused.
- Receipt added to `Documentation/Knowledge Viewer.md` (Create/delete section).

## Tested
Verified on hardware by Jesai: cursor lands in the field for both note and folder prompts, typing works immediately, Return still fires Create and Esc cancels.