### PR TITLE
Codex install resilience: patient retries + honest manual-install fallback

### DIFF
--- a/Sentient OS macOS/App/AppState.swift
+++ b/Sentient OS macOS/App/AppState.swift
@@ -138,16 +138,11 @@ final class AppState {
                     Log("Onboarding: ~/.codex is a real setup — skipping the background codex install")
                     return
                 }
-                // OpenAI's installer fails transiently (its GitHub-JSON parsing flaps per
-                // request), so one attempt isn't enough: retry with a 10s gap while the user is
-                // still on the slides/perms. A retried flap usually succeeds on the next try.
-                for attempt in 1...4 {
-                    await CodexSetup.shared.installCodex()
-                    if CodexSetup.shared.installed { return }
-                    Log("Onboarding: codex install attempt \(attempt) failed — retrying in 10s")
-                    try? await Task.sleep(for: .seconds(10))
-                }
-                Log("Onboarding: codex install still failing after 4 attempts — the login screen's re-kick is the remaining net")
+                // OpenAI's installer fails transiently (its GitHub-JSON parsing flaps per request),
+                // so one attempt isn't enough. The retry policy + the give-up flag live in
+                // CodexSetup.ensureInstalled — ONE source of truth the onboarding screen drives too;
+                // a give-up surfaces the "install it yourself" panel on the codex screen.
+                await CodexSetup.shared.ensureInstalled()
             }
         }
     }

