### PR TITLE
Corpus batching for large first runs (vault build + nightly update)

### DIFF
--- a/Sentient OS macOS/Cloud/CodexCLI.swift
+++ b/Sentient OS macOS/Cloud/CodexCLI.swift
@@ -87,6 +87,11 @@ actor CodexCLI {
         var feature: String = "unknown"        // §7.9: which caller — so a codex.failure is attributable
                                                // (gmail / calendar / vault / proactive / …). Diagnostics
                                                // tag ONLY; never affects the run.
+        var diag: [String: String] = [:]       // caller-supplied structured diagnostics merged into a
+                                               // codex.failure's extra (e.g. the vault's corpus_chars /
+                                               // slices / slice_index). Ints and enums rendered as
+                                               // strings ONLY — never paths, UUIDs, or free text (the
+                                               // Sentry scrubber [Filtered]s those into uselessness).
 
         init(prompt: String) { self.prompt = prompt }
 
@@ -147,6 +152,10 @@ actor CodexCLI {
         /// Subscription window exhausted. `sessionID` (when present) lets the caller resume the
         /// same agentic session later instead of starting over.
         case usageLimit(message: String, sessionID: String?)
+        /// The prompt exceeds codex's server-side 1,048,576-char turn-input cap (rejected at
+        /// turn/start before the model runs). Thrown by the pre-spawn guard in both spines;
+        /// with corpus slicing in place this is a canary that should never fire.
+        case inputTooLarge(chars: Int)
 
         var description: String {
             switch self {
@@ -156,6 +165,7 @@ actor CodexCLI {
             case .exitFailure(let code, let m):   return "codex exited \(code): \(m.prefix(300))"
             case .badEnvelope(let m):             return "Unparseable codex output: \(m.prefix(300))"
             case .usageLimit(let m, _):           return "Codex usage limit: \(m.prefix(200))"
+            case .inputTooLarge(let c):           return "Prompt too large for codex: \(c) chars (server cap 1,048,576)"
             }
         }
     }
@@ -349,14 +359,25 @@ actor CodexCLI {
                 Self.emitCodexFailure(event: "codex.failure", error, feature: invocation.feature,
                                       model: invocation.model, effort: invocation.effort,
                                       resumed: invocation.resumeSessionID != nil,
-                                      durationMS: Int(Date().timeIntervalSince(t0) * 1000))
+                                      durationMS: Int(Date().timeIntervalSince(t0) * 1000),
+                                      diag: invocation.diag)
             }
             throw error
         }
     }
 
