### PR TITLE
Onboarding: frontier-model step with the full engine picker

### DIFF
--- a/Sentient OS macOS/Views/FrontierEnginePicker.swift
+++ b/Sentient OS macOS/Views/FrontierEnginePicker.swift
@@ -1,0 +1,473 @@
+//
+//  FrontierEnginePicker.swift
+//  Sentient OS macOS
+//
+//  The shared frontier-engine picker — the five engine pills (EngineTab) over each engine's
+//  setup panel, rendered identically by Settings → Frontier Model Choice and onboarding's
+//  choose-your-frontier-model step. Owns the tab state, the endpoint fields
+//  (ModelBackend/CustomProvider — the one source of truth), Test & Select (vision-gated
+//  activation: an unproven model can never become the engine), and the honest local-models
+//  warning. The ChatGPT panel is the host's slot: Settings points at Permissions & Health,
+//  onboarding embeds the live codex login. Layout knob: Settings' fixed 3+2 grid, or
+//  onboarding's single centered row. Deep doc: Documentation/Frontier Model Choice (BYOM).md.
+//
+
+import SwiftUI
+
+struct FrontierEnginePicker<ChatGPTPanel: View>: View {
+
+    /// Settings' fixed two-row grid (3 + 2 — a scrollbar appearing must never reflow the strip,
+    /// the jumpy-rewrap of 2026-07-24), or onboarding's single centered row of five.
+    enum Layout { case settingsGrid, singleRow }
+
+    /// The five engine tabs. OpenRouter, LM Studio, and Custom share the endpoint plumbing;
+    /// LM Studio's tab raises the honest local-models warning on first visit (model
+    /// capability, not plumbing, is the local blocker — the translator solved the plumbing).
+    enum Tab: String, CaseIterable, Identifiable {
+        case chatgpt, claude, openRouter, lmStudio, custom
+        var id: Self { self }
+
+        var label: String {
+            switch self {
+            case .chatgpt:    return "ChatGPT Subscription"
+            case .claude:     return "Claude Subscription"
+            case .openRouter: return "OpenRouter"
+            case .lmStudio:   return "LM Studio"
+            case .custom:     return "Custom"
+            }
+        }
+
+        var badge: String? {
+            switch self {
+            case .chatgpt:  return "recommended"
+            case .claude:   return "coming soon"
+            case .lmStudio: return "local"
+            case .custom:   return "local"
+            case .openRouter: return nil
+            }
+        }
+    }
+
+    /// The one model that cleared the computer-use bar in the 2026-07-24 survey (~10 models,
+    /// real tasks). Prefilled on the OpenRouter tab and named in its note.
+    private static var kimiSlug: String { "moonshotai/kimi-k3" }
+
+    let layout: Layout
+    /// Whether the ChatGPT engine counts as healthy (wears the pill's active dot). Settings
+    /// passes true — login honesty lives in Permissions & Health there; onboarding passes the
+    /// live codex login state.
+    let chatgptHealthy: Bool
+    /// Onboarding greys Test & Select until the background codex install answers — the CLI is
+    /// the engine room even for custom endpoints (the vision probe runs through `codex exec`).
+    /// Settings always passes true.
+    let codexReady: Bool
+    private let chatgptPanel: () -> ChatGPTPanel
+
+    init(layout: Layout = .settingsGrid,
+         chatgptHealthy: Bool = true,
+         codexReady: Bool = true,
+         @ViewBuilder chatgptPanel: @escaping () -> ChatGPTPanel) {
+        self.layout = layout
+        self.chatgptHealthy = chatgptHealthy
+        self.codexReady = codexReady
+        self.chatgptPanel = chatgptPanel
+    }
+
+    @AppStorage(ModelBackend.key) private var backendRaw = ModelBackend.chatgpt.rawValue
+    @AppStorage(CustomProvider.presetKey) private var presetRaw = CustomProvider.Preset.openRouter.rawValue
+    @AppStorage(CustomProvider.baseURLKey) private var baseURL = ""
+    @AppStorage(CustomProvider.modelNameKey) private var modelName = ""
+    @AppStorage(CustomProvider.reasoningKey) private var reasoningRaw = "low"
+    /// Set only by a passing Test Model run; any edit below clears it.
+    @AppStorage(CustomProvider.visionVerifiedKey) private var verified = false
+
+    @State private var tab: Tab = .chatgpt
+    @State private var apiKey = ""
+    @State private var showLocalWarning = false
+    /// The local-reality popup fires once per picker visit, on the LM Studio tab.
+    @State private var localWarningShown = false
+
+    /// The Test Model probe, narrated: nil = untested, "…" = running, ✓/✗ lines otherwise.
+    @State private var testing = false
+    @State private var testVerdict: String?
+
+    private var backend: ModelBackend { ModelBackend(rawValue: backendRaw) ?? .chatgpt }
+    private var savedPreset: CustomProvider.Preset { CustomProvider.Preset(rawValue: presetRaw) ?? .openRouter }
+
+    /// The tab wearing the "active engine" dot.
+    private var activeTab: Tab {
+        guard backend == .custom else { return .chatgpt }
+        switch savedPreset {
+        case .openRouter: return .openRouter
+        case .lmStudio:   return .lmStudio
+        case .custom:     return .custom
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: layout == .singleRow ? .center : .leading, spacing: 26) {
+            tabStrip
+
+            Group {
+                switch tab {
+                case .chatgpt:    chatgptPanel()
+                case .claude:     claudePanel
+                case .openRouter: endpointPanel(for: .openRouter)
+                case .lmStudio:   endpointPanel(for: .lmStudio)
+                case .custom:     endpointPanel(for: .custom)
+                }
+            }
+            // The Settings editorial measure — panels never stretch wider than prose stays
+            // readable, in either host (SettingsPane caps at the same width).
+            .frame(maxWidth: 640, alignment: .leading)
+            .id(tab)
+            // A quiet crossfade — no lateral slide: panels differ in height, and a slide on
+            // top of the height change read as an abrupt jump (field feedback 2026-07-25).
+            .transition(.opacity)
+        }
+        .animation(.easeInOut(duration: 0.25), value: tab)
+        .onAppear {
+            tab = activeTab
+            apiKey = CustomProvider.apiKey ?? ""
+        }
+        // The host's ChatGPT panel flipping the backend home (Use ChatGPT) retires any verdict.
+        .onChange(of: backendRaw) {
+            if backend == .chatgpt { testVerdict = nil }
+        }
+        .alert("A note on local frontier models", isPresented: $showLocalWarning) {
+            Button("Understood") {}
+        } message: {
+            Text("Most models you can run locally are far too weak for computer use; in our testing only Kimi K3 performed well enough, and most other open-weights models aren't multimodal (can't see), which computer use requires.\n\nIf you can somehow run Kimi K3 locally, this preset is all yours.\n\nOtherwise run it through OpenRouter, or if privacy is the concern, both OpenAI and Claude subscriptions let you turn off training on your data in your account settings on their own site. Those frontier options remain the best way to use Sentient.")
+        }
+    }
+
+    // MARK: - The engine tab strip
+
+    private var tabStrip: some View {
+        Group {
+            switch layout {
+            case .settingsGrid:
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack(spacing: 8) {
+                        pill(.chatgpt); pill(.claude); pill(.openRouter)
+                    }
+                    HStack(spacing: 8) {
+                        pill(.lmStudio); pill(.custom)
+                    }
+                }
+            case .singleRow:
+                HStack(spacing: 8) {
+                    ForEach(Tab.allCases) { pill($0) }
+                }
+            }
+        }
+        .fixedSize()
+    }
+
+    private func pill(_ t: Tab) -> some View {
+        EngineTab(label: t.label, badge: t.badge,
+                  selected: tab == t, active: activeTab == t && isActiveEngineHealthy(t)) {
+            selectTab(t)
+        }
+    }
+
+    /// The active dot stays honest: a custom engine only wears it once it's proven usable,
+    /// and ChatGPT's honesty is the host's call (Settings: always; onboarding: logged in).
+    private func isActiveEngineHealthy(_ t: Tab) -> Bool {
+        t == .chatgpt ? chatgptHealthy : CustomProvider.current.isUsable
+    }
+
+    /// Browsing tabs never disturbs a live engine: fields are only prefilled while nothing
+    /// custom is active (Test Model and Use-this-model pin the right values when the user
+    /// actually acts). The LM Studio tab raises the local-reality popup once per visit.
+    private func selectTab(_ t: Tab) {
+        tab = t
+        testVerdict = nil
+        if t == .lmStudio, !localWarningShown {
+            localWarningShown = true
+            showLocalWarning = true
+        }
+        guard backend != .custom else { return }
+        switch t {
+        case .openRouter:
+            if modelName.isEmpty { modelName = Self.kimiSlug }   // Kimi K3 forward
+            baseURL = CustomProvider.Preset.openRouter.defaultBaseURL
+        case .lmStudio:
+            if baseURL.isEmpty || baseURL == CustomProvider.Preset.openRouter.defaultBaseURL {
+                baseURL = CustomProvider.Preset.lmStudio.defaultBaseURL
+            }
+        default:
+            break
+        }
+    }
+
+    // MARK: - Claude (coming soon)
+
+    private var claudePanel: some View {
+        SettingsGroup(label: "Your Claude Plan", badge: "coming soon") {
+            VStack(alignment: .leading, spacing: 10) {
+                SettingsProse("Your Claude subscription will power Sentient the same way ChatGPT does today, through Claude Code's own command line. It's on the bench and coming soon.")
+                MonoCaps("claude -p · in the works", size: 8.5, tracking: 1.6, color: Theme.Ink.deepMuted)
+            }
+        }
+    }
+
+    // MARK: - Configurable endpoints (OpenRouter · Custom + its local presets)
+
+    private func endpointPanel(for preset: CustomProvider.Preset) -> some View {
+        SettingsGroup(label: preset == .openRouter ? "Your OpenRouter"
+                           : preset == .lmStudio ? "Your LM Studio" : "Your Endpoint") {
+            VStack(alignment: .leading, spacing: 14) {
+                switch preset {
+                case .openRouter:
+                    SettingsProse("Any model on OpenRouter, billed to your own key.")
+                case .lmStudio:
+                    SettingsProse("A model running on your own hardware, through LM Studio's local server. Sentient's translator makes it a first-class engine, computer use included; whether the model is up to the job is the honest question (see the note when this tab opens).")
+                case .custom:
+                    SettingsProse("Any endpoint that speaks the OpenAI Responses API (a /v1/responses route). Base URL, model name, key if it needs one.")
+                }
+                if preset != .lmStudio {
+                    SettingsProse("One important note: of every model we tested, Kimi K3 at low reasoning is the only open-weights model that can reliably drive computer use. Claude Sonnet 5 with reasoning off, and GPT-5.6 Sol at low reasoning are also great options we can stand by.")
+                }
+
+                // OpenRouter's base URL is fixed — no field, the tab pins it itself.
+                if preset != .openRouter {
+                    fieldRow(label: "BASE URL",
+                             placeholder: preset == .lmStudio
+                                 ? CustomProvider.Preset.lmStudio.defaultBaseURL
+                                 : "https://your-endpoint.example/v1",
+                             text: $baseURL)
+                }
+                fieldRow(label: "MODEL",
+                         placeholder: preset == .openRouter ? Self.kimiSlug
+                             : preset == .lmStudio ? "the model id shown in LM Studio"
+                             : "the model id your server expects",
+                         text: $modelName)
+                secureRow(label: preset == .openRouter ? "OPENROUTER API KEY" : "API KEY",
+                          placeholder: preset == .openRouter ? "sk-or-…" : "optional for keyless servers")
+
+                reasoningField
+
+                SettingsProse("Your model has to be able to see: Sentient acts on your Mac by looking at the screen, so a text-only model can't drive it. The test below checks that for you by asking your model to read a picture.")
+
+                HStack(spacing: 10) {
+                    SettingsPillButton(title: testing ? "Testing…" : "Test & Select",
+                                       tint: codexReady ? Theme.Ink.bright : Theme.Ink.deepMuted) {
+                        guard codexReady, !testing else { return }
+                        runTest(preset: preset)
+                    }
+                    if isActive(preset) {
+                        FrontierActiveLine("This model is running Sentient.")
+                    }
+                }
+                if !codexReady {
+                    MonoWaitLine("installing codex in the background…")
+                }
+                if let testVerdict {
+                    SettingsProse(testVerdict)
+                }
+
+                SettingsHairline()
+                SettingsProse("Gmail and Calendar ride your ChatGPT account, so they sit out while a custom model is active. Everything else works, and your data still never leaves this Mac except what the model itself is sent.")
+            }
+        }
+    }
+
+    /// The endpoint's ONE reasoning level — free text, because models speak different dialects
+    /// (`none`, `low`, `xhigh`, `adaptive`, …), applied to every run this model powers (the
+    /// Speed slider is ChatGPT's). Kimi wants low; Claude-class endpoints need none. Editing it
+    /// re-runs the gate via the field's invalidate, since a wrong level can break the endpoint
+    /// outright.
+    private var reasoningField: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            fieldRow(label: "REASONING",
+                     placeholder: "low · none · xhigh · whatever your model supports",
+                     text: $reasoningRaw)
+            MonoCaps("applies everywhere this model runs", size: 7.5, tracking: 1.6,
+                     color: Theme.Ink.deepMuted)
+        }
+    }
+
+    // MARK: - Pieces
+
+    private func fieldRow(label: String, placeholder: String, text: Binding<String>) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            MonoCaps(label, size: 8.5, tracking: 2.0, color: Theme.Ink.deepMuted)
+            TextField(placeholder, text: text)
+                .textFieldStyle(.plain)
+                .font(.system(size: 11.5)).foregroundStyle(Theme.Ink.statusInk)
+                .padding(.horizontal, 12).padding(.vertical, 8)
+                .background(Color.white.opacity(0.02), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
+                .overlay(RoundedRectangle(cornerRadius: 9, style: .continuous)
+                    .strokeBorder(Theme.stroke, lineWidth: 1))
+                .onChange(of: text.wrappedValue) { invalidate() }
+        }
+    }
+
+    /// Any edit to the endpoint retires the old verdict: a different model has to prove it can
+    /// see for itself. Also drops the backend back to ChatGPT if the running engine just became
+    /// unverified, so Sentient is never left pointed at an unproven model.
+    private func invalidate() {
+        guard verified || backend == .custom else { return }
+        verified = false
+        testVerdict = nil
+        if backend == .custom { backendRaw = ModelBackend.chatgpt.rawValue }
+    }
+
+    private func secureRow(label: String, placeholder: String) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            MonoCaps(label, size: 8.5, tracking: 2.0, color: Theme.Ink.deepMuted)
+            SecureField(placeholder, text: $apiKey)
+                .textFieldStyle(.plain)
+                .font(.system(size: 11.5)).foregroundStyle(Theme.Ink.statusInk)
+                .padding(.horizontal, 12).padding(.vertical, 8)
+                .background(Color.white.opacity(0.02), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
+                .overlay(RoundedRectangle(cornerRadius: 9, style: .continuous)
+                    .strokeBorder(Theme.stroke, lineWidth: 1))
+                .onChange(of: apiKey) {
+                    let trimmed = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if trimmed.isEmpty {
+                        Keychain.delete(CustomProvider.apiKeyAccount)
+                    } else {
+                        Keychain.set(CustomProvider.apiKeyAccount, trimmed)
+                    }
+                    invalidate()
+                }
+            MonoCaps("stored in your mac's keychain", size: 7.5, tracking: 1.6, color: Theme.Ink.deepMuted)
+        }
+    }
+
+    private func isActive(_ preset: CustomProvider.Preset) -> Bool {
+        backend == .custom && savedPreset == preset && CustomProvider.current.isUsable
+    }
+
+    /// Flip the backend to the viewed tab's endpoint — reached ONLY through a passing
+    /// Test & Select run, so an unproven model can never become the engine. Fields already
+    /// autosave (@AppStorage); activation is just the choice becoming official.
+    private func activate(_ preset: CustomProvider.Preset) {
+        presetRaw = preset.rawValue
+        guard CustomProvider.current.isUsable else { return }
+        backendRaw = ModelBackend.custom.rawValue
+    }
+
+    private func runTest(preset: CustomProvider.Preset) {
+        // OpenRouter's URL is pinned (no field on that tab); elsewhere only fill an empty one.
+        if preset == .openRouter {
+            baseURL = preset.defaultBaseURL
+        } else if baseURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            baseURL = preset.defaultBaseURL
+        }
+        presetRaw = preset.rawValue   // the probe reads the SAVED provider — keep it current
+        guard CustomProvider.current.isConfigured else {
+            testVerdict = "✗ It needs a base URL and a model name first."
+            return
+        }
+        testing = true
+        testVerdict = "Showing your model a picture and asking it to read the number… local models can take a minute to load."
+        Task {
+            let verdict = await CodexCLI.probeCustomEndpoint()
+            await MainActor.run {
+                testing = false
+                switch verdict {
+                case .available:
+                    verified = true
+                    activate(preset)   // Test & Select: a passing model becomes the engine
+                    testVerdict = "✓ Your model answered and read the picture. Sentient is now running on it."
+                case .notInstalled:
+                    verified = false
+                    testVerdict = "✗ Codex CLI is missing on this Mac. Install it in Permissions & Health first; it's the engine room even for custom models."
+                case .notWorking(let detail):
+                    verified = false
+                    testVerdict = "✗ \(friendly(detail))"
+                }
+            }
+        }
+    }
+
+    /// Reduce codex's raw stderr to one readable hint; the full detail stays in the console.
+    /// A base URL missing its `/v1` is the single most common setup slip (codex appends
+    /// `/responses` to whatever you give it, so the request lands on a route the server
+    /// doesn't serve), so every failure carries that nudge when it applies.
+    private func friendly(_ detail: String) -> String {
+        let lowered = detail.lowercased()
+        let trimmedURL = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let v1Hint = trimmedURL.hasSuffix("/v1") ? ""
+            : " Most servers also expect the base URL to end in /v1."
+        if lowered.hasPrefix("blind") || lowered.contains("image input") || lowered.contains("multimodal") {
+            return "This model can't see pictures, so it can't act on your Mac. Pick one that accepts images."
+        }
+        if lowered.contains("401") || lowered.contains("unauthorized") {
+            return "The endpoint rejected the API key."
+        }
+        if lowered.contains("connection refused") || lowered.contains("error sending request") {
+            return "Nothing is listening at that base URL. Is the server running?\(v1Hint)"
+        }
+        if lowered.contains("404") || lowered.contains("not found")
+            || lowered.contains("unexpected endpoint") {
+            return "The endpoint answered but has no /v1/responses route.\(v1Hint.isEmpty ? " It must support the OpenAI Responses API." : v1Hint)"
+        }
+        return "No answer from the endpoint.\(v1Hint) \(detail.prefix(180))"
+    }
+}
+
+// MARK: - The engine tab
+
+/// One tab in the engine strip: a fixed-size pill that reads like a place, not a button —
+/// EVERY pill the same width and height so the row's geometry never shifts (scrollbars,
+/// badges, and selection can't reflow it). Selected = elevated wash + white ring; the ACTIVE
+/// engine wears the small green status dot (the same honest LED the health rows use). Badges
+/// whisper in mono-caps under the label.
+struct EngineTab: View {
+    static var pillWidth: CGFloat { 176 }
+    static var pillHeight: CGFloat { 52 }
+
+    let label: String
+    var badge: String? = nil
+    let selected: Bool
+    let active: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: 7) {
+                    if active { HealthDot(color: Theme.Ink.green) }
+                    Text(label)
+                        .font(.system(size: 12.5, weight: selected ? .medium : .regular))
+                        .foregroundStyle(selected ? .white : Theme.Ink.body)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.92)
+                }
+                if let badge {
+                    MonoCaps(badge, size: 7, tracking: 1.4,
+                             color: badge == "recommended" ? Theme.Ink.green.opacity(0.85)
+                                                           : .white.opacity(0.45))
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 12)
+            .frame(width: Self.pillWidth, height: Self.pillHeight)
+            .background(selected ? Theme.elevated : Color.white.opacity(0.02),
+                        in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .overlay(RoundedRectangle(cornerRadius: 14, style: .continuous).strokeBorder(
+                selected ? Color.white.opacity(0.28) : Color.white.opacity(0.10), lineWidth: 1))
+            .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        }
+        .buttonStyle(PressScaleStyle())
+    }
+}
+
+/// The green "this engine is live" line — shared by the picker's endpoint panels and the
+/// Settings pane's ChatGPT panel.
+struct FrontierActiveLine: View {
+    let text: String
+    init(_ text: String) { self.text = text }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            HealthDot(color: Theme.Ink.green)
+            Text(text).font(.system(size: 12, weight: .medium)).foregroundStyle(.white)
+        }
+    }
+}