--- a/Sentient OS macOS/Cloud/CodexCLI.swift
+++ b/Sentient OS macOS/Cloud/CodexCLI.swift
@@ -244,9 +244,16 @@ actor CodexCLI {
     /// (verified end-to-end); it's harmless on the script's binary downloads. Drop the sed once
     /// OpenAI fixes install.sh.
     static func install(onLine: @escaping @Sendable (String) -> Void) async throws {
-        let pipeline = #"curl -fsSL https://chatgpt.com/codex/install.sh | sed 's|curl -fsSL|curl -fsSL -H "Accept: application/json"|g' | CODEX_NON_INTERACTIVE=1 sh"#
+        // Survive a slow connection, fail fast on a dead one. The outer curl (the tiny install.sh)
+        // caps at 60s; the sed injects matching resilience into the script's OWN curl calls (the
+        // real binary download): abort only if throughput stays under ~8 KB/s for 30s, so a
+        // stalled transfer dies in seconds instead of burning the whole budget while a slow-but-
+        // moving download keeps going. The outer timeout is generous (15 min) so a genuinely slow
+        // link can finish — the old 300s ceiling was SIGTERM-ing in-progress downloads on slow
+        // connections [MEASURED from install traces, 2026-07-24].
+        let pipeline = #"curl -fsSL --connect-timeout 30 --max-time 60 https://chatgpt.com/codex/install.sh | sed 's|curl -fsSL|curl -fsSL -H "Accept: application/json" --connect-timeout 30 --speed-limit 8192 --speed-time 30|g' | CODEX_NON_INTERACTIVE=1 sh"#
         let out = try await executeStreaming(binary: "/bin/sh", args: ["-c", pipeline],
-                                             timeout: 300, onLine: onLine)
+                                             timeout: 900, onLine: onLine)
         UserDefaults.standard.removeObject(forKey: pathCacheKey)   // force a fresh discovery scan
         guard locateBinary() != nil else {
             let detail = out.stderr.isEmpty ? out.stdout : out.stderr

--- a/Sentient OS macOS/Cloud/CodexSetup.swift
+++ b/Sentient OS macOS/Cloud/CodexSetup.swift
@@ -54,11 +54,16 @@ final class CodexSetup {
     private(set) var installing = false
     /// Latest streamed progress line, or the final ✓/✗ result.
     private(set) var installStatus: String?
+    /// True once install RETRIES are exhausted and codex still isn't on disk — drives onboarding's
+    /// "install it yourself" panel. Reset when a fresh `ensureInstalled` run begins; any positive
+    /// detection (`refreshInstalled`) clears it.
+    private(set) var installGaveUp = false
 
     /// Cheap re-detect of step 1's status — call on appear and after an install. Runs the probe
     /// off the main thread (`locateBinary()` can spawn a login shell), so it never blocks the UI.
     func refreshInstalled() async {
         installed = await Task.detached { CodexCLI.locateBinary() != nil }.value
+        if installed { installGaveUp = false }
     }
 
     /// One successful installer run already happened this launch — the once-per-launch guard for
@@ -92,6 +97,28 @@ final class CodexSetup {
             stepFailed(.install, error, binaryFound: installed)   // "installer ran, binary missing" if false
         }
         installing = false
+    }
+
+    /// Install with retries; flip `installGaveUp` when the budget is spent and codex still isn't
+    /// here. The ONE place the install RETRY policy lives — both the launch kick (AppState) and the
+    /// onboarding screen drive this, so there's no second, divergent loop. A no-op if codex is
+    /// already present or an install is already running. Each attempt is patient (900s + curl
+    /// speed-limits in CodexCLI.install), so a slow download finishes on the first try; fast-failing
+    /// causes (no network, connection reset, region block) exhaust the retries in a couple minutes
+    /// and surface the "install it yourself" panel.
+    func ensureInstalled(attempts: Int = 3) async {
+        guard !installed, !installing else { return }
+        installGaveUp = false
+        for attempt in 1...attempts {
+            await installCodex()
+            if installed { return }
+            if attempt < attempts {
+                Log("CodexSetup: install attempt \(attempt) failed — retrying in 10s")
+                try? await Task.sleep(for: .seconds(10))
+            }
+        }
+        installGaveUp = !installed
+        if installGaveUp { Log("CodexSetup: install gave up after \(attempts) attempts — surfacing the manual-install panel") }
     }
 
     // MARK: Step 2 — auth (codex login)

--- a/Sentient OS macOS/Views/Onboarding/OnboardingCodexSteps.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingCodexSteps.swift
@@ -55,6 +55,11 @@ struct OnboardingCodexLoginView: View {
                             .kerning(1.5)
                             .foregroundStyle(Theme.faint)
                     }
+                } else if codex.installGaveUp && !codex.installed {
+                    // The auto-install couldn't finish (no network, connection reset, or Codex is
+                    // unavailable in this region). Point the user to install it themselves; the
+                    // `.task` poll below picks Codex up automatically the moment it lands.
+                    CodexInstallFailedPanel()
                 } else {
                     // The login button — greyed until `codex --help` confirms the install landed.
                     OnboardingNextButton(title: "Log in with ChatGPT", enabled: codexConfirmed) {
@@ -84,11 +89,13 @@ struct OnboardingCodexLoginView: View {
         .onAppear {
             Task {
                 await codex.refreshInstalled()
-                // Two nets in one kick: no binary (the launch kick failed or skipped a half-deleted
-                // setup) → install; binary present but the installer hasn't run this launch (the
-                // launch kick deliberately skips USED setups) → run it anyway, because the installer
-                // doubles as the updater and setup should hand the latest CLI to the later steps.
-                if !codex.installing && (!codex.installed || !codex.ranInstallerThisLaunch) {
+                // No binary (the launch kick failed or skipped a half-deleted setup) → retry via
+                // ensureInstalled, which surfaces the manual-install panel if it gives up. Binary
+                // already present but the installer hasn't run this launch → run it anyway (it
+                // doubles as the updater, handing the latest CLI to the later steps).
+                if !codex.installed {
+                    await codex.ensureInstalled()
+                } else if !codex.ranInstallerThisLaunch {
                     await codex.installCodex()
                 }
             }
@@ -124,6 +131,46 @@ struct OnboardingCodexLoginView: View {
 }
 
 // MARK: - Shared onboarding bits
+
+/// Shown on the Codex step when the automatic install has clearly failed (retries exhausted):
+/// no network, a connection reset, or Codex being unavailable in the user's region. It points the
+/// user to install Codex themselves; the step's `codex --help` poll picks it up the moment it
+/// lands, and a relaunch resumes right here (onboarding persists its step). Copy approved 2026-07-24.
+private struct CodexInstallFailedPanel: View {
+    private let guideURL = URL(string: "https://learn.chatgpt.com/docs/codex/cli#getting-started")!
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("Sentient couldn't finish installing Codex automatically.")
+                .font(.system(size: 15))
+                .foregroundStyle(Theme.Ink.body)
+                .multilineTextAlignment(.center)
+
+            Text("You can install it yourself in a minute. Once you do that, you can restart Sentient and pick up right where you left off.")
+                .font(.system(size: 13))
+                .foregroundStyle(Theme.secondary)
+                .multilineTextAlignment(.center)
+                .lineSpacing(3)
+
+            OnboardingNextButton(title: "Open the Codex install guide") {
+                NSWorkspace.shared.open(guideURL)
+            }
+            .padding(.top, 4)
+
+            Text("We also suggest connecting through a VPN.")
+                .font(.system(size: 12.5))
+                .foregroundStyle(Theme.secondary)
+                .multilineTextAlignment(.center)
+
+            Text("Codex isn't available in a few countries.")
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .kerning(0.5)
+                .foregroundStyle(Theme.faint)
+                .padding(.top, 2)
+        }
+        .frame(maxWidth: 460)
+    }
+}
 
 /// The monospace-caps whisper label every onboarding screen opens with.
 struct OnboardingWhisper: View {


### PR DESCRIPTION
## What

Hardens the onboarding Codex-CLI install so a slow or unavailable network can no longer leave the user staring at an endless "installing Codex in the background" spinner. When the install genuinely can't complete, onboarding now shows a clear next step instead of hanging.

## Changes

- **`CodexCLI.install`** — network resilience on the installer pipeline: a connect-timeout on the `install.sh` fetch, plus a throughput floor (`--speed-limit` / `--speed-time`) injected into the script's own binary download, so a *stalled* transfer fails fast (~30s) while a *slow-but-moving* one still finishes. Overall per-attempt budget raised 300s → 900s so a genuinely slow link can complete (the old ceiling was cutting off in-progress downloads).
- **`CodexSetup.ensureInstalled(attempts:)`** — the single source of truth for the install retry policy, plus an `installGaveUp` flag. Both the launch-time kick (`AppState`) and the onboarding screen drive this one method, so there's no second, divergent retry loop.
- **`OnboardingCodexSteps`** — a terminal `CodexInstallFailedPanel` shown once retries are exhausted: a link to the official Codex install guide, a VPN suggestion, and a note that Codex isn't available in a few regions. The step's existing `codex --help` poll picks the CLI up automatically the moment it lands, and onboarding resumes right here on relaunch.

## Notes

- Sits on top of the launch-hardening from #285 (retains the off-main `refreshInstalled`) and the current computer-use bootstrap from #289 — no changes to either.
- Addresses the "stuck installing Codex" onboarding reports.
- Compile-verified (isolated `derivedDataPath`). A live onboarding smoke test on a throttled/blocked network is the remaining follow-up before we consider it fully closed.