+    /// Pre-spawn guard: codex rejects any turn input over 1,048,576 characters server-side
+    /// (`input_too_large`, no flag raises it — measured 2026-07-19). 950 KB leaves margin for
+    /// the char-vs-byte counting gap. Every prompt path is byte-budgeted below this (the vault's
+    /// CorpusSlicer, Proactive's window trim), so a throw here means a NEW unbudgeted prompt
+    /// path slipped in — a named canary instead of a mystery exitFailure.
+    static let promptByteCap = 950_000
+
     private func runInner(_ invocation: Invocation,
                           onLine: (@Sendable (String) -> Void)? = nil) async throws -> Envelope {
+        if invocation.prompt.utf8.count > Self.promptByteCap {
+            throw CLIError.inputTooLarge(chars: invocation.prompt.utf8.count)
+        }
         let availability = await validate()
         guard case .available(let bin) = availability else {
             throw CLIError.notAvailable(availability)
@@ -413,6 +434,11 @@ actor CodexCLI {
         // per run, so a change applies to the very next fire with no restart.
         let effort = ComputerUseSpeed.current.effort
         do {
+            // Same pre-spawn guard as `run` — this spine passes the prompt as ARGV, where an
+            // oversized prompt dies even earlier (ARG_MAX) with an unhelpful spawn error.
+            if prompt.utf8.count > Self.promptByteCap {
+                throw CLIError.inputTooLarge(chars: prompt.utf8.count)
+            }
             guard let bin = Self.locateBinary() else { throw CLIError.notAvailable(.notInstalled) }
             // Self-heal the relaxed confirmation policy: a plugin update (desktop app or a
             // re-bootstrap) lays a fresh STOCK SKILL.md, whose policy stalls headless runs on
@@ -444,23 +470,35 @@ actor CodexCLI {
     }
 
     /// Emit a structured codex failure — the CLIError CASE NAME only (never `.message`/stderr/prompt,
-    /// which embed user content). One seam for the whole cloud spine; `feature` makes it attributable.
+    /// which embed user content). One seam for the whole cloud spine; `feature` makes it attributable;
+    /// `diag` is the caller's structured extras (Invocation.diag — ints/enums only, pre-vetted).
     private static func emitCodexFailure(event: String, _ error: Error, feature: String,
-                                         model: Model, effort: Effort, resumed: Bool, durationMS: Int) {
+                                         model: Model, effort: Effort, resumed: Bool, durationMS: Int,
+                                         diag: [String: String] = [:]) {
         let caseName: String
         let level: CrashReporting.DiagLevel
+        var extra = diag
         switch error {
         case CLIError.usageLimit:   return   // expected, not a defect — the amber caution + resume own it
         case CLIError.notAvailable: (caseName, level) = ("notAvailable", .warning)
         case CLIError.timedOut:     (caseName, level) = ("timedOut", .warning)
         case CLIError.launchFailed: (caseName, level) = ("launchFailed", .error)
-        case CLIError.exitFailure:  (caseName, level) = ("exitFailure", .error)
+        case CLIError.exitFailure(let code, _):
+            (caseName, level) = ("exitFailure", .error)
+            extra["exit_code"] = String(code)
         case CLIError.badEnvelope:  (caseName, level) = ("badEnvelope", .error)
+        case CLIError.inputTooLarge(let chars):
+            // The canary: every prompt path is byte-budgeted, so this should stay at zero.
+            (caseName, level) = ("inputTooLarge", .error)
+            extra["prompt_chars"] = String(chars)
         default:                    (caseName, level) = (String(describing: type(of: error)), .error)
         }
+        extra["effort"] = effort.rawValue
+        extra["resumed"] = String(resumed)
+        extra["duration_ms"] = String(durationMS)
         CrashReporting.captureEvent(event, level: level,
             tags: ["feature": feature, "error": caseName, "model": model.rawValue],
-            extra: ["effort": effort.rawValue, "resumed": String(resumed), "duration_ms": String(durationMS)],
+            extra: extra,
             fingerprint: ["codex", feature, caseName])
     }
 
@@ -555,6 +593,15 @@ actor CodexCLI {
             let detail = errors.isEmpty ? (out.stderr.isEmpty ? out.stdout : out.stderr)
                                         : errors.joined(separator: " · ")
             let lowered = detail.lowercased()
+            // Belt-and-suspenders behind the pre-spawn guard: if a prompt still reached the
+            // server and bounced off the turn-input cap (config drift, a changed cap), name it
+            // instead of letting it fall through as a mystery exitFailure. Checked FIRST — the
+            // wording could drift toward the usage-limit markers.
+            if lowered.contains("input_too_large") || lowered.contains("exceeds the maximum length") {
+                let chars = detail.range(of: #""actual_chars":(\d+)"#, options: .regularExpression)
+                    .flatMap { Int(detail[$0].drop(while: { !$0.isNumber })) } ?? 0
+                throw CLIError.inputTooLarge(chars: chars)
+            }
             if usageLimitMarkers.contains(where: { lowered.contains($0) }) {
                 throw CLIError.usageLimit(message: String(detail.prefix(600)), sessionID: sessionID)
             }

--- a/Sentient OS macOS/Proactive/Proactive.swift
+++ b/Sentient OS macOS/Proactive/Proactive.swift
@@ -63,10 +63,23 @@ actor Proactive {
 
     /// The last-`lookbackDays` summaries, newest first — the exact window the judge reasons over, and
     /// the same background PART 2 now gets. Defined once here so the windowing can never drift.
+    /// Byte-budgeted (CorpusSlicer's shared budget, drop oldest first) so a heavy week can never
+    /// push either stage's prompt over codex's 1 MiB turn-input cap — the judge never needed a
+    /// megabyte; scarcity is the product.
     static func recent(from notes: [CloudNote], now: Date = Date()) -> [CloudNote] {
         let cutoff = now.addingTimeInterval(-Double(lookbackDays) * 86_400)
         func itemDate(_ n: CloudNote) -> Date { n.itemDate ?? .distantPast }
-        return notes.filter { itemDate($0) >= cutoff }.sorted { itemDate($0) > itemDate($1) }
+        let windowed = notes.filter { itemDate($0) >= cutoff }.sorted { itemDate($0) > itemDate($1) }
+        let df = CorpusSlicer.dateFormatter()
+        var bytes = 0
+        for (i, n) in windowed.enumerated() {
+            bytes += CorpusSlicer.render(n, index: i, df: df).utf8.count + 2
+            if bytes > CorpusSlicer.budget {
+                Log("Proactive.recent: window trimmed to the newest \(i)/\(windowed.count) summaries (byte budget)")
+                return Array(windowed.prefix(i))
+            }
+        }
+        return windowed
     }
 
     /// The user's OWN standing proactive instructions (Settings → Proactive & Sidekick), rendered as a

--- a/Sentient OS macOS/Proactive/ProactiveCycle.swift
+++ b/Sentient OS macOS/Proactive/ProactiveCycle.swift
@@ -84,9 +84,17 @@ actor ProactiveCycle {
         let exists = FileManager.default.fileExists(atPath: VaultGenerator.vaultRoot.path)
         progress(.knowledgeBase(exists ? "Updating your knowledge…"
                                        : "Creating your perfect knowledge base from everything we've analyzed…"))
+        // A sliced corpus (too big for one codex prompt) reports each part as it's fed — the
+        // takeover's phase line follows along; single-slice runs emit nothing and keep the line above.
+        let phase: @Sendable (VaultGenerator.Progress) -> Void = { p in
+            if case .folding(let part, let of) = p {
+                progress(.knowledgeBase(exists ? "Updating your knowledge… part \(part) of \(of)"
+                                               : "Creating your knowledge base… part \(part) of \(of)"))
+            }
+        }
         do {
-            if exists { _ = try await VaultCloud.shared.update(notes: notes, onLine: onLine) }
-            else      { _ = try await VaultCloud.shared.create(notes: notes, onLine: onLine) }
+            if exists { _ = try await VaultCloud.shared.update(notes: notes, onProgress: phase, onLine: onLine) }
+            else      { _ = try await VaultCloud.shared.create(notes: notes, onProgress: phase, onLine: onLine) }
             Analytics.signal(exists ? "KnowledgeBase.updated" : "KnowledgeBase.built",
                              parameters: ["newSummaries": "\(notes.count)"])
         } catch {

--- a/Sentient OS macOS/Scheduling/OvernightCaution.swift
+++ b/Sentient OS macOS/Scheduling/OvernightCaution.swift
@@ -22,9 +22,11 @@ import os
 enum OvernightCaution {
 
     enum Kind: String, Codable {
-        case loggedOut    // codex had no working login when the night's cloud work started
-        case noInternet   // the Mac was offline, so the cloud legs couldn't run
-        case usageLimit   // the ChatGPT plan's window was exhausted mid-run
+        case loggedOut      // codex had no working login when the night's cloud work started
+        case noInternet     // the Mac was offline, so the cloud legs couldn't run
+        case usageLimit     // the ChatGPT plan's window was exhausted mid-run
+        case inputTooLarge  // a prompt exceeded codex's turn-input cap (a canary — corpus
+                            // slicing budgets every prompt path, so this should never fire)
 
         /// The banner line — quiet, first-person, honest about what happens next.
         var message: String {
@@ -32,6 +34,7 @@ enum OvernightCaution {
             case .loggedOut:  return "I couldn't work last night. Codex was signed out; log back in and I'll catch up tonight."
             case .noInternet: return "No internet last night, so I couldn't do my overnight work. I'll try again tonight."
             case .usageLimit: return "We hit ChatGPT's usage limit last night. I'll pick it up again tomorrow."
+            case .inputTooLarge: return "Last night's batch was more than ChatGPT accepts at once. Your analysis is saved; I'll try again tonight."
             }
         }
     }
@@ -58,8 +61,21 @@ enum OvernightCaution {
     /// the UI only ever states what was verified). Shared by the 3am run (record + banner) and
     /// the watched takeover's failed screen.
     static func classify(_ error: Error) async -> Kind? {
-        if case CodexCLI.CLIError.usageLimit = error {
-            return .usageLimit                       // typed — certain, no probing needed
+        // Typed errors first — certain, no probing needed. The cycle's stage wrappers each re-wrap
+        // the spine's usage limit in their own enum (create/update/judge/research), so match them
+        // all: a stringly wrap here once left the amber banner blind to a vault-leg usage limit.
+        switch error {
+        case CodexCLI.CLIError.usageLimit,
+             VaultGenerator.VaultError.usageLimit,
+             VaultCloud.CloudError.usageLimit,
+             Proactive.ProError.usageLimit,
+             ProactiveResearch.ResError.usageLimit,
+             GiftLetter.GiftError.usageLimit:
+            return .usageLimit
+        case CodexCLI.CLIError.inputTooLarge:
+            return .inputTooLarge                    // the canary — see Kind
+        default:
+            break
         }
         // A 401 in codex's own output means the token died SERVER-side — auth.json still looks
         // logged-in to the local probe below, so codex's stderr is the only tell (the exact

--- a/Sentient OS macOS/Vault/CorpusSlicer.swift
+++ b/Sentient OS macOS/Vault/CorpusSlicer.swift
@@ -1,0 +1,105 @@
+//
+//  CorpusSlicer.swift
+//  Sentient OS macOS
+//
+//  Slices a summary corpus into byte-budgeted parts so no single codex prompt can exceed the
+//  server-side 1 MiB turn-input cap (large first runs cross it). Deterministic and dumb on
+//  purpose: entries are walked in order and a slice closes when the next entry's rendered cost
+//  would cross the budget — identical input always re-derives identical slices, which is what
+//  makes mid-sequence resume bookkeeping safe. Also owns the staging-dir corpus snapshot that
+//  guarantees that determinism across app restarts (CycleStore returns notes newest-first, so a
+//  fresh fetch after more ingestion would shift every boundary).
+//
+//  Key methods:
+//   - slice(_:budget:)  → [[CloudNote]] (never splits an entry)
+//   - render(_:index:df:) → the EXACT corpus entry text (shared with the vault prompts, so
+//     measurement and rendering can never drift)
+//   - saveCorpus / loadCorpus / deleteCorpus → the .sentient-corpus.json staging snapshot
+//
+//  Doc: Documentation/Vault Generation (Stage 2).md
+//
+
+import Foundation
+
+enum CorpusSlicer {
+
+    /// UTF-8 bytes of rendered corpus per slice. Headroom math: the vault prompt core + output
+    /// instructions + a merge skeleton stay well under the 1,048,576-char server cap with ~33%
+    /// margin (the server counts "characters" — measured within ~0.4% of UTF-8 bytes on this
+    /// corpus shape; the margin also absorbs Unicode counting ambiguity). Shared with Proactive's
+    /// window trim. Don't shave it.
+    static let defaultBudget = 700_000
+
+    /// The live budget — `SENTIENT_SLICE_BUDGET` overrides in DEBUG so self-tests can force
+    /// multi-slice runs from a tiny corpus (Release ignores the env, like SENTIENT_VAULT_ROOT).
+    static var budget: Int {
+        #if DEBUG
+        if let raw = ProcessInfo.processInfo.environment["SENTIENT_SLICE_BUDGET"],
+           let n = Int(raw), n > 0 { return n }
+        #endif
+        return defaultBudget
+    }
+
+    /// One corpus entry, exactly as the build/update prompts render it. When measuring, `index`
+    /// is the entry's position in the FULL corpus; per-prompt numbering restarts at 1 and is never
+    /// longer, so measured cost ≥ rendered cost — budget-safe either way.
+    static func render(_ n: CloudNote, index: Int, df: DateFormatter) -> String {
+        let (loc, src) = VaultGenerator.locSrc(kind: n.kind, folder: n.folder, sourceID: n.sourceID)
+        let title = (n.title?.isEmpty == false) ? n.title! : "(untitled)"
+        let when = n.itemDate.map { " · \(df.string(from: $0))" } ?? ""
+        return "#\(index + 1) · [\(src)] \(loc)\(when)\n\(title) — \(n.text)"
+    }
+
+    /// The prompts' shared date style — one formatter per batch (DateFormatter init is expensive).
+    static func dateFormatter() -> DateFormatter {
+        let df = DateFormatter(); df.dateStyle = .medium; df.timeStyle = .none
+        return df
+    }
+
+    /// Walk entries in order, closing a slice when the next entry would cross the budget. Never
+    /// splits an entry; an oversized single entry gets its own slice (loudly). No ranking, no
+    /// sampling — a resume must re-derive identical slices from identical notes.
+    static func slice(_ notes: [CloudNote], budget: Int = budget) -> [[CloudNote]] {
+        guard !notes.isEmpty else { return [] }
+        let df = dateFormatter()
+        var slices: [[CloudNote]] = []
+        var current: [CloudNote] = []
+        var bytes = 0
+        for (i, n) in notes.enumerated() {
+            let cost = render(n, index: i, df: df).utf8.count + 2      // + the "\n\n" joiner
+            if cost > budget {
+                Log("CorpusSlicer: ⚠️ one entry (\(cost) bytes) exceeds the \(budget)-byte budget — it gets its own slice")
+            }
+            if !current.isEmpty, bytes + cost > budget {
+                slices.append(current); current = []; bytes = 0
+            }
+            current.append(n); bytes += cost
+        }
+        slices.append(current)
+        return slices
+    }
+
+    // MARK: - The staging snapshot (resume determinism)
+
+    private static let snapshotName = ".sentient-corpus.json"
+
+    /// Persist the sliced corpus inside the staging dir, so a resume after a usage limit or an app
+    /// restart re-slices the EXACT same entries in the same order. Written only for multi-slice
+    /// runs; deleted before the staging → vault swap (it must never ride into the knowledge base
+    /// or the mirror), and the orphan-staging sweep takes it along for free. Notes that arrive
+    /// between attempts stay unfed, exactly as with a session-only resume.
+    static func saveCorpus(_ notes: [CloudNote], in staging: URL) throws {
+        let data = try JSONEncoder().encode(notes)
+        try data.write(to: staging.appendingPathComponent(snapshotName), options: .atomic)
+    }
+
+    static func loadCorpus(from staging: URL) -> [CloudNote]? {
+        guard let data = try? Data(contentsOf: staging.appendingPathComponent(snapshotName)) else { return nil }
+        return try? JSONDecoder().decode([CloudNote].self, from: data)
+    }
+
+    /// Remove the snapshot — call before swapping staging into the live vault.
+    static func deleteCorpus(in staging: URL) {
+        try? FileManager.default.removeItem(at: staging.appendingPathComponent(snapshotName))
+    }
+}

--- a/Sentient OS macOS/Vault/VaultCloud.swift
+++ b/Sentient OS macOS/Vault/VaultCloud.swift
@@ -19,7 +19,8 @@ import Foundation
 
 /// A Sendable, store-agnostic description of one summary handed to a Codex call. Decouples the
 /// cloud prompts from any particular store. Built from a CycleNoteItem (the iterative system).
-struct CloudNote: Sendable {
+/// Codable for CorpusSlicer's staging snapshot (multi-slice resume determinism).
+struct CloudNote: Sendable, Codable {
     let kind: SourceKind
     let sourceID: String       // "file:<abs path>" / "notes:<uuid>" — VaultGenerator.locSrc keys on it
     let folder: String
@@ -59,11 +60,13 @@ actor VaultCloud {
     }
 
     /// Load a persisted resume token, discarding it (and its stale key) if it can't actually resume:
-    /// no session id to reopen, or the staging dir is gone (deleted / disk cleaned).
+    /// nothing durable to continue (no session to reopen AND no completed slices in staging), or
+    /// the staging dir is gone (deleted / disk cleaned).
     private static func loadResume(_ key: String) -> VaultGenerator.ResumeToken? {
         guard let data = UserDefaults.standard.data(forKey: key),
               let t = try? JSONDecoder().decode(VaultGenerator.ResumeToken.self, from: data),
-              t.sessionID != nil, FileManager.default.fileExists(atPath: t.stagingPath) else {
+              t.sessionID != nil || (t.sliceIndex ?? 0) > 0,
+              FileManager.default.fileExists(atPath: t.stagingPath) else {
             UserDefaults.standard.removeObject(forKey: key)
             return nil
         }
@@ -73,9 +76,10 @@ actor VaultCloud {
     private func setCreateResume(_ t: VaultGenerator.ResumeToken?) { createResume = t; Self.persistResume(t, Self.createResumeKey) }
     private func setUpdateResume(_ t: VaultGenerator.ResumeToken?) { updateResume = t; Self.persistResume(t, Self.updateResumeKey) }
 
-    /// Persist (only a resumable token — one with a session id) or clear the handle on disk.
+    /// Persist (only a resumable token — a session id to reopen, or completed slices whose fold
+    /// lives in staging) or clear the handle on disk.
     private static func persistResume(_ t: VaultGenerator.ResumeToken?, _ key: String) {
-        if let t, t.sessionID != nil, let data = try? JSONEncoder().encode(t) {
+        if let t, t.sessionID != nil || (t.sliceIndex ?? 0) > 0, let data = try? JSONEncoder().encode(t) {
             UserDefaults.standard.set(data, forKey: key)
         } else {
             UserDefaults.standard.removeObject(forKey: key)
@@ -124,7 +128,9 @@ actor VaultCloud {
     /// corrupt the real vault — worst case the staging copy is discarded (or kept for a durable
     /// resume). This replaced the old in-place edit + `.bak` restore (B1), which is now obsolete.
     @discardableResult
-    func update(notes: [CloudNote], onLine: (@Sendable (String) -> Void)? = nil) async throws -> Int {
+    func update(notes: [CloudNote],
+                onProgress: @Sendable @escaping (VaultGenerator.Progress) -> Void = { _ in },
+                onLine: (@Sendable (String) -> Void)? = nil) async throws -> Int {
         guard !notes.isEmpty else { return 0 }
         let fm = FileManager.default
         let vault = VaultGenerator.vaultRoot
@@ -138,38 +144,99 @@ actor VaultCloud {
             return 0
         }
 
-        // Reuse the resume's staging dir (loadResume already verified it exists + has a session), else
-        // seed a fresh staging dir with a COPY of the live vault so codex has the notes to edit.
+        // Reuse the resume's staging dir (loadResume already verified it's usable), else seed a
+        // fresh staging dir with a COPY of the live vault so codex has the notes to edit.
         // `baseline` is the live vault's fingerprint at seed time — the freshness check compares
         // against it at swap; carried in the resume token so it survives a usage-limit resume.
+        // The cycle's notes are sliced under codex's 1 MiB turn-input cap (a vacation backlog
+        // crosses it) — each slice is one sequential merge run over the SAME staging; the
+        // freshness check + atomic swap happen ONCE, after the last slice.
         let staging: URL
         let baseline: String
-        let inv: CodexCLI.Invocation
+        let slices: [[CloudNote]]
+        var next: Int                                   // the next unfed slice
+        let inFlight: String?                           // a session to resume first
         if let token = updateResume {
             staging = URL(fileURLWithPath: token.stagingPath, isDirectory: true)
             baseline = token.vaultFingerprint ?? VaultGenerator.vaultFingerprint(vault)
-            var i = CodexCLI.Invocation(prompt: """
-                Continue merging the new items into the vault exactly where you left off — the edits \
-                you already made are still in the working directory. When everything is merged, reply \
-                with one line: the number of notes you created or edited.
-                """)
-            i.resumeSessionID = token.sessionID
-            inv = i
+            inFlight = token.sessionID
+            if let idx = token.sliceIndex {
+                guard let corpus = CorpusSlicer.loadCorpus(from: staging) else {
+                    // Snapshot gone — the fold can't be continued safely; restart the merge fresh.
+                    Log("VaultCloud.update: ⚠️ resume snapshot missing — restarting the merge fresh")
+                    setUpdateResume(nil)
+                    try? fm.removeItem(at: staging)
+                    return try await update(notes: notes, onProgress: onProgress, onLine: onLine)
+                }
+                slices = CorpusSlicer.slice(corpus)
+                next = min(idx, slices.count)
+            } else {
+                slices = []                             // pre-slicing / single-slice token: session-resume only
+                next = 0
+            }
         } else {
             staging = try VaultGenerator.newStagingDir(seedFrom: vault)
             baseline = VaultGenerator.vaultFingerprint(vault)       // captured at seed (vault == staging)
-            inv = CodexCLI.Invocation(prompt: Self.updatePrompt(skeleton: Self.skeleton(of: staging), notes: notes))
+            slices = CorpusSlicer.slice(notes)
+            next = 0
+            if slices.count > 1 {
+                try CorpusSlicer.saveCorpus(notes, in: staging)
+                Log("VaultCloud.update: cycle sliced into \(slices.count) parts (budget \(CorpusSlicer.budget) bytes)")
+            }
+            inFlight = nil
         }
-        var invocation = inv
-        invocation.feature = "vault"
-        invocation.effort = .high                                    // incremental KB update (gpt-5.6-sol → high)
-        invocation.sandbox = .workspaceWrite                        // edits confined to the staging dir
-        invocation.cwd = staging.path
-        invocation.timeout = 1_800
+
+        /// The shared per-run configuration every merge invocation gets.
+        func configure(_ prompt: String) -> CodexCLI.Invocation {
+            var i = CodexCLI.Invocation(prompt: prompt)
+            i.feature = "vault"
+            i.effort = .high                                    // incremental KB update (gpt-5.6-sol → high)
+            i.sandbox = .workspaceWrite                        // edits confined to the staging dir
+            i.cwd = staging.path
+            i.timeout = 1_800
+            return i
+        }
 
         Log("VaultCloud.update: merging \(notes.count) notes in staging (\(updateResume == nil ? "fresh" : "resume"))…")
         do {
-            let envelope = try await VaultGenerator().runCodexInStaging(invocation, staging: staging, onLine: onLine)
+            // Finish the in-flight slice's session first (or, for a pre-slicing token, the whole run).
+            if let sid = inFlight {
+                var invocation = configure("""
+                    Continue merging the new items into the vault exactly where you left off — the edits \
+                    you already made are still in the working directory. When everything is merged, reply \
+                    with one line: the number of notes you created or edited.
+                    """)
+                invocation.resumeSessionID = sid
+                invocation.diag = ["slices": "\(max(slices.count, 1))", "slice_index": "\(max(next - 1, 0))"]
+                do {
+                    _ = try await VaultGenerator().runCodexInStaging(invocation, staging: staging, onLine: onLine)
+                } catch let VaultGenerator.VaultError.usageLimit(message, token) {
+                    var t = token; t.sliceIndex = updateResume?.sliceIndex   // unchanged — still the same slice
+                    throw VaultGenerator.VaultError.usageLimit(message: message, resume: t)
+                }
+            }
+
+            // Feed the remaining slices, one fresh merge session each, over the same staging.
+            while next < slices.count {
+                try Task.checkCancellation()                     // the user's STOP, between slices
+                if slices.count > 1 { onProgress(.folding(part: next + 1, of: slices.count)) }
+                var invocation = configure(Self.updatePrompt(skeleton: Self.skeleton(of: staging), notes: slices[next]))
+                invocation.diag = ["corpus_chars": "\(invocation.prompt.utf8.count)",
+                                   "slices": "\(slices.count)", "slice_index": "\(next)"]
+                if slices.count > 1 {
+                    Log("VaultCloud.update: feeding slice \(next + 1)/\(slices.count) — \(slices[next].count) summaries")
+                }
+                do {
+                    _ = try await VaultGenerator().runCodexInStaging(invocation, staging: staging, onLine: onLine)
+                } catch let VaultGenerator.VaultError.usageLimit(message, token) {
+                    guard slices.count > 1 else { throw VaultGenerator.VaultError.usageLimit(message: message, resume: token) }
+                    // A session that never started can't be resumed — its slice stays the next unfed.
+                    var t = token; t.sliceIndex = (token.sessionID != nil) ? next + 1 : next
+                    throw VaultGenerator.VaultError.usageLimit(message: message, resume: t)
+                }
+                next += 1
+            }
+
             // Freshness check (B11): did the live vault change under us — i.e. did the user save a note
             // in the Knowledge editor during the run? If so, our staging snapshot is stale and swapping
             // would CLOBBER their edit. Discard staging instead; the notes stay in CycleStore and the
@@ -183,24 +250,25 @@ actor VaultCloud {
                 try? fm.removeItem(at: staging)
                 return 0
             }
-            try VaultGenerator.swapStagingIntoVault(staging)        // atomic; live vault untouched until here
+            CorpusSlicer.deleteCorpus(in: staging)              // the snapshot must never enter the vault
+            try VaultGenerator.swapStagingIntoVault(staging)    // atomic; live vault untouched until here
             setUpdateResume(nil)
             await markDirty()
-            Log("VaultCloud.update: ✅ \(notes.count) notes (turns \(envelope.numTurns ?? -1), \(envelope.result.count) char report)")
+            Log("VaultCloud.update: ✅ \(notes.count) notes merged")
             return notes.count
         } catch let VaultGenerator.VaultError.usageLimit(message, resume) {
             // Staging is kept; the live vault was never touched. Carry the seed baseline forward so a
             // resume's swap still detects a concurrent editor edit. Durable resume continues next run.
-            setUpdateResume(VaultGenerator.ResumeToken(sessionID: resume.sessionID,
-                                                       stagingPath: resume.stagingPath,
-                                                       vaultFingerprint: baseline))
+            var t = resume; t.vaultFingerprint = baseline
+            setUpdateResume(t)
             throw CloudError.usageLimit(message)
         } catch {
             // Any other failure: discard the staging copy; the live vault was NEVER modified — no
-            // restore dance needed (the whole point of stage-then-swap).
+            // restore dance needed (the whole point of stage-then-swap). Rethrow the TYPED error —
+            // wrapping it in a string used to blind OvernightCaution.classify to the actual kind.
             setUpdateResume(nil)
             try? fm.removeItem(at: staging)
-            throw CloudError.failed("\(error)")
+            throw error
         }
     }
 
@@ -251,17 +319,12 @@ actor VaultCloud {
     }
 
     /// The editing-flavored Stage-2 prompt — lifted verbatim from the old VaultUpdater
-    /// (eval-validated), fed CloudNotes. Surgical edits, not a rebuild.
-    private static func updatePrompt(skeleton: String, notes: [CloudNote]) -> String {
-        var lines: [String] = []
-        lines.reserveCapacity(notes.count)
-        let df = DateFormatter(); df.dateStyle = .medium; df.timeStyle = .none
-        for (i, n) in notes.enumerated() {
-            let (loc, src) = VaultGenerator.locSrc(kind: n.kind, folder: n.folder, sourceID: n.sourceID)
-            let title = (n.title?.isEmpty == false) ? n.title! : "(untitled)"
-            let when = n.itemDate.map { " · \(df.string(from: $0))" } ?? ""
-            lines.append("#\(i + 1) · [\(src)] \(loc)\(when)\n\(title) — \(n.text)")
-        }
+    /// (eval-validated), fed CloudNotes. Surgical edits, not a rebuild. Internal (not private):
+    /// a sliced first build reuses it verbatim for slices 1+ — folding a batch into the staged
+    /// vault is the same job as folding a night into the live one.
+    static func updatePrompt(skeleton: String, notes: [CloudNote]) -> String {
+        let df = CorpusSlicer.dateFormatter()
+        let lines = notes.enumerated().map { i, n in CorpusSlicer.render(n, index: i, df: df) }
 
         return """
         You are the **Sentient OS Knowledge Base Architect** — the cloud brain of a privacy-first \

--- a/Sentient OS macOS/Vault/VaultGenerator.swift
+++ b/Sentient OS macOS/Vault/VaultGenerator.swift
@@ -36,6 +36,7 @@ actor VaultGenerator {
     enum Progress: Sendable {
         case gathering(Int)
         case calling
+        case folding(part: Int, of: Int)   // multi-slice corpus: feeding part N of M
         case writing(notes: Int)        // .md files appearing in staging
         case materializing(notes: Int)
     }
@@ -51,6 +52,12 @@ actor VaultGenerator {
         /// seeded, carried across a usage-limit resume so the swap can still detect a concurrent
         /// editor edit made during the (possibly multi-attempt) run. nil for a build.
         var vaultFingerprint: String? = nil
+        /// Corpus slicing (1.0.1): the next UNFED slice of the staging dir's corpus snapshot.
+        /// nil = a pre-slicing or single-slice token — session-resume only, nothing left to feed.
+        /// With a value, slices 0..<sliceIndex are already folded into staging (so the token is
+        /// worth keeping even without a session id), and `sessionID` (when present) belongs to
+        /// slice sliceIndex - 1, still in flight.
+        var sliceIndex: Int? = nil
     }
 
     enum VaultError: LocalizedError {
@@ -202,42 +209,127 @@ actor VaultGenerator {
             staging = try Self.newStagingDir()
         }
 
-        let prompt: String
-        if let resume, resume.sessionID != nil {
-            prompt = """
-            Continue building the vault exactly where you left off. The notes you already \
-            wrote are still in the working directory — don't rewrite them. Finish the \
-            remaining notes, then reply with one line: the total number of notes in the vault.
-            """
+        // The corpus, sliced under codex's 1 MiB turn-input cap. Slice 0 rides the build prompt;
+        // slices 1+ each fold into staging with the nightly updater's merge prompt, one fresh
+        // session per slice — codex's memory of earlier slices IS the staging dir it already
+        // wrote. A mid-sequence resume re-slices the staging SNAPSHOT, never a fresh CycleStore
+        // fetch (newest-first ordering would shift every boundary; see CorpusSlicer.saveCorpus).
+        let slices: [[CloudNote]]
+        var next: Int                               // the next unfed slice
+        if let resume {
+            if let idx = resume.sliceIndex {
+                guard let corpus = CorpusSlicer.loadCorpus(from: staging) else {
+                    // Snapshot gone (disk cleaning?) — the fold can't be continued safely; start over.
+                    Log("VaultGenerator: ⚠️ resume snapshot missing — restarting the build fresh")
+                    try? fm.removeItem(at: staging)
+                    return try await generate(notes: notes, resume: nil, onProgress: onProgress, onLine: onLine)
+                }
+                slices = CorpusSlicer.slice(corpus)
+                next = min(idx, slices.count)
+            } else {
+                slices = []                         // pre-slicing / single-slice token: session-resume only
+                next = 0
+            }
         } else {
-            prompt = vaultPromptCore + "\n\n" + agenticOutputInstructions + "\n\n"
-                + Self.corpusMessage(notes, closing: "Synthesize them into the vault exactly as specified — write the files now.")
+            slices = CorpusSlicer.slice(notes)
+            next = 0
+            if slices.count > 1 {
+                try CorpusSlicer.saveCorpus(notes, in: staging)
+                Log("VaultGenerator: corpus sliced into \(slices.count) parts (budget \(CorpusSlicer.budget) bytes)")
+            }
         }
-
-        var invocation = CodexCLI.Invocation(prompt: prompt)
-        invocation.feature = "vault"
-        // Effort stays at the .high default — .xhigh thinks far too long on gpt-5.6-sol for the
-        // initial build (downgraded 2026-07-10), and .high is also what a free/go plan's tiny
-        // monthly quota can afford (~70% of it).
-        invocation.sandbox = .workspaceWrite                 // writes confined to the staging dir
-        invocation.cwd = staging.path
-        invocation.resumeSessionID = resume?.sessionID
-        invocation.timeout = 3_600
 
         Log("VaultGenerator: \(resume == nil ? "starting" : "RESUMING") initial generation — \(notes.count) summaries → \(staging.lastPathComponent)")
 
-        let envelope = try await runCodexInStaging(invocation, staging: staging, onProgress: onProgress, onLine: onLine)
+        var inputTokens = 0, outputTokens = 0
+        func record(_ envelope: CodexCLI.Envelope) {
+            inputTokens += envelope.inputTokens ?? 0
+            outputTokens += envelope.outputTokens ?? 0
+        }
 
-        let (notes, folders) = Self.census(of: staging)
-        Log("VaultGenerator: codex finished (turns \(envelope.numTurns ?? -1), \(envelope.durationMS ?? -1)ms) — \(notes) notes / \(folders) folders in staging")
-        guard notes > 0 else {
+        // Finish the in-flight slice's session first (or, for a pre-slicing token, the whole run).
+        if let resume, let sid = resume.sessionID {
+            let buildFlavored = (resume.sliceIndex ?? 1) <= 1        // slice 0 (or legacy) = the build prompt
+            var invocation = CodexCLI.Invocation(prompt: buildFlavored
+                ? """
+                Continue building the vault exactly where you left off. The notes you already \
+                wrote are still in the working directory — don't rewrite them. Finish the \
+                remaining notes, then reply with one line: the total number of notes in the vault.
+                """
+                : """
+                Continue merging the new items into the vault exactly where you left off — the edits \
+                you already made are still in the working directory. When everything is merged, reply \
+                with one line: the number of notes you created or edited.
+                """)
+            invocation.feature = "vault"
+            invocation.sandbox = .workspaceWrite
+            invocation.cwd = staging.path
+            invocation.resumeSessionID = sid
+            invocation.timeout = 3_600
+            invocation.diag = ["slices": "\(max(slices.count, 1))", "slice_index": "\(max(next - 1, 0))"]
+            do {
+                record(try await runCodexInStaging(invocation, staging: staging, onProgress: onProgress, onLine: onLine))
+            } catch let VaultError.usageLimit(message, token) {
+                var t = token; t.sliceIndex = resume.sliceIndex      // unchanged — still the same slice
+                throw VaultError.usageLimit(message: message, resume: t)
+            }
+        }
+
+        // Feed the remaining slices, one fresh codex session each.
+        while next < slices.count {
+            try Task.checkCancellation()                             // the user's STOP, between slices
+            if slices.count > 1 { onProgress(.folding(part: next + 1, of: slices.count)) }
+            let prompt: String
+            if next == 0 {
+                prompt = vaultPromptCore + "\n\n" + agenticOutputInstructions + "\n\n"
+                    + Self.corpusMessage(slices[0], partial: slices.count > 1,
+                                         closing: "Synthesize them into the vault exactly as specified — write the files now.")
+            } else {
+                prompt = VaultCloud.updatePrompt(skeleton: VaultCloud.skeleton(of: staging), notes: slices[next])
+            }
+
+            var invocation = CodexCLI.Invocation(prompt: prompt)
+            invocation.feature = "vault"
+            // Effort stays at the .high default — .xhigh thinks far too long on gpt-5.6-sol for the
+            // initial build (downgraded 2026-07-10), and .high is also what a free/go plan's tiny
+            // monthly quota can afford (~70% of it).
+            invocation.sandbox = .workspaceWrite                 // writes confined to the staging dir
+            invocation.cwd = staging.path
+            invocation.timeout = 3_600
+            invocation.diag = ["corpus_chars": "\(prompt.utf8.count)",
+                               "slices": "\(slices.count)", "slice_index": "\(next)"]
+
+            if slices.count > 1 {
+                Log("VaultGenerator: feeding slice \(next + 1)/\(slices.count) — \(slices[next].count) summaries, \(prompt.utf8.count) bytes")
+            }
+            do {
+                record(try await runCodexInStaging(invocation, staging: staging, onProgress: onProgress, onLine: onLine))
+            } catch let VaultError.usageLimit(message, token) {
+                guard slices.count > 1 else { throw VaultError.usageLimit(message: message, resume: token) }
+                // A session that never started can't be resumed — its slice stays the next unfed.
+                var t = token; t.sliceIndex = (token.sessionID != nil) ? next + 1 : next
+                throw VaultError.usageLimit(message: message, resume: t)
+            }
+            if next == 0, Self.census(of: staging).notes == 0 {
+                // Slice 0 produced nothing — the merges would fold into thin air; fail now, not
+                // after burning the whole sequence's quota.
+                try? fm.removeItem(at: staging)
+                throw VaultError.empty
+            }
+            next += 1
+        }
+
+        let (written, folders) = Self.census(of: staging)
+        Log("VaultGenerator: codex finished — \(written) notes / \(folders) folders in staging")
+        guard written > 0 else {
             try? fm.removeItem(at: staging)
             throw VaultError.empty
         }
 
         // Success → atomically swap staging into the real vault (the only moment the old vault is
         // touched); on any throw the vault is left intact (B11 swapStagingIntoVault).
-        onProgress(.materializing(notes: notes))
+        onProgress(.materializing(notes: written))
+        CorpusSlicer.deleteCorpus(in: staging)               // the snapshot must never enter the vault
         do {
             try Self.swapStagingIntoVault(staging)
         } catch {
@@ -247,11 +339,11 @@ actor VaultGenerator {
             CrashReporting.captureEvent("vault_swap_failed", tags: ["error": ErrorLabel(error)])
             throw error
         }
-        Log("VaultGenerator: ✅ vault swapped into place — \(notes) notes at \(Self.vaultRoot.path)")
+        Log("VaultGenerator: ✅ vault swapped into place — \(written) notes at \(Self.vaultRoot.path)")
 
-        return Result(notes: notes, folders: folders,
-                      inputTokens: envelope.inputTokens ?? 0,
-                      outputTokens: envelope.outputTokens ?? 0,
+        return Result(notes: written, folders: folders,
+                      inputTokens: inputTokens,
+                      outputTokens: outputTokens,
                       vaultPath: Self.vaultRoot.path)
     }
 
@@ -270,18 +362,17 @@ actor VaultGenerator {
 
     // MARK: - Corpus building (the stdin corpus)
 
-    private static func corpusMessage(_ notes: [CloudNote], closing: String) -> String {
-        var lines: [String] = []
-        lines.reserveCapacity(notes.count)
-        let df = DateFormatter(); df.dateStyle = .medium; df.timeStyle = .none
-        for (i, s) in notes.enumerated() {
-            let (loc, src) = locSrc(kind: s.kind, folder: s.folder, sourceID: s.sourceID)
-            let title = (s.title?.isEmpty == false) ? s.title! : "(untitled)"
-            let when = s.itemDate.map { " · \(df.string(from: $0))" } ?? ""
-            lines.append("#\(i + 1) · [\(src)] \(loc)\(when)\n\(title) — \(s.text)")
-        }
+    private static func corpusMessage(_ notes: [CloudNote], partial: Bool = false, closing: String) -> String {
+        let df = CorpusSlicer.dateFormatter()
+        let lines = notes.enumerated().map { i, s in CorpusSlicer.render(s, index: i, df: df) }
+        // `partial` = a sliced corpus: this prompt carries the first part; the rest arrives in
+        // follow-up merge passes over the same working directory. Be honest with the model.
+        let intro = partial
+            ? "Here is the first part of the corpus of on-device summaries of the user's digital life " +
+              "(the remaining parts will be merged into your vault in follow-up passes after this one)."
+            : "Here is the full corpus of on-device summaries of the user's digital life."
         return """
-        Here is the full corpus of on-device summaries of the user's digital life. Each item is \
+        \(intro) Each item is \
         `#<index> · [source] location · item date` then `Title — summary`. \(closing)
 
         ---

--- a/Sentient OS macOS/Vault/VaultGenerator.swift
+++ b/Sentient OS macOS/Vault/VaultGenerator.swift
@@ -227,7 +227,15 @@ actor VaultGenerator {
                 slices = CorpusSlicer.slice(corpus)
                 next = min(idx, slices.count)
             } else {
-                slices = []                         // pre-slicing / single-slice token: session-resume only
+                // Pre-slicing / single-slice token: session-resume only. If that session never wrote
+                // a single note, resuming it buys nothing — restart fresh under the slicer instead
+                // (also covers any stale launch-window token whose oversized first turn never ran).
+                if Self.census(of: staging).notes == 0 {
+                    Log("VaultGenerator: ⚠️ resume session left staging empty — restarting the build fresh")
+                    try? fm.removeItem(at: staging)
+                    return try await generate(notes: notes, resume: nil, onProgress: onProgress, onLine: onLine)
+                }
+                slices = []
                 next = 0
             }
         } else {

--- a/Sentient OS macOS/Views/Dev/DevToolsView.swift
+++ b/Sentient OS macOS/Views/Dev/DevToolsView.swift
@@ -485,6 +485,7 @@ struct DevToolsView: View {
             let r = try await VaultCloud.shared.create(notes: notes) { p in
                 switch p {
                 case .calling:              progress("… thinking")
+                case .folding(let i, let n): progress("… part \(i) of \(n)")
                 case .writing(let n):       progress("… writing \(n) notes")
                 case .materializing(let n): progress("… finishing \(n)")
                 case .gathering:            break

--- a/Sentient OS macOS/Views/ProcessingView.swift
+++ b/Sentient OS macOS/Views/ProcessingView.swift
@@ -520,10 +520,11 @@ struct ProcessingView: View {
 
     private static func failTitle(_ kind: OvernightCaution.Kind?) -> String {
         switch kind {
-        case .loggedOut:  "Codex isn't logged in"
-        case .usageLimit: "We hit ChatGPT's usage limit"
-        case .noInternet: "No internet connection"
-        case nil:         "Processing failed"
+        case .loggedOut:      "Codex isn't logged in"
+        case .usageLimit:     "We hit ChatGPT's usage limit"
+        case .noInternet:     "No internet connection"
+        case .inputTooLarge:  "This batch was too big to send"
+        case nil:             "Processing failed"
         }
     }
 
@@ -531,10 +532,11 @@ struct ProcessingView: View {
     /// Sentry); unclassified ones show the step's own message, as before.
     private static func failBody(_ failure: CycleFailure) -> String {
         switch failure.kind {
-        case .loggedOut:  "Sentient runs on your own ChatGPT account through codex, and that login has stopped working. Log back in and I'll pick up right where we stopped."
-        case .usageLimit: "Your plan's window resets on its own. Everything so far is saved; retry in a while and I'll pick up right where we stopped."
-        case .noInternet: "This step runs in the cloud. Once you're back online, hit Retry; everything so far is saved."
-        case nil:         failure.message
+        case .loggedOut:      "Sentient runs on your own ChatGPT account through codex, and that login has stopped working. Log back in and I'll pick up right where we stopped."
+        case .usageLimit:     "Your plan's window resets on its own. Everything so far is saved; retry in a while and I'll pick up right where we stopped."
+        case .noInternet:     "This step runs in the cloud. Once you're back online, hit Retry; everything so far is saved."
+        case .inputTooLarge:  "Sentient tried to send ChatGPT more than it accepts in one request. Your analysis is saved; if a retry hits this again, update Sentient OS and retry once more."
+        case nil:             failure.message
         }
     }
 


### PR DESCRIPTION
## Corpus batching for large first runs (vault build + nightly update)

Large corpora now feed codex as a byte-budgeted sequence instead of one unbounded prompt, so a data-rich first run (or a heavy week's update backlog) can never exceed the input a single `codex exec` turn accepts.

### What changed

- **`Vault/CorpusSlicer.swift` (new):** deterministic byte-budgeted slicing of the summary corpus (700 KB per part, entries never split), plus a staging-dir corpus snapshot that guarantees identical re-slicing across restarts.
- **`VaultGenerator.generate`:** part one rides the existing build prompt; later parts fold into the same staging dir through the battle-tested update/merge prompt, one fresh codex session each. The single atomic staging → vault swap at the end is unchanged. Single-part corpora take the exact pre-existing code path.
- **`VaultCloud.update`:** the same slicing loop; the freshness check and the one swap stay at the end. Non-usage-limit errors now rethrow typed instead of stringified, so failure classification sees them.
- **Resume:** `ResumeToken` gains `sliceIndex` (the next unfed part; decode-compatible with persisted pre-1.0.1 tokens). Usage-limit resume composes with batching: the in-flight session resumes first, then the remaining parts continue. Tokens with completed parts but no live session are now kept.
- **`CodexCLI`:** a pre-spawn guard rejects any prompt over 950 KB with a new typed `CLIError.inputTooLarge` (both spines), plus an output-side sniff as belt-and-suspenders. `Invocation.diag` carries structured ints (corpus size, part counts) into failure telemetry; `exit_code` added.
- **Classification & UI:** `OvernightCaution` gains the `inputTooLarge` kind (honest copy in the processing takeover + morning banner), and now recognizes every stage wrapper's usage-limit case (previously a vault-leg usage limit classified as nil).
- **Proactive:** the judge/research 7-day window is trimmed to the same shared byte budget, oldest dropped first.
- **Progress:** multi-part runs report "part N of M" in the takeover phase line and Dev Tools.

### Verification (headless self-tests, real codex, all green)

- **Slicer unit checks 13/13:** determinism, budget bounds, order preservation, oversized-entry and empty degenerates, snapshot roundtrip, legacy-token decode compatibility.
- **Guard + classification 6/6:** typed `inputTooLarge` thrown pre-spawn; every stage wrapper's usage-limit case classifies.
- **End-to-end at a 4 KB test budget 8/8** (3 real codex sessions): build + two merges over one staging dir, every part's content in the final vault, one swap, snapshot cleaned, no staging leaks.
- **Mid-sequence resume 6/6:** a token at part 2 continues at part 2 (never re-feeds part 1), the prior fold preserved.
- **Sliced update path 5/5** over a seeded vault (2 real merge sessions).
- **Real-user scale 11/11:** 1,800 mixed-source summaries rendering to 2.55 MB (2.4x the per-turn input cap) built end-to-end in 9 minutes through 4 parts at the production 700 KB budget. All 18 high-signal sentinel notes across all 4 parts survived curation, and a project thread deliberately scattered across every part consolidated into ONE domain (3 notes) in the finished knowledge base — the cross-part seam produces no fragmentation.
- **Stale-token restart 6/6** (second commit): a pre-slicing resume token whose session never wrote a note is detected by its empty staging, discarded, and the build restarts fresh through the batching path.

Scaffolding removed after verification per the eval-harness convention (`Self Tests - Temp/` back to empty); the modes are recreatable on demand.

https://claude.ai/code/session_01Rtf4Zn1tUzDpQJRzZwna92