--- a/Sentient OS macOS/Views/Onboarding/OnboardingCodexSteps.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingCodexSteps.swift
@@ -2,17 +2,17 @@
 //  OnboardingCodexSteps.swift
 //  Sentient OS macOS
 //
-//  Onboarding's codex step — a pure renderer over the SHARED CodexSetup engine (the same
-//  instance the dev tools' CodexSetupView drives; zero setup logic lives here).
+//  Onboarding's codex login, in panel form — a pure renderer over the SHARED CodexSetup engine
+//  (the same instance the dev tools' CodexSetupView drives; zero setup logic lives here).
 //
-//  OnboardingCodexLoginView is purely the browser login: one button that opens the OAuth page,
-//  then the screen NOTICES the finished sign-in on its own (a 2s `codex login status` poll while
-//  the browser is out + a re-check on app foreground) — no "I'm done" button. Continue gates on
-//  logged in. The CLI install happens in the BACKGROUND (AppState's launch kick); in the rare
-//  case it hasn't finished yet, the login button stays greyed and the screen polls `codex --help`
-//  (CodexCLI.isRunnable — the ground truth, not a path check) every 2s, un-greying the moment
-//  codex actually answers. A silent same-engine re-kick is the safety net, so a failed or
-//  skipped install can never dead-end the flow.
+//  OnboardingCodexLoginPanel is the ChatGPT panel inside the frontier-model step's engine
+//  picker (OnboardingFrontierModelView): one button that opens the OAuth page, then the panel
+//  NOTICES the finished sign-in on its own (a 2s `codex login status` poll while the browser is
+//  out; the step adds a re-check on app foreground) — no "I'm done" button. The login button
+//  stays greyed until the step's `codex --help` poll confirms the background CLI install landed
+//  (`codexReady` — the install kicks live in the step, since custom endpoints need the CLI too).
+//  Also home to the shared onboarding bits: OnboardingWhisper · OnboardingDoneLine ·
+//  MonoWaitLine · OnboardingStatusText.
 //
 //  (Computer-use setup is deliberately NOT in onboarding — it happens later, elsewhere.)
 //
