### PR TITLE
Docs: true up for the 1.1 + 1.2 releases

### DIFF
--- a/Sentient OS macOS/Documentation/Auto-Update (Sparkle).md
+++ b/Sentient OS macOS/Documentation/Auto-Update (Sparkle).md
@@ -15,6 +15,11 @@ install genuinely can't happen.
 > Xcode notarized export → `make_dmg.sh` → `release.sh` → GitHub Release + Homebrew tap + live
 > appcast, each leg verified live (Gatekeeper "Notarized Developer ID", cask install on real
 > hardware, feed serving the correct EdDSA-signed enclosure).
+>
+> **The first over-the-air updates — 1.1 (build 2) and 1.2 (build 3) — shipped 2026-07-20**, each
+> through the same two-script pipeline, publishing the appcast + site Download URL so the installed
+> 1.0/1.1 fleet self-updates. 1.2 is the first release to exercise the **windowless silent relaunch**
+> (below) against a real signed update.
 
 ---
 
@@ -56,6 +61,7 @@ requires first shipping a build that carries a new public key.
 | `UpdateController.swift` | Owns the `SPUUpdater` (targets the main bundle), the driver, and the model. `AppState` holds one and calls `start()` on launch — **GUI path only**, never the root wake-helper. `start()` also fires one background check so a fresh launch discovers updates immediately. Implements the **silent-relaunch hook** (`willInstallUpdateOnQuit` → idle-gated `installIfSafe` → self-relaunch) and the `SPUUpdaterDelegate`. Exposes `checkForUpdatesNow(from:)` (tagging the originating window — see `CheckOrigin`) + version/last-checked for the menu and Settings. |
 | `SentientUpdateDriver.swift` | Our custom `SPUUserDriver`. Translates Sparkle's callbacks into `UpdateModel` state and stashes the reply closures. **Mandatory:** `showUpdateFound…` only ever replies `.install`; `showReady(toInstallAndRelaunch:)` auto-installs. ⚠️ The method labels must match Sparkle's imported Swift signatures exactly (Swift matches these witnesses by signature, not `@objc` selector). |
 | `UpdateModel.swift` | `@Observable` bridge between the driver and the UI. A `Phase` state machine (idle → checking → found → downloading → extracting → installing / failed), a `Surface` (`none` / `gate` / `info`), and `CheckOrigin` (`home` / `settings`) — which window a user-initiated check came from. |
+| `UpdateNotice.swift` | The silent-relaunch/just-updated bookkeeping: records the pending silent install (old version string) right before Sparkle relaunches so the new build launches windowless once (guarded against a stale flag), and diffs the persisted last-run version each launch to fire the *"Sentient just updated."* notification + arm the changelog capsule. |
 | `UpdateGateView.swift` | The OLED UI. Two faces: the full-screen **gate** (mandatory — Update / Quit, no skip/remind) and a small dismissible **info card** (user-initiated "Checking…" / "You're up to date" / "Couldn't check"). Mounted as an overlay by BOTH the home (`RootView`) and the Settings window, each passing its `host`: the **info card renders only in the check's origin window** (Settings' Check Now shows over Settings, never buried under it), while the **gate takes over every hosting window**. Draws nothing at rest. |
 
 **Wiring:** `App/AppState.swift` (owns + `start()`s) · `Views/RootView.swift` (`.overlay { UpdateGateView(host: .home) }`)
@@ -70,6 +76,20 @@ where its card appears) · `Views/Settings/SystemPane.swift` (Updates group, che
   calls our `willInstallUpdateOnQuit` delegate hook. We take over and, the moment it's **idle-safe**,
   install + relaunch on our own — no "quit to update" wait, no UI. The user just finds themselves on
   the new version.
+- **The relaunch is windowless.** A silent, idle-gated auto-update relaunches the app **without
+  shoving the home window at the user** — `UpdateNotice` records the silent install right before
+  Sparkle relaunches, the new build consumes the flag once and launches the home WindowGroup
+  `.suppressed` (Dock icon dropped to match), so someone living with Sentient in the menu bar isn't
+  interrupted. `.suppressed` wins over macOS state restoration. A **safety guard**: the flag stores
+  the old version string; if the running build still matches it (an install that never landed), the
+  flag is ignored and destroyed, so a stale flag can never hide the window on a normal launch.
+  User-initiated (gate) updates and mid-onboarding relaunches still present the window normally.
+- **"Sentient just updated" notice.** Every launch diffs a persisted last-run version. On a change it
+  fires the *"Sentient just updated."* macOS notification (explaining the Dock bounce) and arms a
+  persistent green **`CautionCapsule`** — *Sentient just updated!* with a **Read the changelog** pill
+  linking to the latest release — in the home's banner slot (lowest rung, under the red/amber
+  cautions) and over onboarding, until dismissed. `CautionCapsule` lives in its own file, generalized
+  (`actionTitle`/`onAction`) now that two hosts render it.
 - **The idle gate** (`isSafeToRelaunch`): never relaunch out from under an in-flight processing run
   (`PipelineActivity.isRunning`), and never yank the app away from an actively-engaged user — frontmost
   with a key window counts as "in use" unless idle 5+ minutes; if the app isn't frontmost, the relaunch

