### PR TITLE
Add the self-attested upgrade path to the plan crossroads

### DIFF
--- a/Sentient OS macOS/Cloud/CodexAuth.swift
+++ b/Sentient OS macOS/Cloud/CodexAuth.swift
@@ -15,6 +15,7 @@
 //   - currentPlan()          → decode the plan claim from auth.json (pure file read, no network)
 //   - refreshPlan()          → the on-demand refresh POST + write-back → the FRESH plan
 //   - knowledgeBaseOnly      → the persisted "free user chose to continue anyway" mode flag
+//   - assertedPlus           → the persisted "user says they upgraded, we believed them" flag
 //
 //  Fail-open policy: no file / no tokens / unknown plan string → treated as full. Worst case a
 //  limited account hits codex usage-limit errors, which every caller already survives (typed
@@ -63,6 +64,17 @@ enum CodexAuth {
         set { UserDefaults.standard.set(newValue, forKey: kbOnlyKey) }
     }
 
+    /// The user told us they upgraded, and we took their word for it (the crossroads' "I've
+    /// upgraded to ChatGPT Plus" + its confirm). Needed because a just-paid upgrade can still
+    /// read free/go on disk — the claim lags, and the refresh POST can be throttled — so the
+    /// honest check has no way to say yes yet. Sticky: if the claim never catches up, the only
+    /// cost is codex usage-limit errors, which every caller already survives. Reset clears it.
+    static let assertedPlusKey = "plan.assertedPlus"
+    static var assertedPlus: Bool {
+        get { UserDefaults.standard.bool(forKey: assertedPlusKey) }
+        set { UserDefaults.standard.set(newValue, forKey: assertedPlusKey) }
+    }
+
     /// Server-supplied refresh throttle (the POST answers `earliest_refresh_at`) — respected so
     /// focus-return re-checks can never hammer the endpoint.
     private static let earliestRefreshKey = "plan.earliestRefresh"
@@ -89,8 +101,11 @@ enum CodexAuth {
         return nil
     }
 
-    /// True only on a POSITIVE free/go read — the convenience most gates want.
-    static func isLimited() -> Bool { currentPlan()?.tier == .limited }
+    /// True only on a POSITIVE free/go read — the convenience most gates want. A user who told
+    /// us they upgraded is never limited: the whole point of trusting them is that the claim on
+    /// disk is the thing we've decided not to believe (chiefly CodexCLI.planTuned, which would
+    /// otherwise keep downshifting them off gpt-5.6-sol).
+    static func isLimited() -> Bool { !assertedPlus && currentPlan()?.tier == .limited }
 
     /// Extract `chatgpt_plan_type` from a JWT's payload segment (base64url, no signature check —
     /// we're reading our own user's token off their own disk, not authenticating anyone).