@@ -20,119 +20,77 @@
 import SwiftUI
 import AppKit
 
-// MARK: - Step: log in to codex
+// MARK: - The ChatGPT panel: log in to codex
 
-struct OnboardingCodexLoginView: View {
-    let onContinue: () -> Void
+struct OnboardingCodexLoginPanel: View {
+    /// The step's `codex --help` confirmation — the ground truth that un-greys the login button.
+    let codexReady: Bool
 
     @State private var codex = CodexSetup.shared
-    /// `codex --help` answered — the ground-truth install confirmation that un-greys the button.
-    @State private var codexConfirmed = false
+    @AppStorage(ModelBackend.key) private var backendRaw = ModelBackend.chatgpt.rawValue
+
+    private var backend: ModelBackend { ModelBackend(rawValue: backendRaw) ?? .chatgpt }
 
     var body: some View {
-        VStack(spacing: 40) {
-            Spacer()
+        SettingsGroup(label: "Your ChatGPT") {
+            VStack(alignment: .leading, spacing: 14) {
+                SettingsProse("Codex runs on your own ChatGPT subscription, so a plan you already pay for powers everything: knowledge base, morning cards, Sidekick, and the Gmail and Calendar connectors. Recommended, because the connectors only exist here.")
 
-            OnboardingWhisper("CONNECT CODEX")
-
-            Text("Sign in with your ChatGPT account.\nSentient's cloud thinking runs through OpenAI's Codex, on your own plan.")
-                .font(.system(size: 15))
-                .foregroundStyle(Theme.secondary)
-                .multilineTextAlignment(.center)
-                .lineSpacing(4)
-
-            VStack(spacing: 16) {
-                if codex.loggedIn {
-                    OnboardingDoneLine("Logged in to Codex")
-                } else if codex.loggingIn {
-                    Text("Finish signing in in your browser. This screen notices on its own.")
-                        .font(.system(size: 12.5))
-                        .foregroundStyle(Theme.Ink.body)
-                    HStack(spacing: 8) {
-                        ProgressView().controlSize(.mini)
-                        Text("waiting for the browser sign-in…")
-                            .font(.system(size: 11, weight: .medium, design: .monospaced))
-                            .kerning(1.5)
-                            .foregroundStyle(Theme.faint)
-                    }
-                } else if codex.installGaveUp && !codex.installed {
-                    // The auto-install couldn't finish (no network, connection reset, or Codex is
-                    // unavailable in this region). Point the user to install it themselves; the
-                    // `.task` poll below picks Codex up automatically the moment it lands.
-                    CodexInstallFailedPanel()
-                } else {
-                    // The login button — greyed until `codex --help` confirms the install landed.
-                    OnboardingNextButton(title: "Log in with ChatGPT", enabled: codexConfirmed) {
-                        codex.startLogin()
-                    }
-                    if !codexConfirmed {
-                        HStack(spacing: 8) {
-                            ProgressView().controlSize(.mini)
-                            Text("installing codex in the background…")
-                                .font(.system(size: 11, weight: .medium, design: .monospaced))
-                                .kerning(1.5)
-                                .foregroundStyle(Theme.faint)
-                        }
-                    }
-                    OnboardingStatusText(codex.loginStatusLine)
-                }
-            }
-            .frame(maxWidth: 560)
-
-            OnboardingNextButton(title: "Continue", enabled: codex.loggedIn, action: onContinue)
-
-            Spacer()
-
-            OnboardingTrustFooter()
-        }
-        .padding(40)
-        .onAppear {
-            Task {
-                await codex.refreshInstalled()
-                // No binary (the launch kick failed or skipped a half-deleted setup) → retry via
-                // ensureInstalled, which surfaces the manual-install panel if it gives up. Binary
-                // already present but the installer hasn't run this launch → run it anyway (it
-                // doubles as the updater, handing the latest CLI to the later steps).
-                if !codex.installed {
-                    await codex.ensureInstalled()
-                } else if !codex.ranInstallerThisLaunch {
-                    await codex.installCodex()
-                }
-            }
-            Task { await codex.refreshLoginStatus() }
-        }
-        .task {
-            // The confirmation poll: run `codex --help` now, then every 2s until it answers —
-            // "command not found" (no binary) means the install is still going. On the normal
-            // path this succeeds on the first try and the button is never seen greyed.
-            while !Task.isCancelled {
-                if await CodexCLI.isRunnable() {
-                    await codex.refreshInstalled()   // align the shared engine's flag
-                    withAnimation(.easeInOut(duration: 0.3)) { codexConfirmed = true }
-                    return
-                }
-                try? await Task.sleep(for: .seconds(2))
+                loginStates
             }
         }
         .task(id: codex.loggingIn) {
             // The sign-in watcher (replaces the old "I've finished" button): while the browser
             // flow is out, quietly re-check `codex login status` every 2s — the section flips to
-            // the green done line by itself the moment auth.json lands.
+            // the green done line by itself the moment auth.json lands. (Switching tabs cancels
+            // this; the step's foreground re-check still notices a finished sign-in.)
             guard codex.loggingIn else { return }
             while !Task.isCancelled, codex.loggingIn, !codex.loggedIn {
                 try? await Task.sleep(for: .seconds(2))
                 await codex.refreshLoginStatus()
             }
         }
-        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
-            Task { await codex.refreshLoginStatus() }   // back from the browser — often already done
+    }
+
+    /// The login state machine: done → browser out → install failed → the button.
+    @ViewBuilder private var loginStates: some View {
+        if codex.loggedIn {
+            OnboardingDoneLine("Logged in to Codex")
+            if backend != .chatgpt {
+                // A custom engine won Test & Select earlier — logging in doesn't switch
+                // by itself (browsing never disturbs a live engine); this does.
+                SettingsPillButton(title: "Use ChatGPT") {
+                    backendRaw = ModelBackend.chatgpt.rawValue
+                }
+            }
+        } else if codex.loggingIn {
+            Text("Finish signing in in your browser. This screen notices on its own.")
+                .font(.system(size: 12.5))
+                .foregroundStyle(Theme.Ink.body)
+            MonoWaitLine("waiting for the browser sign-in…")
+        } else if codex.installGaveUp && !codex.installed {
+            // The auto-install couldn't finish (no network, connection reset, or Codex is
+            // unavailable in this region). Point the user to install it themselves; the
+            // step's poll picks Codex up automatically the moment it lands.
+            CodexInstallFailedPanel()
+        } else {
+            // The login button — greyed until `codex --help` confirms the install
+            // landed. Centered with its status lines: it's the panel's one big CTA.
+            VStack(spacing: 10) {
+                OnboardingNextButton(title: "Log in with ChatGPT", enabled: codexReady) {
+                    codex.startLogin()
+                }
+                if !codexReady {
+                    MonoWaitLine("installing codex in the background…")
+                }
+                OnboardingStatusText(codex.loginStatusLine)
+            }
+            .frame(maxWidth: .infinity)
         }
     }
 }
 
-// MARK: - Shared onboarding bits
-
-/// Shown on the Codex step when the automatic install has clearly failed (retries exhausted):
+/// Shown on the ChatGPT panel when the automatic install has clearly failed (retries exhausted):
 /// no network, a connection reset, or Codex being unavailable in the user's region. It points the
 /// user to install Codex themselves; the step's `codex --help` poll picks it up the moment it
 /// lands, and a relaunch resumes right here (onboarding persists its step). Copy approved 2026-07-24.
@@ -140,37 +98,29 @@ private struct CodexInstallFailedPanel: View {
     private let guideURL = URL(string: "https://learn.chatgpt.com/docs/codex/cli#getting-started")!
 
     var body: some View {
-        VStack(spacing: 16) {
+        VStack(alignment: .leading, spacing: 14) {
             Text("Sentient couldn't finish installing Codex automatically.")
-                .font(.system(size: 15))
+                .font(.system(size: 14, weight: .medium))
                 .foregroundStyle(Theme.Ink.body)
-                .multilineTextAlignment(.center)
 
-            Text("You can install it yourself in a minute. Once you do that, you can restart Sentient and pick up right where you left off.")
-                .font(.system(size: 13))
-                .foregroundStyle(Theme.secondary)
-                .multilineTextAlignment(.center)
-                .lineSpacing(3)
+            SettingsProse("You can install it yourself in a minute. Once you do that, you can restart Sentient and pick up right where you left off.")
 
             OnboardingNextButton(title: "Open the Codex install guide") {
                 NSWorkspace.shared.open(guideURL)
             }
-            .padding(.top, 4)
+            .frame(maxWidth: .infinity)
 
-            Text("We also suggest connecting through a VPN.")
-                .font(.system(size: 12.5))
-                .foregroundStyle(Theme.secondary)
-                .multilineTextAlignment(.center)
+            SettingsProse("We also suggest connecting through a VPN.")
 
             Text("Codex isn't available in a few countries.")
                 .font(.system(size: 11, weight: .medium, design: .monospaced))
                 .kerning(0.5)
                 .foregroundStyle(Theme.faint)
-                .padding(.top, 2)
         }
-        .frame(maxWidth: 460)
     }
 }
+
+// MARK: - Shared onboarding bits
 
 /// The monospace-caps whisper label every onboarding screen opens with.
 struct OnboardingWhisper: View {
@@ -185,7 +135,7 @@ struct OnboardingWhisper: View {
     }
 }
 
-/// A green-dot "this step is done" line (shared: the login step and the plan crossroads).
+/// A green-dot "this step is done" line (shared: the login panel and the plan crossroads).
 struct OnboardingDoneLine: View {
     let text: String
     init(_ text: String) { self.text = text }
@@ -200,9 +150,26 @@ struct OnboardingDoneLine: View {
     }
 }
 
+/// A mini spinner + mono-caps whisper — the quiet "something is happening on its own" line
+/// (waiting for the browser sign-in, the background codex install, the upgrade watch).
+struct MonoWaitLine: View {
+    let text: String
+    init(_ text: String) { self.text = text }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ProgressView().controlSize(.mini)
+            Text(text)
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .kerning(1.5)
+                .foregroundStyle(Theme.faint)
+        }
+    }
+}
+
 /// The engine's latest streamed/status line — monospaced, colored by its ✓/✗ prefix (the same
 /// convention the dev CodexSetupView renders).
-private struct OnboardingStatusText: View {
+struct OnboardingStatusText: View {
     let status: String?
     init(_ status: String?) { self.status = status }
 
@@ -212,19 +179,20 @@ private struct OnboardingStatusText: View {
                 .font(.system(.caption2, design: .monospaced))
                 .foregroundStyle(status.hasPrefix("✓") ? Theme.Ink.green
                                : status.hasPrefix("✗") ? .red : Theme.secondary)
-                .multilineTextAlignment(.center)
+                .multilineTextAlignment(.leading)
                 .lineLimit(3)
                 .fixedSize(horizontal: false, vertical: true)
         }
     }
 }
 
-#Preview("Onboarding — codex login") {
+#Preview("Onboarding — codex login panel") {
     ZStack {
         Theme.bg.ignoresSafeArea()
-        OnboardingCodexLoginView(onContinue: {})
+        OnboardingCodexLoginPanel(codexReady: true)
+            .frame(maxWidth: 640)
+            .padding(40)
     }
-    .frame(width: 1180, height: 880)
+    .frame(width: 780, height: 500)
     .preferredColorScheme(.dark)
 }
-

--- a/Sentient OS macOS/Views/Onboarding/OnboardingFrontierModelView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingFrontierModelView.swift
@@ -1,0 +1,124 @@
+//
+//  OnboardingFrontierModelView.swift
+//  Sentient OS macOS
+//
+//  Onboarding's frontier-model step (grew out of the codex-login-only screen, 2026-07-25): the
+//  five engine pills in one centered row over the SAME per-engine panels Settings renders
+//  (FrontierEnginePicker), with the live codex login embedded as the ChatGPT panel
+//  (OnboardingCodexLoginPanel). Continue gates on the ACTIVE engine being healthy — ChatGPT
+//  logged in, or a custom endpoint that passed Test & Select — and browsing tabs never disturbs
+//  the active engine. The codex CLI install kick + `codex --help` confirmation poll live HERE,
+//  not in the ChatGPT panel: the CLI is the engine room even for custom endpoints (the vision
+//  probe runs through `codex exec`), so Test & Select greys until it answers, whatever tab the
+//  user is on.
+//
+
+import SwiftUI
+import AppKit
+
+struct OnboardingFrontierModelView: View {
+    let onContinue: () -> Void
+
+    @State private var codex = CodexSetup.shared
+    /// `codex --help` answered — the ground-truth install confirmation (feeds the login button
+    /// AND the custom panels' Test & Select).
+    @State private var codexConfirmed = false
+
+    @AppStorage(ModelBackend.key) private var backendRaw = ModelBackend.chatgpt.rawValue
+    /// Observed so a passing Test & Select re-evaluates `engineReady` in place.
+    @AppStorage(CustomProvider.visionVerifiedKey) private var visionVerified = false
+
+    /// The one Continue gate: the ACTIVE engine is healthy. ChatGPT = logged in to codex;
+    /// a custom endpoint = configured AND vision-verified (a passing Test & Select).
+    private var engineReady: Bool {
+        _ = visionVerified
+        return ModelBackend(rawValue: backendRaw) == .custom
+            ? CustomProvider.current.isUsable
+            : codex.loggedIn
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Top-anchored, not vertically centered: panels differ in height, and re-centering
+            // on every tab switch made the header and pills jump. Anchored, only the area
+            // below the pills changes; the ScrollView carries the tall endpoint panels.
+            ScrollView {
+                VStack(spacing: 34) {
+                    VStack(spacing: 14) {
+                        OnboardingWhisper("FRONTIER MODEL")
+
+                        Text("Choose your frontier model")
+                            .display(26)
+                            .foregroundStyle(Theme.Ink.bright)
+
+                        Text("Sentient's on-device model does about 90% of the thinking. The last 10%, the reasoning behind proactive intelligence, runs on a frontier model of your choice.")
+                            .font(.system(size: 14.5))
+                            .foregroundStyle(Theme.secondary)
+                            .multilineTextAlignment(.center)
+                            .lineSpacing(4)
+                            .frame(maxWidth: 640)
+                    }
+
+                    FrontierEnginePicker(layout: .singleRow,
+                                         chatgptHealthy: codex.loggedIn,
+                                         codexReady: codexConfirmed) {
+                        OnboardingCodexLoginPanel(codexReady: codexConfirmed)
+                    }
+
+                    // The quiet reward: the halo lights only once an engine is actually
+                    // ready (GlowHalo's `active` rides `enabled`), at the armed-CTA subtlety.
+                    OnboardingNextButton(title: "Continue", enabled: engineReady,
+                                         glow: 0.28, action: onContinue)
+                }
+                .padding(.horizontal, 40)
+                .padding(.vertical, 48)
+                .frame(maxWidth: .infinity)
+            }
+            .scrollBounceBehavior(.basedOnSize)
+
+            OnboardingTrustFooter()
+        }
+        .onAppear {
+            Task {
+                await codex.refreshInstalled()
+                // No binary (the launch kick failed or skipped a half-deleted setup) → retry via
+                // ensureInstalled, which surfaces the manual-install panel if it gives up. Binary
+                // already present but the installer hasn't run this launch → run it anyway (it
+                // doubles as the updater, handing the latest CLI to the later steps).
+                if !codex.installed {
+                    await codex.ensureInstalled()
+                } else if !codex.ranInstallerThisLaunch {
+                    await codex.installCodex()
+                }
+            }
+            Task { await codex.refreshLoginStatus() }
+        }
+        .task {
+            // The confirmation poll: run `codex --help` now, then every 2s until it answers —
+            // "command not found" (no binary) means the install is still going. On the normal
+            // path this succeeds on the first try and nothing is ever seen greyed.
+            while !Task.isCancelled {
+                if await CodexCLI.isRunnable() {
+                    await codex.refreshInstalled()   // align the shared engine's flag
+                    withAnimation(.easeInOut(duration: 0.3)) { codexConfirmed = true }
+                    return
+                }
+                try? await Task.sleep(for: .seconds(2))
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            // Back from the browser — often already signed in. Step-level on purpose: the
+            // ChatGPT panel (and its own watcher) may not exist while another tab is showing.
+            Task { await codex.refreshLoginStatus() }
+        }
+    }
+}
+
+#Preview("Onboarding — frontier model") {
+    ZStack {
+        Theme.bg.ignoresSafeArea()
+        OnboardingFrontierModelView(onContinue: {})
+    }
+    .frame(width: 1180, height: 880)
+    .preferredColorScheme(.dark)
+}