--- a/Sentient OS macOS/Documentation/CodexCLI (codex exec Compute Spine).md
+++ b/Sentient OS macOS/Documentation/CodexCLI (codex exec Compute Spine).md
@@ -52,10 +52,11 @@ plumbing).
   terminates the codex child process via a `withTaskCancellationHandler` + process holder.
 
 `Invocation`: `prompt` (always over **stdin**, never argv) · `model` (`.gpt56sol` = `gpt-5.6-sol`, the
-default for knowledge-base work and everything else / `.gpt56luna` = `gpt-5.6-luna`, the Gmail
-tier) · `effort` (`.low` / `.medium` / `.high` / `.xhigh`; **default `.high`** — the Gmail tier
-overrides to `.medium`; nothing runs `.xhigh` since 2026-07-10, gpt-5.6-sol thinks far too long
-there) · `sandbox` (`.readOnly` default / `.workspaceWrite`) · `cwd` · `addDirs`
+default for knowledge-base work and everything else / `.gpt56terra` = `gpt-5.6-terra`, the mid model
+used as the free/go stand-in for sol, see **plan-tuned models** below / `.gpt56luna` =
+`gpt-5.6-luna`, the Gmail tier) · `effort` (`.low` / `.medium` / `.high` / `.xhigh`; **default
+`.high`** — the Gmail tier overrides to `.medium`; nothing runs `.xhigh` since 2026-07-10,
+gpt-5.6-sol thinks far too long there) · `sandbox` (`.readOnly` default / `.workspaceWrite`) · `cwd` · `addDirs`
 (extra writable roots) · `webSearch` (**default `true`** — web search is available to every call)
 · `includeUserConfig` (**default `true`** — loads `~/.codex` + the user's MCP servers, e.g. their
 Gmail MCP, on every call; set `false` for a hermetic run) · `bypassApprovals` (default `false`;
@@ -78,6 +79,28 @@ an absent `open_world_hint` counts as open-world) · `outputSchema`
 `Envelope`: `result` (final agent message) · `sessionID` (thread id — the resume handle) ·
 `numTurns` (completed items) · `durationMS` (wall clock, measured here) · `inputTokens` /
 `cachedInputTokens` / `outputTokens` · `raw` (full JSONL).
+
+## Plan-tuned models (`planTuned`)
+
+Both spines — `run()` (every `Invocation`) and `runAgentCommand` (computer use) — pass the model
+through `planTuned` right before spawning. On a **positive** free/go plan read (`CodexAuth.isLimited()`),
+any `.gpt56sol` call downshifts to **`.gpt56terra` at `.medium`**; the `.luna` Gmail tier is
+untouched, and unknown/missing plans keep sol (CodexAuth's fail-open policy, so paid plans see zero
+change). Free/go ChatGPT accounts lost `gpt-5.6-sol` access through `codex exec` (a server-side
+"model not supported" refusal), so this substitution keeps knowledge-base work answering on those
+plans. Living at the spine means every caller — and any future one — is covered without per-call-site
+checks, and the plan is re-read per run, so an upgrade to Plus puts the very next call back on sol.
+Failure telemetry reports the model that actually ran, so field events show terra for free accounts.
+
+## Input-size guard (`inputTooLarge`)
+
+`codex exec` rejects a single turn's input past ~1 MiB server-side. Both spines reject any prompt
+over **`promptByteCap` = 950 KB** *pre-spawn* with a typed `CLIError.inputTooLarge(chars:)` (plus an
+output-side sniff as belt-and-suspenders), so an oversized prompt fails cleanly and classifiably
+rather than deep inside codex. The knowledge-base path never trips it in normal use — the corpus is
+fed as byte-budgeted parts (`CorpusSlicer`, see `Vault Generation (Stage 2).md`); the guard is the
+floor beneath that batching. `OvernightCaution` classifies the typed error into honest banner /
+takeover copy.
 
 ## Flags we always pass, and why
 
