### PR TITLE
Codex discovery: the managed install takes precedence over any cached path

### DIFF
--- a/Sentient OS macOS/Cloud/CodexCLI.swift
+++ b/Sentient OS macOS/Cloud/CodexCLI.swift
@@ -11,7 +11,7 @@
 //  the doc below).
 //
 //  Key methods:
-//   - CodexCLI.locateBinary()  → cached absolute-path discovery (known paths + zsh -lc which)
+//   - CodexCLI.locateBinary()  → binary discovery (managed install first, then cache/known paths/which)
 //   - install(onLine:)         → run OpenAI's standalone installer (the codex-setup onboarding step)
 //   - startLogin / loginStatus → step 2: interactive `codex login` (browser) + the status check
 //   - validate(force:)         → Availability via ping (only a good verdict is cached)
@@ -185,17 +185,24 @@ actor CodexCLI {
 
     private static let pathCacheKey = "codexcli.binaryPath"
 
-    /// Known install locations, then a login-shell `which` (GUI apps don't inherit the user's
-    /// PATH). The result is cached in UserDefaults and re-verified on every read.
+    /// The managed install first (unconditionally), then known locations, then a login-shell
+    /// `which` (GUI apps don't inherit the user's PATH). Discovery results are cached in
+    /// UserDefaults and re-verified on every read.
     static func locateBinary() -> String? {
         let fm = FileManager.default
+        let home = fm.homeDirectoryForCurrentUser.path
+        // The standalone installer's symlink — the ONE copy our installer keeps current — wins
+        // over everything, INCLUDING the cache: on a Mac that also has a brew/npm codex, a cached
+        // brew path would otherwise field every run with a stale binary while the fresh install
+        // sat unused. `isExecutableFile` resolves the symlink, so a dangling link (e.g. a wiped
+        // `~/.codex/packages`) falls through to the fallbacks instead of being returned.
+        let managed = "\(home)/.local/bin/codex"
+        if fm.isExecutableFile(atPath: managed) { return managed }
         if let cached = UserDefaults.standard.string(forKey: pathCacheKey),
            fm.isExecutableFile(atPath: cached) {
             return cached
         }
-        let home = fm.homeDirectoryForCurrentUser.path
         var known = [
-            "\(home)/.local/bin/codex",        // the standalone installer's symlink
             "/opt/homebrew/bin/codex",         // brew / npm -g (Apple Silicon)
             "/usr/local/bin/codex",
         ]


### PR DESCRIPTION
## What

`CodexCLI.locateBinary()` now checks the managed install location (`~/.local/bin/codex`, the standalone installer's symlink) unconditionally FIRST — before the UserDefaults path cache and the other known locations.

## Why

On a Mac that also has a brew/npm codex, discovery could cache that other path and then return it forever — so every run went through a binary our installer never updates, while the fresh, current CLI sat unused at `~/.local/bin`. Symptoms ranged from codex's models-cache error line appearing in the notch (#268) to computer-use tasks failing in-app while codex worked fine from Terminal (#263): the terminal was resolving the new binary, Sentient the old one.

The managed install is the one copy our setup engine keeps current, so it must always win when present. `isExecutableFile` resolves the symlink, so a dangling link (a wiped install target) falls through to the cache/known-path/login-shell-`which` fallbacks unchanged — brew-only Macs resolve exactly as before.

Part of the fix for #268 / #263; a follow-up adds keeping the managed CLI itself current post-onboarding.

## Test plan

- [x] Headless 8-scenario harness of the new resolution order (real filesystem fixtures): managed beats a cached brew path · dangling managed symlink falls back to a valid cache · brew-only Mac resolves and caches · a stale cache is never returned · clean-Mac managed hit writes no needless cache entry · the installer's real managed-symlink shape wins over the cache. All pass.
- [x] Clean build (isolated DerivedData).
- [ ] On-hardware sanity: with both a brew codex and the managed install present, a Sidekick/command run invokes `~/.local/bin/codex`.