--- a/Sentient OS macOS/Views/Onboarding/OnboardingPermissionsView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingPermissionsView.swift
@@ -5,11 +5,12 @@
 //  Onboarding's permissions step: Sentient's three core grants as the same StatusLine rows
 //  Settings → Health uses, with the same fix actions. The rows unlock SEQUENTIALLY (each greyed
 //  until the previous one is granted) and Full Disk Access is deliberately LAST: FDA is the one
-//  grant that forces an app relaunch, and putting it at the end means the relaunch restarts the
-//  background codex install as late as possible — so it's done before the user reaches the codex
-//  login step. Continue stays disabled until all three are green; the persisted onboarding step
-//  brings the user straight back here after the FDA relaunch. Statuses re-probe when the app
-//  foregrounds (returning from System Settings).
+//  grant that forces an app relaunch, so it lands only once the other grants are banked. The
+//  frontier-model step (codex login included) comes BEFORE this screen — the relaunch never
+//  disturbs it, since auth.json and the engine choice persist on disk. Continue stays disabled
+//  until all three are green; the persisted onboarding step brings the user straight back here
+//  after the FDA relaunch. Statuses re-probe when the app foregrounds (returning from System
+//  Settings).
 //
 
 import SwiftUI

--- a/Sentient OS macOS/Views/Onboarding/OnboardingPlanView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingPlanView.swift
@@ -2,9 +2,11 @@
 //  OnboardingPlanView.swift
 //  Sentient OS macOS
 //
