### PR TITLE
Light the notch for gmail/calendar card fires

### DIFF
--- a/Sentient OS macOS/Notch Magic/CommandCoordinator.swift
+++ b/Sentient OS macOS/Notch Magic/CommandCoordinator.swift
@@ -12,7 +12,8 @@
 //  Hotkey path: press → notch OPENS + mic (if already authorized) · still-held @250ms → committed
 //  listening · release(hold) → transcribe → submit(.voice) · release(tap) → a focused TYPE field →
 //  submit. Prompt-bar path: submit(.promptBar). Card-fire path: beginExternalRun (a proactive card's
-//  computer-use fire adopts the same run — ONE task at a time, app-wide, and the notch shows it).
+//  fire — computer, gmail, or calendar — adopts the same run — ONE task at a time, app-wide, and the
+//  notch shows it).
 //  Every command is computer use, which raises the notch. A hotkey press during any real run is the
 //  universal STOP. Doc: Documentation/Notch Magic/.
 //
@@ -174,9 +175,9 @@ final class CommandCoordinator {
         run.stop()
     }
 
-    // MARK: Adopted external runs (a proactive card's computer-use fire)
+    // MARK: Adopted external runs (a proactive card's fire — any channel)
 
-    /// A proactive card's computer-use fire adopting the notch: the run model lights up — locking
+    /// A proactive card's fire (computer, gmail, or calendar) adopting the notch: the run model lights up — locking
     /// out every other entry point — and the notch rises in `.running`, exactly like a command-bar
     /// launch. Returns false when a task already owns the run (the ONE-task-at-a-time lock): the
     /// caller must not fire. Doubles as the gate-held re-check — a fire the permission gate held

--- a/Sentient OS macOS/Notch Magic/CommandRunModel.swift
+++ b/Sentient OS macOS/Notch Magic/CommandRunModel.swift
@@ -6,7 +6,7 @@
 //  output line(s) into `statusLine`. `stop()` cancels the run (CodexCLI terminates codex). One run at a time.
 //
 //  Every way to start a task — the home command bar, the right-⌘ hotkey, AND a proactive card's
-//  computer-use fire (which ADOPTS this run via adoptExternal/externalPush/completeExternal) — drives
+//  fire, any channel (which ADOPTS this run via adoptExternal/externalPush/completeExternal) — drives
 //  the SAME instance (owned by CommandCoordinator), so the prompt bar, the notch, and the card are all
 //  views of one run, and `isRunning` is the app-wide one-task-at-a-time lock. `onFinished` lets the
 //  coordinator move the notch from running → finishing. Everything also tees to Log()
@@ -143,7 +143,7 @@ final class CommandRunModel {
         if let externalStop { externalStop() } else { task?.cancel() }
     }
 
-    // MARK: Adopted external runs (a proactive card's computer-use fire)
+    // MARK: Adopted external runs (a proactive card's fire — any channel)
 
     /// Adopt a proactive card's fire as THE one run: `isRunning` + `statusLine` light the notch
     /// and the prompt bar, and every other entry point — hotkey, submits, other cards — is locked

