### PR TITLE
Silent auto-update relaunches windowless + a just-updated notice

### DIFF
--- a/Sentient OS macOS/App/AppState.swift
+++ b/Sentient OS macOS/App/AppState.swift
@@ -76,6 +76,13 @@ final class AppState {
         notch.start()                // raise the notch overlay window
         dockPolicy.start()           // drop the Dock icon whenever the home window closes
         update.start()               // start Sparkle + one silent launch check (gates a mandatory update)
+        UpdateNotice.checkAtLaunch() // version changed since last run → macOS notif + the in-app changelog capsule
+        // A silent auto-update relaunch opens no window, so DockPolicy's open/close notifications
+        // never fire — evaluate once (next runloop tick, after launch settles) so the Dock icon
+        // drops to match the windowless launch instead of lingering with nothing behind it.
+        if UpdateNotice.suppressHomeThisLaunch {
+            Task { dockPolicy.reevaluate() }
+        }
 
         // Notifications, banked silently: PROVISIONAL authorization shows NO prompt — macOS just
         // grants quiet Notification Center delivery and lists us in Settings → Notifications (the

--- a/Sentient OS macOS/App/Sentient_OS_macOSApp.swift
+++ b/Sentient OS macOS/App/Sentient_OS_macOSApp.swift
@@ -40,7 +40,10 @@ struct SentientOSApp: App {
         .defaultSize(width: 1180, height: 880)   // the proactive home's canvas
         // Always present the home at launch: after a quit with only Settings open, state
         // restoration would otherwise bring back JUST the Settings window — an app with no home.
-        .defaultLaunchBehavior(.presented)
+        // The ONE exception: the relaunch after a SILENT auto-update (UpdateNotice's consumed
+        // flag) stays windowless — a background update must never shove the home at a user who
+        // was living with Sentient in the menu bar.
+        .defaultLaunchBehavior(UpdateNotice.suppressHomeThisLaunch ? .suppressed : .presented)
 
         // Every auxiliary window below carries .restorationBehavior(.disabled): the home is the
         // app's ONLY launch surface, so macOS window restoration must never reopen a stray

--- a/Sentient OS macOS/System/Notify.swift
+++ b/Sentient OS macOS/System/Notify.swift
@@ -2,12 +2,11 @@
 //  Notify.swift
 //  Sentient OS macOS
 //
-//  One small wrapper over UNUserNotificationCenter. Notify.now() (the morning "your suggestions
-//  are ready" note and scheduled reminders) is still DORMANT — it ships with the
-//  proactive/reminder wiring (git 67d8078 has an old schedule/cancel implementation to mine).
-//  The permission ask, though, is live: onboarding's permissions screen fires Notify.ask() the
-//  moment it appears, so the native prompt happens once, with no extra UI; now() also asks
-//  lazily as a backstop.
+//  One small wrapper over UNUserNotificationCenter. Notify.now() is LIVE for the "Sentient just
+//  updated." note (UpdateNotice.checkAtLaunch); the proactive-reminder tier still to come rides
+//  the same call (git 67d8078 has an old schedule/cancel implementation to mine). The permission
+//  ask is live too: onboarding's permissions screen fires Notify.ask() the moment it appears, so
+//  the native prompt happens once, with no extra UI; now() also asks lazily as a backstop.
 //
 
 import Foundation

--- a/Sentient OS macOS/Updates/UpdateController.swift
+++ b/Sentient OS macOS/Updates/UpdateController.swift
@@ -132,6 +132,9 @@ final class UpdateController: NSObject, SPUUpdaterDelegate {
         idleTimer?.invalidate()
         idleTimer = nil
         Log("Sparkle: idle-safe — installing staged update and relaunching silently")
+        // The user wasn't in the app — the new version must come back windowless (UpdateNotice's
+        // flag suppresses the home WindowGroup at the relaunch). Gate installs never stamp this.
+        UpdateNotice.recordSilentRelaunch()
         install()   // Sparkle terminates, installs, and relaunches us — zero UI.
     }
 

--- a/Sentient OS macOS/Updates/UpdateNotice.swift
+++ b/Sentient OS macOS/Updates/UpdateNotice.swift
@@ -1,0 +1,84 @@
+//
+//  UpdateNotice.swift
+//  Sentient OS macOS
+//
+//  The "Sentient just updated" seam, in two halves:
+//  · The WINDOWLESS-RELAUNCH FLAG — UpdateController stamps `recordSilentRelaunch()` the
+//    instant an idle-gated silent install fires (the user wasn't in the app), and the NEW
+//    version consumes it as `suppressHomeThisLaunch`: the home WindowGroup launches
+//    `.suppressed`, so a background auto-update never shoves the window at someone who was
+//    just living with Sentient in the menu bar. User-initiated updates (the OLED gate) and
+//    mid-onboarding relaunches never suppress — those users should see the app come back.
+//  · The UPDATE NOTICE — `checkAtLaunch()` diffs the persisted last-run version against the
+//    running one; a change fires the "Sentient just updated." macOS notification (so the
+//    relaunch Dock bounce is always explained) and arms the persistent in-app capsule
+//    (UpdateNoticeCapsule, "Read the changelog"), which survives until the user dismisses it.
+//
+
+import AppKit
+import Foundation
+
+@MainActor
+enum UpdateNotice {
+
+    /// Written by the OLD version at its last breath (value = its own version string); consumed
+    /// once by the new version at scene build.
+    private static let suppressKey = "update.suppressHomeOnRelaunch"
+    /// The armed in-app notice (value = the new version string). Persists until dismissed, so a
+    /// menu-bar user who opens the home days after a silent update still sees it.
+    private static let noticeKey = "update.notice"
+    /// The version this app last ran as — the diff that detects EVERY update path (silent
+    /// relaunch, install-on-quit, even a manual reinstall).
+    private static let lastRunVersionKey = "app.lastRunVersion"
+
+    static let changelogURL = URL(string: "https://github.com/Sentient-OS-Labs/sentient-os/releases/latest")!
+
+    /// Called by UpdateController right before a SILENT (idle-gated) install relaunches the app.
+    /// Only ever recorded after onboarding: a mid-onboarding user may have closed a broken
+    /// onboarding window, and the post-update relaunch should bring it back fixed.
+    static func recordSilentRelaunch() {
+        guard UserDefaults.standard.bool(forKey: AppState.onboardingKey) else { return }
+        UserDefaults.standard.set(UpdateController.currentVersionString, forKey: suppressKey)
+    }
+
+    /// True exactly on the launch that follows a silent auto-update — the home window stays
+    /// suppressed. The stored value is the OLD version: if it matches the running one the
+    /// install never actually landed (a failed swap relaunched the same build), and the window
+    /// presents normally rather than silently vanishing on a normal launch.
+    static let suppressHomeThisLaunch: Bool = {
+        let defaults = UserDefaults.standard
+        guard let oldVersion = defaults.string(forKey: suppressKey) else { return false }
+        defaults.removeObject(forKey: suppressKey)
+        return oldVersion != UpdateController.currentVersionString
+    }()
+
+    /// Launch-time version diff (AppState.init, after the self-test guard). A changed version
+    /// means an update landed: fire the macOS notification and arm the in-app capsule. The
+    /// first-ever launch just records — a fresh install is not an update.
+    static func checkAtLaunch() {
+        let defaults = UserDefaults.standard
+        let current = UpdateController.currentVersionString
+        let last = defaults.string(forKey: lastRunVersionKey)
+        defaults.set(current, forKey: lastRunVersionKey)
+        guard let last, last != current else { return }
+        Log("Update: version changed \(last) → \(current) — arming the just-updated notice")
+        defaults.set(current, forKey: noticeKey)
+        Task { await Notify.now(title: "Sentient just updated.", body: "Now running version \(shortVersion).") }
+    }
+
+    /// The armed notice's version — nil when none. Views read this on appearance (the same
+    /// pull-on-appear pattern as OvernightCaution.latest()).
+    static var pending: String? { UserDefaults.standard.string(forKey: noticeKey) }
+
+    static func dismiss() { UserDefaults.standard.removeObject(forKey: noticeKey) }
+
+    /// "Read the changelog" — the latest GitHub release; opening it retires the notice.
+    static func openChangelog() {
+        NSWorkspace.shared.open(changelogURL)
+        dismiss()
+    }
+
+    private static var shortVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+    }
+}

--- a/Sentient OS macOS/Views/CautionCapsule.swift
+++ b/Sentient OS macOS/Views/CautionCapsule.swift
@@ -1,0 +1,108 @@
+//
+//  CautionCapsule.swift
+//  Sentient OS macOS
+//
+//  The banner capsule for the home's single top-right slot: amber for the morning-after
+//  caution, red for a live HealthCaution issue, green for the just-updated notice. Message +
+//  optional action pill + dismiss ✕. UpdateNoticeCapsule is the self-contained green variant
+//  (reads/retires UpdateNotice itself) — rendered by the home's banner slot AND overlaid on
+//  onboarding by RootView, the second render site that moved this out of HomeView.swift.
+//
+
+import SwiftUI
+
+struct CautionCapsule: View {
+    let message: String
+    var accent: Color = Theme.Ink.amber
+    var actionTitle: String? = nil
+    var onAction: () -> Void = {}
+    let onDismiss: () -> Void
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 10) {
+            HealthDot(color: accent)
+            Text(message)
+                .font(.system(size: 12.5))
+                .foregroundStyle(Theme.Ink.statusInk)
+                .lineSpacing(3)
+                .fixedSize(horizontal: false, vertical: true)
+            if let actionTitle {
+                SettingsPillButton(title: actionTitle, action: onAction)
+            }
+            Button(action: onDismiss) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(Theme.Ink.label)
+                    .padding(4)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 16).padding(.vertical, 11)
+        .frame(maxWidth: 480, alignment: .leading)
+        .background(Color.white.opacity(0.04), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: 14, style: .continuous)
+            .strokeBorder(accent.opacity(0.28), lineWidth: 1))
+    }
+}
+
+/// The green "Sentient just updated!" capsule — self-contained: reads UpdateNotice on
+/// appearance, draws nothing when no notice is armed, and retires it on dismiss or on
+/// opening the changelog. Hosts decide placement; this owns everything else.
+struct UpdateNoticeCapsule: View {
+    @State private var armed = false
+
+    var body: some View {
+        Group {
+            if armed {
+                CautionCapsule(message: "Sentient just updated!",
+                               accent: Theme.Ink.green,
+                               actionTitle: "Read the changelog",
+                               onAction: {
+                                   UpdateNotice.openChangelog()
+                                   retire()
+                               },
+                               onDismiss: {
+                                   UpdateNotice.dismiss()
+                                   retire()
+                               })
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .onAppear { armed = UpdateNotice.pending != nil }
+    }
+
+    private func retire() {
+        withAnimation(.easeInOut(duration: 0.25)) { armed = false }
+    }
+}
+
+#Preview("Caution capsules") {
+    ZStack {
+        Color.black.ignoresSafeArea()
+        VStack(alignment: .trailing, spacing: 14) {
+            CautionCapsule(message: OvernightCaution.Kind.loggedOut.message,
+                           actionTitle: "Open Settings", onAction: {}, onDismiss: {})
+            CautionCapsule(message: OvernightCaution.Kind.noInternet.message, onDismiss: {})
+            CautionCapsule(message: OvernightCaution.Kind.usageLimit.message, onDismiss: {})
+            CautionCapsule(message: HealthCaution.Issue.permissions([.fullDiskAccess]).message,
+                           accent: Theme.Ink.red,
+                           actionTitle: "Open Settings", onAction: {}, onDismiss: {})
+            CautionCapsule(message: HealthCaution.Issue.permissions([.fullDiskAccess, .launchAtLogin]).message,
+                           accent: Theme.Ink.red,
+                           actionTitle: "Open Settings", onAction: {}, onDismiss: {})
+            CautionCapsule(message: HealthCaution.Issue.codexSignedOut.message,
+                           accent: Theme.Ink.red,
+                           actionTitle: "Open Settings", onAction: {}, onDismiss: {})
+            CautionCapsule(message: HealthCaution.Issue.computerUseBroken(payloadGone: true).message,
+                           accent: Theme.Ink.red,
+                           actionTitle: "Open Settings", onAction: {}, onDismiss: {})
+            CautionCapsule(message: "Sentient just updated!",
+                           accent: Theme.Ink.green,
+                           actionTitle: "Read the changelog", onAction: {}, onDismiss: {})
+        }
+        .padding(40)
+    }
+    .frame(width: 620, height: 620)
+    .preferredColorScheme(.dark)
+}

--- a/Sentient OS macOS/Views/HomeView.swift
+++ b/Sentient OS macOS/Views/HomeView.swift
@@ -195,13 +195,15 @@ struct HomeView: View {
     // OvernightCaution recorded it at ProactiveCycle's choke point; the next fully successful
     // cycle clears it on its own). Both roads lead to Settings → Permissions & Health. Live
     // issues re-probe on foreground and melt away when fixed; ✕ mutes a live issue's kind for
-    // the session (a lower rung may then surface), while the amber ✕ clears the record.
+    // the session (a lower rung may then surface), while the amber ✕ clears the record. Below
+    // both: the green just-updated notice (UpdateNotice) with its changelog link — good news
+    // never outranks something broken.
 
     private var cautionBanner: some View {
         Group {
             if let issue = liveIssue {
-                CautionCapsule(message: issue.message, accent: Theme.Ink.red, showsSettings: true,
-                               onOpenSettings: openHealthSettings,
+                CautionCapsule(message: issue.message, accent: Theme.Ink.red,
+                               actionTitle: "Open Settings", onAction: openHealthSettings,
                                onDismiss: {
                                    HealthCaution.dismiss(issue)
                                    withAnimation(.easeInOut(duration: 0.25)) { liveIssue = nil }
@@ -210,13 +212,17 @@ struct HomeView: View {
                     .transition(.opacity.combined(with: .move(edge: .top)))
             } else if let caution {
                 CautionCapsule(message: caution.kind.message,
-                               showsSettings: caution.kind == .loggedOut,
-                               onOpenSettings: openHealthSettings,
+                               actionTitle: caution.kind == .loggedOut ? "Open Settings" : nil,
+                               onAction: openHealthSettings,
                                onDismiss: {
                                    OvernightCaution.clear()
                                    withAnimation(.easeInOut(duration: 0.25)) { self.caution = nil }
                                })
                     .transition(.opacity.combined(with: .move(edge: .top)))
+            } else {
+                // The lowest rung — the green just-updated notice. Self-contained: draws
+                // nothing unless UpdateNotice armed one at launch.
+                UpdateNoticeCapsule()
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
@@ -531,73 +537,6 @@ struct HomeView: View {
     private func closeLetter() {
         withAnimation(.easeInOut(duration: 0.26)) { letterShown = false }
     }
-}
-
-// MARK: - The caution capsule (rendered by cautionBanner — amber for the morning-after event,
-// red for a live HealthCaution issue)
-
-private struct CautionCapsule: View {
-    let message: String
-    var accent: Color = Theme.Ink.amber
-    var showsSettings = false
-    let onOpenSettings: () -> Void
-    let onDismiss: () -> Void
-
-    var body: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 10) {
-            HealthDot(color: accent)
-            Text(message)
-                .font(.system(size: 12.5))
-                .foregroundStyle(Theme.Ink.statusInk)
-                .lineSpacing(3)
-                .fixedSize(horizontal: false, vertical: true)
-            if showsSettings {
-                SettingsPillButton(title: "Open Settings", action: onOpenSettings)
-            }
-            Button(action: onDismiss) {
-                Image(systemName: "xmark")
-                    .font(.system(size: 9, weight: .semibold))
-                    .foregroundStyle(Theme.Ink.label)
-                    .padding(4)
-                    .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-        }
-        .padding(.horizontal, 16).padding(.vertical, 11)
-        .frame(maxWidth: 480, alignment: .leading)
-        .background(Color.white.opacity(0.04), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
-        .overlay(RoundedRectangle(cornerRadius: 14, style: .continuous)
-            .strokeBorder(accent.opacity(0.28), lineWidth: 1))
-    }
-}
-
-#Preview("Caution capsules") {
-    ZStack {
-        Color.black.ignoresSafeArea()
-        VStack(alignment: .trailing, spacing: 14) {
-            CautionCapsule(message: OvernightCaution.Kind.loggedOut.message, showsSettings: true,
-                           onOpenSettings: {}, onDismiss: {})
-            CautionCapsule(message: OvernightCaution.Kind.noInternet.message,
-                           onOpenSettings: {}, onDismiss: {})
-            CautionCapsule(message: OvernightCaution.Kind.usageLimit.message,
-                           onOpenSettings: {}, onDismiss: {})
-            CautionCapsule(message: HealthCaution.Issue.permissions([.fullDiskAccess]).message,
-                           accent: Theme.Ink.red, showsSettings: true,
-                           onOpenSettings: {}, onDismiss: {})
-            CautionCapsule(message: HealthCaution.Issue.permissions([.fullDiskAccess, .launchAtLogin]).message,
-                           accent: Theme.Ink.red, showsSettings: true,
-                           onOpenSettings: {}, onDismiss: {})
-            CautionCapsule(message: HealthCaution.Issue.codexSignedOut.message,
-                           accent: Theme.Ink.red, showsSettings: true,
-                           onOpenSettings: {}, onDismiss: {})
-            CautionCapsule(message: HealthCaution.Issue.computerUseBroken(payloadGone: true).message,
-                           accent: Theme.Ink.red, showsSettings: true,
-                           onOpenSettings: {}, onDismiss: {})
-        }
-        .padding(40)
-    }
-    .frame(width: 620, height: 560)
-    .preferredColorScheme(.dark)
 }
 
 // MARK: - Top-bar nav item

--- a/Sentient OS macOS/Views/RootView.swift
+++ b/Sentient OS macOS/Views/RootView.swift
@@ -74,6 +74,13 @@ struct RootView: View {
                     }
                 }
                 .transition(.opacity)
+                // The just-updated notice, overlaid on ONBOARDING only (the home renders it in
+                // its own banner slot): a mid-onboarding user may have closed a broken window,
+                // and the post-update relaunch that brings it back should say why it's back.
+                .overlay(alignment: .topTrailing) {
+                    UpdateNoticeCapsule()
+                        .padding(.trailing, 24).padding(.top, 24)
+                }
             } else if isProcessing, let modelPath {
                 // Same engine + UI as the dev "start on device" buttons; .auto = backfill new
                 // buckets, catch up the rest. (Gmail is a dev-tools leg; the home button is on-device.)


### PR DESCRIPTION
## What

- **A silent (idle-gated) auto-update now relaunches the app windowless.** `UpdateNotice` records the silent install right before Sparkle relaunches; the new version consumes the flag once and the home WindowGroup launches `.suppressed`, with the Dock icon dropped to match — so a user living with Sentient in the menu bar never gets the home window shoved at them. User-initiated (gate) updates and mid-onboarding relaunches still present the window normally.
- **Safety guard:** the flag stores the old version string; if the running build matches it (an install that never landed), the flag is ignored and destroyed — a stale flag can never hide the window on a normal launch.
- **Update detection + notices:** every launch diffs a persisted last-run version. On change: the "Sentient just updated." macOS notification fires (explains the Dock bounce), and a persistent green capsule — *Sentient just updated!* with a **Read the changelog** pill linking to the latest release — arms until dismissed. It renders in the home's banner slot (lowest rung, under the red/amber cautions) and overlays onboarding.
- `CautionCapsule` moved to its own file and generalized (`actionTitle`/`onAction`) now that two hosts render it.

## Testing

Verified with real launches of the built app against every scenario: fresh install (records silently, no notice), version change (notice armed, window presents), suppress flag (windowless accessory launch, flag consumed, notice persists), same-version flag (window presents, flag destroyed), and a windowed graceful quit followed by a suppressed relaunch — confirming `.suppressed` wins over macOS state restoration. Remaining on-hardware checks: capsule visuals in both hosts, the notification banner on a signed build, and the true Sparkle end-to-end on the next release.