-//  The plan crossroads — the step between codex login and the ready screen, and ONLY free/go
-//  accounts ever see it: a full plan (plus/pro/team/…, or anything we can't read — fail open)
-//  auto-advances before a single pixel renders. Free/go users get an honest fork: upgrade to
+//  The plan crossroads — the step right behind the frontier-model step (before permissions),
+//  and ONLY free/go ChatGPT accounts ever see it: a full plan (plus/pro/team/…, or anything we
+//  can't read — fail open) auto-advances before a single pixel renders, and so does a CUSTOM
+//  frontier engine (their own endpoint powers everything; the ChatGPT plan is irrelevant even
+//  when a stale free/go codex login sits on disk). Free/go users get an honest fork: upgrade to
 //  Plus (opens ChatGPT's pricing page, then this screen notices the upgrade on its own via
 //  CodexAuth.refreshPlan — the same on-demand token re-mint codex does every 8 days), say they
 //  ALREADY upgraded (a confirm, then we simply believe them — CodexAuth.assertedPlus; people
@@ -88,13 +90,7 @@ struct OnboardingPlanView: View {
                     .lineSpacing(4)
 
                 VStack(spacing: 16) {
-                    HStack(spacing: 8) {
-                        ProgressView().controlSize(.mini)
-                        Text("waiting for your upgrade…")
-                            .font(.system(size: 11, weight: .medium, design: .monospaced))
-                            .kerning(1.5)
-                            .foregroundStyle(Theme.faint)
-                    }
+                    MonoWaitLine("waiting for your upgrade…")
                     // The trust path, not a check: the account can read Free here long after a
                     // real payment (the refreshed token re-mints from the same stale session),
                     // so the button takes the user's word — same confirm as the crossroads'.
@@ -116,6 +112,12 @@ struct OnboardingPlanView: View {
         }
         .padding(40)
         .task {
+            // A custom frontier engine bypasses the ChatGPT plan entirely (knowledgeBaseOnly
+            // already reads false there) — never show the crossroads, whatever the disk claims.
+            if previewPlan == nil, ModelBackend.current == .custom {
+                onContinue()
+                return
+            }
             // The silent gate: read the claim off disk (no network). Anything but a positive
             // free/go read means this screen isn't for them.
             let current = previewPlan ?? CodexAuth.currentPlan()

--- a/Sentient OS macOS/Views/Onboarding/OnboardingView.swift
+++ b/Sentient OS macOS/Views/Onboarding/OnboardingView.swift
@@ -4,8 +4,11 @@
 //
 //  First-launch onboarding: the film slide (OnboardingFilmView — the website's self-scrolling
 //  film in a webview, parking on the morning home),
-//  then permissions (OnboardingPermissionsView), then codex login (OnboardingCodexSteps),
-//  then the plan crossroads (OnboardingPlanView — free/go accounts only; full plans skip it),
+//  then the frontier-model step (OnboardingFrontierModelView — the engine pills over the
+//  Settings panels, with the codex login embedded as the ChatGPT panel),
+//  then the plan crossroads (OnboardingPlanView — free/go ChatGPT accounts only; full plans
+//  and custom engines skip it; it rides directly behind the login that triggers it),
+//  then permissions (OnboardingPermissionsView),
 //  then the ready-to-process screen (OnboardingReadyView) whose Start Analysis presents the REAL
 //  ProcessingView takeover (pausable) — and only a finished run calls `onFinished` and reveals
 //  the home. If the on-device model hasn't finished downloading (ModelDownload — AppState kicks
@@ -73,13 +76,13 @@ struct OnboardingView: View {
                 // rest and blooms its own Continue (OnboardingFilmView owns the choreography).
                 OnboardingFilmView(onContinue: advance).transition(.opacity)
             case 1:
-                OnboardingPermissionsView(onContinue: advance).transition(.opacity)
+                OnboardingFrontierModelView(onContinue: advance).transition(.opacity)
             case 2:
-                OnboardingCodexLoginView(onContinue: advance).transition(.opacity)
-            case 3:
-                // The plan crossroads — free/go accounts decide here; full plans skip it
-                // before it renders (OnboardingPlanView auto-advances).
+                // The plan crossroads — free/go ChatGPT accounts decide here; full plans and
+                // custom engines skip it before it renders (OnboardingPlanView auto-advances).
                 OnboardingPlanView(onContinue: advance).transition(.opacity)
+            case 3:
+                OnboardingPermissionsView(onContinue: advance).transition(.opacity)
             default:
                 if analyzing, let modelPath {
                     // The REAL first analysis — the same engine + takeover as the home's Analyze
@@ -198,9 +201,9 @@ struct OnboardingView: View {
 
     private func goBack() {
         var target = step - 1
-        // The crossroads only exists for free/go accounts — never strand a full plan on an
-        // auto-advancing screen (back would visibly bounce forward again).
-        if target == 3 && !CodexAuth.isLimited() { target -= 1 }
+        // The crossroads only exists for free/go ChatGPT accounts — never strand a full plan
+        // or a custom engine on an auto-advancing screen (back would visibly bounce forward).
+        if target == 2 && (!CodexAuth.isLimited() || ModelBackend.current == .custom) { target -= 1 }
         withAnimation(.easeInOut(duration: 0.25)) { step = max(0, target) }
     }
 

--- a/Sentient OS macOS/Views/Settings/FrontierModelPane.swift
+++ b/Sentient OS macOS/Views/Settings/FrontierModelPane.swift
@@ -3,81 +3,21 @@
 //  Sentient OS macOS
 //
 //  Settings → Frontier Model Choice: which frontier engine powers the cloud ~10% of Sentient
-//  (the on-device model does the rest). Four engine tabs: ChatGPT (recommended, activates
-//  directly) · Claude (coming soon) · OpenRouter (prefilled, Kimi K3 forward — the only tested
-//  model that reliably drives computer use) · Custom (any Responses-API endpoint, with an
-//  LM Studio preset that prefills the base URL and raises the honest local-models warning).
-//  Activation is gated on the vision probe: "Use this model" appears only after the
-//  model PROVES it can read a screenshot (Test Model). Writes ModelBackend/CustomProvider (the
-//  one source of truth); everything applies to the very next run, no restart.
+//  (the on-device model does the rest). A thin wrapper over the SHARED FrontierEnginePicker
+//  (the pills + per-engine panels onboarding's choose-your-frontier-model step renders too);
+//  what's Settings' own here is the pane chrome and the ChatGPT panel — activate directly with
+//  Use ChatGPT, and point at Permissions & Health for login/plan (onboarding embeds the live
+//  login instead). Writes ModelBackend/CustomProvider (the one source of truth); everything
+//  applies to the very next run, no restart.
 //
 
 import SwiftUI
 
 struct FrontierModelPane: View {
 
-    /// The five engine tabs. OpenRouter, LM Studio, and Custom share the endpoint plumbing;
-    /// LM Studio's tab raises the honest local-models warning on first visit (model
-    /// capability, not plumbing, is the local blocker — the translator solved the plumbing).
-    private enum Tab: String, CaseIterable, Identifiable {
-        case chatgpt, claude, openRouter, lmStudio, custom
-        var id: Self { self }
-
-        var label: String {
-            switch self {
-            case .chatgpt:    return "ChatGPT Subscription"
-            case .claude:     return "Claude Subscription"
-            case .openRouter: return "OpenRouter"
-            case .lmStudio:   return "LM Studio"
-            case .custom:     return "Custom"
-            }
-        }
-
-        var badge: String? {
-            switch self {
-            case .chatgpt:  return "recommended"
-            case .claude:   return "coming soon"
-            case .lmStudio: return "local"
-            case .custom:   return "local"
-            case .openRouter: return nil
-            }
-        }
-    }
-
-    /// The one model that cleared the computer-use bar in the 2026-07-24 survey (~10 models,
-    /// real tasks). Prefilled on the OpenRouter tab and named in its note.
-    private static let kimiSlug = "moonshotai/kimi-k3"
-
     @AppStorage(ModelBackend.key) private var backendRaw = ModelBackend.chatgpt.rawValue
-    @AppStorage(CustomProvider.presetKey) private var presetRaw = CustomProvider.Preset.openRouter.rawValue
-    @AppStorage(CustomProvider.baseURLKey) private var baseURL = ""
-    @AppStorage(CustomProvider.modelNameKey) private var modelName = ""
-    @AppStorage(CustomProvider.reasoningKey) private var reasoningRaw = "low"
-    /// Set only by a passing Test Model run; any edit below clears it.
-    @AppStorage(CustomProvider.visionVerifiedKey) private var verified = false
-
-    @State private var tab: Tab = .chatgpt
-    @State private var apiKey = ""
-    @State private var showLocalWarning = false
-    /// The local-reality popup fires once per pane visit, on the LM Studio tab.
-    @State private var localWarningShown = false
-
-    /// The Test Model probe, narrated: nil = untested, "…" = running, ✓/✗ lines otherwise.
-    @State private var testing = false
-    @State private var testVerdict: String?
 
     private var backend: ModelBackend { ModelBackend(rawValue: backendRaw) ?? .chatgpt }
-    private var savedPreset: CustomProvider.Preset { CustomProvider.Preset(rawValue: presetRaw) ?? .openRouter }
-
-    /// The tab wearing the "active engine" dot.
-    private var activeTab: Tab {
-        guard backend == .custom else { return .chatgpt }
-        switch savedPreset {
-        case .openRouter: return .openRouter
-        case .lmStudio:   return .lmStudio
-        case .custom:     return .custom
-        }
-    }
 
     var body: some View {
         SettingsPane(title: "Frontier Model Choice",
@@ -85,362 +25,29 @@ struct FrontierModelPane: View {
             VStack(alignment: .leading, spacing: 26) {
                 SettingsProse("Everything Sentient reads stays on this Mac. For the heavy cloud reasoning, the knowledge base, the morning cards, Sidekick, it taps one frontier model of your choosing: your ChatGPT subscription, your Claude plan (coming soon), or a model endpoint of your own.")
 
-                tabStrip
-
-                Group {
-                    switch tab {
-                    case .chatgpt:    chatgptPanel
-                    case .claude:     claudePanel
-                    case .openRouter: endpointPanel(for: .openRouter)
-                    case .lmStudio:   endpointPanel(for: .lmStudio)
-                    case .custom:     endpointPanel(for: .custom)
-                    }
+                FrontierEnginePicker {
+                    chatgptPanel
                 }
-                .id(tab)
-                .transition(.opacity.combined(with: .move(edge: .trailing)))
-            }
-            .animation(.spring(response: 0.32, dampingFraction: 0.86), value: tab)
-        }
-        .onAppear {
-            tab = activeTab
-            apiKey = CustomProvider.apiKey ?? ""
-        }
-        .alert("A note on local frontier models", isPresented: $showLocalWarning) {
-            Button("Understood") {}
-        } message: {
-            Text("Most models you can run locally are far too weak for computer use; in our testing only Kimi K3 performed well enough, and most other open-weights models aren't multimodal (can't see), which computer use requires.\n\nIf you can somehow run Kimi K3 locally, this preset is all yours.\n\nOtherwise run it through OpenRouter, or if privacy is the concern, both OpenAI and Claude subscriptions let you turn off training on your data in your account settings on their own site. Those frontier options remain the best way to use Sentient.")
-        }
-    }
-
-    // MARK: - The engine tab strip
-
-    /// A FIXED two-row grid of equal-width pills (3 + 2) — deliberately not a flow layout: a
-    /// scrollbar appearing must never reflow the strip (the jumpy-rewrap of 2026-07-24), and
-    /// the fixed rows keep the pane comfortable at the window's normal width.
-    private var tabStrip: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack(spacing: 8) {
-                pill(.chatgpt); pill(.claude); pill(.openRouter)
-            }
-            HStack(spacing: 8) {
-                pill(.lmStudio); pill(.custom)
             }
         }
-        .fixedSize()
     }
 
-    private func pill(_ t: Tab) -> some View {
-        EngineTab(label: t.label, badge: t.badge,
-                  selected: tab == t, active: activeTab == t && isActiveEngineHealthy(t)) {
-            selectTab(t)
-        }
-    }
-
-    /// The active dot stays honest: a custom engine only wears it once it's proven usable.
-    private func isActiveEngineHealthy(_ t: Tab) -> Bool {
-        t == .chatgpt || CustomProvider.current.isUsable
-    }
-
-    /// Browsing tabs never disturbs a live engine: fields are only prefilled while nothing
-    /// custom is active (Test Model and Use-this-model pin the right values when the user
-    /// actually acts). The LM Studio tab raises the local-reality popup once per visit.
-    private func selectTab(_ t: Tab) {
-        tab = t
-        testVerdict = nil
-        if t == .lmStudio, !localWarningShown {
-            localWarningShown = true
-            showLocalWarning = true
-        }
-        guard backend != .custom else { return }
-        switch t {
-        case .openRouter:
-            if modelName.isEmpty { modelName = Self.kimiSlug }   // Kimi K3 forward
-            baseURL = CustomProvider.Preset.openRouter.defaultBaseURL
-        case .lmStudio:
-            if baseURL.isEmpty || baseURL == CustomProvider.Preset.openRouter.defaultBaseURL {
-                baseURL = CustomProvider.Preset.lmStudio.defaultBaseURL
-            }
-        default:
-            break
-        }
-    }
-
-    // MARK: - ChatGPT
+    // MARK: - ChatGPT (Settings' own panel — login honesty lives in Permissions & Health)
 
     private var chatgptPanel: some View {
         SettingsGroup(label: "Your ChatGPT") {
             VStack(alignment: .leading, spacing: 14) {
                 SettingsProse("Codex runs on your own ChatGPT subscription, so a plan you already pay for powers everything: knowledge base, morning cards, Sidekick, and the Gmail and Calendar connectors. Recommended, because the connectors only exist here.")
                 if backend == .chatgpt {
-                    activeLine("Sentient is running on your ChatGPT.")
+                    FrontierActiveLine("Sentient is running on your ChatGPT.")
                     SettingsProse("Login and plan live in Permissions & Health.")
                 } else {
                     SettingsPillButton(title: "Use ChatGPT") {
                         backendRaw = ModelBackend.chatgpt.rawValue
-                        testVerdict = nil
                     }
                 }
             }
         }
-    }
-
-    // MARK: - Claude (coming soon)
-
-    private var claudePanel: some View {
-        SettingsGroup(label: "Your Claude Plan", badge: "coming soon") {
-            VStack(alignment: .leading, spacing: 10) {
-                SettingsProse("Your Claude subscription will power Sentient the same way ChatGPT does today, through Claude Code's own command line. It's on the bench and coming soon.")
-                MonoCaps("claude -p · in the works", size: 8.5, tracking: 1.6, color: Theme.Ink.deepMuted)
-            }
-        }
-    }
-
-    // MARK: - Configurable endpoints (OpenRouter · Custom + its local presets)
-
-    private func endpointPanel(for preset: CustomProvider.Preset) -> some View {
-        SettingsGroup(label: preset == .openRouter ? "Your OpenRouter"
-                           : preset == .lmStudio ? "Your LM Studio" : "Your Endpoint") {
-            VStack(alignment: .leading, spacing: 14) {
-                switch preset {
-                case .openRouter:
-                    SettingsProse("Any model on OpenRouter, billed to your own key.")
-                case .lmStudio:
-                    SettingsProse("A model running on your own hardware, through LM Studio's local server. Sentient's translator makes it a first-class engine, computer use included; whether the model is up to the job is the honest question (see the note when this tab opens).")
-                case .custom:
-                    SettingsProse("Any endpoint that speaks the OpenAI Responses API (a /v1/responses route). Base URL, model name, key if it needs one.")
-                }
-                if preset != .lmStudio {
-                    SettingsProse("One important note: of every model we tested, Kimi K3 at low reasoning is the only open-weights model that can reliably drive computer use. Claude Sonnet 5 with reasoning off, and GPT-5.6 Sol at low reasoning are also great options we can stand by.")
-                }
-
-                // OpenRouter's base URL is fixed — no field, the tab pins it itself.
-                if preset != .openRouter {
-                    fieldRow(label: "BASE URL",
-                             placeholder: preset == .lmStudio
-                                 ? CustomProvider.Preset.lmStudio.defaultBaseURL
-                                 : "https://your-endpoint.example/v1",
-                             text: $baseURL)
-                }
-                fieldRow(label: "MODEL",
-                         placeholder: preset == .openRouter ? Self.kimiSlug
-                             : preset == .lmStudio ? "the model id shown in LM Studio"
-                             : "the model id your server expects",
-                         text: $modelName)
-                secureRow(label: preset == .openRouter ? "OPENROUTER API KEY" : "API KEY",
-                          placeholder: preset == .openRouter ? "sk-or-…" : "optional for keyless servers")
-
-                reasoningField
-
-                SettingsProse("Your model has to be able to see: Sentient acts on your Mac by looking at the screen, so a text-only model can't drive it. The test below checks that for you by asking your model to read a picture.")
-
-                HStack(spacing: 10) {
-                    SettingsPillButton(title: testing ? "Testing…" : "Test & Select") {
-                        guard !testing else { return }
-                        runTest(preset: preset)
-                    }
-                    if isActive(preset) {
-                        activeLine("This model is running Sentient.")
-                    }
-                }
-                if let testVerdict {
-                    SettingsProse(testVerdict)
-                }
-
-                SettingsHairline()
-                SettingsProse("Gmail and Calendar ride your ChatGPT account, so they sit out while a custom model is active. Everything else works, and your data still never leaves this Mac except what the model itself is sent.")
-            }
-        }
-    }
-
-    /// The endpoint's ONE reasoning level — free text, because models speak different dialects
-    /// (`none`, `low`, `xhigh`, `adaptive`, …), applied to every run this model powers (the
-    /// Speed slider is ChatGPT's). Kimi wants low; Claude-class endpoints need none. Editing it
-    /// re-runs the gate via the field's invalidate, since a wrong level can break the endpoint
-    /// outright.
-    private var reasoningField: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            fieldRow(label: "REASONING",
-                     placeholder: "low · none · xhigh · whatever your model supports",
-                     text: $reasoningRaw)
-            MonoCaps("applies everywhere this model runs", size: 7.5, tracking: 1.6,
-                     color: Theme.Ink.deepMuted)
-        }
-    }
-
-    // MARK: - Pieces
-
-    private func activeLine(_ text: String) -> some View {
-        HStack(spacing: 8) {
-            HealthDot(color: Theme.Ink.green)
-            Text(text).font(.system(size: 12, weight: .medium)).foregroundStyle(.white)
-        }
-    }
-
-    private func fieldRow(label: String, placeholder: String, text: Binding<String>) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            MonoCaps(label, size: 8.5, tracking: 2.0, color: Theme.Ink.deepMuted)
-            TextField(placeholder, text: text)
-                .textFieldStyle(.plain)
-                .font(.system(size: 11.5)).foregroundStyle(Theme.Ink.statusInk)
-                .padding(.horizontal, 12).padding(.vertical, 8)
-                .background(Color.white.opacity(0.02), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
-                .overlay(RoundedRectangle(cornerRadius: 9, style: .continuous)
-                    .strokeBorder(Theme.stroke, lineWidth: 1))
-                .onChange(of: text.wrappedValue) { invalidate() }
-        }
-    }
-
-    /// Any edit to the endpoint retires the old verdict: a different model has to prove it can
-    /// see for itself. Also drops the backend back to ChatGPT if the running engine just became
-    /// unverified, so Sentient is never left pointed at an unproven model.
-    private func invalidate() {
-        guard verified || backend == .custom else { return }
-        verified = false
-        testVerdict = nil
-        if backend == .custom { backendRaw = ModelBackend.chatgpt.rawValue }
-    }
-
-    private func secureRow(label: String, placeholder: String) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            MonoCaps(label, size: 8.5, tracking: 2.0, color: Theme.Ink.deepMuted)
-            SecureField(placeholder, text: $apiKey)
-                .textFieldStyle(.plain)
-                .font(.system(size: 11.5)).foregroundStyle(Theme.Ink.statusInk)
-                .padding(.horizontal, 12).padding(.vertical, 8)
-                .background(Color.white.opacity(0.02), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
-                .overlay(RoundedRectangle(cornerRadius: 9, style: .continuous)
-                    .strokeBorder(Theme.stroke, lineWidth: 1))
-                .onChange(of: apiKey) {
-                    let trimmed = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
-                    if trimmed.isEmpty {
-                        Keychain.delete(CustomProvider.apiKeyAccount)
-                    } else {
-                        Keychain.set(CustomProvider.apiKeyAccount, trimmed)
-                    }
-                    invalidate()
-                }
-            MonoCaps("stored in your mac's keychain", size: 7.5, tracking: 1.6, color: Theme.Ink.deepMuted)
-        }
-    }
-
-    private func isActive(_ preset: CustomProvider.Preset) -> Bool {
-        backend == .custom && savedPreset == preset && CustomProvider.current.isUsable
-    }
-
-    /// Flip the backend to the viewed tab's endpoint — reached ONLY through a passing
-    /// Test & Select run, so an unproven model can never become the engine. Fields already
-    /// autosave (@AppStorage); activation is just the choice becoming official.
-    private func activate(_ preset: CustomProvider.Preset) {
-        presetRaw = preset.rawValue
-        guard CustomProvider.current.isUsable else { return }
-        backendRaw = ModelBackend.custom.rawValue
-    }
-
-    private func runTest(preset: CustomProvider.Preset) {
-        // OpenRouter's URL is pinned (no field on that tab); elsewhere only fill an empty one.
-        if preset == .openRouter {
-            baseURL = preset.defaultBaseURL
-        } else if baseURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            baseURL = preset.defaultBaseURL
-        }
-        presetRaw = preset.rawValue   // the probe reads the SAVED provider — keep it current
-        guard CustomProvider.current.isConfigured else {
-            testVerdict = "✗ It needs a base URL and a model name first."
-            return
-        }
-        testing = true
-        testVerdict = "Showing your model a picture and asking it to read the number… local models can take a minute to load."
-        Task {
-            let verdict = await CodexCLI.probeCustomEndpoint()
-            await MainActor.run {
-                testing = false
-                switch verdict {
-                case .available:
-                    verified = true
-                    activate(preset)   // Test & Select: a passing model becomes the engine
-                    testVerdict = "✓ Your model answered and read the picture. Sentient is now running on it."
-                case .notInstalled:
-                    verified = false
-                    testVerdict = "✗ Codex CLI is missing on this Mac. Install it in Permissions & Health first; it's the engine room even for custom models."
-                case .notWorking(let detail):
-                    verified = false
-                    testVerdict = "✗ \(friendly(detail))"
-                }
-            }
-        }
-    }
-
-    /// Reduce codex's raw stderr to one readable hint; the full detail stays in the console.
-    /// A base URL missing its `/v1` is the single most common setup slip (codex appends
-    /// `/responses` to whatever you give it, so the request lands on a route the server
-    /// doesn't serve), so every failure carries that nudge when it applies.
-    private func friendly(_ detail: String) -> String {
-        let lowered = detail.lowercased()
-        let trimmedURL = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
-            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-        let v1Hint = trimmedURL.hasSuffix("/v1") ? ""
-            : " Most servers also expect the base URL to end in /v1."
-        if lowered.hasPrefix("blind") || lowered.contains("image input") || lowered.contains("multimodal") {
-            return "This model can't see pictures, so it can't act on your Mac. Pick one that accepts images."
-        }
-        if lowered.contains("401") || lowered.contains("unauthorized") {
-            return "The endpoint rejected the API key."
-        }
-        if lowered.contains("connection refused") || lowered.contains("error sending request") {
-            return "Nothing is listening at that base URL. Is the server running?\(v1Hint)"
-        }
-        if lowered.contains("404") || lowered.contains("not found")
-            || lowered.contains("unexpected endpoint") {
-            return "The endpoint answered but has no /v1/responses route.\(v1Hint.isEmpty ? " It must support the OpenAI Responses API." : v1Hint)"
-        }
-        return "No answer from the endpoint.\(v1Hint) \(detail.prefix(180))"
-    }
-}
-
-// MARK: - The engine tab
-
-/// One tab in the engine strip: a fixed-size pill that reads like a place, not a button —
-/// EVERY pill the same width and height so the row's geometry never shifts (scrollbars,
-/// badges, and selection can't reflow it). Selected = elevated wash + white ring; the ACTIVE
-/// engine wears the small green status dot (the same honest LED the health rows use). Badges
-/// whisper in mono-caps under the label.
-private struct EngineTab: View {
-    static let pillWidth: CGFloat = 176
-    static let pillHeight: CGFloat = 52
-
-    let label: String
-    var badge: String? = nil
-    let selected: Bool
-    let active: Bool
-    let action: () -> Void
-
-    var body: some View {
-        Button(action: action) {
-            VStack(alignment: .leading, spacing: 3) {
-                HStack(spacing: 7) {
-                    if active { HealthDot(color: Theme.Ink.green) }
-                    Text(label)
-                        .font(.system(size: 12.5, weight: selected ? .medium : .regular))
-                        .foregroundStyle(selected ? .white : Theme.Ink.body)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.92)
-                }
-                if let badge {
-                    MonoCaps(badge, size: 7, tracking: 1.4,
-                             color: badge == "recommended" ? Theme.Ink.green.opacity(0.85)
-                                                           : .white.opacity(0.45))
-                }
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, 12)
-            .frame(width: Self.pillWidth, height: Self.pillHeight)
-            .background(selected ? Theme.elevated : Color.white.opacity(0.02),
-                        in: RoundedRectangle(cornerRadius: 14, style: .continuous))
-            .overlay(RoundedRectangle(cornerRadius: 14, style: .continuous).strokeBorder(
-                selected ? Color.white.opacity(0.28) : Color.white.opacity(0.10), lineWidth: 1))
-            .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
-        }
-        .buttonStyle(PressScaleStyle())
     }
 }
 


