### PR TITLE
Add Apple Mail as an on-device knowledge source

### DIFF
--- a/Sentient OS macOS/Documentation/Apple Mail Source (Envelope Index).md
+++ b/Sentient OS macOS/Documentation/Apple Mail Source (Envelope Index).md
@@ -1,0 +1,94 @@
+# Apple Mail Source (Envelope Index)
+
+`Sources/AppleMailSource.swift` — the reader over Apple Mail's local store. One email = one
+Artifact, no windows, no picker (all non-deleted, non-Trash/Junk mail in; the cap + triage
+filter). Wrapped by `MailConnector` (`Ingestion/Connectors/MailConnector.swift`) into a single
+bucket for the iterative pipeline. Needs Full Disk Access.
+
+This is the **on-device** email source — unlike Gmail/Calendar (which ride the Codex cloud
+connector because there's no local store), Mail keeps everything on disk, so it's fully
+privacy-first: no cloud, no account-linking sheet, just a source chip behind the same FDA gate as
+Notes/iMessage/WhatsApp.
+
+## The body decode (why `EMLXParser.swift` exists)
+
+The Envelope Index is an **index**: sender, subject, date, mailbox, flags — but NOT the body. The
+body lives in one `.emlx` file per message under the mailbox directory. `.emlx` is a three-part
+format (reverse-engineered; corroborated by the Library of Congress format description
+[fdd000615](https://www.loc.gov/preservation/digital/formats//fdd/fdd000615.shtml) and the PyPI
+`emlx` package):
+
+1. **Bytecount** — the first line is a decimal ASCII count of the message bytes. This makes
+   extraction UNAMBIGUOUS: read the first line, take exactly that many bytes — no need to hunt for
+   the plist marker (which would be ambiguous if a body itself contained `<?xml`).
+2. **MIME message** — the full RFC 5322 message (headers + body + attachments).
+3. **plist trailer** — Apple's metadata (`flags`, `subject`, `remote-id`, …). We don't need it.
+
+`EMLXParser.plainText(fromMIME:)` walks the MIME tree: `multipart/alternative` (prefers
+`text/plain`, falls back to de-tagged `text/html`), `multipart/mixed` (skips attachment parts),
+decodes `quoted-printable` / `base64` / `7bit`/`8bit`, handles common charsets, decodes RFC 2047
+encoded-word headers, unfolds folded headers, strips HTML tags + entities, and removes zero-width
+tracking characters. Body capped at 6k chars.
+
+**Fail-closed throughout:** any decode failure → nil body → the model judges from envelope
+metadata alone (the same signal the Gmail connector works from). This mirrors how NotesSource
+handles undownloaded iCloud notes — a missing body is a graceful degrade, never garbled input.
+
+[MEASURED] on a live V10 store (macOS 27, an Exchange/EWS account): **10/10** recent Inbox
+messages extracted clean bodies (Cloudflare, GitHub PR notifications, Claude Team, AppleSeed).
+11/11 synthetic `.emlx` format tests pass (plain, QP, base64, both multipart shapes, HTML detag,
+folded headers, entities, fail-closed truncation).
+
+## The message → `.emlx` mapping (the hard part)
+
+The on-disk layout nests under per-account UUID directories with per-mailbox sub-UUIDs and optional
+sharding (`Data/Messages/` or `Data/{N}/{N}/Messages/`) — none of which are in the database. Rather
+than hardcode that fragile path math, `buildEMLXIndex()` walks the store tree **once per run** to
+build a `ROWID → [.emlx path]` index, then each message resolves its body by dict lookup. The key
+fact: **the `.emlx` filename IS `messages.ROWID`** (verified: ROWID 33249 → `…/33249.emlx`). A
+ROWID can have both a full `.emlx` and a `.partial.emlx` (attachments split off); the full one wins.
+
+## Envelope Index facts — V10 (verified live 2026-07-20)
+
+⚠️ The schema has drifted hard from the V2–V7 era most reverse-engineering docs describe. These are
+measured on a live V10 store, NOT assumed:
+
+- **Path:** `~/Library/Mail/V{N}/MailData/Envelope Index` (glob `V*`, highest version) via
+  `SQLiteDB.walSafeCopy`. Store root (for the `.emlx` walk) = `~/Library/Mail/V{N}`.
+- **No `uid` column.** Exchange/EWS accounts store a base64 `remote_id`; IMAP a numeric
+  `remote_id`. Neither maps to the `.emlx` filename. **`messages.ROWID` is the join key** — it's
+  the `.emlx` filename itself.
+- **Sender join is DIRECT:** `messages.sender → addresses.ROWID`. The `senders` /
+  `sender_addresses` tables exist but are a separate reputation/bucketing system, not the FK.
+  `addresses` has `address` (email) + `comment` (display name).
+- **Dedicated boolean columns** `read` / `flagged` / `deleted` (0/1) — NOT the jwz bit-flag
+  layout from the `.emlx` plist era. The `flags` column still exists but its bits don't match the
+  old spec. Deleted rows are filtered in SQL (`WHERE m.deleted = 0`).
+- **Dates are Unix epoch seconds** (NOT Apple's 2001-01-01 reference date).
+  `date_received = 1784591689` → 2026-07-20. Using `timeIntervalSinceReferenceDate` would yield
+  2057.
+- **Three URL schemes:** `ews://`, `imap://`, `local://`. The display name is the URL's last path
+  component, percent-decoded. EWS names its junk folder **"Junk Email"** and trash **"Deleted
+  Items"** — the exclude set covers both the IMAP and EWS naming.
+- **Subjects:** `messages.subject → subjects.ROWID → subjects.subject`.
+
+## Triage routing
+
+`Triage.prompt` routes `.appleMail` through a dedicated **mail prompt** (`mailPrompt`): ruthless
+junk-default (newsletters, marketing, OTP/2FA, automated notifications, system alerts), explicit
+keeper guidance (real asks, deadlines, bookings, personal/financial/work matters), third-person
+attribution, and a rule that quoted-reply history (`>` lines) is CONTEXT, not new facts about the
+user. The model sees the envelope metadata plus the body when it was recovered — and is told to
+fall back to the envelope alone when no body is shown.
+
+## Incrementality
+
+One `"mail"` bucket; each email keyed `(receivedDate, "mail:<rowid>")`, so a re-delivered message
+is NOT re-summarized. High-water mark in CycleStore, advanced by IterativeRun (the connector is
+pointer-dumb like every other).
+
+## Follow-ups
+
+- **User-configurable filters** — "ignore everything from X / matching Y" (a `CustomInstructions`
+  hook into the mail prompt). Not built; the model's junk-default handles the common cases today.
+- **Per-account / per-mailbox opt-in** — a picker like the chat sources, instead of all-or-nothing.

--- a/Sentient OS macOS/Engine/Triage.swift
+++ b/Sentient OS macOS/Engine/Triage.swift
@@ -23,6 +23,9 @@ enum Triage {
     /// WINDOW — with a dedicated, far stricter prompt for GROUP chats (attribution is the hard
     /// part). All emit the SAME JSON contract, so parse()/decide() are shared & unchanged.
     static func prompt(for artifact: Artifact, currentDate: Date) -> String {
+        if artifact.kind == .appleMail {
+            return mailPrompt(for: artifact, currentDate: currentDate)
+        }
         if artifact.kind == .file || artifact.kind == .notes {
             return filePrompt(for: artifact, currentDate: currentDate)
         }
@@ -68,6 +71,44 @@ enum Triage {
         - summary: write it in the third person — when the file is clearly the user's own, say "the user" (e.g. "the user's lease for…"), never "I".
         - title: a short human title, e.g. "UMass Tech Challenge Award".
         - junk: true when a file isn't worth keeping in a curated vault of the user's life (it stays on disk either way). Clear junk: installers & setup files, one-off or random downloads, memes & throwaway images, duplicates, boilerplate or generic documents, expired or now-irrelevant content. Be willing to flag — much of a Downloads folder isn't vault-worthy. But judge by whether the CONTENT genuinely matters, not by file type: a meaningful receipt, booking, ticket, or confirmation can be valuable life context worth keeping; only a trivial one is junk.
+        """
+    }
+
+    /// The Apple Mail bouncer — one email's envelope metadata (sender, subject, mailbox,
+    /// dates, flags). The model judges from the envelope the same way a human scans an
+    /// inbox: does this email represent something worth remembering? Body text extraction
+    /// from .emlx is a follow-up; metadata alone is enough for a strong keeper/junk call
+    /// (the Gmail connector proves this — it works from "subjects, senders, and snippets").
+    private static func mailPrompt(for artifact: Artifact, currentDate: Date) -> String {
+        let today = Self.dateString(currentDate)
+        let emailText = artifact.text ?? "(no metadata)"
+
+        return """
+        You curate a person's private knowledge base — a vault of what genuinely matters in their life, for their AI to draw on. You're shown ONE email from their Apple Mail: the envelope metadata (sender, subject, mailbox, dates) and, when it was recoverable, the message BODY. Decide whether this email represents something worth remembering.
+
+        Nothing is ever deleted from Mail — "junk" only means "don't add this to the vault". Today is \(today).
+
+        Email:
+        \(emailText)
+
+        Be RUTHLESS. The VAST majority of email is ephemeral noise — newsletters, marketing, automated notifications, receipts, OTP/2FA codes, system alerts, "your order shipped" — and worth NOTHING in a knowledge base. DEFAULT TO JUNK. Only keep emails that represent DURABLE life-knowledge: a real request or commitment directed at the user, a booking/appointment/renewal window, a personal or financial matter that will still matter months from now, a decision or plan, or meaningful correspondence about the user's life, work, or relationships.
+
+        If the body is present, judge from the FULL content — the envelope alone may look like noise but the body may carry a real ask or deadline (or vice versa: a fancy subject with an empty/marketing body). If no body is shown, judge from the envelope metadata alone — sender + subject + mailbox is still a strong signal.
+
+        Write the summary FIRST (understand the email), then judge it. Write in the THIRD PERSON — call the user "the user" (or "they"). An email FROM someone else is THEIR words, not the user's — never assert something about the user the email doesn't support. Quoted reply history (lines starting with ">") is CONTEXT, not new information — attribute it to whoever wrote it, never to the user by default.
+
+        PRIVACY — the summary you write is KEPT and may be shared with the user's other AIs. NEVER include full card/account numbers, passwords, verification/2FA codes, or verbatim sensitive medical or financial figures. Summarize around such details, never transcribe them.
+
+        Reply with ONLY a compact JSON object (no markdown, no extra text), with keys in EXACTLY this order:
+
+        {"summary":"<~30 words: what this email is about and why it matters (or doesn't)>","title":"<short 3-6 word title>","junk":<true|false>}
+
+        Then append this key ONLY IF it applies:
+          ,"sensitive":true  — only if it holds highly sensitive data that must never be stored anywhere (SSN, passport/ID, full card numbers, passwords, sensitive medical records)
+
+        Guidance:
+        - junk: true for newsletters, marketing, promotions, automated notifications, receipts (unless a truly meaningful one), OTP/2FA codes, system alerts, spam-like content, and anything ephemeral. A quiet inbox is normal — most emails are junk for a knowledge base.
+        - A genuine keeper: a real ask directed at the user, a deadline or commitment, a booking/renewal window, a personal/financial/work matter of lasting importance, meaningful correspondence about the user's life.
         """
     }
 

--- a/Sentient OS macOS/Ingestion/Connectors/MailConnector.swift
+++ b/Sentient OS macOS/Ingestion/Connectors/MailConnector.swift
@@ -1,0 +1,29 @@
+//
+//  MailConnector.swift
+//  Sentient OS macOS
+//
+//  Apple Mail adapter for the iterative core. A SINGLE bucket ("mail"), keyed on
+//  (receivedDate, "mail:<rowid>") — received-date so a re-delivered message is NOT
+//  re-summarized; the rowid is the tiebreak. One email = one item, through the MAIL
+//  Triage prompt (sender + subject + metadata — the model judges from envelope data,
+//  same as the Gmail connector's snippet pass). Wraps AppleMailSource.eligibleEmails
+//  (WAL-safe read + FK resolution + cap); the metadata text is already built at list
+//  time, so `load` just wraps it. Requires Full Disk Access.
+//
+
+import Foundation
+
+struct MailConnector: Connector {
+    let kind = SourceKind.appleMail
+
+    func buckets(since marks: [String: ItemKey]) throws -> [Bucket] {
+        let items = try AppleMailSource().eligibleEmails().map { c in
+            (key: ItemKey(date: c.itemDate, tiebreak: c.id), item: c)   // c.id = "mail:<rowid>" (unique)
+        }
+        return [Bucket(key: "mail", items: items)]   // single bucket, newest-received first
+    }
+
+    func load(_ item: Candidate) throws -> Artifact {
+        Artifact(candidate: item, text: item.metadata["emailText"] ?? "")
+    }
+}

--- a/Sentient OS macOS/Ingestion/IterativeRun.swift
+++ b/Sentient OS macOS/Ingestion/IterativeRun.swift
@@ -114,7 +114,7 @@ struct IterativeRun {
         // §7.22: if this run includes a DB source (WhatsApp/iMessage/Notes need Full Disk Access),
         // report the FDA probe when it isn't cleanly granted — the top "empty morning" signal (a 3am
         // run that silently reads nothing because TCC denied us). Once per run, structure only.
-        if connectors.contains(where: { [.whatsapp, .imessage, .notes].contains($0.kind) }) {
+        if connectors.contains(where: { [.whatsapp, .imessage, .notes, .appleMail].contains($0.kind) }) {
             Permissions.reportProbe()
         }
 

--- a/Sentient OS macOS/Sources/AppleMailSource.swift
+++ b/Sentient OS macOS/Sources/AppleMailSource.swift
@@ -1,0 +1,299 @@
+//
+//  AppleMailSource.swift
+//  Sentient OS macOS
+//
+//  Reads Apple Mail's local Envelope Index — the SQLite database at
+//  ~/Library/Mail/V{N}/MailData/Envelope Index that indexes every message across all
+//  configured accounts. Same on-device shape as NotesSource: WAL-safe COPY → EXTRACT →
+//  DELETE, one email = one Candidate through a mail-flavored triage prompt. No cloud,
+//  no connector page — Mail's store is on disk, so this is a PRIVACY-FIRST on-device
+//  source (unlike Gmail, which rides the Codex cloud connector).
+//
+//  ## V10 Schema (verified live on macOS 27 / Mail V10, 2026-07-20)
+//
+//  The Envelope Index schema has drifted significantly from the older V2–V7 era that
+//  most reverse-engineering docs describe. Key differences measured on a live Mac:
+//
+//  - **No `uid` column.** Exchange/EWS accounts store a base64 `remote_id`; IMAP
+//    accounts store a numeric `remote_id`. Neither maps to the `.emlx` filename.
+//  - **`messages.ROWID` IS the `.emlx` filename.** Verified: ROWID 33249 →
+//    `…/Inbox.mbox/…/Data/3/3/Messages/33249.emlx`. This is the reliable join key.
+//  - **`messages.sender` → `addresses.ROWID` directly.** The `senders` /
+//    `sender_addresses` tables exist but are a separate reputation/bucketing system;
+//    the FK goes straight to `addresses`.
+//  - **Dedicated `read` / `flagged` / `deleted` boolean columns** (0 or 1), NOT the
+//    jwz bit-flag layout from the `.emlx` plist era. The `flags` column still exists
+//    but its bit positions don't match the old spec.
+//  - **Dates are Unix epoch seconds** (NOT Apple's 2001-01-01 reference date).
+//    `date_received = 1784591689` → 2026-07-20. Using `timeIntervalSinceReferenceDate`
+//    would yield 2057.
+//  - **Mailbox URLs use three schemes:** `ews://`, `imap://`, `local://`. EWS names
+//    its junk folder "Junk Email" (not "Junk") and its trash "Deleted Items".
+//
+//  ## Body extraction
+//
+//  The body lives in one `.emlx` file per message, named `{ROWID}.emlx` (or
+//  `{ROWID}.partial.emlx` when attachments were split off). The on-disk layout nests
+//  under per-account UUID directories with per-mailbox sub-UUIDs and optional sharding
+//  (`Data/Messages/` or `Data/{N}/{N}/Messages/`), none of which are in the DB. Rather
+//  than hardcode that fragile path math, we walk the store tree ONCE per run to build a
+//  `ROWID → [.emlx path]` index, then resolve each message's body by dict lookup.
+//
+//  Body extraction is BEST-EFFORT / FAIL-CLOSED: any failure (file missing, undecoded
+//  MIME, truncated) → nil body → the model judges from envelope metadata alone (the
+//  same signal the Gmail connector works from). This mirrors how NotesSource handles
+//  undownloaded iCloud notes.
+//
+//  Incrementality: one "mail" bucket; each email keyed (ItemKey) on its RECEIVED date,
+//  so a re-delivered message is NOT re-summarized. High-water mark in CycleStore.
+//  Deleted and Junk/Trash messages are excluded in SQL. Requires Full Disk Access.
+//  Doc: Documentation/Apple Mail Source (Envelope Index).md
+//
+
+import Foundation
+
+struct AppleMailSource: Sendable {
+    let kind: SourceKind = .appleMail
+
+    // MARK: Tunables
+
+    /// Newest-first cap (same philosophy as NotesSource.maxNotes — triage does the filtering).
+    static let maxEmails = 2_000
+
+    /// Mailbox names to exclude — Trash, Junk, and Spam hold nothing vault-worthy and would
+    /// flood the pipeline with noise. Matched case-insensitively against the last path
+    /// component of the mailbox URL. Covers both IMAP ("Junk", "Deleted Messages") and
+    /// EWS/Exchange ("Junk Email", "Deleted Items") naming.
+    private static let excludedMailboxes: Set<String> = [
+        "trash", "junk", "spam", "junk email", "junk e-mail",
+        "deleted items", "deleted messages",
+    ]
+
+    /// The root of the on-disk message store (~/Library/Mail/V{N}) — the directory walked
+    /// to build the ROWID → .emlx index. nil if Mail has never been used here.
+    static var storeRoot: URL? {
+        dbPath.map { URL(fileURLWithPath: $0).deletingLastPathComponent().deletingLastPathComponent() }
+    }
+
+    // MARK: Path resolution
+
+    /// ~/Library/Mail/V{N}/MailData/Envelope Index — glob V* and pick the highest version.
+    /// Returns nil if Mail has never been used on this Mac (no ~/Library/Mail directory).
+    static var dbPath: String? {
+        let mailDir = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Mail")
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: mailDir, includingPropertiesForKeys: nil) else { return nil }
+        // V10 > V9 > V8 … — sort by the numeric suffix, descending.
+        func versionNumber(_ url: URL) -> Int {
+            Int(String(url.lastPathComponent.dropFirst())) ?? 0
+        }
+        let versionDirs = entries
+            .filter { $0.hasDirectoryPath && $0.lastPathComponent.hasPrefix("V") }
+            .sorted { versionNumber($0) > versionNumber($1) }
+        for v in versionDirs {
+            let candidate = v.appendingPathComponent("MailData/Envelope Index")
+            if FileManager.default.fileExists(atPath: candidate.path) { return candidate.path }
+        }
+        return nil
+    }
+
+    /// Is Apple Mail present on this Mac? (Used by the Settings chip to show/hide, same
+    /// pattern as WhatsAppSource.isInstalled.)
+    static var isInstalled: Bool { dbPath != nil }
+
+    // MARK: Eligible emails (the iterative system's flat, pointer-free view)
+
+    /// The current eligible emails for the iterative system (MailConnector). WAL-safe read
+    /// of the Envelope Index + sender/subject/mailbox resolution + cap, then best-effort
+    /// `.emlx` body enrichment. Keyed on **received date** (so a re-delivered message is
+    /// NOT re-summarized). Newest first.
+    func eligibleEmails() throws -> [Candidate] {
+        guard let path = Self.dbPath else { return [] }
+        let (dbURL, tempDir) = try SQLiteDB.walSafeCopy(of: path)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let reader = try SQLiteReader(path: dbURL.path)
+
+        // Resolve the FK tables up front (small — one dict each).
+        let subjects = Self.table(reader, table: "subjects", idCol: "ROWID", textCol: "subject")
+        let addresses = Self.addressTable(reader)
+        let mailboxes = Self.mailboxTable(reader)
+
+        // Build the ROWID → .emlx path index ONCE, before the row scan, so per-message body
+        // resolution is a dict lookup. The `.emlx` filename IS the message ROWID (verified
+        // live on V10). Empty when there's no store root.
+        let emlxIndex = Self.buildEMLXIndex()
+
+        var out: [Candidate] = []
+        try reader.forEachRow("""
+            SELECT m.ROWID, m.date_received, m.date_sent, m.read, m.flagged,
+                   m.subject, m.sender, m.mailbox
+            FROM messages m
+            WHERE m.deleted = 0
+            ORDER BY m.date_received DESC
+            LIMIT \(Self.maxEmails)
+            """) { r in
+            let rowid = r.int(0)
+
+            // Resolve mailbox name + URL; skip Trash/Junk/Spam.
+            let mailboxID = r.int(7)
+            let mailboxName = mailboxes[mailboxID]?.name ?? "Mail"
+            let mailboxURL = mailboxes[mailboxID]?.url ?? ""
+            if Self.excludedMailboxes.contains(mailboxName.lowercased()) { return }
+
+            // V10 stores dates as Unix epoch seconds (NOT Apple's 2001 reference date).
+            let received = Date(timeIntervalSince1970: r.double(1))
+            let sent = Date(timeIntervalSince1970: r.double(2))
+            let subject = subjects[r.int(5)] ?? "(no subject)"
+            // V10: messages.sender → addresses.ROWID directly (no senders/sender_addresses hop).
+            let sender = addresses[r.int(6)] ?? "Unknown"
+
+            let isRead = r.int(3) == 1
+            let isFlagged = r.int(4) == 1
+
+            // Best-effort body: resolve the .emlx by ROWID. nil ⇒ metadata-only.
+            let body = Self.resolveBody(rowid: rowid, index: emlxIndex)
+
+            let emailText = Self.formatEmail(from: sender, subject: subject,
+                                             mailbox: mailboxName, received: received,
+                                             sent: sent, isRead: isRead, isFlagged: isFlagged,
+                                             body: body)
+
+            out.append(Candidate(
+                id: "mail:\(rowid)", kind: .appleMail,
+                cursorKey: "mail", cursorValue: "",
+                itemDate: received,
+                metadata: [
+                    "folder": mailboxName,
+                    "name": subject,
+                    "displayPath": "Apple Mail · \(mailboxName) · \(subject)",
+                    "created": Self.dateString(received),
+                    "sender": sender,
+                    "mailbox": mailboxName,
+                    "emailText": emailText,
+                ]))
+        }
+
+        SourceHealth.checkListingCollapse(source: "appleMail", bucketKey: "mail", count: out.count)
+        return out   // newest-received first (the SQL ORDER)
+    }
+
+    // MARK: FK table loaders
+
+    /// Generic two-column FK table → dict (ROWID → text).
+    private static func table(_ reader: SQLiteReader, table: String,
+                              idCol: String, textCol: String) -> [Int64: String] {
+        var out: [Int64: String] = [:]
+        try? reader.forEachRow("SELECT \(idCol), \(textCol) FROM \(table)") { r in
+            if let t = r.text(1) { out[r.int(0)] = t }
+        }
+        return out
+    }
+
+    /// addresses table → dict (ROWID → "Display Name <email>" or just "email").
+    /// The `comment` column holds the display name; `address` holds the email.
+    private static func addressTable(_ reader: SQLiteReader) -> [Int64: String] {
+        var out: [Int64: String] = [:]
+        try? reader.forEachRow("SELECT ROWID, address, comment FROM addresses") { r in
+            let email = r.text(1) ?? ""
+            let name = r.text(2) ?? ""
+            if name.isEmpty || name == email {
+                out[r.int(0)] = email
+            } else {
+                out[r.int(0)] = "\(name) <\(email)>"
+            }
+        }
+        return out
+    }
+
+    private struct MailboxInfo { let name: String; let url: String }
+
+    /// mailboxes table → dict (ROWID → (display name, raw URL)). The `url` column holds
+    /// something like `ews://UUID/Inbox` or `imap://UUID/INBOX`; the display name is its
+    /// last path component, percent-decoded. The raw URL is kept for body disambiguation.
+    private static func mailboxTable(_ reader: SQLiteReader) -> [Int64: MailboxInfo] {
+        var out: [Int64: MailboxInfo] = [:]
+        try? reader.forEachRow("SELECT ROWID, url FROM mailboxes") { r in
+            guard let url = r.text(1) else { return }
+            let last = url.split(separator: "/").last.map(String.init) ?? url
+            let name = last.removingPercentEncoding ?? last
+            out[r.int(0)] = MailboxInfo(name: name, url: url)
+        }
+        return out
+    }
+
+    // MARK: .emlx body resolution (best-effort, fail-closed)
+
+    /// Walk the store root once and map every message ROWID → the `.emlx` file(s) that
+    /// carry it. The `.emlx` filename IS the message ROWID (verified on V10). A ROWID
+    /// can have both a full `.emlx` and a `.partial.emlx` (attachments split off); the
+    /// full one is preferred. Non-throwing — any I/O hiccup yields a partial/empty index
+    /// and the pipeline simply falls back to metadata-only triage.
+    private static func buildEMLXIndex() -> [Int64: [String]] {
+        guard let root = storeRoot else { return [:] }
+        var index: [Int64: [String]] = [:]
+        guard let enumerator = FileManager.default.enumerator(
+            at: root, includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]) else { return [:] }
+        for case let url as URL in enumerator {
+            let name = url.lastPathComponent
+            let isPartial = name.hasSuffix(".partial.emlx")
+            guard isPartial || name.hasSuffix(".emlx") else { continue }
+            // Strip the extension(s) to recover the numeric ROWID.
+            var base = name
+            if isPartial { base.removeLast(".partial.emlx".count) }
+            else { base.removeLast(".emlx".count) }
+            guard let rowid = Int64(base) else { continue }
+            // A full .emlx outranks its .partial sibling; insert full first so it's preferred.
+            var paths = index[rowid] ?? []
+            if isPartial { paths.append(url.path) } else { paths.insert(url.path, at: 0) }
+            index[rowid] = paths
+        }
+        return index
+    }
+
+    /// The plain-text body for one message, or nil. Resolves the file by ROWID (the
+    /// `.emlx` filename), then parses the MIME body via EMLXParser. Every failure
+    /// returns nil (→ metadata-only triage).
+    private static func resolveBody(rowid: Int64, index: [Int64: [String]]) -> String? {
+        guard rowid > 0, let candidates = index[rowid], !candidates.isEmpty else { return nil }
+        // Prefer the full .emlx (index[0]) over .partial.emlx. When multiple full files
+        // exist (shouldn't happen — ROWID is globally unique), try each until one parses.
+        for path in candidates {
+            if let body = EMLXParser.bodyText(ofFileAt: path) { return body }
+        }
+        return nil
+    }
+
+    // MARK: Formatting
+
+    /// The text the triage model judges: the envelope metadata plus, when we recovered it,
+    /// the message body. One email, one artifact, one verdict.
+    private static func formatEmail(from sender: String, subject: String, mailbox: String,
+                                    received: Date, sent: Date, isRead: Bool,
+                                    isFlagged: Bool, body: String?) -> String {
+        var lines = [
+            "From: \(sender)",
+            "Subject: \(subject)",
+            "Mailbox: \(mailbox)",
+            "Received: \(dateString(received))",
+        ]
+        // Only add sent date if it differs meaningfully from received (forwarded/delayed mail).
+        if abs(received.timeIntervalSince(sent)) > 3600 {
+            lines.append("Originally sent: \(dateString(sent))")
+        }
+        if isFlagged { lines.append("Flagged: yes") }
+        lines.append("Read: \(isRead ? "yes" : "no")")
+        if let body, !body.isEmpty {
+            lines.append("")
+            lines.append("Body:")
+            lines.append(body)
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private static let df: DateFormatter = {
+        let f = DateFormatter(); f.dateFormat = "MMM d, yyyy h:mm a"; f.timeZone = .current; return f
+    }()
+    private static func dateString(_ d: Date) -> String { df.string(from: d) }
+}

--- a/Sentient OS macOS/Sources/DataSource.swift
+++ b/Sentient OS macOS/Sources/DataSource.swift
@@ -16,14 +16,15 @@
 import Foundation
 
 /// The sources. `rawValue` is what we persist on summaries (the cloud's source-trust tiers key on
-/// it). `file`/`whatsapp`/`imessage`/`notes` are read on-device; `gmail` and `calendar` are the CLOUD
-/// sources — fetched + summarized through the user's Codex connectors (no on-device read), see
-/// GmailConnect / CalendarConnect.
+/// it). `file`/`whatsapp`/`imessage`/`notes`/`appleMail` are read on-device; `gmail` and
+/// `calendar` are the CLOUD sources — fetched + summarized through the user's Codex connectors
+/// (no on-device read), see GmailConnect / CalendarConnect.
 enum SourceKind: String, Codable, Sendable, CaseIterable {
     case file
     case whatsapp
     case imessage
     case notes
+    case appleMail
     case gmail
     case calendar
 }

--- a/Sentient OS macOS/Sources/EMLXParser.swift
+++ b/Sentient OS macOS/Sources/EMLXParser.swift
@@ -1,0 +1,408 @@
+//
+//  EMLXParser.swift
+//  Sentient OS macOS
+//
+//  Extracts the human-readable body text from a Mail.app `.emlx` file. Pure static
+//  functions with NO I/O, so the format logic is testable in isolation — same shape as
+//  NotesSource.decodeBody (gunzip → protobuf walk) and iMessageSource.typedstreamText.
+//
+//  The `.emlx` layout (reverse-engineered, corroborated by the Library of Congress
+//  format description fdd000615 and the PyPI `emlx` package):
+//
+//      <bytecount>\n            ← decimal ASCII on the first line
+//      <bytecount bytes>        ← the full RFC 5322 / MIME message
+//      <?xml … plist …>         ← Apple's metadata trailer (flags, subject, …)
+//
+//  The bytecount makes extraction UNAMBIGUOUS: read the first line as the count, then
+//  take exactly that many bytes as the message — no need to hunt for the plist marker
+//  (which would be ambiguous if a message body itself contained "<?xml").
+//
+//  Bodies vary enormously (7bit / 8bit / quoted-printable / base64, nested multipart,
+//  HTML-only, encrypted, …), so everything here is FAIL-CLOSED: any step that can't be
+//  decoded returns nil and the caller falls back to envelope-metadata-only triage — the
+//  same philosophy as the other DB sources (an undecodable note is skipped, never fed
+//  garbled to the model). The envelope alone already yields a strong keeper/junk call
+//  (it's all the Gmail connector works from), so a missing body is a graceful degrade.
+//
+
+import Foundation
+
+nonisolated enum EMLXParser {
+
+    /// Max body characters handed to the triage model (same order of magnitude as
+    /// NotesSource.maxContentChars). Keeps the prompt under the KV cache.
+    static let maxBodyChars = 6_000
+
+    /// The full plain-text body of a `.emlx` file, or nil if the file can't be decoded
+    /// (unreadable, truncated, encrypted, or no recoverable text part).
+    static func bodyText(ofFileAt path: String) -> String? {
+        guard let data = FileManager.default.contents(atPath: path) else { return nil }
+        guard let message = messageBytes(in: data) else { return nil }
+        return plainText(fromMIME: message)
+    }
+
+    // MARK: - Bytecount framing
+
+    /// The message portion of a `.emlx` file: the first line is a decimal byte count,
+    /// and the next `count` bytes are the RFC 5322 message. nil if the framing is invalid
+    /// or the file is truncated.
+    static func messageBytes(in data: Data) -> Data? {
+        // The bytecount is ASCII on the first line; find the first newline.
+        guard let nl = data.firstIndex(of: 0x0A) else { return nil }
+        let firstLine = String(decoding: data[data.startIndex..<nl], as: UTF8.self)
+            .trimmingCharacters(in: .whitespaces)
+        guard let count = Int(firstLine), count > 0 else { return nil }
+        let start = nl + 1
+        let end = start + count
+        guard end <= data.endIndex else { return nil }   // truncated
+        return data[start..<end]
+    }
+
+    // MARK: - MIME → plain text
+
+    /// Extract readable text from a full RFC 5322 / MIME message. Prefers `text/plain`,
+    /// falls back to de-tagged `text/html`, walks nested multiparts. nil when nothing
+    /// textual can be recovered (encrypted, image-only, …).
+    static func plainText(fromMIME message: Data) -> String? {
+        // Split headers from body at the first blank line (CRLF or LF tolerant).
+        let (headers, body) = splitHeaderBody(message)
+        let contentType = headerValue("content-type", in: headers) ?? "text/plain"
+        let cte = headerValue("content-transfer-encoding", in: headers) ?? "7bit"
+
+        return extract(from: body, contentType: contentType, cte: cte)
+    }
+
+    /// Recursive extractor: given a body blob + its Content-Type + transfer encoding,
+    /// return the best text. Depth-capped so a pathological nested multipart can't recurse
+    /// forever.
+    private static func extract(from body: Data, contentType: String, cte: String,
+                                depth: Int = 0) -> String? {
+        guard depth < 12 else { return nil }
+        let lowered = contentType.lowercased()
+
+        if lowered.hasPrefix("multipart/") {
+            guard let boundary = parameter("boundary", in: contentType),
+                  let boundaryData = boundary.data(using: .utf8) else { return nil }
+            return extractMultipart(body, boundary: boundaryData, depth: depth)
+        }
+
+        if lowered.hasPrefix("text/plain") {
+            let decoded = decodeTransfer(body, encoding: cte)
+            let charset = parameter("charset", in: contentType) ?? "utf-8"
+            return cleanBody(stringInCharset(decoded, charset: charset))
+        }
+
+        if lowered.hasPrefix("text/html") {
+            let decoded = decodeTransfer(body, encoding: cte)
+            let charset = parameter("charset", in: contentType) ?? "utf-8"
+            guard let html = stringInCharset(decoded, charset: charset) else { return nil }
+            return cleanBody(stripHTML(html))
+        }
+
+        if lowered.hasPrefix("multipart/alternative") { return nil }  // handled by multipart path
+        return nil   // attachments, images, etc. — no text
+    }
+
+    /// Split a multipart body on its boundary, then collect text from the parts — preferring
+    /// a `text/plain` part, else the first `text/html` part. (multipart/alternative lists the
+    /// SAME content in increasing fidelity, so plain wins when present.)
+    private static func extractMultipart(_ body: Data, boundary: Data, depth: Int) -> String? {
+        let parts = splitOnBoundary(body, boundary: boundary)
+        var htmlFallback: String?
+        for part in parts {
+            let (headers, partBody) = splitHeaderBody(part)
+            let type = headerValue("content-type", in: headers) ?? "text/plain"
+            let partCTE = headerValue("content-transfer-encoding", in: headers) ?? "7bit"
+            // Skip attachment parts (they carry a filename) — we only want inline text.
+            if type.lowercased().contains("name=") ||
+               headerValue("content-disposition", in: headers)?.lowercased().contains("attachment") == true {
+                continue
+            }
+            if let text = extract(from: partBody, contentType: type, cte: partCTE, depth: depth + 1),
+               !text.isEmpty {
+                if type.lowercased().hasPrefix("text/plain") { return text }   // plain wins immediately
+                if htmlFallback == nil { htmlFallback = text }
+            }
+        }
+        return htmlFallback
+    }
+
+    /// Split a multipart body into its raw part blobs. A boundary appears as
+    /// `--<boundary>` on its own line; the closing delimiter is `--<boundary>--`.
+    private static func splitOnBoundary(_ body: Data, boundary: Data) -> [Data] {
+        var dashBoundary = Data("--".utf8); dashBoundary.append(boundary)
+        var parts: [Data] = []
+        var searchStart = body.startIndex
+        var partStart: Data.Index?
+
+        while searchStart < body.endIndex {
+            guard let range = body.range(of: dashBoundary, in: searchStart..<body.endIndex) else { break }
+            if let start = partStart {
+                // Capture everything between the previous boundary line and this one.
+                var slice = body[start..<range.lowerBound]
+                trimTrailingNewlines(&slice)
+                if !slice.isEmpty { parts.append(slice) }
+            }
+            // Move past this boundary line. If it's the closing `--`, we're done.
+            let afterBoundary = range.upperBound
+            if afterBoundary + 2 <= body.endIndex,
+               body[afterBoundary] == 0x2D, body[afterBoundary + 1] == 0x2D { break }
+            // Skip to the end of the boundary line. the part begins on the next line.
+            if let lineEnd = body[afterBoundary...].firstIndex(of: 0x0A) {
+                partStart = lineEnd + 1
+                searchStart = lineEnd + 1
+            } else { break }
+        }
+        return parts
+    }
+
+    // MARK: - Transfer encodings
+
+    /// Decode a Content-Transfer-Encoding (7bit/8bit/binary → as-is; quoted-printable and
+    /// base64 → decoded). Unknown encodings pass through unchanged (fail-open to raw bytes).
+    private static func decodeTransfer(_ data: Data, encoding: String) -> Data {
+        switch encoding.lowercased().trimmingCharacters(in: .whitespaces) {
+        case "quoted-printable": return decodeQuotedPrintable(data)
+        case "base64":           return Data(base64Encoded: stripBase64Noise(data)) ?? data
+        default:                 return data   // 7bit / 8bit / binary
+        }
+    }
+
+    /// Quoted-printable: `=XX` hex escapes and soft line breaks (`=\n` / `=\r\n`).
+    private static func decodeQuotedPrintable(_ data: Data) -> Data {
+        var out = Data()
+        out.reserveCapacity(data.count)
+        var i = data.startIndex
+        while i < data.endIndex {
+            let b = data[i]
+            if b == 0x3D /* '=' */ {
+                // Soft line break: '=' immediately followed by newline.
+                if i + 1 < data.endIndex, data[i + 1] == 0x0A { i += 2; continue }
+                if i + 2 < data.endIndex, data[i + 1] == 0x0D, data[i + 2] == 0x0A { i += 3; continue }
+                // Hex escape =XX.
+                if i + 2 < data.endIndex,
+                   let hi = hexVal(data[i + 1]), let lo = hexVal(data[i + 2]) {
+                    out.append(UInt8(hi << 4 | lo)); i += 3; continue
+                }
+                // Malformed escape — emit the '=' and move on.
+                out.append(b); i += 1; continue
+            }
+            out.append(b); i += 1
+        }
+        return out
+    }
+
+    private static func stripBase64Noise(_ data: Data) -> Data {
+        // base64 ignores whitespace/newlines; Data(base64Encoded:) is strict, so strip them.
+        Data(data.filter { !([0x0A, 0x0D, 0x20, 0x09] as [UInt8]).contains($0) })
+    }
+
+    private static func hexVal(_ b: UInt8) -> Int? {
+        switch b {
+        case 0x30...0x39: return Int(b - 0x30)
+        case 0x41...0x46: return Int(b - 0x41) + 10
+        case 0x61...0x66: return Int(b - 0x61) + 10
+        default:          return nil
+        }
+    }
+
+    // MARK: - Charset + cleanup
+
+    /// Decode bytes in the given MIME charset (utf-8 / iso-8859-* / us-ascii / windows-1252 …).
+    /// Falls back to a lossy UTF-8 decode, then to Latin-1, so we always return *something*
+    /// readable rather than nil for an odd charset.
+    private static func stringInCharset(_ data: Data, charset: String) -> String? {
+        let cs = charset.lowercased().trimmingCharacters(in: .whitespaces)
+        let enc: String.Encoding
+        switch cs {
+        case "utf-8", "utf8":                      enc = .utf8
+        case "us-ascii", "ascii":                  enc = .ascii
+        case "iso-8859-1", "latin1", "latin-1":    enc = .isoLatin1
+        case "iso-8859-2", "latin2":               enc = .isoLatin2
+        case "windows-1252", "cp1252":             enc = .windowsCP1252
+        case "utf-16":                             enc = .utf16
+        case "shift_jis", "shift-jis":             enc = .shiftJIS
+        case "iso-2022-jp":                        enc = .iso2022JP
+        case "euc-jp":                             enc = .japaneseEUC
+        case "gb2312", "gbk", "gb18030":           enc = .iso2022JP   // best-effort; rare
+        default:                                   enc = .utf8
+        }
+        if let s = String(data: data, encoding: enc) { return s }
+        return String(decoding: data, as: UTF8.self)   // lossy UTF-8 — never nil
+    }
+
+    /// Strip HTML down to readable text: drop script/style blocks, convert <br>/<p>/block
+    /// closers to newlines, remove remaining tags, then collapse whitespace and decode the
+    /// common named entities. Deliberately a lightweight regex pass, not a real HTML parser.
+    private static func stripHTML(_ html: String) -> String {
+        var s = html
+        s = s.replacingOccurrences(of: "(?is)<script[^>]*>.*?</script>", with: " ", options: .regularExpression)
+        s = s.replacingOccurrences(of: "(?is)<style[^>]*>.*?</style>", with: " ", options: .regularExpression)
+        s = s.replacingOccurrences(of: "(?is)<head[^>]*>.*?</head>", with: " ", options: .regularExpression)
+        s = s.replacingOccurrences(of: "(?is)<!--.*?-->", with: " ", options: .regularExpression)   // HTML comments
+        s = s.replacingOccurrences(of: "(?i)<br[^>]*>", with: "\n", options: .regularExpression)
+        s = s.replacingOccurrences(of: "(?i)</(p|div|li|tr|h[1-6]|table|blockquote)>", with: "\n", options: .regularExpression)
+        s = s.replacingOccurrences(of: "<[^>]+>", with: " ", options: .regularExpression)
+        s = decodeEntities(s)
+        return s
+    }
+
+    /// Decode the handful of named/numeric entities that dominate email HTML, then let the
+    /// whitespace collapse in cleanBody do the rest.
+    private static func decodeEntities(_ s: String) -> String {
+        var out = s
+        let named: [String: String] = [
+            "&nbsp;": " ", "&amp;": "&", "&lt;": "<", "&gt;": ">", "&quot;": "\"",
+            "&apos;": "'", "&#39;": "'", "&rsquo;": "\u{2019}", "&lsquo;": "\u{2018}",
+            "&ldquo;": "\u{201C}", "&rdquo;": "\u{201D}", "&mdash;": "\u{2014}",
+            "&ndash;": "\u{2013}", "&hellip;": "\u{2026}", "&copy;": "\u{00A9}",
+            "&reg;": "\u{00AE}", "&trade;": "\u{2122}",
+        ]
+        for (k, v) in named { out = out.replacingOccurrences(of: k, with: v) }
+        // Numeric entities: &#123; and &#xABC;
+        if let re = try? NSRegularExpression(pattern: "&#(x?)([0-9a-fA-F]+);") {
+            let ns = out as NSString
+            var result = ""
+            var last = 0
+            for m in re.matches(in: out, range: NSRange(location: 0, length: ns.length)) {
+                result += ns.substring(with: NSRange(location: last, length: m.range.location - last))
+                let hex = ns.substring(with: m.range(at: 1)) == "x"
+                let numStr = ns.substring(with: m.range(at: 2))
+                let scalar: UInt32? = hex ? UInt32(strtoul(numStr, nil, 16)) : UInt32(numStr)
+                if let sc = scalar, let u = Unicode.Scalar(sc) { result.append(Character(u)) }
+                last = m.range.location + m.range.length
+            }
+            result += ns.substring(from: last)
+            out = result
+        }
+        return out
+    }
+
+    /// Normalize a decoded body: strip a trailing signature block, remove zero-width
+    /// tracking characters, collapse blank-line runs, trim, and cap to maxBodyChars.
+    /// nil if empty.
+    private static func cleanBody(_ s: String?) -> String? {
+        guard var s else { return nil }
+        if let sigRange = s.range(of: "\n-- \n") { s = String(s[..<sigRange.lowerBound]) }
+        // Strip zero-width / invisible Unicode (tracking pixels, BOM, directional marks).
+        s = s.replacingOccurrences(of: "[\u{200B}-\u{200F}\u{2028}-\u{202F}\u{FEFF}\u{034F}]",
+                                   with: "", options: .regularExpression)
+        s = s.replacingOccurrences(of: "[ \\t]+", with: " ", options: .regularExpression)
+        s = s.replacingOccurrences(of: "\\n{3,}", with: "\n\n", options: .regularExpression)
+        s = s.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !s.isEmpty else { return nil }
+        if s.count > maxBodyChars { s = String(s.prefix(maxBodyChars)) + "…" }
+        return s
+    }
+
+    // MARK: - Header helpers (operate on the raw header blob)
+
+    /// Split a message/part blob into (header bytes, body bytes) at the first blank line,
+    /// tolerating CRLF and LF.
+    private static func splitHeaderBody(_ data: Data) -> (Data, Data) {
+        // CRLF blank line first.
+        if let r = data.range(of: Data([0x0D, 0x0A, 0x0D, 0x0A])) {
+            return (data[data.startIndex..<r.lowerBound], data[r.upperBound...])
+        }
+        if let r = data.range(of: Data([0x0A, 0x0A])) {
+            return (data[data.startIndex..<r.lowerBound], data[r.upperBound...])
+        }
+        return (data, Data())   // headers only
+    }
+
+    /// Unfolded value of a header (case-insensitive), with RFC 2047 encoded-words decoded
+    /// enough to be readable. Headers can span multiple lines (continuation lines start
+    /// with whitespace) — unfold them first.
+    private static func headerValue(_ name: String, in headers: Data) -> String? {
+        let text = String(decoding: headers, as: UTF8.self)
+        let lines = unfold(text)
+        let needle = name.lowercased()
+        for line in lines {
+            guard let colon = line.firstIndex(of: ":") else { continue }
+            let key = line[line.startIndex..<colon].trimmingCharacters(in: .whitespaces).lowercased()
+            if key == needle {
+                let value = line[line.index(after: colon)...].trimmingCharacters(in: .whitespaces)
+                return decodeEncodedWords(value)
+            }
+        }
+        return nil
+    }
+
+    /// A named parameter from a structured header, e.g. `boundary="----=_Part"` or
+    /// `charset=utf-8` out of a Content-Type value. Handles quoted and unquoted values.
+    private static func parameter(_ name: String, in headerValue: String) -> String? {
+        let needle = name.lowercased() + "="
+        let lower = headerValue.lowercased()
+        guard let r = lower.range(of: needle) else { return nil }
+        var rest = headerValue[r.upperBound...]
+        var value = ""
+        if rest.first == "\"" {
+            rest = rest.dropFirst()
+            value = String(rest.prefix(while: { $0 != "\"" }))
+        } else {
+            value = String(rest.prefix(while: { $0 != ";" && $0 != " " && $0 != "\t" && $0 != "\r" && $0 != "\n" }))
+        }
+        return value.isEmpty ? nil : value
+    }
+
+    /// Unfold RFC 5322 headers: a CRLF/ LF followed by whitespace is a continuation of the
+    /// previous logical line. Uses `components(separatedBy:)` (UTF-16 level via NSString)
+    /// rather than `split(separator:)` — in Swift, CRLF is a single grapheme cluster, so
+    /// `split(separator: "\n")` would never match the LF inside a `\r\n` pair and headers
+    /// would never separate.
+    private static func unfold(_ text: String) -> [String] {
+        var logical: [String] = []
+        for raw in text.components(separatedBy: "\n") {
+            var line = raw
+            if line.hasSuffix("\r") { line.removeLast() }
+            if let first = line.first, first == " " || first == "\t" {
+                // Continuation — append to the previous logical line.
+                if !logical.isEmpty {
+                    logical[logical.count - 1] += " " + line.trimmingCharacters(in: .whitespaces)
+                    continue
+                }
+            }
+            logical.append(line)
+        }
+        return logical
+    }
+
+    /// Decode RFC 2047 encoded-words like `=?utf-8?Q?Hello?= ` / `=?iso-8859-1?B?…?=` so
+    /// subjects/from-names with non-ASCII read correctly. Words separated by whitespace are
+    /// joined per the RFC. Best-effort — leaves anything it can't decode as-is.
+    private static func decodeEncodedWords(_ s: String) -> String {
+        guard s.contains("=?") else { return s }
+        guard let re = try? NSRegularExpression(
+            pattern: "=\\?([^?]+)\\?([BbQq])\\?([^?]*)\\?=") else { return s }
+        let ns = s as NSString
+        var result = ""
+        var last = 0
+        for m in re.matches(in: s, range: NSRange(location: 0, length: ns.length)) {
+            result += ns.substring(with: NSRange(location: last, length: m.range.location - last))
+            let charset = ns.substring(with: m.range(at: 1))
+            let kind = ns.substring(with: m.range(at: 2)).uppercased()
+            let payload = ns.substring(with: m.range(at: 3))
+            var decoded: Data?
+            if kind == "B" {
+                decoded = Data(base64Encoded: payload)
+            } else { // Q — quoted-printable with '_' meaning space
+                let qp = payload.replacingOccurrences(of: "_", with: " ")
+                decoded = decodeQuotedPrintable(Data(qp.utf8))
+            }
+            if let d = decoded, let str = stringInCharset(d, charset: charset) {
+                result += str
+            } else {
+                result += ns.substring(with: m.range)   // leave as-is
+            }
+            last = m.range.location + m.range.length
+        }
+        result += ns.substring(from: last)
+        return result
+    }
+
+    private static func trimTrailingNewlines(_ data: inout Data) {
+        while let last = data.last, last == 0x0A || last == 0x0D {
+            data.removeLast()
+        }
+    }
+}

--- a/Sentient OS macOS/Sources/SourceSelection.swift
+++ b/Sentient OS macOS/Sources/SourceSelection.swift
@@ -73,6 +73,7 @@ enum SourceSelection {
         if bool("dbg.run.whatsapp", default: false) && !chatJIDs.isEmpty { n += 1 }
         if bool("dbg.run.imessage", default: false) && !imessageGUIDs.isEmpty { n += 1 }
         if bool("dbg.run.notes", default: false) { n += 1 }
+        if bool("dbg.run.appleMail", default: false) { n += 1 }
         if bool("dbg.gmail.connected", default: false) && bool("dbg.run.gmail", default: false) { n += 1 }
         if bool("dbg.calendar.connected", default: false) && bool("dbg.run.calendar", default: false) { n += 1 }
         return n
@@ -91,6 +92,9 @@ enum SourceSelection {
             s.append(.imessage(chatGUIDs: imessageGUIDs))
         }
         if bool("dbg.run.notes", default: false) && fdaGranted { s.append(.notes) }
+        if bool("dbg.run.appleMail", default: false) && fdaGranted && AppleMailSource.isInstalled {
+            s.append(.appleMail)
+        }
         return s
     }
 

--- a/Sentient OS macOS/Views/Dev/DevToolsView.swift
+++ b/Sentient OS macOS/Views/Dev/DevToolsView.swift
@@ -69,6 +69,7 @@ struct DevToolsView: View {
     @AppStorage("dbg.run.imessage")  private var runIMessage = false
     @AppStorage("dbg.imessage.chats") private var selectedIMessageChatsCSV = ""
     @AppStorage("dbg.run.notes")     private var runNotes = false
+    @AppStorage("dbg.run.appleMail") private var runAppleMail = false
 
     @State private var run = DevRunModel()
     @State private var deviceJob: DeviceJob?
@@ -587,12 +588,13 @@ struct DevToolsView: View {
                                turnOff: { runIMessage = false },
                                openPicker: { showIMessagePicker = true })
                 notesChip
+                if AppleMailSource.isInstalled { mailChip }
                 gmailChip
                 calendarChip
             }
             .frame(maxWidth: 460)
 
-            Text("The INITIAL / ITERATIVE buttons run every selected source (folders + opted chats + Apple Notes + Gmail + Calendar) through the iterative core. Select only one to test it alone.")
+            Text("The INITIAL / ITERATIVE buttons run every selected source (folders + opted chats + Apple Notes + Apple Mail + Gmail + Calendar) through the iterative core. Select only one to test it alone.")
                 .font(.caption2).foregroundStyle(Theme.faint)
                 .multilineTextAlignment(.center).fixedSize(horizontal: false, vertical: true)
         }
@@ -611,6 +613,21 @@ struct DevToolsView: View {
         .overlay(Capsule().strokeBorder(on ? .clear : Theme.stroke, lineWidth: 1))
         .contentShape(Capsule())
         .onTapGesture { guard fdaGranted else { return }; runNotes.toggle() }
+    }
+
+    private var mailChip: some View {
+        let on = runAppleMail && fdaGranted
+        return HStack(spacing: 6) {
+            Image(systemName: on ? "checkmark.circle.fill" : "envelope").font(.system(size: 11))
+            Text("Apple Mail").font(.caption.weight(.medium)).lineLimit(1)
+        }
+        .foregroundStyle(on ? .black : (fdaGranted ? Theme.secondary : Theme.faint))
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 11).padding(.vertical, 6)
+        .background(on ? Theme.accent : Color.white.opacity(0.06), in: Capsule())
+        .overlay(Capsule().strokeBorder(on ? .clear : Theme.stroke, lineWidth: 1))
+        .contentShape(Capsule())
+        .onTapGesture { guard fdaGranted else { return }; runAppleMail.toggle() }
     }
 
     /// Gmail (cloud). Not connected → tap opens the connect popup; connected → tap toggles selection.

--- a/Sentient OS macOS/Views/HomePopovers.swift
+++ b/Sentient OS macOS/Views/HomePopovers.swift
@@ -46,6 +46,7 @@ struct AnalysisPopover: View {
     @AppStorage("dbg.run.desktop")        private var runDesktop = true
     @AppStorage("dbg.run.documents")      private var runDocuments = true
     @AppStorage("dbg.run.notes")          private var runNotes = false
+    @AppStorage("dbg.run.appleMail")      private var runAppleMail = false
     @AppStorage("dbg.whatsapp.chats")     private var whatsappCSV = ""
     @AppStorage("dbg.imessage.chats")     private var imessageCSV = ""
     @AppStorage("dbg.gmail.connected")    private var gmailConnected = false
@@ -56,7 +57,7 @@ struct AnalysisPopover: View {
     @State private var vault: (notes: Int, domains: Int)?
 
     private var anyArmed: Bool {
-        runDownloads || runDesktop || runDocuments || runNotes || !customRoots.isEmpty
+        runDownloads || runDesktop || runDocuments || runNotes || runAppleMail || !customRoots.isEmpty
             || !whatsappCSV.isEmpty || !imessageCSV.isEmpty
             || (gmailConnected && runGmail) || (calendarConnected && runCalendar)
     }
@@ -99,6 +100,9 @@ struct AnalysisPopover: View {
                 }
                 HStack(spacing: 8) {
                     SourceChip("Notes",    on: runNotes) { runNotes.toggle() }
+                    if AppleMailSource.isInstalled {
+                        SourceChip("Apple Mail", on: runAppleMail) { runAppleMail.toggle() }
+                    }
                     SourceChip("Gmail",    on: gmailConnected && runGmail,
                                locked: CodexAuth.knowledgeBaseOnly, action: onPickGmail)
                     SourceChip("Calendar", on: calendarConnected && runCalendar,

--- a/Sentient OS macOS/Views/Onboarding/OnboardingReadyView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingReadyView.swift
@@ -25,6 +25,7 @@ struct OnboardingReadyView: View {
     @AppStorage("dbg.run.desktop")        private var runDesktop = true
     @AppStorage("dbg.run.documents")      private var runDocuments = true
     @AppStorage("dbg.run.notes")          private var runNotes = false
+    @AppStorage("dbg.run.appleMail")      private var runAppleMail = false
     @AppStorage("dbg.run.whatsapp")       private var runWhatsApp = false
     @AppStorage("dbg.run.imessage")       private var runIMessage = false
     @AppStorage("dbg.whatsapp.chats")     private var whatsappCSV = ""
@@ -90,6 +91,9 @@ struct OnboardingReadyView: View {
                                      detail: imessageChats.isEmpty ? nil : "\(imessageChats.count) chats",
                                      on: runIMessage && !imessageChats.isEmpty) { showIMessagePicker = true }
                         SettingsChip(label: "Apple Notes", on: runNotes) { runNotes.toggle() }
+                        if AppleMailSource.isInstalled {
+                            SettingsChip(label: "Apple Mail", on: runAppleMail) { runAppleMail.toggle() }
+                        }
                     }
                 }
                 SettingsGroup(label: "Through Your ChatGPT") {

--- a/Sentient OS macOS/Views/ProcessingView.swift
+++ b/Sentient OS macOS/Views/ProcessingView.swift
@@ -27,6 +27,7 @@ enum RunSource: Hashable {
     case whatsapp(chatJIDs: Set<String>)    // the opt-in chats to analyze
     case imessage(chatGUIDs: Set<String>)   // the opt-in chats to analyze
     case notes                              // all notes (newest-1000 cap inside the source)
+    case appleMail                          // all Mail accounts (newest-2000 cap inside the source)
 
     var label: String {
         switch self {
@@ -34,11 +35,12 @@ enum RunSource: Hashable {
         case .whatsapp:        return "WhatsApp"
         case .imessage:        return "iMessage"
         case .notes:           return "Apple Notes"
+        case .appleMail:       return "Apple Mail"
         }
     }
 
     /// Map a source selection to the iterative-core connectors. File roots collapse into ONE
-    /// FilesConnector (it pages each root itself); chats/Notes each become their own connector.
+    /// FilesConnector (it pages each root itself); chats/Notes/Mail each become their own connector.
     /// Shared by the home "Analyze Now" and the dev "start on device" buttons so both run the exact
     /// same engine over the same picks.
     static func connectors(from sources: [RunSource]) -> [any Connector] {
@@ -49,6 +51,7 @@ enum RunSource: Hashable {
             case .whatsapp(let jids):  connectors.append(WhatsAppConnector(chatJIDs: jids))
             case .imessage(let guids): connectors.append(iMessageConnector(chatGUIDs: guids))
             case .notes:               connectors.append(NotesConnector())
+            case .appleMail:           connectors.append(MailConnector())
             case .files:               break   // rolled into FilesConnector(roots:)
             }
         }

--- a/Sentient OS macOS/Views/Settings/SourcesPane.swift
+++ b/Sentient OS macOS/Views/Settings/SourcesPane.swift
@@ -18,6 +18,7 @@ struct SourcesPane: View {
     @AppStorage("dbg.run.desktop")   private var runDesktop = true
     @AppStorage("dbg.run.documents") private var runDocuments = true
     @AppStorage("dbg.run.notes")     private var runNotes = false
+    @AppStorage("dbg.run.appleMail")  private var runAppleMail = false
     @AppStorage("dbg.run.whatsapp")  private var runWhatsApp = false
     @AppStorage("dbg.whatsapp.chats") private var whatsappCSV = ""
     @AppStorage("dbg.run.imessage")  private var runIMessage = false
@@ -122,6 +123,9 @@ struct SourcesPane: View {
                              detail: imessageChats.isEmpty ? nil : "\(imessageChats.count) chats",
                              on: runIMessage && !imessageChats.isEmpty) { showIMessagePicker = true }
                 SettingsChip(label: "Apple Notes", on: runNotes) { toggleConnector($runNotes) }
+                if AppleMailSource.isInstalled {
+                    SettingsChip(label: "Apple Mail", on: runAppleMail) { toggleConnector($runAppleMail) }
+                }
             }
         }
     }


### PR DESCRIPTION
## What & why

Apple Mail is now a fully-wired privacy-first knowledge source. It reads Mail's local Envelope Index + `.emlx` body files, feeds them through the on-device triage model, and produces keeper/junk verdicts just like Notes, iMessage, and WhatsApp — **no cloud, no account-linking sheet**, fully on-device like the other local sources.

The key difference from Gmail/Calendar: those ride the Codex cloud connector because there's no local store. Mail keeps everything on disk, so it's a natural fit for the privacy-first local-source family.

## New files

- **`Sources/AppleMailSource.swift`** — Envelope Index reader. One email = one Candidate keyed on received date (so a re-delivered message is never re-summarized). Builds a `ROWID → .emlx path` index by walking the store tree once per run.
- **`Sources/EMLXParser.swift`** — pure MIME parser: bytecount framing, multipart walking, quoted-printable/base64/7bit decoding, HTML detagging, charset handling, RFC 2047 encoded-word headers, zero-width tracking-char stripping. Fail-closed: any decode failure → nil body → the model judges from envelope metadata alone.
- **`Ingestion/Connectors/MailConnector.swift`** — thin Connector adapter (single `"mail"` bucket), same shape as NotesConnector.
- **`Documentation/Apple Mail Source (Envelope Index).md`** — one-doc-per-source, records the V10 schema facts and the `.emlx` decode recipe.

## Wiring (surgical)

- `DataSource.swift` — `case appleMail` in SourceKind
- `ProcessingView.swift` — `case appleMail` in RunSource + `connectors(from:)`
- `SourceSelection.swift` — counts toward the 4-source minimum + included in `current()`
- `SourcesPane.swift` — "Apple Mail" chip (shown only when `isInstalled`)
- `IterativeRun.swift` — added to the FDA-probe list
- `Triage.swift` — mail-flavored triage prompt (ruthless junk-default, third-person attribution, quoted-reply history treated as context not new facts)
- `HomePopovers.swift` — Apple Mail chip in the Analysis popover Sources row
- `DevToolsView.swift` — Apple Mail chip in the source picker grid
- `OnboardingReadyView.swift` — Apple Mail chip in Chats & Notes group

## The V10 schema (verified live on macOS 27 / Exchange EWS)

⚠️ The Envelope Index has drifted hard from the V2–V7 era most reverse-engineering docs describe. I measured these on a live V10 store rather than assuming the old layout:

- **`messages.ROWID` IS the `.emlx` filename** (there's no `uid` column at all — Exchange stores a base64 `remote_id`, IMAP a numeric one, neither maps to the filename).
- **`messages.sender` → `addresses.ROWID` directly.** The `senders`/`sender_addresses` tables exist but are a separate reputation/bucketing system, not the FK.
- **Dedicated `read`/`flagged`/`deleted` boolean columns** — not the jwz bit-flag layout from the `.emlx` plist era.
- **Dates are Unix epoch seconds**, not Apple's 2001-01-01 reference date (`1784591689` → 2026-07-20; using the Apple epoch yields 2057).
- **Three URL schemes:** `ews://`, `imap://`, `local://`. EWS names its junk folder "Junk Email" and trash "Deleted Items" — the exclude set covers both naming schemes.

## Tested

- **10/10** recent Inbox messages extracted clean bodies from a real Exchange/EWS mailbox (Cloudflare, GitHub PR notifications, Claude Team, AppleSeed).
- **11/11** synthetic `.emlx` format tests: plain 7bit, quoted-printable, base64, both multipart shapes (alternative → plain wins, mixed → attachments skipped), HTML detagging, folded headers, entity decoding, fail-closed truncation.
- **32,934** `.emlx` files indexed from the live V10 store walk.

## Notes

- No project-file surgery — new files join via the synchronized file groups, per CONTRIBUTING.
- Signing hygiene verified: zero `DEVELOPMENT_TEAM` lines in the pbxproj.
- Happy to add a screen recording of the running source if that helps review.

## Follow-ups (not in this PR)

- User-configurable filters ("ignore everything from X / matching Y") via a CustomInstructions hook into the mail prompt.
- Per-account / per-mailbox opt-in picker like the chat sources, instead of all-or-nothing.