### PR TITLE
Docs true-up: codex discovery precedence + model-download disk preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Download the DMG from [the latest release](https://github.com/Sentient-OS-Labs/s
 brew install --cask sentient-os-labs/tap/sentient-os
 ```
 
-You'll need an Apple Silicon Mac (M1 or newer) on macOS 15 or later. 8 GB of RAM is enough; we tuned the on-device model until it fit.
+You'll need an Apple Silicon Mac (M1 or newer) on macOS 15 or later. 8 GB of RAM is enough; we tuned the on-device model until it fit. Keep about 10 GB of disk free before you start: the on-device model is a 3.7 GB download, and it needs room to land.
 
 One requirement: the full version of Sentient runs its cloud compute through your own ChatGPT Plus subscription (about $20 a month, paid to OpenAI, not to us). That's not a catch, that's the architecture: your Mac does about 90% of the compute, your frontier model covers the rest, and that's how Sentient stays free with a straight face. A free ChatGPT account still gets the preview tier: the overnight reading, the knowledge base, the Knowledge window, and the MCP mirror.
 
@@ -204,7 +204,7 @@ And when you want out entirely: one click in Settings wipes the cloud copy and r
 <summary><b>What Macs does it run on?</b></summary>
 <br/>
 
-Apple Silicon (M1 or newer) on macOS 15 or later. 8 GB of RAM is enough; the on-device model has inference optimizations to work in it.
+Apple Silicon (M1 or newer) on macOS 15 or later. 8 GB of RAM is enough; the on-device model has inference optimizations to work in it. You'll also want about 10 GB of free disk space when you first set it up, since the on-device model is a 3.7 GB download.
 
 </details>
 

--- a/Sentient OS macOS/Documentation/CodexCLI (codex exec Compute Spine).md
+++ b/Sentient OS macOS/Documentation/CodexCLI (codex exec Compute Spine).md
@@ -17,11 +17,19 @@ plumbing).
 
 ## Surface
 
-- `CodexCLI.locateBinary()` — known paths (`~/.local/bin/codex`, `/opt/homebrew/bin/codex`,
-  `/usr/local/bin/codex`), then every nvm-managed node version's `bin/codex` (newest first —
-  npm-under-nvm hides the binary in a versioned dir), then a login `zsh -lic "which codex"`
-  (interactive — `.zshrc` is where nvm/asdf init; `-lc` alone never sources it). Cached in
-  UserDefaults (`codexcli.binaryPath`), re-verified on every read.
+- `CodexCLI.locateBinary()` — the **managed install first, unconditionally**:
+  `~/.local/bin/codex` (the standalone installer's symlink — the one copy our setup engine keeps
+  current) wins over everything including the cache whenever it's executable
+  (`isExecutableFile` resolves the symlink, so a dangling link falls through). ⚠️ This precedence
+  is load-bearing: on a Mac that also has a brew/npm codex, a cached brew path would otherwise
+  field every run with a stale binary forever while the fresh install sat unused — runs failed
+  in-app while codex "worked fine in Terminal" (field-found 2026-07-24, the launch-week
+  dual-install breakage). Then the fallbacks: the UserDefaults cache (`codexcli.binaryPath`,
+  re-verified on every read), known paths (`/opt/homebrew/bin/codex`, `/usr/local/bin/codex`),
+  every nvm-managed node version's `bin/codex` (newest first — npm-under-nvm hides the binary in
+  a versioned dir), then a login `zsh -lic "which codex"` (interactive — `.zshrc` is where
+  nvm/asdf init; `-lc` alone never sources it). Only scan/`which` results are cached; the managed
+  hit never writes the cache (it needs no memo, and the cache stays useful as the fallback).
 - `install(onLine:)` — runs OpenAI's official standalone installer (`curl … install.sh |
   CODEX_NON_INTERACTIVE=1 sh`) streaming its output; success = the binary is actually present after
   (a `curl | sh` pipeline can exit 0 with nothing installed). The `CodexSetup` engine's step 1.

--- a/Sentient OS macOS/Documentation/Diagnostics (Sentry).md
+++ b/Sentient OS macOS/Documentation/Diagnostics (Sentry).md
@@ -144,7 +144,7 @@ TelemetryDeck since 2026-07-12):
 | `codex.fire_fallback` | `ProactiveExecutor.runConnector` | a sandboxed connector fire's write auto-cancelled (agent `COULD_NOT` + the verbatim "cancelled MCP tool call" in the raw JSONL) and the executor retried once on the legacy bypass path — the signal that codex's apps-approve config surface changed under us | `channel` (gmail/calendar) | warning |
 | `codex_auth.refresh_failed` | `CodexAuth` | the on-demand codex token re-mint gets a non-OK HTTP status | `status` | warning |
 | `engine.load_failed` | `IterativeRun` | the on-device model won't load (→ a 0-item run) | `error`, `model_present` | error |
-| `model.download.failed` | `ModelDownload` | the onboarding model download exhausted its retries / aborted | `reason` | error |
+| `model.download.failed` | `ModelDownload` | the onboarding model download exhausted its retries / aborted | `reason` — `disk_space` (the 10 GB preflight floor refused to start), `disk_write` (the disk filled mid-transfer), `checksum_mismatch`, `upstream_changed`, `bad_response`, `short_delivery`, `network` | error |
 | `source.dropped` | `IterativeRun` | `connector.buckets()` throws (FDA denied / DB-copy failed) → whole source skipped | `source`, `error` | error |
 | `engine.hard_stop` | `IterativeRun` | the GPU-wedge cascade the reloads couldn't clear | `reloads_without_progress`, `consecutive_failures` | error |
 | `triage.parse_failure_spike` | `IterativeRun` | ≥20% of a run's items were garbled model replies (not real junk), ≥30 items | `parse_failures`, `done` | warning |


### PR DESCRIPTION
## What

Two documentation true-ups, no code:

- **CodexCLI deep doc**: the `locateBinary()` section now describes the managed-install-first resolution shipped in #292 — `~/.local/bin/codex` wins unconditionally (including over the discovery cache) whenever executable, with the cache/known-paths/nvm/login-shell-`which` chain as fallbacks, and why that precedence is load-bearing on dual-install Macs.
- **README + Sentry catalog**: the ~10 GB free-disk guidance for the 3.7 GB on-device model download (README install section + FAQ), and the `model.download.failed` event's reason values (`disk_space`, `disk_write`, `checksum_mismatch`, …) in the diagnostics catalog.