### PR TITLE
Docs: true up for the 1.3 release

### DIFF
--- a/Sentient OS macOS/Documentation/Auto-Update (Sparkle).md
+++ b/Sentient OS macOS/Documentation/Auto-Update (Sparkle).md
@@ -16,10 +16,12 @@ install genuinely can't happen.
 > appcast, each leg verified live (Gatekeeper "Notarized Developer ID", cask install on real
 > hardware, feed serving the correct EdDSA-signed enclosure).
 >
-> **The first over-the-air updates — 1.1 (build 2) and 1.2 (build 3) — shipped 2026-07-20**, each
-> through the same two-script pipeline, publishing the appcast + site Download URL so the installed
-> 1.0/1.1 fleet self-updates. 1.2 is the first release to exercise the **windowless silent relaunch**
-> (below) against a real signed update.
+> **The over-the-air updates — 1.1 (build 2) and 1.2 (build 3) on 2026-07-20, then 1.3 (build 4) on
+> 2026-07-25 — all shipped** through the same two-script pipeline, publishing the appcast + site
+> Download URL so the installed fleet self-updates. 1.2 was the first release to exercise the
+> **windowless silent relaunch** (below) against a real signed update; 1.3 shipped the bring-your-own
+> frontier-model engine (`Frontier Model Choice (BYOM).md`) plus computer-use-setup and
+> Codex-install reliability fixes.
 
 ---
 

--- a/Sentient OS macOS/Documentation/Codex Setup Handoff (Onboarding).md
+++ b/Sentient OS macOS/Documentation/Codex Setup Handoff (Onboarding).md
@@ -51,6 +51,18 @@ for step in await codex.whatsNeeded() {        // e.g. [.computerUse] if 1 & 2 a
 - **Dumb sequential also works.** If you'd rather just call `installCodex()` → login → `setupComputerUse()`
   in order without `whatsNeeded()`, that's safe — every action self-guards. `whatsNeeded()` just lets you
   skip rendering finished steps.
+- **The install is network-resilient (shipped in 1.3).** A slow or unavailable network can no longer
+  leave the user staring at an endless "installing Codex" spinner. `CodexCLI.install` puts a
+  connect-timeout on the `install.sh` fetch and a throughput floor (`--speed-limit`/`--speed-time`) on
+  the script's own binary download, so a *stalled* transfer fails fast (~30 s) while a *slow-but-moving*
+  one still finishes; the per-attempt budget is 900 s (raised from 300 s, which was cutting off
+  in-progress downloads on genuinely slow links). **`CodexSetup.ensureInstalled(attempts:)` is the
+  single source of truth for the retry policy** (+ an `installGaveUp` flag) — both the launch-time kick
+  (`AppState`) and the onboarding screen drive this one method, so there's no second, divergent retry
+  loop. When retries are exhausted, onboarding shows a terminal **`CodexInstallFailedPanel`** (a link to
+  the official Codex install guide, a VPN suggestion, and a note that Codex is unavailable in a few
+  regions) instead of hanging; the step's existing `codex --help` poll picks the CLI up the moment it
+  lands, so onboarding resumes on its own (including after a relaunch).
 - **Computer use is ~505 MB + a few minutes** (downloads OpenAI's DMG). Stream `computerUseStatus` to the
   UI (it carries live "Downloading… 42%", "Copying plugin…", "✓ ready" lines). Gate it behind step 1 (it
   refuses if codex isn't installed — and it re-probes the DISK for the binary, not the cached flag, so a


### PR DESCRIPTION
Two small doc gaps 1.3 opened (both features already verified in the field):

- **Auto-Update (Sparkle)** — status block now records 1.3 (build 4, 2026-07-25) alongside 1.1/1.2, and points at the BYOM deep doc.
- **Codex Setup Handoff (Onboarding)** — documents the 1.3 install-resilience work: the network timeouts + throughput floor on `CodexCLI.install`, the 300s→900s per-attempt budget, `ensureInstalled(attempts:)` as the single retry-policy source (+ `installGaveUp`), and the terminal `CodexInstallFailedPanel` fallback.

BYOM, the computer-use setup fix, codex discovery precedence, and the disk preflight were already documented by #295 / #291 / #294 — this fills what those left. Docs only, public-surface framing checked.