@@ -123,7 +146,7 @@ ChatGPT-plan limit message is still unverified — refine the markers during dog
 | `--output-schema` | clean conforming JSON for the proactive `{time, text}` shape |
 | Resume | same thread id, full memory; workspace = process cwd (see above) |
 | Web search | `-c tools.web_search=true` → `web_search` items, correct live answer |
-| Context | Measured on gpt-5.5: 1M API context, **400k input limit through codex** — covered the 10k-summary corpus (200–400k tokens) over stdin. gpt-5.6-sol (same flagship class, adopted 2026-07-09) has run the same corpus fine; re-measure the limit if a corpus-size failure ever appears. (The Gmail tier on `gpt-5.6-luna` chunks weekly to stay well under its own cap.) |
+| Context | 1M API context, but a **~1 MiB per-turn input cap through `codex exec`** (server-side, `input_too_large`) is the real constraint for a big corpus. Handled by feeding the corpus as byte-budgeted parts (`CorpusSlicer`, 700 KB each) with the 950 KB `inputTooLarge` guard beneath — verified end-to-end on a 2.55 MB real-scale corpus. (The Gmail tier on `gpt-5.6-luna` chunks weekly to stay well under its own cap.) |
 | Overhead | ~25k input tokens per call (codex system prompt + tools), almost fully cached |
 
 ## Notes

--- a/Sentient OS macOS/Documentation/Home — Proactive Intelligence (For You).md
+++ b/Sentient OS macOS/Documentation/Home — Proactive Intelligence (For You).md
@@ -142,18 +142,19 @@ to the jesai deck — those devs were pitching), `.jesai` / `.launch` are the ha
   `Proactive Intelligence (Judge).md` §The welcome gift). **Firing is real:** `runReal` routes through
   `ProactiveExecutor.fire`, streams codex's live play-by-play into the card (`liveLines`, with a
   per-card **STOP** that terminates the codex process), flies the card away on success and removes it
-  from the persisted set; a failure returns it to the offer state for edit + retry. **A computer-use
-  fire also ADOPTS the notch (2026-07-17):** `runReal` opens with
-  `CommandCoordinator.beginExternalRun` — the shared `CommandRunModel` lights up with the card's
+  from the persisted set; a failure returns it to the offer state for edit + retry. **A fire also
+  ADOPTS the notch (2026-07-17; extended to Gmail/Calendar 2026-07-20):** `runReal` opens with
+  `CommandCoordinator.beginExternalRun` for **any fireable method** (`ProactiveExecutor.isFireable`
+  — computer, Gmail, Calendar) — the shared `CommandRunModel` lights up with the card's
   title, the raw lines tee into its cleaned `statusLine` (`externalPush`), and the ✓/■/✗ finishing
   flourish plays on the bezel. `run.isRunning` is thereby the app-wide **one-task-at-a-time lock**:
-  while ANY task runs (Sidekick, the bar, a card), other computer cards' fire CTAs dim
+  while ANY task runs (Sidekick, the bar, a card), other fireable cards' fire CTAs dim
   (`fireDimmed`, card + letter) and `ForYouModel.run` refuses, with `beginExternalRun`'s refusal
   doubling as the re-check for a gate-held fire; every STOP surface — the card's, the notch's, the
   bar's, a fresh Sidekick press — cancels the one Task, and the adoption completes exactly once at
   the fire's unwind (a stopped fire records NO scoreboard row and "stopped" analytics).
-  Gmail/Calendar and research fires are exempt by decision: quiet card-only, no notch, no lock,
-  concurrent is fine. (Doc: `Notch Magic/Notch Magic.md` §6.) **Drafts are
+  Only **research fires are exempt** — they fire nothing, so no notch, no lock. (Doc:
+  `Notch Magic/Notch Magic.md` §6.) **Drafts are
   editable, auto-saved:** every edit in the letter view's draft block (body, To:, Subject) commits on
   a 300ms debounce into `preparedContent`/`recipient` (both in-memory and in
   `ProactiveResearch.latest()`), so what the user edited is verbatim what fires — no Save button.

