### PR TITLE
Self-heal the Computer Use Automation grant on every fire (fixes list_apps hang)

### DIFF
--- a/Sentient OS macOS/Cloud/CodexCLI.swift
+++ b/Sentient OS macOS/Cloud/CodexCLI.swift
@@ -460,6 +460,11 @@ actor CodexCLI {
             // re-bootstrap) lays a fresh STOCK SKILL.md, whose policy stalls headless runs on
             // "shall I proceed?" questions nothing can answer. Cheap file check, idempotent.
             ComputerUseSkillPatch.ensureApplied()
+            // Self-heal the Automation grant (Sentient → Codex Computer Use over Apple Events) too:
+            // if it's missing, the very first MCP call (`list_apps`) blocks forever. The gate also
+            // heals this on every intercept, but `runAgentCommand` is the load-bearing seam — every
+            // fire reaches it, and defense-in-depth here costs one indexed TCC SELECT.
+            Permissions.selfHealComputerUseAutomation(context: "CodexCLI.runAgentCommand")
             var args = ["exec", "--dangerously-bypass-approvals-and-sandbox",
                         "-m", model.rawValue,
                         "-c", "model_reasoning_effort=\"\(effort.rawValue)\""]

--- a/Sentient OS macOS/Views/Permissions/ComputerUseGate.swift
+++ b/Sentient OS macOS/Views/Permissions/ComputerUseGate.swift
@@ -89,6 +89,12 @@ final class ComputerUseGate {
     ///     optional nudge never eats what the user fired.
     func intercept(_ action: @escaping @MainActor () -> Void) -> Bool {
         refresh()
+        // The executor also needs the Automation grant (Sentient → the helper over Apple Events);
+        // it's user-invisible and FDA-writable, so heal it on EVERY fire — not just when this window
+        // shows. Without this, a previously-working setup whose grant got dropped (a Sentient rebuild
+        // with new signing, a ChatGPT.app/plugin update, an OS update) hangs at `list_apps` forever,
+        // because the fast-return path below never reaches the old `present()`-site self-heal.
+        Permissions.selfHealComputerUseAutomation(context: "ComputerUseGate")
         let blocking = !allRequiredGranted
         if !blocking {
             // Seen working — arm the home's regression banner (HealthCaution rung ③).
@@ -188,9 +194,6 @@ final class ComputerUseGate {
     // Sidekick fires from anywhere; a SwiftUI Window scene can't be raised from the coordinator)
 
     private func present() {
-        // The executor also needs the Automation grant (Sentient → the helper over Apple Events);
-        // it's user-invisible and FDA-writable, so heal it here — before the first fire.
-        Permissions.selfHealComputerUseAutomation(context: "ComputerUseGate")
         if window == nil {
             let hosting = NSHostingController(rootView: ComputerUseGateView(gate: self))
             let w = NSWindow(contentViewController: hosting)


### PR DESCRIPTION
## Summary

A previously-working setup whose Automation grant (Sentient → Codex Computer Use helper over Apple Events) gets dropped — e.g. after a Sentient rebuild with new signing, a ChatGPT.app/plugin update, or an OS update — hangs at the first MCP call `list_apps` forever, because nothing re-requests the grant before the call blocks.

- In `CodexCLI.runAgentCommand`: self-heal the Automation grant before exec. This is the load-bearing seam — every fire reaches it — and the cost is one indexed TCC `SELECT`. Defense-in-depth alongside the gate.
- In `ComputerUseGate.intercept`: move the existing `selfHealComputerUseAutomation` call out of `present()` (which only runs when the gate window is shown) to the top of `intercept()` (which runs on every fire). Without this, the fast-return path for an otherwise-granted setup never reaches the old heal site.

## Test plan

- [ ] Reproduce the hang locally: revoke the Sentient → Codex helper Automation grant, fire any sidekick action. Before this change, the run stalls on `list_apps`. After, the grant is re-requested and the run proceeds.
- [ ] Verify a healthy setup (grant already present) still fires with no new prompts — the heal is a no-op when the grant exists.
- [ ] Confirm the gate window still heals on first present for fresh installs.