### PR TITLE
dev ui quality of life

### DIFF
--- a/Sentient OS macOS/Views/Onboarding/OnboardingView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingView.swift
@@ -147,11 +147,11 @@ struct OnboardingView: View {
         // DEV-ONLY: skip straight to the home (testing relaunches land back in onboarding until
         // a full first analysis flips the flag). Quietly marks onboarding complete — deliberately
         // NOT onFinished, so the Constellation finale stays reserved for the real finish.
-        // Compile-gated out of Release entirely. Hidden on step 0 (the film webview) — the film
-        // is meant to read as a native screen, not a page with dev chrome floating over it.
+        // Compile-gated out of Release entirely. On EVERY step including the film (step 0) — a dev
+        // relaunching into onboarding shouldn't have to sit through the film to reach the handle.
         #if DEBUG
         .overlay(alignment: .bottomTrailing) {
-            if !analyzing && step > 0 {
+            if !analyzing {
                 Button {
                     withAnimation(.easeInOut(duration: 0.3)) { appState.hasCompletedOnboarding = true }
                 } label: {


### PR DESCRIPTION
Shows the DEBUG-only **SKIP TO HOME** handle on the onboarding film screen (step 0) too — previously it was gated behind `step > 0`, so a dev relaunching into onboarding had to sit through the film first.

- Still `#if DEBUG` — compiled out of Release entirely, invisible to users.
- Still hidden over the analysis takeover.
- One-line condition change (`!analyzing && step > 0` → `!analyzing`) plus a comment refresh.