--- a/Sentient OS macOS/Views/HomeView.swift
+++ b/Sentient OS macOS/Views/HomeView.swift
@@ -317,7 +317,7 @@ struct HomeView: View {
                     slot: slots[min(item.offset, slots.count - 1)],
                     dealFrom: CGPoint(x: geo.size.width / 2, y: -160),
                     fireDimmed: appState.commandCoordinator.run.isRunning
-                        && item.element.action?.method == .computer,
+                        && item.element.action.map { ProactiveExecutor.isFireable($0.method) } == true,
                     onOffer: { model.run(item.element.id) },
                     onDetail: { openLetter(item.element.b) },
                     onOpenEnvelope: {
@@ -513,7 +513,7 @@ struct HomeView: View {
                            liveDraft: model.entry(b.id)?.action?.preparedContent ?? b.draft ?? "",
                            liveRecipient: model.entry(b.id)?.action?.recipient ?? "",
                            fireDimmed: appState.commandCoordinator.run.isRunning
-                               && model.entry(b.id)?.action?.method == .computer,
+                               && model.entry(b.id)?.action.map { ProactiveExecutor.isFireable($0.method) } == true,
                            onCommitEdit: { model.applyEdit(b.id, content: $0, recipient: $1) },
                            onOffer: {
                                closeLetter()
@@ -655,11 +655,11 @@ final class ForYouModel {
     func run(_ id: String) {
         guard let e = entry(id), e.phase == .offer, e.b.offer != nil else { return }
         if let action = e.action {   // real card → fire for real (behind the first-use permission gate)
-            // The app-wide one-task lock (computer use only): while ANY task owns the run — a
+            // The app-wide one-task lock (every fireable channel): while ANY task owns the run — a
             // Sidekick/command-bar run or another card — a new fire can't start (the CTA is
-            // dimmed; this is the backstop for a click that lands anyway). Gmail/Calendar
-            // connector writes and research are exempt: quiet card-only, concurrent is fine.
-            if action.method == .computer, coordinator?.run.isRunning == true {
+            // dimmed; this is the backstop for a click that lands anyway). Only research is
+            // exempt (nothing fires).
+            if ProactiveExecutor.isFireable(action.method), coordinator?.run.isRunning == true {
                 Log("card fire blocked — a task is already running (one at a time)")
                 return
             }
@@ -691,18 +691,24 @@ final class ForYouModel {
     /// so a re-deal won't show it again. `ProactiveExecutor.fire` reads `action.preparedContent`, so a
     /// draft the user edited in the letter is exactly what gets sent.
     ///
-    /// A computer-use fire is also ADOPTED by the notch (`beginExternalRun`): the shared run lights
-    /// up (the one-task lock engages), the card's lines tee into it, and every exit — success,
-    /// failure, ANY stop — completes the adoption exactly once, here, when `fire` unwinds (it
-    /// always returns, even cancelled). `beginExternalRun`'s refusal doubles as the re-check for a
-    /// fire the permission gate held while another task started.
+    /// Every fireable fire (computer, gmail, calendar) is also ADOPTED by the notch
+    /// (`beginExternalRun`): the shared run lights up (the one-task lock engages), the card's lines
+    /// tee into it, and every exit — success, failure, ANY stop — completes the adoption exactly
+    /// once, here, when `fire` unwinds (it always returns, even cancelled). `beginExternalRun`'s
+    /// refusal doubles as the re-check for a fire the permission gate held while another task
+    /// started.
     private func runReal(_ id: String, _ action: PreparedAction) {
         let v = visit
-        let external = action.method == .computer
+        let external = ProactiveExecutor.isFireable(action.method)
         if external {
+            let fallback: String = switch action.method {
+            case .gmail:    "Sending your email…"
+            case .calendar: "Updating your calendar…"
+            default:        "Working on your Mac…"
+            }
             guard let coordinator,
                   coordinator.beginExternalRun(
-                      caption: entry(id)?.b.title ?? "Working on your Mac…",
+                      caption: entry(id)?.b.title ?? fallback,
                       onStopRequest: { [weak self] in self?.stopRun(id) })
             else { Log("card fire blocked at launch — a task already owns the run"); return }
         }


### PR DESCRIPTION
## What

Gmail and Calendar proactive-card fires now light the notch with live status, exactly like computer-use fires: the fire adopts the shared run (`beginExternalRun`), codex's play-by-play streams into the notch and the card, and the run ends with the same ✓/■/✗ flourish.

With adoption, connector fires now also participate in the app-wide one-task-at-a-time lock: while any fire or Sidekick/command-bar job runs, every other fireable card's CTA dims and a fresh right-⌘ press is the universal STOP. Research cards remain quiet (nothing fires).

## How

- `HomeView.swift` — `runReal`'s adoption flag generalizes from `.computer` to any fireable method (`ProactiveExecutor.isFireable`); method-appropriate notch caption fallbacks; the one-task-lock backstop and both `fireDimmed` sites extend the same way.
- `CommandRunModel.swift` / `CommandCoordinator.swift` — comment updates only (the adoption seam was already channel-agnostic).

## Verification

Builds clean (isolated DerivedData). Live-fire testing on hardware pending — merging to share; docs update follows once verified.