--- a/Sentient OS macOS/Documentation/Notch Magic/Notch Magic.md
+++ b/Sentient OS macOS/Documentation/Notch Magic/Notch Magic.md
@@ -20,7 +20,7 @@ Documentation for **Notch Magic** — Sentient OS's global hold-to-talk / tap-to
 
 The **Sidekick key** is the user's choice in Settings → Proactive & Sidekick: **right ⌘** (default) or **right ⌥**. Both are right-side modifiers, so either works permission-free (§4); the rest of this doc says "right ⌘" as the default, but everything applies to whichever key is chosen.
 
-Doors 1–4 funnel through **`CommandCoordinator` → `CommandRunModel` → `CodexCLI.runAgentCommand`**; a card fire keeps its own executor spine (`ProactiveExecutor` → `runAgentCommand`) but adopts the same `CommandRunModel` — so **`run.isRunning` is the app-wide ONE-task-at-a-time lock** (while anything runs, every other entry point is locked out, and a fresh hotkey press is the universal STOP; gmail/calendar connector fires are exempt — quiet, card-only). The notch is a live view of `coordinator.phase` (+ `coordinator.run`). The notch is the Mac's "face" coming alive — it descends from the bezel **glowing**, shows what it heard (or lets you type), then streams the work — *Thinking through your task*, **Remembering** the notes it reads from your knowledge base, the actions — with a STOP button, and retracts.
+Doors 1–4 funnel through **`CommandCoordinator` → `CommandRunModel` → `CodexCLI.runAgentCommand`**; a card fire keeps its own executor spine (`ProactiveExecutor` → `runAgentCommand`) but adopts the same `CommandRunModel` — so **`run.isRunning` is the app-wide ONE-task-at-a-time lock** (while anything runs, every other entry point is locked out, and a fresh hotkey press is the universal STOP). **Every fireable card adopts the run** — Gmail and Calendar fires light the notch just like computer-use fires (2026-07-20); only research cards stay quiet (nothing fires). The notch is a live view of `coordinator.phase` (+ `coordinator.run`). The notch is the Mac's "face" coming alive — it descends from the bezel **glowing**, shows what it heard (or lets you type), then streams the work — *Thinking through your task*, **Remembering** the notes it reads from your knowledge base, the actions — with a STOP button, and retracts.
 
 Every command is **computer use** (the dedicated browser-use channel was removed — see the root architecture doc §7), and the notch shows for all of them.
 