--- a/Sentient OS macOS/Ingestion/FactoryReset.swift
+++ b/Sentient OS macOS/Ingestion/FactoryReset.swift
@@ -30,6 +30,7 @@ enum FactoryReset {
         let d = UserDefaults.standard
         d.removeObject(forKey: "onboarding.step")
         d.removeObject(forKey: CodexAuth.kbOnlyKey)     // the crossroads re-detects the plan fresh
+        d.removeObject(forKey: CodexAuth.assertedPlusKey)   // …and asks again before trusting
         d.removeObject(forKey: AppState.onboardingKey)
         d.removeObject(forKey: ComputerUseGate.screenRecordingOfferedKey)   // re-offer Sentient's optional grants on rebuild
         d.removeObject(forKey: ComputerUseGate.micSpeechOfferedKey)

--- a/Sentient OS macOS/Views/GlowButton.swift
+++ b/Sentient OS macOS/Views/GlowButton.swift
@@ -41,16 +41,22 @@ struct GlowButton: View {
 /// The glow CTA's quiet sibling — a grey outlined capsule for the visible-but-subordinate
 /// choice beside it (the crossroads' "continue with just the knowledge base", the free home's
 /// "Reset Sentient…"). Present enough to read as a real button, never competing with the glow.
+/// `large` matches the glow button's height and fills its container — for the one case where the
+/// two sit SIDE BY SIDE as a row (the crossroads' "I've upgraded to ChatGPT Plus") rather than
+/// stacked; still no halo, so the glow stays the only jewelry on the screen.
 struct QuietPillButton: View {
     let title: String
+    var large: Bool = false
     let action: () -> Void
 
     var body: some View {
         Button(action: action) {
             Text(title)
-                .font(.system(size: 13.5, weight: .medium))
+                .font(.system(size: large ? 14.5 : 13.5, weight: .medium))
                 .foregroundStyle(Theme.Ink.bright)
-                .padding(.horizontal, 22).padding(.vertical, 12)
+                .lineLimit(1)
+                .frame(maxWidth: large ? .infinity : nil)
+                .padding(.horizontal, 22).padding(.vertical, large ? 17 : 12)
                 .background(Capsule().fill(.white.opacity(0.07)))
                 .overlay(Capsule().strokeBorder(.white.opacity(0.16), lineWidth: 1))
                 .contentShape(Capsule())

--- a/Sentient OS macOS/Views/Onboarding/OnboardingPlanView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingPlanView.swift
@@ -6,10 +6,12 @@
 //  accounts ever see it: a full plan (plus/pro/team/…, or anything we can't read — fail open)
 //  auto-advances before a single pixel renders. Free/go users get an honest fork: upgrade to
 //  Plus (opens ChatGPT's pricing page, then this screen notices the upgrade on its own via
-//  CodexAuth.refreshPlan — the same on-demand token re-mint codex does every 8 days), or
-//  continue with just the knowledge base (sets CodexAuth.knowledgeBaseOnly, the app-wide
-//  limited-mode gate). This screen sets expectations; the real conversion surface is the home's
-//  post-reveal preview message, after they've seen the magic.
+//  CodexAuth.refreshPlan — the same on-demand token re-mint codex does every 8 days), say they
+//  ALREADY upgraded (a confirm, then we simply believe them — CodexAuth.assertedPlus; people
+//  upgrade in their own browser and arrive here before any check could prove it), or continue
+//  with just the knowledge base (sets CodexAuth.knowledgeBaseOnly, the app-wide limited-mode
+//  gate). This screen sets expectations; the real conversion surface is the home's post-reveal
+//  preview message, after they've seen the magic.
 //
 
 import SwiftUI
@@ -24,7 +26,7 @@ struct OnboardingPlanView: View {
     @State private var phase: Phase = .checking
     @State private var plan: CodexAuth.Plan?
     @State private var checkingUpgrade = false
-    @State private var statusLine: String?
+    @State private var confirmingUpgrade = false
 
     private var planName: String { plan?.displayName ?? "Free" }
 
@@ -63,10 +65,16 @@ struct OnboardingPlanView: View {
                 }
 
                 VStack(spacing: 18) {
-                    GlowButton(title: "Upgrade on ChatGPT",
-                               systemImage: "arrow.up.forward",
-                               action: openUpgrade)
-                        .frame(maxWidth: 380)
+                    // The two ways forward, side by side: go buy it, or tell us you already did.
+                    HStack(spacing: 16) {
+                        GlowButton(title: "Upgrade on ChatGPT",
+                                   systemImage: "arrow.up.forward",
+                                   action: openUpgrade)
+                        QuietPillButton(title: "I've upgraded to ChatGPT Plus", large: true) {
+                            confirmingUpgrade = true
+                        }
+                    }
+                    .frame(maxWidth: 540)
                     continueFreeButton
                 }
 
@@ -87,16 +95,11 @@ struct OnboardingPlanView: View {
                             .kerning(1.5)
                             .foregroundStyle(Theme.faint)
                     }
-                    OnboardingNextButton(title: checkingUpgrade ? "Checking…" : "I've upgraded",
-                                         enabled: !checkingUpgrade) {
-                        check(manual: true)
-                    }
-                    if let statusLine {
-                        Text(statusLine)
-                            .font(.system(.caption2, design: .monospaced))
-                            .foregroundStyle(Theme.secondary)
-                            .multilineTextAlignment(.center)
-                            .frame(maxWidth: 480)
+                    // The trust path, not a check: the account can read Free here long after a
+                    // real payment (the refreshed token re-mints from the same stale session),
+                    // so the button takes the user's word — same confirm as the crossroads'.
+                    OnboardingNextButton(title: "I've upgraded") {
+                        confirmingUpgrade = true
                     }
                     continueFreeButton
                         .padding(.top, 8)
@@ -125,9 +128,15 @@ struct OnboardingPlanView: View {
                 onContinue()
             }
         }
+        .alert("Are you on ChatGPT Plus?", isPresented: $confirmingUpgrade) {
+            Button("Yes, I'm on Plus!") { acceptSelfAttestedUpgrade() }
+            Button("Wait", role: .cancel) { }
+        } message: {
+            Text("Sentient will unlock the full experience and take your word for it.\n\nNote that the ChatGPT Go plan does not offer enough Codex use to unlock the full experience.")
+        }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
-            // Back from the browser — quietly re-check. Silent when still free (they may just
-            // be reading the pricing page); only the manual button reports a "still free" result.
+            // Back from the browser — quietly re-check, and auto-advance if the fresh claim
+            // happens to read full. Always silent: the trust button is the real way forward.
             if phase == .waiting { check() }
         }
     }
@@ -136,33 +145,43 @@ struct OnboardingPlanView: View {
 
     private func openUpgrade() {
         NSWorkspace.shared.open(CodexAuth.upgradeURL)
-        statusLine = nil
         withAnimation(.easeInOut(duration: 0.25)) { phase = .waiting }
     }
 
-    /// The upgrade check — CodexAuth.refreshPlan re-mints the token so a just-paid upgrade shows
-    /// up immediately (the claim on disk would otherwise lag on codex's 8-day timer). Single
-    /// in-flight; focus-return calls stay quiet on failure, the manual button explains itself.
-    private func check(manual: Bool = false) {
+    /// "I've upgraded", confirmed — the trust path, and the ONLY user-driven way forward from
+    /// either phase. A real payment can read Free here indefinitely (the refresh POST re-mints
+    /// a token from the same stale session — only OpenAI's server knows the truth, and it checks
+    /// at exec time), so we take the user's word and move on immediately: full mode, same as a
+    /// verified Plus account. The refresh still fires, unawaited — if it lands, the claim on
+    /// disk becomes true too and nothing downstream has to lean on the assertion.
+    private func acceptSelfAttestedUpgrade() {
+        CodexAuth.assertedPlus = true
+        CodexAuth.knowledgeBaseOnly = false
+        Analytics.signal("PlanGate.selfAttested", parameters: ["plan": plan?.raw ?? "unknown"])
+        Task { _ = try? await CodexAuth.refreshPlan() }
+        onContinue()
+    }
+
+    /// The silent focus-return check — CodexAuth.refreshPlan re-mints the token, and IF the
+    /// fresh claim reads full the screen auto-advances. Best-effort only (the claim often stays
+    /// stale after a real payment); the user's own way forward is the trust button above, so
+    /// this never reports failure. Single in-flight.
+    private func check() {
         guard !checkingUpgrade else { return }
         checkingUpgrade = true
-        if manual { statusLine = nil }
         Task {
             defer { checkingUpgrade = false }
-            do {
-                let fresh = try await CodexAuth.refreshPlan()
-                if let fresh { plan = fresh }
-                if fresh?.tier != .limited {
-                    CodexAuth.knowledgeBaseOnly = false
-                    Analytics.signal("PlanGate.upgraded")
-                    withAnimation(.easeInOut(duration: 0.3)) { phase = .unlocked }
-                    try? await Task.sleep(for: .seconds(1.4))
-                    onContinue()
-                } else if manual {
-                    statusLine = "Still seeing \(fresh?.displayName ?? planName) on your account. It can take a minute after paying; try again shortly."
-                }
-            } catch {
-                if manual { statusLine = "Couldn't check right now; try again in a moment." }
+            let fresh: CodexAuth.Plan?
+            do { fresh = try await CodexAuth.refreshPlan() }
+            catch { return }   // network/refresh failure — stay quiet, the trust button carries
+            if let fresh { plan = fresh }
+            // Fail open like every other gate: an unreadable fresh claim counts as full.
+            if fresh?.tier != .limited {
+                CodexAuth.knowledgeBaseOnly = false
+                Analytics.signal("PlanGate.upgraded")
+                withAnimation(.easeInOut(duration: 0.3)) { phase = .unlocked }
+                try? await Task.sleep(for: .seconds(1.4))
+                onContinue()
             }
         }
     }


### PR DESCRIPTION
## What

The onboarding plan crossroads now trusts the user about their ChatGPT plan instead of making them wait on a verification loop:

- **Crossroads**: the glow "Upgrade on ChatGPT" CTA shares its row with a new "I've upgraded to ChatGPT Plus" button (a large `QuietPillButton` variant — same height, no second glow).
- **Waiting phase**: its "I've upgraded" button is now the same trust path, replacing the manual re-check and its "still seeing Free" status line.
- Both open one native confirm ("Are you on ChatGPT Plus?"). Confirming sets `CodexAuth.assertedPlus`, clears knowledge-base-only mode, and continues straight into the full experience — proactive, Sidekick, nightly runs, connectors.

## Why

A fresh Plus upgrade can take a while to reflect in the local codex plan claim (codex refreshes its token on an 8-day cadence, and an on-demand refresh re-mints from the existing session). OpenAI's server is the real enforcement point at exec time anyway — so when the user says they've upgraded, believing them is both the honest and the friendlier design.

## Details

- `CodexAuth.isLimited()` respects the assertion, so `CodexCLI.planTuned` no longer downshifts an asserted-Plus user off `gpt-5.6-sol`.
- The silent focus-return auto-advance survives as a best-effort nicety (if the fresh claim reads full, the screen advances on its own).
- `FactoryReset` clears the assertion alongside `plan.kbOnly`, so a Reset re-detects fresh.
- New analytics signal: `PlanGate.selfAttested`.

## Testing

- Isolated `xcodebuild` (Debug) passes.
- Flow exercised on a free-plan account through the crossroads and waiting phases; end-to-end re-test on a real stale-claim account is the remaining check before the docs update.