### PR DESCRIPTION
## What

- **New onboarding step: Choose your frontier model.** The codex-login screen grew into the full engine choice: the five engine pills (ChatGPT · Claude · OpenRouter · LM Studio · Custom) in one row, over the same per-engine setup panels Settings renders, Test & Select included.
- **Shared `FrontierEnginePicker`.** The pills + panels extracted out of `FrontierModelPane`, which is now a thin Settings wrapper over it — one implementation, two surfaces. The ChatGPT panel is a host slot: Settings points at Permissions & Health; onboarding embeds the live codex login (`OnboardingCodexLoginPanel`).
- **Flow reorder.** The frontier-model step now comes before permissions (film → frontier model → plan crossroads → permissions → ready). The crossroads rides directly behind the login that triggers it, and custom engines skip it entirely — their endpoint powers everything, so the ChatGPT plan is irrelevant there.
- **Continue gates on a healthy engine**: ChatGPT logged in, or a custom endpoint that passed Test & Select. Browsing tabs never disturbs the active engine, same semantics as Settings.
- **Onboarding-only guard:** Test & Select greys with an 'installing codex in the background' whisper until the background CLI install answers (the CLI is the engine room even for custom endpoints).
- **Motion polish:** tab switches crossfade with a pinned header — no slide, no re-centering jump. Applies to the Settings pane too via the shared picker. Continue wears the subtle glow halo once armed.

## Testing

- Debug build verified.
- Walked live: the ChatGPT login flow, the install-failed panel, the OpenRouter Test & Select path, and the tab-switch motion.