@@ -65,7 +65,7 @@ Every command is **computer use** (the dedicated browser-use channel was removed
 | **`SpinningLogo.swift`** | The 2D spectrum-ring logo (matches the app icon). |
 | **`NotchView.swift`** | `NotchView` (binder) + `NotchContent` (the pure visual: morph, phases, the depth-bed shadow, layered edge glow, the read-back / Remembering / status captions, the hover swell + its asymmetric springs) + `NotchMetrics` (per-phase + hover sizing) + `NotchStopButton` + the `.blurDissolve` transition. |
 
-Edits outside this folder: `AppState.swift` (owns/starts the two objects), `Views/HomeView.swift` (`PromptBar` drives `appState.commandCoordinator`; `ForYouModel.runReal` adopts the run for a card's computer-use fire, §6), `Cloud/CodexCLI.swift` (`runAgentCommand` gained an optional `imagePath` → `codex exec -i`, §6a), `System/Permissions.swift` (`hasScreenRecording()`, already present), and the project's `INFOPLIST_KEY_NSMicrophoneUsageDescription` + `INFOPLIST_KEY_NSSpeechRecognitionUsageDescription` build settings.
+Edits outside this folder: `AppState.swift` (owns/starts the two objects), `Views/HomeView.swift` (`PromptBar` drives `appState.commandCoordinator`; `ForYouModel.runReal` adopts the run for any fireable card's fire — computer, Gmail, Calendar, §6), `Cloud/CodexCLI.swift` (`runAgentCommand` gained an optional `imagePath` → `codex exec -i`, §6a), `System/Permissions.swift` (`hasScreenRecording()`, already present), and the project's `INFOPLIST_KEY_NSMicrophoneUsageDescription` + `INFOPLIST_KEY_NSSpeechRecognitionUsageDescription` build settings.
 
 There is still a **DEV bench** `Views/Dev/HotkeyLabView.swift` (DEV TOOLS → HOTKEY LAB) — the original proof of the permission-free hotkey (now on NSEvent monitors, same mechanism as the real thing). It's superseded by `SidekickHotkeyMonitor`; **retire it** once you're confident (see §13).
 
@@ -129,7 +129,8 @@ steps aside with `.hidden`. See `Permission Guide (First-Use Grants).md`).
 
 **Adopted external runs — a proactive card's fire lights the same notch (2026-07-17).**
 `beginExternalRun(caption:onStopRequest:)` is the card-fire door: `ForYouModel.runReal`
-(computer-method cards only) adopts THE run — `run.adoptExternal` flips `isRunning`, seeds
+(**any fireable card** — `ProactiveExecutor.isFireable`, i.e. computer, Gmail, and Calendar since
+2026-07-20; not research) adopts THE run — `run.adoptExternal` flips `isRunning`, seeds
 `statusLine` with the card's title, and the notch rises in `.running` on the main display. The work
 itself stays in the card's own Task (`ProactiveExecutor.fire`); its raw codex lines tee through
 `run.externalPush` (the same stream cleaning below, "Remembering" included), and every exit
@@ -140,10 +141,10 @@ cancel), so the notch STOP, the bar STOP, Esc, and the hotkey press all reach it
 own STOP ends the notch identically, from the fire's unwind. **`run.isRunning` is therefore the
 app-wide ONE-task-at-a-time lock:** the existing guards lock every other entry point while a card
 fires, `beginExternalRun` returns `false` while anything runs (doubling as the re-check for a fire
-the permission gate held for minutes), and the home dims other computer cards' CTAs. By decision
-(2026-07-17): **gmail/calendar connector fires and research cards are fully EXEMPT** — quiet,
-card-only, no lock, concurrent is fine. Home-side wiring:
-`Home — Proactive Intelligence (For You).md`.
+the permission gate held for minutes), and the home dims other fireable cards' CTAs. Since
+2026-07-20 Gmail and Calendar fires adopt the run too (live status in the notch, in the lock); only
+**research cards are EXEMPT** — they fire nothing, so they stay quiet, no notch, no lock. Home-side
+wiring: `Home — Proactive Intelligence (For You).md`.
 
 **The hotkey flow — press OPENS, then it branches to voice or type:**
 - `voicePressBegan()` (onPress): **first the UNIVERSAL STOP (2026-07-17) — a press while ANY real task is running (hotkey-, command-bar-, or card-launched) cancels it via `stop()`** (one task, one notch, one key; hoisted above the voice gate so a Mac with no speech model still gets the cancel; the onboarding demo is exempt — the film narrates through it). Then the transcribing bail, then — from idle only, `isInteracting` blocks a fresh press mid-interaction — **knowledge-base-only plans get answered RIGHT HERE** — a 2s `flash("get ChatGPT Plus to wake Sidekick")`, the same instant beat as the mic notice, and the notch never opens for listening or typing (live-checked per press, so it can never go stale; the run costs codex quota those plans don't have). Otherwise: `setPhase(.opening)` *immediately* (the "pull it open" feel). Start the mic **only if `VoiceCapture.isAuthorized`** — never PROMPT on a press.
@@ -310,7 +311,7 @@ All of the below is **confirmed working on Jesai's bezel** (live screenshots/rec
 - **The hotkey mechanism swap (2026-07-09):** the CGEventTap was replaced with NSEvent global+local `flagsChanged` monitors (lesson 13) with a post-launch install guard (lesson 14) — verified live on hardware: fresh TCC state (`tccutil reset`) → **no Keystroke Receiving dialog**, hold-to-talk + tap-to-type + Esc cancel all working, launch clean.
 - **The notch as a button (2026-07-13):** hover swell + haptic + depth-bed drop shadow + click-to-type (§7a), the asymmetric enter/exit springs, the two-tier proximity poll (§7b), and the top-edge Fitts fixes (lesson 15) — all verified on Jesai's bezel, including top-edge clicks across the notch's width and menu-bar click-through immediately beside it.
 - **External-primary anchoring + all-display screenshots (2026-07-14):** [VERIFIED live, external display as primary] hover → swell → click → type → run all landed on the built-in bezel (`NotchAnchor`, §7f) with the live status streaming there, while the hotkey kept the main display; and the same run attached BOTH displays' frames (log: `📸 2 display screenshots captured`), main display first, with the both-displays prompt line — confirmed by dumping the exact codex inputs (prompt + frames) via temp scaffolding, since deleted.
-- **Adopted card fires + the universal stop (2026-07-17):** [verified live on hardware] a proactive card's computer-use fire raises the notch with the card's title + the cleaned live stream + the ✓/■/✗ flourish; `run.isRunning` locks every entry point app-wide (other computer cards dim); every STOP surface — card, notch, bar, a fresh hotkey press — cancels the one task; gmail/calendar fires stay quiet + exempt (§6).
+- **Adopted card fires + the universal stop (2026-07-17):** [verified live on hardware] a proactive card's fire raises the notch with the card's title + the cleaned live stream + the ✓/■/✗ flourish; `run.isRunning` locks every entry point app-wide (other fireable cards dim); every STOP surface — card, notch, bar, a fresh hotkey press — cancels the one task. Gmail/Calendar fires adopt the run too since 2026-07-20 (live status, in the lock); only research fires stay quiet + exempt (§6).
 - **Not yet done:** §12 polish backlog; productionization (§13). Reduced-motion + VoiceOver coded but unverified. The SkyLight pin during a Spaces swipe on the *built-in-as-secondary* display is untested (best-effort with a public fallback either way).
 
 ---

--- a/Sentient OS macOS/Documentation/Plan Gate (CodexAuth & Knowledge-Base-Only).md
+++ b/Sentient OS macOS/Documentation/Plan Gate (CodexAuth & Knowledge-Base-Only).md
@@ -17,7 +17,9 @@ pure file read, no network, safe every launch and every cycle.
   business, edu, enterprise, unknown future strings — → `.full`. **Fail open**: no file, no
   tokens (API-key auth), or an undecodable claim all read as full; only a POSITIVE free/go
   read gates anything. Worst case a limited account hits codex usage-limit errors, which every
-  caller already survives (typed `.usageLimit` + resume handles).
+  caller already survives (typed `.usageLimit` + resume handles). `CodexAuth.isLimited()` — the
+  convenience most gates read — is `!assertedPlus && currentPlan()?.tier == .limited`, so a user
+  who told us they upgraded (§3) is never treated as limited.
 - Plan **enforcement** is entirely server-side (OpenAI rate-limits by its own account state, per
   `X-Codex-Plan-Type`); the JWT claim is only how *we* read the plan. The codex client itself
   uses the claim purely for display.
@@ -65,10 +67,19 @@ for them). Free/go accounts see:
 > your AIs. · WITH CHATGPT PLUS: the three feature rows (same vocabulary as the free home)
 > · [Upgrade on ChatGPT] (glow) · (Continue with just the knowledge base) (QuietPillButton)
 
