### PR TITLE
Move Codex detection off CodexSetup's singleton initializer (launch hardening)

### DIFF
--- a/Sentient OS macOS/Cloud/CodexSetup.swift
+++ b/Sentient OS macOS/Cloud/CodexSetup.swift
@@ -13,7 +13,7 @@
 //  bootstrap runs through ComputerUseSetup; this file owns the flow.
 //
 //  Key methods:
-//   - refreshInstalled()   → re-detect whether the codex binary is present
+//   - refreshInstalled()   → re-detect whether the codex binary is present (async, off-main)
 //   - installCodex()       → step 1: run OpenAI's installer (ALWAYS runs — it doubles as the
 //                            updater over an existing install; streams progress)
 //   - startLogin/confirmLogin → step 2: interactive `codex login` (browser) + confirm
@@ -33,19 +33,33 @@ final class CodexSetup {
     /// One shared instance so onboarding and the dev tools observe the same setup state.
     static let shared = CodexSetup()
 
-    private init() {}
+    private init() {
+        // Warm up `installed` off the main thread. Kicking a Task here is safe: it's enqueued, so
+        // this initializer returns and the singleton's `dispatch_once` completes before the probe
+        // ever runs — and the probe does its disk/shell work off the main actor. Detection must
+        // NEVER run synchronously inside this initializer (see `installed`).
+        Task { await refreshInstalled() }
+    }
 
     // MARK: Step 1 — install
 
     /// Is the Codex CLI binary present on disk? (NOT whether it's logged in — that's step 2.)
-    private(set) var installed: Bool = CodexCLI.locateBinary() != nil
+    /// Starts `false`; warmed up asynchronously OFF the main thread by `init`. This must NEVER be
+    /// computed inside this singleton's lazy initializer: `locateBinary()`'s last-resort fallback
+    /// spawns a login shell (a blocking `Process`), and inside the `@MainActor` `dispatch_once`
+    /// that lets `waitUntilExit` pump the main runloop and re-enter the same once-block — a
+    /// recursive-lock trap. Detection stays off the initializer, always.
+    private(set) var installed: Bool = false
     /// An install is currently running (drives the spinner + disables the button).
     private(set) var installing = false
     /// Latest streamed progress line, or the final ✓/✗ result.
     private(set) var installStatus: String?
 
-    /// Cheap re-detect of step 1's status — call on appear and after an install.
-    func refreshInstalled() { installed = CodexCLI.locateBinary() != nil }
+    /// Cheap re-detect of step 1's status — call on appear and after an install. Runs the probe
+    /// off the main thread (`locateBinary()` can spawn a login shell), so it never blocks the UI.
+    func refreshInstalled() async {
+        installed = await Task.detached { CodexCLI.locateBinary() != nil }.value
+    }
 
     /// One successful installer run already happened this launch — the once-per-launch guard for
     /// the onboarding screen's update kick (a second run would just re-resolve the same release).
@@ -163,7 +177,7 @@ final class CodexSetup {
             computerUseStatus = "✓ Computer use already set up"
             return
         }
-        refreshInstalled()   // fresh probe, not the cached flag — the user may have installed codex themselves
+        await refreshInstalled()   // fresh probe, not the cached flag — the user may have installed codex themselves
         guard installed else { computerUseStatus = "✗ Install the Codex CLI first"; return }
         settingUpComputerUse = true
         computerUseStatus = force ? "Re-installing…" : "Starting…"
@@ -212,7 +226,7 @@ final class CodexSetup {
     /// "just run all three in order" driver can ignore it because every action (installCodex /
     /// startLogin / setupComputerUse) already self-guards and no-ops when its step is done.
     func whatsNeeded() async -> [Step] {
-        refreshInstalled()
+        await refreshInstalled()
         await refreshLoginStatus()
         refreshComputerUse()
         var pending: [Step] = []

--- a/Sentient OS macOS/Views/CodexSetupView.swift
+++ b/Sentient OS macOS/Views/CodexSetupView.swift
@@ -42,8 +42,8 @@ struct CodexSetupView: View {
         .frame(width: 560, height: 640)
         .background(Theme.bg)
         .onAppear {
-            codex.refreshInstalled()
             codex.refreshComputerUse()
+            Task { await codex.refreshInstalled() }
             Task { await codex.refreshLoginStatus() }
         }
     }

--- a/Sentient OS macOS/Views/Onboarding/OnboardingCodexSteps.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingCodexSteps.swift
@@ -82,15 +82,17 @@ struct OnboardingCodexLoginView: View {
         }
         .padding(40)
         .onAppear {
-            codex.refreshInstalled()
-            Task { await codex.refreshLoginStatus() }
-            // Two nets in one kick: no binary (the launch kick failed or skipped a half-deleted
-            // setup) → install; binary present but the installer hasn't run this launch (the
-            // launch kick deliberately skips USED setups) → run it anyway, because the installer
-            // doubles as the updater and setup should hand the latest CLI to the later steps.
-            if !codex.installing && (!codex.installed || !codex.ranInstallerThisLaunch) {
-                Task { await codex.installCodex() }
+            Task {
+                await codex.refreshInstalled()
+                // Two nets in one kick: no binary (the launch kick failed or skipped a half-deleted
+                // setup) → install; binary present but the installer hasn't run this launch (the
+                // launch kick deliberately skips USED setups) → run it anyway, because the installer
+                // doubles as the updater and setup should hand the latest CLI to the later steps.
+                if !codex.installing && (!codex.installed || !codex.ranInstallerThisLaunch) {
+                    await codex.installCodex()
+                }
             }
+            Task { await codex.refreshLoginStatus() }
         }
         .task {
             // The confirmation poll: run `codex --help` now, then every 2s until it answers —
@@ -98,7 +100,7 @@ struct OnboardingCodexLoginView: View {
             // path this succeeds on the first try and the button is never seen greyed.
             while !Task.isCancelled {
                 if await CodexCLI.isRunnable() {
-                    codex.refreshInstalled()   // align the shared engine's flag
+                    await codex.refreshInstalled()   // align the shared engine's flag
                     withAnimation(.easeInOut(duration: 0.3)) { codexConfirmed = true }
                     return
                 }

--- a/Sentient OS macOS/Views/Settings/HealthPane.swift
+++ b/Sentient OS macOS/Views/Settings/HealthPane.swift
@@ -482,7 +482,7 @@ struct HealthPane: View {
         refreshMicSpeech()
         screenRec = Permissions.hasScreenRecording()
         notifStatus = await UNUserNotificationCenter.current().notificationSettings().authorizationStatus
-        codex.refreshInstalled()
+        await codex.refreshInstalled()
         codex.refreshComputerUse()
         plan = CodexAuth.currentPlan()   // pure file read (the JWT claim on disk)
         if fdaGranted {


### PR DESCRIPTION
## Summary

Hardens app launch against a main-thread re-entrancy in `CodexSetup`.

`CodexSetup.installed` computed `CodexCLI.locateBinary()` inside the shared singleton's **lazy initializer**. On a Mac with no codex binary on disk, `locateBinary()` exhausts its known paths and falls through to a login-shell probe (`whichViaLoginShell` → a blocking `Process.waitUntilExit()`). Run on the main thread inside the singleton's `dispatch_once`, that call pumps the main run loop, which can dispatch another main-actor job that touches `CodexSetup.shared` again — re-entering the still-running `dispatch_once` on the same thread, which libdispatch aborts (`EXC_BREAKPOINT`, "trying to lock recursively"). Because a fresh Mac has no cached binary path, this lands squarely on first-run / onboarding.

## The fix

- `installed` starts `false` and is **warmed up asynchronously, off the main thread** (`init` enqueues a `Task`, so the initializer returns and the `dispatch_once` completes before any probe runs).
- `refreshInstalled()` is now `async` and runs the probe via `Task.detached`, so `locateBinary()`'s login-shell fallback never executes on the main thread. This also removes a latent main-thread stall the same call could cause on view appear.
- All six `refreshInstalled()` call sites updated to `await`; the onboarding install decision reads a fresh value inside the same task, preserving existing behavior.

**Invariant going forward:** never run blocking work inside `CodexSetup`'s initializer — detection stays off the once-block.

## Why it's safe (no stale-flag regressions)

- The home health banner (`HealthCaution.probe`) reads `CodexCLI.locateBinary()` directly, **not** `CodexSetup.installed`, so it's unaffected.
- `RootView`/`ProcessingView`/`HomeView` don't gate on `installed`. The only readers (dev tools, Settings → Health, onboarding, and the post-`installCodex` check) either await a fresh probe or aren't launch-critical.
- The remaining stored-property initializer in the once-block (`computerUseReady = ComputerUseSetup.isInstalled`) is pure file-existence checks — no `Process`, no run-loop pump.

## Verification

- Clean isolated build: **BUILD SUCCEEDED**, 0 errors, 0 new warnings on changed lines.
- Full read-through of every launch-time reader of the codex setup flags (see "Why it's safe").
- Note: not runtime-reproduced — the trigger is timing-dependent (fresh Mac, no codex on disk). The change removes the precondition structurally rather than patching timing. Suggested manual check when a no-codex machine is available: launch onboarding and confirm it survives past the first ~2 seconds.

Fixes #269.