-- **Upgrade** opens `CodexAuth.upgradeURL` and enters a waiting state: auto-recheck on app
-  foreground (`refreshPlan()`) + a manual "I've upgraded" button; silent when still free on
-  focus-return (they may just be reading), explicit status line on manual checks. Unlock →
-  green done line → auto-advance.
+- **Upgrade on ChatGPT** (glow) opens `CodexAuth.upgradeURL` and enters a waiting state with
+  auto-recheck on app foreground (`refreshPlan()`).
+- **"I've upgraded to ChatGPT Plus"** — a trust path that shares the crossroads row with the glow
+  CTA (and replaces the waiting phase's old manual re-check + "still seeing Free" status line).
+  It opens one native confirm ("Are you on ChatGPT Plus?"); confirming sets **`CodexAuth.assertedPlus`**
+  (`plan.assertedPlus`), clears knowledge-base-only mode, and continues straight into the full
+  experience — proactive, Sidekick, nightly runs, connectors. A fresh Plus upgrade can take a while
+  to reflect in the local claim (codex refreshes its token on an 8-day cadence, and the refresh POST
+  can be throttled), and OpenAI's server is the real enforcement point at exec time anyway — so when
+  the user says they've upgraded, believing them is both the honest and the friendlier design. It's
+  sticky: `assertedPlus` makes `isLimited()` return false everywhere (chiefly so `CodexCLI.planTuned`
+  stops downshifting them off gpt-5.6-sol), and if the claim never catches up the only cost is codex
+  usage-limit errors, which every caller already survives. Reset clears it.
 - **Continue** sets `CodexAuth.knowledgeBaseOnly` (`plan.kbOnly`) — THE app-wide gate flag.
 - Analytics: `PlanGate.shown` (with the raw plan string) / `.upgraded` / `.continuedFree`.
 

--- a/Sentient OS macOS/Documentation/Vault Generation (Stage 2).md
+++ b/Sentient OS macOS/Documentation/Vault Generation (Stage 2).md
@@ -57,6 +57,43 @@ overwrite the edit.
 *(This replaced the pre-B11 update path, which edited the live vault in place with a `.bak` restore —
 that whole choreography, B1, is now deleted.)*
 
+## Corpus batching — large first runs (`Vault/CorpusSlicer.swift`)
+
+`codex exec` accepts a bounded per-turn input (~1 MiB, server-side). A data-rich Mac's first build
+(thousands of survivor summaries) or a heavy week's update backlog can render past that in one
+prompt, so the corpus is fed as a **byte-budgeted sequence of parts** instead of a single prompt.
+
+- **`CorpusSlicer.slice(_:budget:)`** walks the notes in order and closes a part when the next
+  entry's rendered cost would cross the budget (**700 KB default**, ~33% headroom under the cap;
+  entries are never split — an oversized single entry gets its own part, loudly). It's deliberately
+  dumb and deterministic: no ranking, no sampling, so identical input always re-derives identical
+  parts — the property mid-sequence resume depends on. `CorpusSlicer.render` is the SAME entry
+  rendering the prompts use, so measured cost can never drift from what's actually sent.
+- **How the parts fold into one vault:** part one rides the existing **build** prompt; every later
+  part folds into the *same staging dir* through the battle-tested **update/merge** prompt, a fresh
+  codex session each. The single atomic staging → vault swap at the very end is unchanged, so a
+  many-part run still lands as one clean replace. A single-part corpus takes the exact pre-existing
+  code path — zero behavior change for normal-sized runs. `VaultCloud.update()` runs the same
+  slicing loop, with the freshness check and the one swap still at the end.
+- **Resume across parts:** `ResumeToken` carries a `sliceIndex` (the next unfed part) alongside the
+  session id and staging path (decode-compatible with older tokens, which default to part 0). A
+  usage-limit or restart mid-sequence resumes the in-flight session first, then continues the
+  remaining parts — never re-feeding a completed one. A **staging-dir corpus snapshot**
+  (`.sentient-corpus.json`, written only for multi-part runs, deleted before the swap and swept with
+  any orphan staging) guarantees the identical re-slice across restarts even though `CycleStore`
+  returns notes newest-first (a fresh fetch after more ingestion would otherwise shift every
+  boundary).
+- **The guard behind it:** `CodexCLI` rejects any prompt over `promptByteCap` (**950 KB**) pre-spawn
+  with a typed `CLIError.inputTooLarge` — a belt-and-suspenders floor so a mis-budgeted prompt fails
+  cleanly and classifiably (surfaced by `OvernightCaution` as honest banner/takeover copy) instead
+  of erroring deep inside codex. Proactive's judge/research 7-day window is trimmed to the same
+  shared byte budget (oldest dropped first).
+- **Progress:** a multi-part run reports "part N of M" in the takeover phase line and Dev Tools.
+
+Verified end-to-end at real-user scale: ~1,800 mixed-source summaries (2.55 MB rendered, 2.4× the
+per-turn cap) built through 4 parts, with a project thread deliberately scattered across every part
+consolidating into ONE domain in the finished vault — the cross-part seam produces no fragmentation.
+
 ## Progress
 
 Two channels, both optional:


### PR DESCRIPTION
Brings the codebase `Documentation/` in line with what shipped in 1.1 and 1.2 (both verified in the field before documenting, per the doc law).

- **Vault Generation (Stage 2)** — new section on corpus batching (`CorpusSlicer`, byte-budgeted parts, mid-sequence resume, the 950 KB `inputTooLarge` guard).
- **CodexCLI** — the plan-tuned sol→terra downshift for free/go accounts, the `inputTooLarge` guard, and the context receipt corrected to the ~1 MiB per-turn cap.
- **Auto-Update (Sparkle)** — the windowless silent relaunch + 'just updated' notice (`UpdateNotice`), and the status block noting 1.1/1.2 shipped OTA.
- **Plan Gate** — the self-attested 'I've upgraded to Plus' path (`assertedPlus`).
- **Notch Magic + Home (For You)** — Gmail/Calendar card fires now adopt the run and light the notch; only research fires stay exempt.

Docs only, no code. Public-surface framing checked (capabilities, not incident write-ups).